### PR TITLE
Features/fix api crashes

### DIFF
--- a/src/mdw-sync/services/indexer.service.ts
+++ b/src/mdw-sync/services/indexer.service.ts
@@ -131,6 +131,10 @@ export class IndexerService implements OnModuleInit {
       // Get tip height from MDW
       const middlewareUrl = this.configService.get<string>('mdw.middlewareUrl');
       const status = await fetchJson(`${middlewareUrl}/v3/status`);
+      if (!status?.mdw_height) {
+        this.logger.warn('MDW status unavailable or returned an empty response, skipping sync cycle');
+        return;
+      }
       const tipHeight = status.mdw_height;
 
       // Update tip height

--- a/src/social/controllers/posts.controller.ts
+++ b/src/social/controllers/posts.controller.ts
@@ -152,13 +152,14 @@ export class PostsController {
   @Get()
   async listAll(
     @Query('page', new DefaultValuePipe(1), ParseIntPipe) page = 1,
-    @Query('limit', new DefaultValuePipe(100), ParseIntPipe) limit = 100,
+    @Query('limit', new DefaultValuePipe(30), ParseIntPipe) limit = 30,
     @Query('order_by') orderBy: string = 'created_at',
     @Query('order_direction') orderDirection: 'ASC' | 'DESC' = 'DESC',
     @Query('search') search?: string,
     @Query('account_address') account_address?: string,
     @Query('topics') topics?: string,
   ) {
+    limit = Math.min(limit, 30);
     // Build base query for filtering to get distinct post IDs
     // This prevents duplicates when posts have multiple topics
     const baseQuery = this.postRepository

--- a/src/tokens/tokens.controller.ts
+++ b/src/tokens/tokens.controller.ts
@@ -76,11 +76,12 @@ export class TokensController {
     @Query('creator_address') creator_address = undefined,
     @Query('owner_address') owner_address = undefined,
     @Query('page', new DefaultValuePipe(1), ParseIntPipe) page = 1,
-    @Query('limit', new DefaultValuePipe(100), ParseIntPipe) limit = 100,
+    @Query('limit', new DefaultValuePipe(30), ParseIntPipe) limit = 30,
     @Query('order_by') orderBy: string = 'market_cap',
     @Query('order_direction') orderDirection: 'ASC' | 'DESC' = 'DESC',
     @Query('collection') collection: 'all' | 'word' | 'number' = 'all',
   ): Promise<Pagination<Token>> {
+    limit = Math.min(limit, 30);
     // Now, wrap with RANK()
     // allowed sort fields to avoid SQL Injection
     const allowedSortFields = [

--- a/src/tokens/tokens.service.ts
+++ b/src/tokens/tokens.service.ts
@@ -855,10 +855,13 @@ export class TokensService {
 
   async _loadHoldersFromContract(token: Token, aex9Address: string) {
     try {
-      const { tokenContractInstance } =
-        await this.getTokenContractsBySaleAddress(
-          token.sale_address as Encoded.ContractAddress,
-        );
+      const contracts = await this.getTokenContractsBySaleAddress(
+        token.sale_address as Encoded.ContractAddress,
+      );
+      if (!contracts?.tokenContractInstance) {
+        return [];
+      }
+      const { tokenContractInstance } = contracts;
       const holderBalances = await tokenContractInstance.balances();
       const holders = Array.from(holderBalances.decodedResult)
         .map(([key, value]: any) => ({


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core sync and networking paths (MDW pagination, websocket reconnect behavior, global `fetchJson` timeout), which can change runtime behavior under load or during upstream outages. Changes are defensive but could alter retry/timeout characteristics and throughput.
> 
> **Overview**
> Hardens external calls and long-running sync loops to avoid hangs/crashes: `fetchJson` now enforces a default 30s timeout, and `CoinGeckoService.fetchFromApi` adds timeout + explicit handling for 204/429 and non-JSON responses.
> 
> Eliminates unbounded recursion/infinite polling in MDW sync and websockets by switching to iterative pagination/processing with safety caps (`syncBlocks`, `processTransactionPage`, `fetchMicroBlocksForKeyBlock`, token holder loading) and by adding bounded OPEN-state waiting plus reconnect-on-send-failure in `WebSocketService`.
> 
> Reduces default and maximum `limit` for `GET /posts` and `GET /tokens` to 30, adds error-catching for async websocket callbacks in `LiveIndexerService`, and makes token contract lookup treat on-chain “not_present”/404 as an expected miss (plus a small trending-score formula fix).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ea71cc3d9afa0c2cee9b0337b860271346d4384. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->