### PR TITLE
Release

### DIFF
--- a/docs/popular-post-ranking.md
+++ b/docs/popular-post-ranking.md
@@ -1,6 +1,6 @@
 ## Popular post ranking
 
-The popular post endpoint ranks content by a weighted engagement score, then applies time decay so newer activity stays visible.
+The popular post endpoint ranks content by accumulated engagement — a "Top" style ranking with no time decay. The time window itself acts as the freshness filter.
 
 The current implementation rewards posts that attract:
 
@@ -19,11 +19,9 @@ The ranking powers `GET /posts/popular`.
 
 Supported windows:
 
-- `24h`
+- `24h` (default)
 - `7d`
 - `all`
-
-The same scoring model is used for all windows, but the time decay and candidate pool differ per window.
 
 ## Which posts are even eligible
 
@@ -49,32 +47,21 @@ MAX_CANDIDATES_ALL: 10000,
 
 This means popularity is computed only within the newest candidate pool for that window, not across every post ever created.
 
-## High-level formula
+## Formula
 
-Each candidate gets a weighted numerator from engagement and content signals:
+Each candidate gets a score from accumulated engagement and content signals:
 
 ```text
-numerator =
+score =
   w_comments * log(1 + comments) +
   w_tips_amount * log(1 + tipsAmountAE) +
   w_tips_count * log(1 + tipsCount) +
-  w_interactions_per_hour * log(1 + interactionsPerHour) +
-  w_reads * log(1 + readsPerHour) +
+  w_reads * log(1 + reads) +
   w_trending * trendingBoost +
   w_quality * contentQuality
 ```
 
-Then the score is decayed by age:
-
-```text
-score = numerator / (ageHours + t_bias) ^ gravity
-```
-
-Where:
-
-- `ageHours` is the post age in hours,
-- `t_bias` prevents very new posts from exploding,
-- `gravity` controls how fast older posts fall.
+There is no time-decay divisor. The score is purely based on engagement within the selected window.
 
 ## Current weights
 
@@ -82,13 +69,12 @@ All weights live in `src/configs/constants.ts` under `POPULAR_RANKING_CONFIG`.
 
 ```ts
 WEIGHTS: {
-  comments: 1.7,
-  tipsAmountAE: 4.0,
-  tipsCount: 1,
-  interactionsPerHour: 0.2,
-  trendingBoost: 0.4,
+  comments: 2.5,
+  tipsAmountAE: 2.0,
+  tipsCount: 1.0,
+  trendingBoost: 0.5,
   contentQuality: 0.3,
-  reads: 1.0,
+  reads: 1.5,
 }
 ```
 
@@ -96,11 +82,15 @@ WEIGHTS: {
 
 The biggest direct drivers are:
 
-- `tipsAmountAE`
 - `comments`
+- `tipsAmountAE`
 - `reads`
 
-Because logarithms are used for the count- and amount-based signals, all of them have diminishing returns. Doubling activity helps, but not linearly forever.
+Because logarithms are used for all count- and amount-based signals, they have diminishing returns. Doubling activity helps, but not linearly forever.
+
+### Why tips are not the dominant signal
+
+Tipping is a rare action on this network. The weight for `tipsAmountAE` (2.0) is deliberately lower than `comments` (2.5) so that a single generous tip cannot vault a post above all others. Comments and reads — being the most common engagement signals — lead the ranking.
 
 ## Ranking signals
 
@@ -108,51 +98,33 @@ Because logarithms are used for the count- and amount-based signals, all of them
 
 The score uses `post.total_comments`.
 
-More discussion helps a post trend, but through `log(1 + comments)`, so going from 0 to 5 comments matters more than going from 500 to 505.
+More discussion helps a post rank higher, but through `log(1 + comments)`, so going from 0 to 5 comments matters more than going from 500 to 505.
 
 ### 2. Tip amount
 
-The total AE tipped on the post is summed and scored with:
+The total AE tipped on the post (excluding self-tips) is summed and scored with:
 
 ```text
 log(1 + tipsAmountAE)
 ```
 
-This is currently the strongest direct engagement signal in the formula.
-
 ### 3. Tip count
 
 The number of tips also contributes separately from total value. This helps distinguish one large tip from repeated support by multiple users.
 
-### 4. Interactions per hour
-
-The service calculates:
-
-```text
-interactionsPerHour = (comments + uniqueTippers) / ageHours
-```
-
-This rewards momentum. A post getting discussion and support quickly performs better than a post that accumulated the same totals much more slowly.
-
-### 5. Reads
+### 4. Reads
 
 Reads are pulled from `post_reads_daily` and summed across the selected window.
 
-The ranking uses:
+The ranking uses raw reads:
 
 ```text
-readsPerHour = reads / ageHours
+log(1 + reads)
 ```
 
-Then applies:
+Reads are not normalized by age — the window boundary handles freshness.
 
-```text
-log(1 + readsPerHour)
-```
-
-So reads do matter, but they are normalized by age and weighted more modestly than tip amount.
-
-### 6. Trending topic boost
+### 5. Trending topic boost
 
 If a post has topics, the system looks up the highest trending-tag score among them and normalizes it:
 
@@ -162,7 +134,7 @@ trendingBoost = min(1, maxTrendingTagScore / 100)
 
 A post with at least one strongly trending topic gets a modest boost. The algorithm uses the single strongest topic score, not the sum of all topic scores.
 
-### 7. Content quality
+### 6. Content quality
 
 The content-quality factor is a heuristic in the range `[0..1]`.
 
@@ -176,36 +148,6 @@ It penalizes very short, emoji-heavy posts especially hard.
 
 In practice, this helps reduce spammy low-effort content from dominating on pure engagement tricks alone.
 
-## Time decay by window
-
-The time-decay settings are:
-
-```ts
-GRAVITY: 1.6,
-GRAVITY_7D: 0.5,
-T_BIAS: 1.0,
-```
-
-How that behaves:
-
-- `24h` uses `gravity = 1.6`, so recency matters a lot.
-- `7d` uses `gravity = 0.5`, so good posts stay competitive longer.
-- `all` uses `gravity = 0.0`, so there is no age decay after a post enters the candidate pool.
-
-This means the `24h` feed is momentum-heavy, while the `all` feed behaves more like an all-time best-of list within the capped candidate set.
-
-## Score floors
-
-After scoring, low-signal items are filtered out entirely:
-
-```ts
-SCORE_FLOOR_DEFAULT: 0.01,
-SCORE_FLOOR_7D: 0.008,
-SCORE_FLOOR_ALL: 0.1,
-```
-
-If a post does not reach the floor for the selected window, it will not appear in the cached popular ranking at all.
-
 ## Governance polls and plugin content
 
 The popular feed can also include plugin-provided content items, not only regular posts.
@@ -217,7 +159,7 @@ For polls:
 - `votes_count` is used as the `comments`-equivalent engagement signal,
 - tips are currently treated as `0`,
 - reads are currently treated as `0`,
-- the same content-quality and decay logic still applies.
+- the same content-quality logic still applies.
 
 This is why the endpoint can return mixed item types while still ranking them with a comparable scoring model.
 
@@ -241,11 +183,9 @@ So the feed is intentionally refreshed often.
 
 A post is most likely to rank highly when it is:
 
-- recent,
 - top-level,
-- receiving comments quickly,
-- receiving meaningful AE tips,
-- getting support from multiple unique tippers,
+- receiving many comments,
+- receiving meaningful AE tips from multiple tippers,
 - being read actively,
 - connected to a trending topic,
 - written with enough substance to avoid quality penalties.
@@ -254,8 +194,8 @@ A post is most likely to rank highly when it is:
 
 | File | Purpose |
 |------|---------|
-| `src/social/services/popular-ranking.service.ts` | Main candidate selection, scoring, decay, and Redis caching |
-| `src/configs/constants.ts` | Ranking weights, decay, score floors, and candidate caps |
+| `src/social/services/popular-ranking.service.ts` | Main candidate selection, scoring, and Redis caching |
+| `src/configs/constants.ts` | Ranking weights and candidate caps |
 | `src/social/controllers/posts.controller.ts` | Exposes `GET /posts/popular` |
 | `src/plugins/popular-ranking.interface.ts` | Plugin contract for non-post content |
 | `src/plugins/governance/services/governance-popular-ranking.service.ts` | Governance poll contribution to popular ranking |
@@ -266,9 +206,13 @@ A post is most likely to rank highly when it is:
 
 Most numeric signals use `log(1 + x)` so the ranking favors meaningful activity without letting one giant raw number dominate forever.
 
-### Why recency still wins in 24h
+### Why there is no time decay
 
-The `24h` window is intended to surface active conversations now, not just the largest totals accumulated earlier in the day.
+This is a "Top" ranking, not a "Hot" ranking. The time window itself (24h, 7d, all) acts as the freshness filter. Within a window, posts compete purely on accumulated engagement. This is simpler, more transparent, and better suited for a low-activity network where posts need time to gather signals.
+
+### Why there are no score floors
+
+All posts within the candidate pool are included. On a low-activity network, filtering out low-signal posts would leave the feed empty. Zero-engagement posts simply sort to the bottom by their small content-quality score.
 
 ### Why user wallet and reputation signals are excluded
 

--- a/docs/popular-post-ranking.md
+++ b/docs/popular-post-ranking.md
@@ -179,6 +179,8 @@ REDIS_TTL_SECONDS: 30
 
 So the feed is intentionally refreshed often.
 
+When the cache is empty (cold start or after TTL expiry with no cron), recompute is triggered in the background with a per-window mutex to prevent stampede. The current request falls back to recent posts while the cache is being rebuilt.
+
 ## Practical interpretation
 
 A post is most likely to rank highly when it is:

--- a/docs/popular-post-ranking.md
+++ b/docs/popular-post-ranking.md
@@ -96,7 +96,7 @@ Tipping is a rare action on this network. The weight for `tipsAmountAE` (2.0) is
 
 ### 1. Comments
 
-The score uses `post.total_comments`.
+The score counts comments (replies) on the post, excluding the post author's own replies. This prevents authors from inflating their ranking by replying to their own posts.
 
 More discussion helps a post rank higher, but through `log(1 + comments)`, so going from 0 to 5 comments matters more than going from 500 to 505.
 

--- a/docs/popular-post-ranking.md
+++ b/docs/popular-post-ranking.md
@@ -56,6 +56,7 @@ score =
   w_comments * log(1 + comments) +
   w_tips_amount * log(1 + tipsAmountAE) +
   w_tips_count * log(1 + tipsCount) +
+  w_unique_tippers * log(1 + uniqueTippers) +
   w_reads * log(1 + reads) +
   w_trending * trendingBoost +
   w_quality * contentQuality
@@ -72,6 +73,7 @@ WEIGHTS: {
   comments: 2.5,
   tipsAmountAE: 2.0,
   tipsCount: 1.0,
+  uniqueTippers: 1.5,
   trendingBoost: 0.5,
   contentQuality: 0.3,
   reads: 1.5,
@@ -84,13 +86,14 @@ The biggest direct drivers are:
 
 - `comments`
 - `tipsAmountAE`
+- `uniqueTippers`
 - `reads`
 
 Because logarithms are used for all count- and amount-based signals, they have diminishing returns. Doubling activity helps, but not linearly forever.
 
 ### Why tips are not the dominant signal
 
-Tipping is a rare action on this network. The weight for `tipsAmountAE` (2.0) is deliberately lower than `comments` (2.5) so that a single generous tip cannot vault a post above all others. Comments and reads — being the most common engagement signals — lead the ranking.
+Tipping is a rare action on this network. The weight for `tipsAmountAE` (2.0) is deliberately lower than `comments` (2.5) so that a single generous tip cannot vault a post above all others. The separate `uniqueTippers` signal (1.5) ensures that broad community support outweighs a single large tip — five people each tipping a small amount scores higher than one whale tipping the same total.
 
 ## Ranking signals
 
@@ -110,9 +113,13 @@ log(1 + tipsAmountAE)
 
 ### 3. Tip count
 
-The number of tips also contributes separately from total value. This helps distinguish one large tip from repeated support by multiple users.
+The number of tips also contributes separately from total value.
 
-### 4. Reads
+### 4. Unique tippers
+
+The number of distinct addresses that tipped a post (excluding self-tips). This rewards breadth of support — a post tipped by five different users ranks higher than one tipped five times by the same person, even if the total AE is the same.
+
+### 5. Reads
 
 Reads are pulled from `post_reads_daily` and summed across the selected window.
 
@@ -124,7 +131,7 @@ log(1 + reads)
 
 Reads are not normalized by age — the window boundary handles freshness.
 
-### 5. Trending topic boost
+### 6. Trending topic boost
 
 If a post has topics, the system looks up the highest trending-tag score among them and normalizes it:
 
@@ -134,7 +141,7 @@ trendingBoost = min(1, maxTrendingTagScore / 100)
 
 A post with at least one strongly trending topic gets a modest boost. The algorithm uses the single strongest topic score, not the sum of all topic scores.
 
-### 6. Content quality
+### 7. Content quality
 
 The content-quality factor is a heuristic in the range `[0..1]`.
 

--- a/docs/popular-post-ranking.md
+++ b/docs/popular-post-ranking.md
@@ -9,8 +9,7 @@ The current implementation rewards posts that attract:
 - unique tippers,
 - reads,
 - association with currently trending topics,
-- better-quality content,
-- stronger author reputation signals.
+- better-quality content.
 
 It does not simply sort by raw comment count or raw tip amount.
 
@@ -52,7 +51,7 @@ This means popularity is computed only within the newest candidate pool for that
 
 ## High-level formula
 
-Each candidate gets a weighted numerator from engagement and author signals:
+Each candidate gets a weighted numerator from engagement and content signals:
 
 ```text
 numerator =
@@ -62,11 +61,7 @@ numerator =
   w_interactions_per_hour * log(1 + interactionsPerHour) +
   w_reads * log(1 + readsPerHour) +
   w_trending * trendingBoost +
-  w_quality * contentQuality +
-  w_balance * accountBalanceFactor +
-  w_account_age * accountAgeFactor +
-  w_invites * invitesFactor +
-  w_owned_trends * ownedTrendsFactor
+  w_quality * contentQuality
 ```
 
 Then the score is decayed by age:
@@ -93,10 +88,6 @@ WEIGHTS: {
   interactionsPerHour: 0.2,
   trendingBoost: 0.4,
   contentQuality: 0.3,
-  accountBalance: 0.2,
-  accountAge: 0.02,
-  invites: 2,
-  ownedTrends: 1.5,
   reads: 1.0,
 }
 ```
@@ -106,9 +97,7 @@ WEIGHTS: {
 The biggest direct drivers are:
 
 - `tipsAmountAE`
-- `invites`
 - `comments`
-- `ownedTrends`
 - `reads`
 
 Because logarithms are used for the count- and amount-based signals, all of them have diminishing returns. Doubling activity helps, but not linearly forever.
@@ -187,45 +176,6 @@ It penalizes very short, emoji-heavy posts especially hard.
 
 In practice, this helps reduce spammy low-effort content from dominating on pure engagement tricks alone.
 
-### 8. Author account balance
-
-The author's AE balance is fetched and normalized against:
-
-```ts
-BALANCE_NORMALIZER_AE: 500_000
-```
-
-This becomes a small reputation-style factor in the range `[0..1]`.
-
-### 9. Author account age
-
-Older accounts receive a tiny boost via a sigmoid-style curve centered roughly around the first two weeks of account age.
-
-This is intentionally a very small factor.
-
-### 10. Invitations sent
-
-The algorithm counts invitations sent by the author and normalizes them logarithmically up to 100 invites:
-
-```text
-invitesFactor = log(1 + sentInvites) / log(1 + 100)
-```
-
-This acts as a reputation/community-building signal.
-
-### 11. Owned token portfolio value
-
-The service calculates the author's token holdings value and normalizes it into `[0..1]`.
-
-By default the normalization is based on AE value:
-
-```ts
-OWNED_TRENDS_VALUE_CURRENCY: 'ae'
-OWNED_TRENDS_VALUE_NORMALIZER_AE: 20000
-```
-
-So an account with roughly `20,000 AE` worth of tracked token holdings approaches the maximum contribution from this factor.
-
 ## Time decay by window
 
 The time-decay settings are:
@@ -267,7 +217,7 @@ For polls:
 - `votes_count` is used as the `comments`-equivalent engagement signal,
 - tips are currently treated as `0`,
 - reads are currently treated as `0`,
-- the same content-quality, author, and decay logic still applies.
+- the same content-quality and decay logic still applies.
 
 This is why the endpoint can return mixed item types while still ranking them with a comparable scoring model.
 
@@ -298,8 +248,7 @@ A post is most likely to rank highly when it is:
 - getting support from multiple unique tippers,
 - being read actively,
 - connected to a trending topic,
-- written with enough substance to avoid quality penalties,
-- authored by an account with stronger reputation-style signals.
+- written with enough substance to avoid quality penalties.
 
 ## Files involved
 
@@ -321,6 +270,6 @@ Most numeric signals use `log(1 + x)` so the ranking favors meaningful activity 
 
 The `24h` window is intended to surface active conversations now, not just the largest totals accumulated earlier in the day.
 
-### Why reputation signals exist
+### Why user wallet and reputation signals are excluded
 
-Account balance, account age, invites, and owned token value are all relatively small compared to direct engagement, but they help the feed lean toward established, credible participants when engagement is otherwise close.
+Popular ranking intentionally does not use author account balance, account age, invite counts, or owned-token portfolio value. The feed is driven by engagement on the content itself plus topic momentum and lightweight quality heuristics, so visibility does not depend on wealth or account metadata.

--- a/src/configs/constants.ts
+++ b/src/configs/constants.ts
@@ -226,10 +226,6 @@ export const POPULAR_RANKING_CONFIG = {
     interactionsPerHour: 0.2, // w_it (minor)
     trendingBoost: 0.4, // w_tr (minor)
     contentQuality: 0.3, // w_q (minor, prevents spam)
-    accountBalance: 0.2, // w_bal (very minor)
-    accountAge: 0.02, // w_age (very minor)
-    invites: 2, // w_inv (supporting reputation)
-    ownedTrends: 1.5, // w_owned (↑ important among account signals)
     reads: 1.0, // w_reads (modest influence)
   },
 
@@ -257,16 +253,6 @@ export const POPULAR_RANKING_CONFIG = {
   },
   REDIS_TTL_SECONDS: 30, // 30 seconds - very fresh popular feed
 
-  // owned trends normalization
-  OWNED_TRENDS_MAX_TRENDING_SCORE: 100,
-  OWNED_TRENDS_LOG_NORMALIZER: 10_000, // legacy (score-based)
-  OWNED_TRENDS_VALUE_CURRENCY: 'ae' as 'ae' | 'usd', // controls owned-trends currency basis
-  OWNED_TRENDS_VALUE_NORMALIZER_AE: 20000, // 20k AE portfolio ~ full score
-  OWNED_TRENDS_VALUE_NORMALIZER_USD: 500000, // $500k portfolio ~ full score
-
-  // AE balance normalization (account balance factor)
-  BALANCE_NORMALIZER_AE: 500_000, // 0.5M AE ~ full score
-  BALANCE_CACHE_TTL_SECONDS: 600, // 10 minutes
   // Bot UA denylist (lowercase substrings)
   BOT_UA_DENYLIST: [
     'bot',

--- a/src/configs/constants.ts
+++ b/src/configs/constants.ts
@@ -223,7 +223,8 @@ export const POPULAR_RANKING_CONFIG = {
   WEIGHTS: {
     comments: 2.5, // w_c (primary engagement signal)
     tipsAmountAE: 1.5, // w_ta (meaningful but not dominant since tipping is rare)
-    tipsCount: 1.0, // w_tc (diversity of tippers)
+    tipsCount: 1.0, // w_tc (total tip actions)
+    uniqueTippers: 1.5, // w_ut (breadth of support — many tippers > one whale)
     trendingBoost: 0.5, // w_tr (topical relevance)
     contentQuality: 0.3, // w_q (anti-spam)
     reads: 1.5, // w_reads (common passive signal)

--- a/src/configs/constants.ts
+++ b/src/configs/constants.ts
@@ -211,28 +211,23 @@ export const TOKEN_LIST_ELIGIBILITY_CONFIG = {
 } as const;
 
 /**
- * Popular posts ranking configuration (v1)
+ * Popular posts ranking configuration — "Top" style (no time decay).
+ * Posts are ranked purely by accumulated engagement within the selected window.
  */
 export const POPULAR_RANKING_CONFIG = {
-  // default time windows (hours)
+  // time windows (hours)
   WINDOW_24H_HOURS: 24,
   WINDOW_7D_HOURS: 24 * 7,
 
-  // weights
+  // weights — tipping is rare so comments and reads lead
   WEIGHTS: {
-    comments: 1.7, // w_c (↑ more important)
-    tipsAmountAE: 4.0, // w_ta (↑ most important)
-    tipsCount: 1, // w_tc (supporting)
-    interactionsPerHour: 0.2, // w_it (minor)
-    trendingBoost: 0.4, // w_tr (minor)
-    contentQuality: 0.3, // w_q (minor, prevents spam)
-    reads: 1.0, // w_reads (modest influence)
+    comments: 2.5, // w_c (primary engagement signal)
+    tipsAmountAE: 1.5, // w_ta (meaningful but not dominant since tipping is rare)
+    tipsCount: 1.0, // w_tc (diversity of tippers)
+    trendingBoost: 0.5, // w_tr (topical relevance)
+    contentQuality: 0.3, // w_q (anti-spam)
+    reads: 1.5, // w_reads (common passive signal)
   },
-
-  // time decay
-  GRAVITY: 1.6, // 24h
-  GRAVITY_7D: 0.5, // Reduced from 1.0 to reduce time decay for weekly window
-  T_BIAS: 1.0,
 
   // content quality params
   CONTENT: {
@@ -251,7 +246,7 @@ export const POPULAR_RANKING_CONFIG = {
     popular7d: 'popular:7d',
     popularAll: 'popular:all',
   },
-  REDIS_TTL_SECONDS: 30, // 30 seconds - very fresh popular feed
+  REDIS_TTL_SECONDS: 30,
 
   // Bot UA denylist (lowercase substrings)
   BOT_UA_DENYLIST: [
@@ -263,10 +258,6 @@ export const POPULAR_RANKING_CONFIG = {
     'monitor',
     'curl',
   ],
-  // score floors to hide zero-signal posts
-  SCORE_FLOOR_DEFAULT: 0.01, // 24h
-  SCORE_FLOOR_7D: 0.008, // 7d
-  SCORE_FLOOR_ALL: 0.1, // all-time
 
   // candidate caps
   MAX_CANDIDATES_24H: 500,

--- a/src/social/controllers/posts.controller.ts
+++ b/src/social/controllers/posts.controller.ts
@@ -380,7 +380,8 @@ export class PostsController {
   @ApiOperation({
     operationId: 'popular',
     summary: 'Popular posts',
-    description: 'Returns popular posts for selected time window.',
+    description:
+      'Returns top posts for selected time window (24h, 7d, all). Ranked by accumulated engagement — no time decay.',
   })
   @ApiOkResponsePaginated(PostDto)
   @Get('popular')

--- a/src/social/controllers/posts.controller.ts
+++ b/src/social/controllers/posts.controller.ts
@@ -459,10 +459,17 @@ export class PostsController {
       }
       return response;
     } catch (error) {
-      const fallbackBasePosts = await this.postRepository
+      const windowHoursMap = { '24h': 24, '7d': 24 * 7, all: 0 } as const;
+      const windowHours = windowHoursMap[window] || 0;
+      const fallbackQb = this.postRepository
         .createQueryBuilder('post')
         .where('post.is_hidden = false')
-        .andWhere('post.post_id IS NULL')
+        .andWhere('post.post_id IS NULL');
+      if (windowHours > 0) {
+        const since = new Date(Date.now() - windowHours * 60 * 60 * 1000);
+        fallbackQb.andWhere('post.created_at >= :since', { since });
+      }
+      const fallbackBasePosts = await fallbackQb
         .orderBy('post.created_at', 'DESC')
         .offset(offset)
         .limit(limit)

--- a/src/social/controllers/posts.controller.ts
+++ b/src/social/controllers/posts.controller.ts
@@ -380,8 +380,7 @@ export class PostsController {
   @ApiOperation({
     operationId: 'popular',
     summary: 'Popular posts',
-    description:
-      'Returns popular posts for selected time window. Views are ignored in v1.',
+    description: 'Returns popular posts for selected time window.',
   })
   @ApiOkResponsePaginated(PostDto)
   @Get('popular')

--- a/src/social/post.module.ts
+++ b/src/social/post.module.ts
@@ -1,13 +1,10 @@
-import { AeModule } from '@/ae/ae.module';
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Post } from './entities/post.entity';
 import { Topic } from './entities/topic.entity';
 import { Tip } from '@/tipping/entities/tip.entity';
 import { TrendingTag } from '@/trending-tags/entities/trending-tags.entity';
-import { TokenHolder } from '@/tokens/entities/token-holders.entity';
 import { Token } from '@/tokens/entities/token.entity';
-import { Invitation } from '@/affiliation/entities/invitation.entity';
 import { PostReadsDaily } from './entities/post-reads.entity';
 import { ReadsService } from './services/reads.service';
 import { PostService } from './services/post.service';
@@ -16,7 +13,6 @@ import { TransactionsModule } from '@/transactions/transactions.module';
 import { PostsController } from './controllers/posts.controller';
 import { TopicsController } from './controllers/topics.controller';
 import { GiphyController } from './controllers/giphy.controller';
-import { AccountModule } from '@/account/account.module';
 import { GovernancePluginModule } from '@/plugins/governance/governance-plugin.module';
 import { getPopularRankingContributorProvider } from '@/plugins';
 import { ProfileModule } from '@/profile/profile.module';
@@ -24,8 +20,6 @@ import { TokensModule } from '@/tokens/tokens.module';
 
 @Module({
   imports: [
-    AeModule,
-    AccountModule,
     ProfileModule,
     TokensModule,
     TransactionsModule,
@@ -35,9 +29,7 @@ import { TokensModule } from '@/tokens/tokens.module';
       Topic,
       Tip,
       TrendingTag,
-      TokenHolder,
       Token,
-      Invitation,
       PostReadsDaily,
     ]),
   ],

--- a/src/social/services/popular-ranking.service.spec.ts
+++ b/src/social/services/popular-ranking.service.spec.ts
@@ -131,9 +131,11 @@ describe('PopularRankingService', () => {
     );
   });
 
-  it('falls back to recent posts when Redis cache is empty', async () => {
+  it('falls back to window-filtered recent posts when Redis cache is empty', async () => {
     jest.spyOn(service, 'recompute').mockResolvedValue(undefined);
-    redisMock.zcard.mockResolvedValueOnce(0);
+    redisMock.zcard
+      .mockResolvedValueOnce(0) // getVerifiedPopularIds — cache empty
+      .mockResolvedValueOnce(0); // after awaited recompute — still empty
 
     const fallbackPost = {
       id: 'fallback-1',
@@ -158,6 +160,10 @@ describe('PopularRankingService', () => {
     expect(fallbackQueryBuilder.orderBy).toHaveBeenCalledWith(
       'post.created_at',
       'DESC',
+    );
+    expect(fallbackQueryBuilder.andWhere).toHaveBeenCalledWith(
+      'post.created_at >= :since',
+      expect.objectContaining({ since: expect.any(Date) }),
     );
   });
 });

--- a/src/social/services/popular-ranking.service.spec.ts
+++ b/src/social/services/popular-ranking.service.spec.ts
@@ -130,4 +130,34 @@ describe('PopularRankingService', () => {
       'comment.sender_address != parent.sender_address',
     );
   });
+
+  it('falls back to recent posts when Redis cache is empty', async () => {
+    jest.spyOn(service, 'recompute').mockResolvedValue(undefined);
+    redisMock.zcard.mockResolvedValueOnce(0);
+
+    const fallbackPost = {
+      id: 'fallback-1',
+      created_at: new Date().toISOString(),
+      content: 'hello',
+    };
+    const fallbackQueryBuilder = {
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      offset: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      getMany: jest.fn().mockResolvedValue([fallbackPost]),
+    };
+    postRepository.createQueryBuilder = jest
+      .fn()
+      .mockReturnValueOnce(fallbackQueryBuilder);
+
+    const result = await service.getPopularPosts('24h', 10, 0);
+
+    expect(result).toEqual([fallbackPost]);
+    expect(fallbackQueryBuilder.orderBy).toHaveBeenCalledWith(
+      'post.created_at',
+      'DESC',
+    );
+  });
 });

--- a/src/social/services/popular-ranking.service.spec.ts
+++ b/src/social/services/popular-ranking.service.spec.ts
@@ -1,9 +1,9 @@
 const pipelineMock = {
   zadd: jest.fn().mockReturnThis(),
   expire: jest.fn().mockReturnThis(),
-  exec: jest.fn().mockResolvedValue(
-    Array.from({ length: 64 }, () => [null, 1] as const),
-  ),
+  exec: jest
+    .fn()
+    .mockResolvedValue(Array.from({ length: 64 }, () => [null, 1] as const)),
 };
 
 const redisMock = {
@@ -56,6 +56,15 @@ describe('PopularRankingService', () => {
       groupBy: jest.fn().mockReturnThis(),
       getRawMany: jest.fn().mockResolvedValue([]),
     };
+    const commentQueryBuilder = {
+      innerJoin: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnThis(),
+      addSelect: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      groupBy: jest.fn().mockReturnThis(),
+      getRawMany: jest.fn().mockResolvedValue([]),
+    };
     const readsQueryBuilder = {
       select: jest.fn().mockReturnThis(),
       addSelect: jest.fn().mockReturnThis(),
@@ -66,7 +75,10 @@ describe('PopularRankingService', () => {
     };
 
     postRepository = {
-      createQueryBuilder: jest.fn().mockReturnValue(candidateQueryBuilder),
+      createQueryBuilder: jest
+        .fn()
+        .mockReturnValueOnce(candidateQueryBuilder)
+        .mockReturnValueOnce(commentQueryBuilder),
     };
     tipRepository = {
       createQueryBuilder: jest.fn().mockReturnValue(tipQueryBuilder),
@@ -100,6 +112,22 @@ describe('PopularRankingService', () => {
     );
     expect(tipQueryBuilder.andWhere).toHaveBeenCalledWith(
       'tip.sender_address != post.sender_address',
+    );
+  });
+
+  it('excludes self-comments from ranking comment count', async () => {
+    await service.recompute('7d', 10);
+
+    const commentQueryBuilder =
+      postRepository.createQueryBuilder.mock.results[1].value;
+
+    expect(commentQueryBuilder.innerJoin).toHaveBeenCalledWith(
+      expect.any(Function),
+      'parent',
+      'parent.id = comment.post_id',
+    );
+    expect(commentQueryBuilder.andWhere).toHaveBeenCalledWith(
+      'comment.sender_address != parent.sender_address',
     );
   });
 });

--- a/src/social/services/popular-ranking.service.spec.ts
+++ b/src/social/services/popular-ranking.service.spec.ts
@@ -1,7 +1,16 @@
+const pipelineMock = {
+  zadd: jest.fn().mockReturnThis(),
+  expire: jest.fn().mockReturnThis(),
+  exec: jest.fn().mockResolvedValue(
+    Array.from({ length: 64 }, () => [null, 1] as const),
+  ),
+};
+
 const redisMock = {
   ping: jest.fn().mockResolvedValue('PONG'),
   del: jest.fn().mockResolvedValue(1),
-  pipeline: jest.fn(),
+  zcard: jest.fn().mockResolvedValue(1),
+  pipeline: jest.fn().mockReturnValue(pipelineMock),
 };
 
 jest.mock('ioredis', () => {
@@ -79,7 +88,7 @@ describe('PopularRankingService', () => {
   });
 
   it('excludes self-tips from popular ranking tip aggregates', async () => {
-    await service.recompute('24h', 10);
+    await service.recompute('7d', 10);
 
     const tipQueryBuilder =
       tipRepository.createQueryBuilder.mock.results[0].value;

--- a/src/social/services/popular-ranking.service.spec.ts
+++ b/src/social/services/popular-ranking.service.spec.ts
@@ -18,9 +18,6 @@ describe('PopularRankingService', () => {
   let postRepository: any;
   let tipRepository: any;
   let trendingTagRepository: any;
-  let accountRepository: any;
-  let tokenHolderRepository: any;
-  let invitationRepository: any;
   let postReadsRepository: any;
 
   beforeEach(() => {
@@ -50,21 +47,6 @@ describe('PopularRankingService', () => {
       groupBy: jest.fn().mockReturnThis(),
       getRawMany: jest.fn().mockResolvedValue([]),
     };
-    const holderQueryBuilder = {
-      leftJoin: jest.fn().mockReturnThis(),
-      select: jest.fn().mockReturnThis(),
-      addSelect: jest.fn().mockReturnThis(),
-      where: jest.fn().mockReturnThis(),
-      groupBy: jest.fn().mockReturnThis(),
-      getRawMany: jest.fn().mockResolvedValue([]),
-    };
-    const invitationQueryBuilder = {
-      select: jest.fn().mockReturnThis(),
-      addSelect: jest.fn().mockReturnThis(),
-      where: jest.fn().mockReturnThis(),
-      groupBy: jest.fn().mockReturnThis(),
-      getRawMany: jest.fn().mockResolvedValue([]),
-    };
     const readsQueryBuilder = {
       select: jest.fn().mockReturnThis(),
       addSelect: jest.fn().mockReturnThis(),
@@ -83,15 +65,6 @@ describe('PopularRankingService', () => {
     trendingTagRepository = {
       find: jest.fn().mockResolvedValue([]),
     };
-    accountRepository = {
-      findBy: jest.fn().mockResolvedValue([]),
-    };
-    tokenHolderRepository = {
-      createQueryBuilder: jest.fn().mockReturnValue(holderQueryBuilder),
-    };
-    invitationRepository = {
-      createQueryBuilder: jest.fn().mockReturnValue(invitationQueryBuilder),
-    };
     postReadsRepository = {
       createQueryBuilder: jest.fn().mockReturnValue(readsQueryBuilder),
     };
@@ -100,11 +73,6 @@ describe('PopularRankingService', () => {
       postRepository as any,
       tipRepository as any,
       trendingTagRepository as any,
-      accountRepository as any,
-      tokenHolderRepository as any,
-      {} as any,
-      { sdk: { getBalance: jest.fn() } } as any,
-      invitationRepository as any,
       postReadsRepository as any,
       [],
     );

--- a/src/social/services/popular-ranking.service.ts
+++ b/src/social/services/popular-ranking.service.ts
@@ -20,8 +20,8 @@ export type PopularWindow = '24h' | '7d' | 'all';
 interface PopularScoreItem {
   postId: string;
   score: number;
-  type?: string; // 'post' or plugin content type (e.g., 'poll')
-  metadata?: Record<string, any>; // Store plugin-specific metadata
+  type?: string;
+  metadata?: Record<string, any>;
 }
 
 @Injectable()
@@ -50,7 +50,7 @@ export class PopularRankingService {
     if (window === '7d') {
       return POPULAR_RANKING_CONFIG.WINDOW_7D_HOURS;
     }
-    return Number.MAX_SAFE_INTEGER; // all-time
+    return Number.MAX_SAFE_INTEGER;
   }
 
   private getRedisKey(window: PopularWindow): string {
@@ -65,7 +65,6 @@ export class PopularRankingService {
 
   /**
    * Get verified popular post IDs from Redis, ensuring they exist in DB
-   * This shared method ensures consistency between getPopularPosts and getTotalPostsCount
    */
   private async getVerifiedPopularIds(
     window: PopularWindow,
@@ -73,12 +72,10 @@ export class PopularRankingService {
   ): Promise<string[]> {
     const key = this.getRedisKey(window);
 
-    // Get popular post ranks from Redis (ID -> rank/score)
     let popularRanks = new Map<string, number>();
     try {
       const totalPopular = await this.redis.zcard(key);
       if (totalPopular > 0) {
-        // Fetch all popular IDs with their scores
         const cached = await this.redis.zrevrange(
           key,
           0,
@@ -94,7 +91,6 @@ export class PopularRankingService {
       popularRanks = new Map();
     }
 
-    // If no popular posts cached, try to compute them
     if (popularRanks.size === 0) {
       const fallbackMax =
         window === 'all'
@@ -128,7 +124,6 @@ export class PopularRankingService {
           `Failed to recompute popular posts for window ${window}:`,
           error,
         );
-        // Continue with empty popular ranks
       }
     }
 
@@ -136,28 +131,23 @@ export class PopularRankingService {
       return [];
     }
 
-    // Get popular post IDs sorted by score DESC
     const allPopularIds = Array.from(popularRanks.entries())
-      .sort((a, b) => b[1] - a[1]) // Sort by score DESC
+      .sort((a, b) => b[1] - a[1])
       .map(([id]) => id);
 
-    // Separate post IDs from plugin content IDs
     const postIds: string[] = [];
     const pluginContentIds: string[] = [];
     for (const id of allPopularIds) {
       if (id.includes(':')) {
-        // Plugin content IDs have format "type:id"
         pluginContentIds.push(id);
       } else {
         postIds.push(id);
       }
     }
 
-    // Verify which post IDs exist in DB
     const CHUNK_SIZE = 1000;
     const existingIdsSet = new Set<string>();
 
-    // Verify posts
     for (let i = 0; i < postIds.length; i += CHUNK_SIZE) {
       const chunk = postIds.slice(i, i + CHUNK_SIZE);
       const existingPosts = await this.postRepository.findBy({
@@ -168,11 +158,7 @@ export class PopularRankingService {
       existingPosts.forEach((p) => existingIdsSet.add(p.id));
     }
 
-    // Verify plugin content IDs by checking with contributors
-    // For now, we'll trust plugin IDs from Redis (they should be valid)
-    // In the future, we could add validation here
     for (const id of pluginContentIds) {
-      // Check if any contributor can provide this ID
       const [type] = id.split(':');
       const hasContributor = this.rankingContributors.some(
         (c) => c.name === type,
@@ -182,10 +168,7 @@ export class PopularRankingService {
       }
     }
 
-    // Filter allPopularIds to only include verified IDs, preserving the score DESC order
-    const verifiedIds = allPopularIds.filter((id) => existingIdsSet.has(id));
-
-    return verifiedIds;
+    return allPopularIds.filter((id) => existingIdsSet.has(id));
   }
 
   async getPopularPosts(
@@ -194,33 +177,28 @@ export class PopularRankingService {
     offset = 0,
     maxCandidates?: number,
   ): Promise<(Post | PopularRankingContentItem)[]> {
-    // Get verified popular IDs (ensures consistency with getTotalPostsCount)
     const verifiedIds = await this.getVerifiedPopularIds(window, maxCandidates);
 
     if (verifiedIds.length === 0) {
       return [];
     }
 
-    // Paginate the verified IDs
     const paginatedIds = verifiedIds.slice(offset, offset + limit);
 
     if (paginatedIds.length === 0) {
       return [];
     }
 
-    // Separate post IDs from plugin content IDs
     const postIds: string[] = [];
     const pluginContentIds: string[] = [];
     for (const id of paginatedIds) {
       if (id.includes(':')) {
-        // Plugin content IDs have format "type:id"
         pluginContentIds.push(id);
       } else {
         postIds.push(id);
       }
     }
 
-    // Fetch posts
     const posts =
       postIds.length > 0
         ? await this.postRepository.findBy({
@@ -230,10 +208,8 @@ export class PopularRankingService {
           })
         : [];
 
-    // Fetch plugin content items
     const pluginItems: PopularRankingContentItem[] = [];
     if (pluginContentIds.length > 0) {
-      // Get the content type from the ID prefix (e.g., "poll:123" -> "poll")
       const itemsByType = new Map<string, string[]>();
       for (const id of pluginContentIds) {
         const [type] = id.split(':');
@@ -243,12 +219,10 @@ export class PopularRankingService {
         itemsByType.get(type)!.push(id);
       }
 
-      // Fetch from each contributor
       for (const contributor of this.rankingContributors) {
         const typeIds = itemsByType.get(contributor.name);
         if (typeIds && typeIds.length > 0) {
           try {
-            // Fetch all candidates and filter to requested IDs
             const allItems = await contributor.getRankingCandidates(
               window,
               window === 'all'
@@ -256,7 +230,7 @@ export class PopularRankingService {
                 : new Date(
                     Date.now() - this.getWindowHours(window) * 60 * 60 * 1000,
                   ),
-              10000, // Large limit to get all items
+              10000,
             );
             const requestedItems = allItems.filter((item) =>
               typeIds.includes(item.id),
@@ -272,7 +246,6 @@ export class PopularRankingService {
       }
     }
 
-    // Merge posts and plugin items, preserving order from paginatedIds
     const postsMap = new Map(posts.map((p) => [p.id, p]));
     const pluginItemsMap = new Map(pluginItems.map((item) => [item.id, item]));
 
@@ -292,7 +265,6 @@ export class PopularRankingService {
     return result;
   }
 
-  // Public metadata helper to keep encapsulation
   async getTotalCached(window: PopularWindow): Promise<number | undefined> {
     const key = this.getRedisKey(window);
     try {
@@ -302,15 +274,8 @@ export class PopularRankingService {
     }
   }
 
-  /**
-   * Get total count of popular posts for a given window
-   * Uses the exact same verification logic as getPopularPosts to ensure consistency
-   * This ensures pagination metadata matches actual returned posts even if posts are deleted/hidden
-   */
   async getTotalPostsCount(window: PopularWindow): Promise<number> {
     try {
-      // Use the same shared method as getPopularPosts to get verified IDs
-      // This ensures both methods use the exact same verification logic at the same point in time
       const verifiedIds = await this.getVerifiedPopularIds(window);
       return verifiedIds.length;
     } catch (error) {
@@ -331,7 +296,6 @@ export class PopularRankingService {
       `Starting recompute for window ${window} with maxCandidates ${maxCandidates}, key=${key}`,
     );
 
-    // Verify Redis connection
     try {
       await this.redis.ping();
     } catch (error) {
@@ -339,7 +303,6 @@ export class PopularRankingService {
       throw error;
     }
 
-    // Fetch candidate posts (top-level, not hidden) within window
     const candidates = await this.postRepository
       .createQueryBuilder('post')
       .leftJoinAndSelect('post.topics', 'topic')
@@ -356,7 +319,6 @@ export class PopularRankingService {
       `Found ${candidates.length} candidate posts for window ${window}`,
     );
 
-    // Fetch plugin content items
     const pluginContentItems: PopularRankingContentItem[] = [];
     const pluginLimit = Math.floor(
       maxCandidates / Math.max(1, this.rankingContributors.length + 1),
@@ -391,7 +353,6 @@ export class PopularRankingService {
       return;
     }
 
-    // Log first few candidate IDs for debugging
     if (candidates.length > 0) {
       this.logger.log(
         `First 5 candidate IDs: ${candidates
@@ -401,7 +362,7 @@ export class PopularRankingService {
       );
     }
 
-    // Preload tips per post (sum and count and unique tippers)
+    // Preload tips per post
     const ids = candidates.map((c) => c.id);
     const tipsRaw = await this.tipRepository
       .createQueryBuilder('tip')
@@ -453,148 +414,47 @@ export class PopularRankingService {
     );
 
     // Score posts
-    const scoredPosts: PopularScoreItem[] = await Promise.all(
-      candidates.map(async (post) => {
-        const comments = post.total_comments || 0;
-        const tipsAgg = tipsByPost.get(post.id);
-        const tipsAmountAE = tipsAgg
-          ? parseFloat(tipsAgg.amount_sum || '0')
-          : 0;
-        const tipsCount = tipsAgg ? parseInt(tipsAgg.count || '0', 10) : 0;
-        const uniqueTippers = tipsAgg
-          ? parseInt(tipsAgg.unique_tippers || '0', 10)
-          : 0;
-
-        const ageHours = Math.max(
-          1,
-          (Date.now() - new Date(post.created_at).getTime()) / 3_600_000,
-        );
-        const interactionsPerHour = (comments + uniqueTippers) / ageHours;
-
-        // trending boost (max topic score)
-        let trendingBoost = 0;
-        if (post.topics?.length) {
-          let maxScore = 0;
-          for (const topic of post.topics) {
-            const s = trendingByTag.get((topic.name || '').toLowerCase());
-            if (s && s > maxScore) maxScore = s;
-          }
-          trendingBoost = Math.min(
-            1,
-            maxScore / POPULAR_RANKING_CONFIG.TRENDING_MAX_SCORE,
-          );
-        }
-
-        const contentQuality = this.computeContentQuality(post.content || '');
-
-        const w = POPULAR_RANKING_CONFIG.WEIGHTS;
-        const reads = readsByPost.get(post.id) || 0;
-        const readsPerHour = reads / ageHours;
-        const numerator =
-          w.comments * Math.log(1 + comments) +
-          w.tipsAmountAE * Math.log(1 + tipsAmountAE) +
-          w.tipsCount * Math.log(1 + tipsCount) +
-          w.interactionsPerHour * Math.log(1 + interactionsPerHour) +
-          w.reads * Math.log(1 + readsPerHour) +
-          w.trendingBoost * trendingBoost +
-          w.contentQuality * contentQuality;
-
-        // Apply gravity based on window
-        // For "all" window, no gravity (0.0) means all posts compete equally regardless of age
-        // This allows all-time great posts to shine, not just recent popular ones
-        let gravity = 0.0;
-        if (window === '7d') {
-          gravity = POPULAR_RANKING_CONFIG.GRAVITY_7D;
-        } else if (window === '24h') {
-          gravity = POPULAR_RANKING_CONFIG.GRAVITY;
-        }
-        // window === 'all' uses gravity = 0.0 (no time decay)
-        const score =
-          numerator /
-          Math.pow(ageHours + POPULAR_RANKING_CONFIG.T_BIAS, gravity);
-        return { postId: post.id, score, type: 'post' };
-      }),
-    );
+    const scoredPosts: PopularScoreItem[] = candidates.map((post) => {
+      const tipsAgg = tipsByPost.get(post.id);
+      return {
+        postId: post.id,
+        score: this.computeScore(trendingByTag, {
+          content: post.content,
+          comments: post.total_comments || 0,
+          tipsAmountAE: tipsAgg
+            ? parseFloat(tipsAgg.amount_sum || '0')
+            : 0,
+          tipsCount: tipsAgg ? parseInt(tipsAgg.count || '0', 10) : 0,
+          reads: readsByPost.get(post.id) || 0,
+          topics: post.topics,
+        }),
+        type: 'post',
+      };
+    });
 
     // Score plugin content items
-    const scoredPluginItems: PopularScoreItem[] = await Promise.all(
-      pluginContentItems.map(async (item) => {
-        // Use votes_count as comments equivalent for polls
-        const comments = item.total_comments || 0;
-        // Plugin items don't have tips (for now)
-        const tipsAmountAE = 0;
-        const tipsCount = 0;
-        const uniqueTippers = 0;
-
-        const ageHours = Math.max(
-          1,
-          (Date.now() - new Date(item.created_at).getTime()) / 3_600_000,
-        );
-        const interactionsPerHour = (comments + uniqueTippers) / ageHours;
-
-        // Trending boost (max topic score)
-        let trendingBoost = 0;
-        if (item.topics?.length) {
-          let maxScore = 0;
-          for (const topic of item.topics) {
-            const s = trendingByTag.get((topic.name || '').toLowerCase());
-            if (s && s > maxScore) maxScore = s;
-          }
-          trendingBoost = Math.min(
-            1,
-            maxScore / POPULAR_RANKING_CONFIG.TRENDING_MAX_SCORE,
-          );
-        }
-
-        const contentQuality = this.computeContentQuality(item.content || '');
-
-        const w = POPULAR_RANKING_CONFIG.WEIGHTS;
-        const reads = 0; // Plugin items don't have reads tracking (for now)
-        const readsPerHour = reads / ageHours;
-        const numerator =
-          w.comments * Math.log(1 + comments) +
-          w.tipsAmountAE * Math.log(1 + tipsAmountAE) +
-          w.tipsCount * Math.log(1 + tipsCount) +
-          w.interactionsPerHour * Math.log(1 + interactionsPerHour) +
-          w.reads * Math.log(1 + readsPerHour) +
-          w.trendingBoost * trendingBoost +
-          w.contentQuality * contentQuality;
-
-        let gravity = 0.0;
-        if (window === '7d') {
-          gravity = POPULAR_RANKING_CONFIG.GRAVITY_7D;
-        } else if (window === '24h') {
-          gravity = POPULAR_RANKING_CONFIG.GRAVITY;
-        }
-        const score =
-          numerator /
-          Math.pow(ageHours + POPULAR_RANKING_CONFIG.T_BIAS, gravity);
-        return {
-          postId: item.id,
-          score,
-          type: item.type,
-          metadata: item.metadata,
-        };
+    const scoredPluginItems: PopularScoreItem[] = pluginContentItems.map(
+      (item) => ({
+        postId: item.id,
+        score: this.computeScore(trendingByTag, {
+          content: item.content,
+          comments: item.total_comments || 0,
+          tipsAmountAE: 0,
+          tipsCount: 0,
+          reads: 0,
+          topics: item.topics,
+        }),
+        type: item.type,
+        metadata: item.metadata,
       }),
     );
 
-    // Merge all scored items
     const scored = [...scoredPosts, ...scoredPluginItems];
 
-    // Apply score floor (hide zero-signal posts)
-    let scoreFloor: number = POPULAR_RANKING_CONFIG.SCORE_FLOOR_DEFAULT;
-    if (window === '7d') {
-      scoreFloor = POPULAR_RANKING_CONFIG.SCORE_FLOOR_7D;
-    } else if (window === 'all') {
-      scoreFloor = POPULAR_RANKING_CONFIG.SCORE_FLOOR_ALL;
-    }
-    const eligible = scored.filter((s) => s.score >= scoreFloor);
-
     this.logger.log(
-      `Window ${window}: ${scored.length} posts scored, ${eligible.length} eligible (scoreFloor: ${scoreFloor})`,
+      `Window ${window}: ${scored.length} posts scored, all eligible (no score floor)`,
     );
 
-    // Log top scores for debugging
     if (scored.length > 0) {
       const topScores = scored
         .sort((a, b) => b.score - a.score)
@@ -606,25 +466,20 @@ export class PopularRankingService {
 
     // Cache in Redis ZSET
     try {
-      // Delete existing key first
       await this.redis.del(key);
 
-      if (eligible.length === 0) {
-        this.logger.warn(
-          `No eligible posts to cache for window ${window} (all posts below score floor ${scoreFloor})`,
-        );
+      if (scored.length === 0) {
+        this.logger.warn(`No posts to cache for window ${window}`);
         return;
       }
 
-      // Use pipeline instead of multi for better error handling
       const pipeline = this.redis.pipeline();
-      for (const item of eligible) {
+      for (const item of scored) {
         pipeline.zadd(key, item.score.toString(), item.postId);
       }
       pipeline.expire(key, POPULAR_RANKING_CONFIG.REDIS_TTL_SECONDS);
       const results = await pipeline.exec();
 
-      // Check for errors in results
       if (results === null) {
         const error = new Error(`Redis pipeline failed for window ${window}`);
         this.logger.error(error.message);
@@ -643,14 +498,13 @@ export class PopularRankingService {
       }
 
       this.logger.log(
-        `Successfully cached ${eligible.length} popular posts in Redis key ${key}`,
+        `Successfully cached ${scored.length} popular posts in Redis key ${key}`,
       );
 
-      // Verify the cache was written
       const verifyCount = await this.redis.zcard(key);
-      if (verifyCount !== eligible.length) {
+      if (verifyCount !== scored.length) {
         const error = new Error(
-          `Redis key ${key} has ${verifyCount} items but expected ${eligible.length}`,
+          `Redis key ${key} has ${verifyCount} items but expected ${scored.length}`,
         );
         this.logger.error(error.message);
         throw error;
@@ -664,7 +518,57 @@ export class PopularRankingService {
     }
   }
 
-  // Debug helper: returns top-N with feature breakdowns without caching side-effects
+  private async loadTrendingByTagMap(): Promise<Map<string, number>> {
+    let trending: TrendingTag[] = [];
+    try {
+      trending = await this.trendingTagRepository.find();
+    } catch {
+      trending = [];
+    }
+    return new Map(trending.map((t) => [t.tag.toLowerCase(), t.score] as const));
+  }
+
+  private computeScore(
+    trendingByTag: Map<string, number>,
+    input: {
+      content: string;
+      comments: number;
+      tipsAmountAE: number;
+      tipsCount: number;
+      reads: number;
+      topics?: Array<{ name?: string }>;
+    },
+  ): number {
+    const { comments, tipsAmountAE, tipsCount, reads } = input;
+
+    let trendingBoost = 0;
+    if (input.topics?.length) {
+      let maxScore = 0;
+      for (const topic of input.topics) {
+        const s = trendingByTag.get((topic.name || '').toLowerCase());
+        if (s && s > maxScore) {
+          maxScore = s;
+        }
+      }
+      trendingBoost = Math.min(
+        1,
+        maxScore / POPULAR_RANKING_CONFIG.TRENDING_MAX_SCORE,
+      );
+    }
+
+    const contentQuality = this.computeContentQuality(input.content || '');
+    const w = POPULAR_RANKING_CONFIG.WEIGHTS;
+
+    return (
+      w.comments * Math.log(1 + comments) +
+      w.tipsAmountAE * Math.log(1 + tipsAmountAE) +
+      w.tipsCount * Math.log(1 + tipsCount) +
+      w.reads * Math.log(1 + reads) +
+      w.trendingBoost * trendingBoost +
+      w.contentQuality * contentQuality
+    );
+  }
+
   async explain(window: PopularWindow, limit = 20, offset = 0) {
     const key = this.getRedisKey(window);
     const ids = await this.redis.zrevrange(key, offset, offset + limit - 1);
@@ -709,7 +613,7 @@ export class PopularRankingService {
       len < cfg.shortLengthThreshold &&
       emojiRatio > cfg.highEmojiRatioThreshold
     ) {
-      quality *= 0.25; // strong penalty for emoji-only very short posts
+      quality *= 0.25;
     }
 
     return Math.max(0, Math.min(1, quality));

--- a/src/social/services/popular-ranking.service.ts
+++ b/src/social/services/popular-ranking.service.ts
@@ -28,6 +28,7 @@ interface PopularScoreItem {
 export class PopularRankingService {
   private readonly logger = new Logger(PopularRankingService.name);
   private readonly redis = new Redis(REDIS_CONFIG);
+  private readonly recomputeInFlight = new Map<PopularWindow, Promise<void>>();
 
   constructor(
     @InjectRepository(Post)
@@ -92,39 +93,7 @@ export class PopularRankingService {
     }
 
     if (popularRanks.size === 0) {
-      const fallbackMax =
-        window === 'all'
-          ? POPULAR_RANKING_CONFIG.MAX_CANDIDATES_ALL
-          : window === '7d'
-            ? POPULAR_RANKING_CONFIG.MAX_CANDIDATES_7D
-            : POPULAR_RANKING_CONFIG.MAX_CANDIDATES_24H;
-      try {
-        await this.recompute(window, maxCandidates ?? fallbackMax);
-        const totalPopular = await this.redis.zcard(key);
-        if (totalPopular > 0) {
-          const cached = await this.redis.zrevrange(
-            key,
-            0,
-            totalPopular - 1,
-            'WITHSCORES',
-          );
-          for (let i = 0; i < cached.length; i += 2) {
-            popularRanks.set(cached[i], parseFloat(cached[i + 1]));
-          }
-          this.logger.log(
-            `Recomputed popular posts for window ${window}: ${totalPopular} posts cached`,
-          );
-        } else {
-          this.logger.warn(
-            `Recompute completed but no posts cached for window ${window}`,
-          );
-        }
-      } catch (error) {
-        this.logger.error(
-          `Failed to recompute popular posts for window ${window}:`,
-          error,
-        );
-      }
+      this.triggerBackgroundRecompute(window, maxCandidates);
     }
 
     if (popularRanks.size === 0) {
@@ -169,6 +138,40 @@ export class PopularRankingService {
     }
 
     return allPopularIds.filter((id) => existingIdsSet.has(id));
+  }
+
+  /**
+   * Fire-and-forget recompute with per-window mutex to prevent stampede.
+   * If a recompute for this window is already in flight, the call is a no-op.
+   */
+  private triggerBackgroundRecompute(
+    window: PopularWindow,
+    maxCandidates?: number,
+  ): void {
+    if (this.recomputeInFlight.has(window)) {
+      return;
+    }
+
+    const fallbackMax =
+      window === 'all'
+        ? POPULAR_RANKING_CONFIG.MAX_CANDIDATES_ALL
+        : window === '7d'
+          ? POPULAR_RANKING_CONFIG.MAX_CANDIDATES_7D
+          : POPULAR_RANKING_CONFIG.MAX_CANDIDATES_24H;
+
+    const task = this.recompute(window, maxCandidates ?? fallbackMax)
+      .then(() =>
+        this.logger.log(`Background recompute finished for window ${window}`),
+      )
+      .catch((error) =>
+        this.logger.error(
+          `Background recompute failed for window ${window}:`,
+          error,
+        ),
+      )
+      .finally(() => this.recomputeInFlight.delete(window));
+
+    this.recomputeInFlight.set(window, task);
   }
 
   async getPopularPosts(

--- a/src/social/services/popular-ranking.service.ts
+++ b/src/social/services/popular-ranking.service.ts
@@ -93,7 +93,24 @@ export class PopularRankingService {
     }
 
     if (popularRanks.size === 0) {
-      this.triggerBackgroundRecompute(window, maxCandidates);
+      await this.awaitOrTriggerRecompute(window, maxCandidates);
+
+      try {
+        const totalPopular = await this.redis.zcard(key);
+        if (totalPopular > 0) {
+          const cached = await this.redis.zrevrange(
+            key,
+            0,
+            totalPopular - 1,
+            'WITHSCORES',
+          );
+          for (let i = 0; i < cached.length; i += 2) {
+            popularRanks.set(cached[i], parseFloat(cached[i + 1]));
+          }
+        }
+      } catch (error) {
+        this.logger.error(`Error loading from Redis after recompute:`, error);
+      }
     }
 
     if (popularRanks.size === 0) {
@@ -143,36 +160,57 @@ export class PopularRankingService {
   /**
    * Fallback when the ranked cache is empty (cold start / TTL expiry).
    * Returns the most recent top-level, visible posts so the feed is never blank.
+   * Respects the time window so each window returns different results.
    */
   private async fetchRecentFallback(
+    window: PopularWindow,
     limit: number,
     offset: number,
   ): Promise<Post[]> {
-    return this.postRepository
+    const qb = this.postRepository
       .createQueryBuilder('post')
       .where('post.is_hidden = false')
-      .andWhere('post.post_id IS NULL')
+      .andWhere('post.post_id IS NULL');
+
+    if (window !== 'all') {
+      const hours = this.getWindowHours(window);
+      const since = new Date(Date.now() - hours * 60 * 60 * 1000);
+      qb.andWhere('post.created_at >= :since', { since });
+    }
+
+    return qb
       .orderBy('post.created_at', 'DESC')
       .offset(offset)
       .limit(limit)
       .getMany();
   }
 
-  private async countRecentFallback(): Promise<number> {
-    return this.postRepository.count({
-      where: { is_hidden: false, post_id: null },
-    });
+  private async countRecentFallback(window: PopularWindow): Promise<number> {
+    const qb = this.postRepository
+      .createQueryBuilder('post')
+      .where('post.is_hidden = false')
+      .andWhere('post.post_id IS NULL');
+
+    if (window !== 'all') {
+      const hours = this.getWindowHours(window);
+      const since = new Date(Date.now() - hours * 60 * 60 * 1000);
+      qb.andWhere('post.created_at >= :since', { since });
+    }
+
+    return qb.getCount();
   }
 
   /**
-   * Fire-and-forget recompute with per-window mutex to prevent stampede.
-   * If a recompute for this window is already in flight, the call is a no-op.
+   * Await an existing in-flight recompute or start one.
+   * Per-window mutex prevents stampede — concurrent callers share one promise.
    */
-  private triggerBackgroundRecompute(
+  private async awaitOrTriggerRecompute(
     window: PopularWindow,
     maxCandidates?: number,
-  ): void {
-    if (this.recomputeInFlight.has(window)) {
+  ): Promise<void> {
+    const existing = this.recomputeInFlight.get(window);
+    if (existing) {
+      await existing;
       return;
     }
 
@@ -184,18 +222,13 @@ export class PopularRankingService {
           : POPULAR_RANKING_CONFIG.MAX_CANDIDATES_24H;
 
     const task = this.recompute(window, maxCandidates ?? fallbackMax)
-      .then(() =>
-        this.logger.log(`Background recompute finished for window ${window}`),
-      )
       .catch((error) =>
-        this.logger.error(
-          `Background recompute failed for window ${window}:`,
-          error,
-        ),
+        this.logger.error(`Recompute failed for window ${window}:`, error),
       )
       .finally(() => this.recomputeInFlight.delete(window));
 
     this.recomputeInFlight.set(window, task);
+    await task;
   }
 
   async getPopularPosts(
@@ -207,7 +240,7 @@ export class PopularRankingService {
     const verifiedIds = await this.getVerifiedPopularIds(window, maxCandidates);
 
     if (verifiedIds.length === 0) {
-      return this.fetchRecentFallback(limit, offset);
+      return this.fetchRecentFallback(window, limit, offset);
     }
 
     const paginatedIds = verifiedIds.slice(offset, offset + limit);
@@ -307,7 +340,7 @@ export class PopularRankingService {
       if (verifiedIds.length > 0) {
         return verifiedIds.length;
       }
-      return this.countRecentFallback();
+      return this.countRecentFallback(window);
     } catch (error) {
       this.logger.error(
         `Error in getTotalPostsCount for window ${window}:`,

--- a/src/social/services/popular-ranking.service.ts
+++ b/src/social/services/popular-ranking.service.ts
@@ -385,16 +385,24 @@ export class PopularRankingService {
       }>();
     const tipsByPost = new Map(tipsRaw.map((t) => [t.post_id, t] as const));
 
-    // Trending tags map (tag -> score)
-    let trending = [] as TrendingTag[];
-    try {
-      trending = await this.trendingTagRepository.find();
-    } catch {
-      trending = [] as TrendingTag[];
-    }
-    const trendingByTag = new Map(
-      trending.map((t) => [t.tag.toLowerCase(), t.score] as const),
+    // Preload comment counts excluding the post author's own replies
+    const commentsRaw = await this.postRepository
+      .createQueryBuilder('comment')
+      .innerJoin(Post, 'parent', 'parent.id = comment.post_id')
+      .select('comment.post_id', 'parent_id')
+      .addSelect('COUNT(*)', 'count')
+      .where('comment.post_id IN (:...ids)', { ids })
+      .andWhere('comment.is_hidden = false')
+      .andWhere('comment.sender_address != parent.sender_address')
+      .groupBy('comment.post_id')
+      .getRawMany<{ parent_id: string; count: string }>();
+    const commentsByPost = new Map(
+      commentsRaw.map(
+        (r) => [r.parent_id, parseInt(r.count || '0', 10)] as const,
+      ),
     );
+
+    const trendingByTag = await this.loadTrendingByTagMap();
 
     // Preload reads over window per post
     const fromDate = new Date(Date.now() - hours * 3600 * 1000);
@@ -423,10 +431,8 @@ export class PopularRankingService {
         postId: post.id,
         score: this.computeScore(trendingByTag, {
           content: post.content,
-          comments: post.total_comments || 0,
-          tipsAmountAE: tipsAgg
-            ? parseFloat(tipsAgg.amount_sum || '0')
-            : 0,
+          comments: commentsByPost.get(post.id) || 0,
+          tipsAmountAE: tipsAgg ? parseFloat(tipsAgg.amount_sum || '0') : 0,
           tipsCount: tipsAgg ? parseInt(tipsAgg.count || '0', 10) : 0,
           reads: readsByPost.get(post.id) || 0,
           topics: post.topics,
@@ -528,7 +534,9 @@ export class PopularRankingService {
     } catch {
       trending = [];
     }
-    return new Map(trending.map((t) => [t.tag.toLowerCase(), t.score] as const));
+    return new Map(
+      trending.map((t) => [t.tag.toLowerCase(), t.score] as const),
+    );
   }
 
   private computeScore(

--- a/src/social/services/popular-ranking.service.ts
+++ b/src/social/services/popular-ranking.service.ts
@@ -141,6 +141,30 @@ export class PopularRankingService {
   }
 
   /**
+   * Fallback when the ranked cache is empty (cold start / TTL expiry).
+   * Returns the most recent top-level, visible posts so the feed is never blank.
+   */
+  private async fetchRecentFallback(
+    limit: number,
+    offset: number,
+  ): Promise<Post[]> {
+    return this.postRepository
+      .createQueryBuilder('post')
+      .where('post.is_hidden = false')
+      .andWhere('post.post_id IS NULL')
+      .orderBy('post.created_at', 'DESC')
+      .offset(offset)
+      .limit(limit)
+      .getMany();
+  }
+
+  private async countRecentFallback(): Promise<number> {
+    return this.postRepository.count({
+      where: { is_hidden: false, post_id: null },
+    });
+  }
+
+  /**
    * Fire-and-forget recompute with per-window mutex to prevent stampede.
    * If a recompute for this window is already in flight, the call is a no-op.
    */
@@ -183,7 +207,7 @@ export class PopularRankingService {
     const verifiedIds = await this.getVerifiedPopularIds(window, maxCandidates);
 
     if (verifiedIds.length === 0) {
-      return [];
+      return this.fetchRecentFallback(limit, offset);
     }
 
     const paginatedIds = verifiedIds.slice(offset, offset + limit);
@@ -280,7 +304,10 @@ export class PopularRankingService {
   async getTotalPostsCount(window: PopularWindow): Promise<number> {
     try {
       const verifiedIds = await this.getVerifiedPopularIds(window);
-      return verifiedIds.length;
+      if (verifiedIds.length > 0) {
+        return verifiedIds.length;
+      }
+      return this.countRecentFallback();
     } catch (error) {
       this.logger.error(
         `Error in getTotalPostsCount for window ${window}:`,

--- a/src/social/services/popular-ranking.service.ts
+++ b/src/social/services/popular-ranking.service.ts
@@ -7,11 +7,6 @@ import { TrendingTag } from '@/trending-tags/entities/trending-tags.entity';
 import { POPULAR_RANKING_CONFIG } from '@/configs/constants';
 import Redis from 'ioredis';
 import { REDIS_CONFIG } from '@/configs/redis';
-import { Account } from '@/account/entities/account.entity';
-import { TokenHolder } from '@/tokens/entities/token-holders.entity';
-import { Token } from '@/tokens/entities/token.entity';
-import { AeSdkService } from '@/ae/ae-sdk.service';
-import { Invitation } from '@/affiliation/entities/invitation.entity';
 import { PostReadsDaily } from '../entities/post-reads.entity';
 import {
   PopularRankingContributor,
@@ -41,15 +36,6 @@ export class PopularRankingService {
     private readonly tipRepository: Repository<Tip>,
     @InjectRepository(TrendingTag)
     private readonly trendingTagRepository: Repository<TrendingTag>,
-    @InjectRepository(Account)
-    private readonly accountRepository: Repository<Account>,
-    @InjectRepository(TokenHolder)
-    private readonly tokenHolderRepository: Repository<TokenHolder>,
-    @InjectRepository(Token)
-    private readonly tokenRepository: Repository<Token>,
-    private readonly aeSdkService: AeSdkService,
-    @InjectRepository(Invitation)
-    private readonly invitationRepository: Repository<Invitation>,
     @InjectRepository(PostReadsDaily)
     private readonly postReadsRepository: Repository<PostReadsDaily>,
     @Optional()
@@ -446,65 +432,6 @@ export class PopularRankingService {
       trending.map((t) => [t.tag.toLowerCase(), t.score] as const),
     );
 
-    // Load authors accounts for signals
-    const authors = Array.from(
-      new Set(candidates.map((p) => p.sender_address)),
-    );
-    const accounts = await this.accountRepository.findBy({
-      address: In(authors),
-    });
-    const accountByAddress = new Map(
-      accounts.map((a) => [a.address, a] as const),
-    );
-
-    // Preload owned tokens portfolio value per author (without trending weight)
-    const aeValueField =
-      "COALESCE((token.price_data->>'ae')::numeric, token.price::numeric, 0)";
-    const usdValueField = "COALESCE((token.price_data->>'usd')::numeric, 0)";
-    const valueField =
-      POPULAR_RANKING_CONFIG.OWNED_TRENDS_VALUE_CURRENCY === 'usd'
-        ? usdValueField
-        : aeValueField;
-
-    let tokenHoldings: { address: string; owned_value: string }[] = [];
-    try {
-      tokenHoldings = await this.tokenHolderRepository
-        .createQueryBuilder('holder')
-        .leftJoin(Token, 'token', 'token.address = holder.aex9_address')
-        .select('holder.address', 'address')
-        .addSelect(
-          `SUM((CAST(holder.balance AS numeric) / NULLIF(POWER(10, token.decimals::int), 0)) * ${valueField})`,
-          'owned_value',
-        )
-        .where('holder.address IN (:...authors)', { authors })
-        .groupBy('holder.address')
-        .getRawMany<{ address: string; owned_value: string }>();
-    } catch {
-      tokenHoldings = [];
-    }
-    const ownedValueByAddress = new Map(
-      tokenHoldings.map(
-        (r) => [r.address, parseFloat(r.owned_value || '0')] as const,
-      ),
-    );
-
-    // Preload invites sent per author from invitations
-    let invitesRows: { sender: string; sent: string }[] = [];
-    try {
-      invitesRows = await this.invitationRepository
-        .createQueryBuilder('inv')
-        .select('inv.sender_address', 'sender')
-        .addSelect('COUNT(*)', 'sent')
-        .where('inv.sender_address IN (:...authors)', { authors })
-        .groupBy('inv.sender_address')
-        .getRawMany<{ sender: string; sent: string }>();
-    } catch {
-      invitesRows = [];
-    }
-    const invitesByAddress = new Map(
-      invitesRows.map((r) => [r.sender, parseInt(r.sent || '0', 10)] as const),
-    );
-
     // Preload reads over window per post
     const fromDate = new Date(Date.now() - hours * 3600 * 1000);
     const fromDateOnly = `${fromDate.getUTCFullYear()}-${String(
@@ -560,71 +487,9 @@ export class PopularRankingService {
 
         const contentQuality = this.computeContentQuality(post.content || '');
 
-        // account signals
-        const account = accountByAddress.get(post.sender_address);
-        let accountBalanceFactor = 0;
-        let accountAgeFactor = 0;
-        let invitesFactor = 0;
-        if (account) {
-          // AE balance via Ae SDK with short Redis cache
-          const cacheKey = `accbal:${account.address}`;
-          let aeBalance = 0;
-          const cached = await this.redis.get(cacheKey);
-          if (cached) {
-            aeBalance = parseFloat(cached) || 0;
-          } else {
-            try {
-              const raw = await this.aeSdkService.sdk.getBalance(
-                account.address as `ak_${string}`,
-              );
-              aeBalance = Number(raw) / 1e18; // wei -> AE
-              await this.redis.setex(
-                cacheKey,
-                POPULAR_RANKING_CONFIG.BALANCE_CACHE_TTL_SECONDS,
-                aeBalance.toString(),
-              );
-            } catch {
-              aeBalance = 0;
-            }
-          }
-          accountBalanceFactor = Math.max(
-            0,
-            Math.min(
-              1,
-              aeBalance / POPULAR_RANKING_CONFIG.BALANCE_NORMALIZER_AE,
-            ),
-          );
-
-          const days =
-            (Date.now() - new Date(account.created_at).getTime()) / 86_400_000;
-          accountAgeFactor = Math.max(
-            0,
-            Math.min(1, 1 / (1 + Math.exp(-(days - 14) / 14))),
-          );
-
-          const sentInvites =
-            invitesByAddress.get(account.address) ??
-            account.total_invitation_count ??
-            0;
-          invitesFactor = Math.min(
-            1,
-            Math.log(1 + sentInvites) / Math.log(1 + 100),
-          );
-        }
-
         const w = POPULAR_RANKING_CONFIG.WEIGHTS;
         const reads = readsByPost.get(post.id) || 0;
         const readsPerHour = reads / ageHours;
-        // owned trends factor: normalize value portfolio into [0..1]
-        const ownedRaw = ownedValueByAddress.get(post.sender_address) || 0;
-        const normalizer =
-          POPULAR_RANKING_CONFIG.OWNED_TRENDS_VALUE_CURRENCY === 'usd'
-            ? POPULAR_RANKING_CONFIG.OWNED_TRENDS_VALUE_NORMALIZER_USD
-            : POPULAR_RANKING_CONFIG.OWNED_TRENDS_VALUE_NORMALIZER_AE;
-        const ownedNorm = Math.max(
-          0,
-          Math.min(1, ownedRaw / Math.max(1, normalizer)),
-        );
         const numerator =
           w.comments * Math.log(1 + comments) +
           w.tipsAmountAE * Math.log(1 + tipsAmountAE) +
@@ -632,11 +497,7 @@ export class PopularRankingService {
           w.interactionsPerHour * Math.log(1 + interactionsPerHour) +
           w.reads * Math.log(1 + readsPerHour) +
           w.trendingBoost * trendingBoost +
-          w.contentQuality * contentQuality +
-          w.accountBalance * accountBalanceFactor +
-          w.accountAge * accountAgeFactor +
-          w.invites * invitesFactor +
-          w.ownedTrends * ownedNorm;
+          w.contentQuality * contentQuality;
 
         // Apply gravity based on window
         // For "all" window, no gravity (0.0) means all posts compete equally regardless of age
@@ -687,69 +548,9 @@ export class PopularRankingService {
 
         const contentQuality = this.computeContentQuality(item.content || '');
 
-        // Account signals
-        const account = accountByAddress.get(item.sender_address);
-        let accountBalanceFactor = 0;
-        let accountAgeFactor = 0;
-        let invitesFactor = 0;
-        if (account) {
-          const cacheKey = `accbal:${account.address}`;
-          let aeBalance = 0;
-          const cached = await this.redis.get(cacheKey);
-          if (cached) {
-            aeBalance = parseFloat(cached) || 0;
-          } else {
-            try {
-              const raw = await this.aeSdkService.sdk.getBalance(
-                account.address as `ak_${string}`,
-              );
-              aeBalance = Number(raw) / 1e18;
-              await this.redis.setex(
-                cacheKey,
-                POPULAR_RANKING_CONFIG.BALANCE_CACHE_TTL_SECONDS,
-                aeBalance.toString(),
-              );
-            } catch {
-              aeBalance = 0;
-            }
-          }
-          accountBalanceFactor = Math.max(
-            0,
-            Math.min(
-              1,
-              aeBalance / POPULAR_RANKING_CONFIG.BALANCE_NORMALIZER_AE,
-            ),
-          );
-
-          const days =
-            (Date.now() - new Date(account.created_at).getTime()) / 86_400_000;
-          accountAgeFactor = Math.max(
-            0,
-            Math.min(1, 1 / (1 + Math.exp(-(days - 14) / 14))),
-          );
-
-          const sentInvites =
-            invitesByAddress.get(account.address) ??
-            account.total_invitation_count ??
-            0;
-          invitesFactor = Math.min(
-            1,
-            Math.log(1 + sentInvites) / Math.log(1 + 100),
-          );
-        }
-
         const w = POPULAR_RANKING_CONFIG.WEIGHTS;
         const reads = 0; // Plugin items don't have reads tracking (for now)
         const readsPerHour = reads / ageHours;
-        const ownedRaw = ownedValueByAddress.get(item.sender_address) || 0;
-        const normalizer =
-          POPULAR_RANKING_CONFIG.OWNED_TRENDS_VALUE_CURRENCY === 'usd'
-            ? POPULAR_RANKING_CONFIG.OWNED_TRENDS_VALUE_NORMALIZER_USD
-            : POPULAR_RANKING_CONFIG.OWNED_TRENDS_VALUE_NORMALIZER_AE;
-        const ownedNorm = Math.max(
-          0,
-          Math.min(1, ownedRaw / Math.max(1, normalizer)),
-        );
         const numerator =
           w.comments * Math.log(1 + comments) +
           w.tipsAmountAE * Math.log(1 + tipsAmountAE) +
@@ -757,11 +558,7 @@ export class PopularRankingService {
           w.interactionsPerHour * Math.log(1 + interactionsPerHour) +
           w.reads * Math.log(1 + readsPerHour) +
           w.trendingBoost * trendingBoost +
-          w.contentQuality * contentQuality +
-          w.accountBalance * accountBalanceFactor +
-          w.accountAge * accountAgeFactor +
-          w.invites * invitesFactor +
-          w.ownedTrends * ownedNorm;
+          w.contentQuality * contentQuality;
 
         let gravity = 0.0;
         if (window === '7d') {

--- a/src/social/services/popular-ranking.service.ts
+++ b/src/social/services/popular-ranking.service.ts
@@ -461,6 +461,9 @@ export class PopularRankingService {
           comments: commentsByPost.get(post.id) || 0,
           tipsAmountAE: tipsAgg ? parseFloat(tipsAgg.amount_sum || '0') : 0,
           tipsCount: tipsAgg ? parseInt(tipsAgg.count || '0', 10) : 0,
+          uniqueTippers: tipsAgg
+            ? parseInt(tipsAgg.unique_tippers || '0', 10)
+            : 0,
           reads: readsByPost.get(post.id) || 0,
           topics: post.topics,
         }),
@@ -477,6 +480,7 @@ export class PopularRankingService {
           comments: item.total_comments || 0,
           tipsAmountAE: 0,
           tipsCount: 0,
+          uniqueTippers: 0,
           reads: 0,
           topics: item.topics,
         }),
@@ -573,11 +577,12 @@ export class PopularRankingService {
       comments: number;
       tipsAmountAE: number;
       tipsCount: number;
+      uniqueTippers: number;
       reads: number;
       topics?: Array<{ name?: string }>;
     },
   ): number {
-    const { comments, tipsAmountAE, tipsCount, reads } = input;
+    const { comments, tipsAmountAE, tipsCount, uniqueTippers, reads } = input;
 
     let trendingBoost = 0;
     if (input.topics?.length) {
@@ -601,6 +606,7 @@ export class PopularRankingService {
       w.comments * Math.log(1 + comments) +
       w.tipsAmountAE * Math.log(1 + tipsAmountAE) +
       w.tipsCount * Math.log(1 + tipsCount) +
+      w.uniqueTippers * Math.log(1 + uniqueTippers) +
       w.reads * Math.log(1 + reads) +
       w.trendingBoost * trendingBoost +
       w.contentQuality * contentQuality


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the core `GET /posts/popular` ranking algorithm and its inputs (removing time-decay and author/reputation signals), which can materially alter feed ordering and cache behavior. Adds new fallback and recompute-mutex logic that affects runtime performance and Redis load under cold-cache conditions.
> 
> **Overview**
> Switches `GET /posts/popular` from a time-decayed “Hot” ranking to a windowed **“Top” ranking**: scores are now purely accumulated engagement within the selected window, adding `uniqueTippers`, using raw `reads`, and removing time decay, score floors, and all author wallet/reputation signals.
> 
> Improves Redis handling in `PopularRankingService` by adding a per-window recompute mutex to prevent cache stampedes and returning a window-filtered **recent-posts fallback** when the ranked cache is empty; the controller’s error fallback is updated to respect the requested window.
> 
> Cleans up wiring/tests/docs accordingly: `POPULAR_RANKING_CONFIG` is simplified (new weights, removed decay/floors/reputation config), `PostModule` drops unused module/entity dependencies, and docs/tests are updated for self-comment exclusion and cold-cache fallback behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7526121d15ff59f0e72215039ceb1bce5c6a2240. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->