### PR TITLE
Refactoring

### DIFF
--- a/src/account/controllers/accounts.controller.ts
+++ b/src/account/controllers/accounts.controller.ts
@@ -171,7 +171,7 @@ export class AccountsController {
   })
   @ApiParam({ name: 'address', type: 'string', description: 'Account address' })
   @ApiOkResponse({ type: [PortfolioHistorySnapshotDto] })
-  @CacheTTL(60 * 10) // 10 minutes
+  @CacheTTL(10 * 60_000)
   @Get(':address/portfolio/history')
   async getPortfolioHistory(
     //
@@ -214,7 +214,7 @@ export class AccountsController {
   })
   @ApiParam({ name: 'address', type: 'string', description: 'Account address' })
   @ApiOkResponse({ type: [PortfolioHistorySnapshotDto] })
-  @CacheTTL(60 * 10)
+  @CacheTTL(10 * 60_000)
   @Get(':address/portfolio/tokens/history')
   async getTokensPnlHistory(
     @Param('address') address: string,
@@ -269,7 +269,7 @@ export class AccountsController {
   })
   @Header('Content-Type', 'image/svg+xml')
   @Header('Content-Disposition', 'inline; filename="pnl-chart.svg"')
-  @CacheTTL(60 * 10)
+  @CacheTTL(10 * 60_000)
   @Get(':address/portfolio/pnl-chart.svg')
   async getPortfolioPnlChart(
     @Param('address') address: string,
@@ -317,7 +317,7 @@ export class AccountsController {
   @ApiOperation({ operationId: 'getPortfolioStats' })
   @ApiParam({ name: 'address', type: 'string', description: 'Account address' })
   @ApiOkResponse({ type: TradingStatsResponseDto })
-  @CacheTTL(60 * 10) // 10 minutes
+  @CacheTTL(10 * 60_000)
   @Get(':address/portfolio/stats')
   async getPortfolioStats(
     @Param('address') address: string,
@@ -350,7 +350,7 @@ export class AccountsController {
   // single account - MUST come after more specific routes
   @ApiOperation({ operationId: 'getAccount' })
   @ApiParam({ name: 'address', type: 'string' })
-  @CacheTTL(60 * 10) // 10 minutes cache
+  @CacheTTL(10 * 60_000)
   @Get(':address')
   async getAccount(@Param('address') address: string) {
     const account = await this.accountRepository.findOne({

--- a/src/account/controllers/leaderboard.controller.ts
+++ b/src/account/controllers/leaderboard.controller.ts
@@ -85,7 +85,7 @@ export class LeaderboardController {
     example: 36,
     description: 'Upper bound of candidate addresses to evaluate',
   })
-  @CacheTTL(60) // cache 1 minute
+  @CacheTTL(60_000)
   @Get()
   async getLeaderboard(
     @Query('window') window: LeaderboardWindow = '7d',

--- a/src/account/services/account.service.ts
+++ b/src/account/services/account.service.ts
@@ -1,4 +1,4 @@
-import { TX_FUNCTIONS, ACTIVE_NETWORK } from '@/configs';
+import { ACTIVE_NETWORK, TX_FUNCTIONS } from '@/configs';
 import { PULL_ACCOUNTS_ENABLED } from '@/configs/constants';
 import { Transaction } from '@/transactions/entities/transaction.entity';
 import { Injectable, Logger } from '@nestjs/common';
@@ -29,6 +29,8 @@ export class AccountService {
     }
   }
 
+  private static readonly ACCOUNT_BATCH_SIZE = 500;
+
   isPullingAccounts = false;
   async saveAllActiveAccounts() {
     if (this.isPullingAccounts) {
@@ -36,61 +38,49 @@ export class AccountService {
     }
     this.isPullingAccounts = true;
     try {
-      const uniqueAddresses = await this.transactionRepository
-        .createQueryBuilder('transaction')
-        .select(
-          'DISTINCT ON (transaction.address) transaction.address',
-          'address',
-        )
-        .getRawMany();
+      const aggregated: Array<{
+        address: string;
+        total_tx_count: number;
+        total_buy_tx_count: number;
+        total_sell_tx_count: number;
+        total_created_tokens: number;
+        total_volume: string;
+      }> = await this.transactionRepository.query(
+        `SELECT
+          address,
+          COUNT(*)::int                                    AS total_tx_count,
+          COUNT(*) FILTER (WHERE tx_type = $1)::int        AS total_buy_tx_count,
+          COUNT(*) FILTER (WHERE tx_type = $2)::int        AS total_sell_tx_count,
+          COUNT(*) FILTER (WHERE tx_type = $3)::int        AS total_created_tokens,
+          COALESCE(SUM(CAST(NULLIF(amount->>'ae','NaN') AS DECIMAL)), 0) AS total_volume
+        FROM transactions
+        GROUP BY address`,
+        [TX_FUNCTIONS.buy, TX_FUNCTIONS.sell, TX_FUNCTIONS.create_community],
+      );
 
-      for (const address of uniqueAddresses) {
-        const accountExists = await this.accountRepository.exists({
-          where: { address: address.address },
-        });
+      for (
+        let i = 0;
+        i < aggregated.length;
+        i += AccountService.ACCOUNT_BATCH_SIZE
+      ) {
+        const batch = aggregated
+          .slice(i, i + AccountService.ACCOUNT_BATCH_SIZE)
+          .map((row) => ({
+            address: row.address,
+            total_tx_count: row.total_tx_count,
+            total_buy_tx_count: row.total_buy_tx_count,
+            total_sell_tx_count: row.total_sell_tx_count,
+            total_created_tokens: row.total_created_tokens,
+            total_volume: new BigNumber(row.total_volume),
+          }));
 
-        if (accountExists) {
-          continue;
-        }
-
-        const totalTransactions = await this.transactionRepository.count({
-          where: { address: address.address },
-        });
-        const totalBuyTransactions = await this.transactionRepository.count({
-          where: { address: address.address, tx_type: TX_FUNCTIONS.buy },
-        });
-        const totalSellTransactions = await this.transactionRepository.count({
-          where: { address: address.address, tx_type: TX_FUNCTIONS.sell },
-        });
-        const totalCreatedTokens = await this.transactionRepository.count({
-          where: {
-            address: address.address,
-            tx_type: TX_FUNCTIONS.create_community,
-          },
-        });
-
-        // total volume sum of amount->ae
-        const totalVolume = await this.transactionRepository
-          .createQueryBuilder('transactions')
-          .select(
-            "SUM(CAST(NULLIF(transactions.amount->>'ae', 'NaN') AS DECIMAL))",
-            'total_volume',
-          )
-          .where('transactions.address = :address', {
-            address: address.address,
-          })
-          .getRawOne();
-
-        const accountData = {
-          address: address.address,
-          total_tx_count: totalTransactions,
-          total_buy_tx_count: totalBuyTransactions,
-          total_sell_tx_count: totalSellTransactions,
-          total_created_tokens: totalCreatedTokens,
-          total_volume: new BigNumber(totalVolume.total_volume),
-        };
-
-        await this.accountRepository.save(accountData);
+        await this.accountRepository
+          .createQueryBuilder()
+          .insert()
+          .into(Account)
+          .values(batch)
+          .orIgnore()
+          .execute();
       }
     } catch (error) {
       this.logger.error('Error pulling and saving accounts', error);

--- a/src/account/services/portfolio.service.ts
+++ b/src/account/services/portfolio.service.ts
@@ -195,47 +195,16 @@ export class PortfolioService {
       }
     }
 
-    const resolvedAddress = await this.resolveAccountAddress(address);
-
-    // Fetch price history and current price in parallel.
-    // For historical prices, query the local coin_historical_prices table first
-    // (populated by the background CoinGecko sync). Only fall back to the live
-    // CoinGecko API when the DB has no data for the needed range.
-    // Extend start backward a few days so the first snapshot always has a price
-    // data point at or before it, even when the range starts close to midnight.
-    const priceRangeStartMs = start.clone().subtract(3, 'days').valueOf();
-    const priceRangeEndMs = end.valueOf();
-
-    const [dbPriceRows, currentAePrice] = await Promise.all([
-      this.coinHistoricalPriceService.getHistoricalPriceData(
-        AETERNITY_COIN_ID,
-        'usd',
-        priceRangeStartMs,
-        priceRangeEndMs,
-      ),
-      this.coinGeckoService.getPriceData(new BigNumber(1)),
-    ]);
-
-    let aePriceHistory: Array<[number, number]>;
-    if (dbPriceRows.length > 0) {
-      // DB data sorted ascending — reverse to match the descending order
-      // expected by findClosestHistoricalPrice.
-      aePriceHistory = dbPriceRows.reverse();
-    } else {
-      // DB has no data for this range; serve from cache / DB / fallback JSON.
-      const daysNeeded = Math.ceil(now.diff(start, 'days', true)) + 3;
-      const days = Math.min(365, Math.max(7, daysNeeded));
-      aePriceHistory = await this.coinGeckoService
-        .getHistoricalPrice(AETERNITY_COIN_ID, 'usd', days, 'daily')
-        .then((prices) => prices.sort((a, b) => b[0] - a[0]));
-    }
-    // Resolve all block heights in a single batch query against the local key_blocks table.
-    // Any timestamps not covered by the table (sync gaps) fall back to individual resolution.
     const targetTimestamps = timestamps.map((t) => t.valueOf());
-    const heightMap = await batchTimestampToAeHeight(
-      targetTimestamps,
-      this.dataSource,
-    );
+    const [{ aePriceHistory, currentAePrice }, resolvedAddress, heightMap] =
+      await Promise.all([
+        this.loadAePriceHistory(start, end, now),
+        this.resolveAccountAddress(address),
+        // Resolve all block heights in a single batch query against the local
+        // key_blocks table. Any timestamps not covered by the table (sync gaps)
+        // fall back to individual resolution.
+        batchTimestampToAeHeight(targetTimestamps, this.dataSource),
+      ]);
     // Build the ordered block-height array.  If a timestamp was not resolved by
     // either key_blocks or transactions (extremely rare — would require a gap in
     // both tables), propagate the nearest already-resolved height rather than
@@ -490,6 +459,48 @@ export class PortfolioService {
     }
 
     return address;
+  }
+
+  private async loadAePriceHistory(
+    start: Moment,
+    end: Moment,
+    now: Moment,
+  ): Promise<{
+    aePriceHistory: Array<[number, number]>;
+    currentAePrice: Awaited<ReturnType<CoinGeckoService['getPriceData']>>;
+  }> {
+    // Query the local coin_historical_prices table first (populated by the
+    // background CoinGecko sync). Only fall back to the live CoinGecko API
+    // when the DB has no data for the needed range.
+    // Extend start backward a few days so the first snapshot always has a price
+    // data point at or before it, even when the range starts close to midnight.
+    const priceRangeStartMs = start.clone().subtract(3, 'days').valueOf();
+    const priceRangeEndMs = end.valueOf();
+
+    const [dbPriceRows, currentAePrice] = await Promise.all([
+      this.coinHistoricalPriceService.getHistoricalPriceData(
+        AETERNITY_COIN_ID,
+        'usd',
+        priceRangeStartMs,
+        priceRangeEndMs,
+      ),
+      this.coinGeckoService.getPriceData(new BigNumber(1)),
+    ]);
+
+    let aePriceHistory: Array<[number, number]>;
+    if (dbPriceRows.length > 0) {
+      // DB data sorted ascending — reverse to match the descending order
+      // expected by findClosestHistoricalPrice.
+      aePriceHistory = dbPriceRows.reverse();
+    } else {
+      const daysNeeded = Math.ceil(now.diff(start, 'days', true)) + 3;
+      const days = Math.min(365, Math.max(7, daysNeeded));
+      aePriceHistory = await this.coinGeckoService
+        .getHistoricalPrice(AETERNITY_COIN_ID, 'usd', days, 'daily')
+        .then((prices) => prices.sort((a, b) => b[0] - a[0]));
+    }
+
+    return { aePriceHistory, currentAePrice };
   }
 
   private getCachedBalance(

--- a/src/ae-pricing/services/coin-historical-price.service.ts
+++ b/src/ae-pricing/services/coin-historical-price.service.ts
@@ -37,6 +37,7 @@ export class CoinHistoricalPriceService {
         order: {
           timestamp_ms: 'ASC',
         },
+        select: ['timestamp_ms', 'price'],
       });
 
       // TypeORM returns bigint as string, convert to number

--- a/src/ae/websocket.service.spec.ts
+++ b/src/ae/websocket.service.spec.ts
@@ -18,7 +18,7 @@ jest.mock('ws', () => {
     send: jest.fn(),
     close: jest.fn(),
     on: jest.fn(),
-    removeEventListener: jest.fn(),
+    removeAllListeners: jest.fn(),
     ping: jest.fn(),
     readyState: 1, // Simulate an "open" WebSocket
   }));
@@ -40,7 +40,7 @@ describe('WebSocketService', () => {
       send: jest.fn(),
       close: jest.fn(),
       ping: jest.fn(),
-      removeEventListener: jest.fn(),
+      removeAllListeners: jest.fn(),
       on: jest.fn((event, callback) => {
         eventListeners[event] = callback;
       }),

--- a/src/ae/websocket.service.ts
+++ b/src/ae/websocket.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
 import camelcaseKeysDeep from 'camelcase-keys-deep';
 import {
   ACTIVE_NETWORK,
@@ -26,12 +26,16 @@ type PingI = {
 };
 
 @Injectable()
-export class WebSocketService {
+export class WebSocketService implements OnModuleDestroy {
   private readonly logger = new Logger(WebSocketService.name);
   wsClient: WebSocket;
   subscribersQueue: IMiddlewareWebSocketSubscriptionMessage[] = [];
   isWsConnected = false;
   reconnectInterval: NodeJS.Timeout;
+
+  private readonly boundOpen = this.handleWebsocketOpen.bind(this);
+  private readonly boundClose = this.handleWebsocketClose.bind(this);
+  private readonly boundMessage = this.handleWebsocketMessage.bind(this);
 
   pings = [];
 
@@ -251,12 +255,10 @@ export class WebSocketService {
           );
         });
       });
+      this.wsClient.removeAllListeners();
       this.wsClient.close();
-      this.wsClient.removeEventListener('open', this.handleWebsocketOpen);
-      this.wsClient.removeEventListener('close', this.handleWebsocketClose);
-      this.wsClient.removeEventListener('message', this.handleWebsocketClose);
     } catch (error) {
-      //
+      this.logger.debug('disconnect error (safe to ignore)', error);
     }
   }
 
@@ -266,10 +268,10 @@ export class WebSocketService {
     }
 
     this.wsClient = new WebSocket(url);
-    this.wsClient.on('error', console.error);
-    this.wsClient.on('open', this.handleWebsocketOpen.bind(this));
-    this.wsClient.on('close', this.handleWebsocketClose.bind(this));
-    this.wsClient.on('message', this.handleWebsocketMessage.bind(this));
+    this.wsClient.on('error', (err) => this.logger.error('ws error', err));
+    this.wsClient.on('open', this.boundOpen);
+    this.wsClient.on('close', this.boundClose);
+    this.wsClient.on('message', this.boundMessage);
     this.wsClient.on('pong', (data: any) => {
       const parsedData = JSON.parse(data.toString());
       const pingData = parsedData.payload;
@@ -278,14 +280,11 @@ export class WebSocketService {
     this.pings = [];
   }
 
-  /**
-   * Forces a reconnection to the WebSocket server.
-   * This method disconnects the current WebSocket connection,
-   * waits for 1 second to ensure complete disconnection,
-   * and then reconnects to the server.
-   *
-   * @returns {Promise<void>}
-   */
+  onModuleDestroy() {
+    clearInterval(this.reconnectInterval);
+    this.disconnect();
+  }
+
   @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
   async forceReconnect() {
     this.logger.log('forceReconnect');

--- a/src/analytics/services/cache-daily-analytics-data.service.ts
+++ b/src/analytics/services/cache-daily-analytics-data.service.ts
@@ -5,7 +5,7 @@ import { Cron, CronExpression } from '@nestjs/schedule';
 import { InjectRepository } from '@nestjs/typeorm';
 import { BigNumber } from 'bignumber.js';
 import moment from 'moment';
-import { Between, LessThan, Repository } from 'typeorm';
+import { LessThan, Repository } from 'typeorm';
 import { Analytic } from '../entities/analytic.entity';
 import { Token } from '@/tokens/entities/token.entity';
 
@@ -106,66 +106,53 @@ export class CacheDailyAnalyticsDataService {
   }
 
   async getDateAnalytics(startOfDay: Date, endOfDay: Date) {
-    const transactions = await this.transactionsRepository.find({
-      where: {
-        created_at: Between(startOfDay, endOfDay),
-      },
-    });
-    // total created tokens before end of day
+    const [txAgg] = await this.transactionsRepository.query(
+      `SELECT
+         COUNT(*)::int                              AS total_transactions,
+         COUNT(DISTINCT address)::int               AS total_active_accounts,
+         COALESCE(SUM(
+           CAST(NULLIF(amount->>'ae', 'NaN') AS decimal)
+         ), 0)                                      AS total_volume,
+         COUNT(*) FILTER (
+           WHERE tx_type = $3
+         )::int                                     AS total_created_tokens
+       FROM transactions
+       WHERE created_at BETWEEN $1 AND $2`,
+      [startOfDay, endOfDay, TX_FUNCTIONS.create_community],
+    );
+
     const totalTokens = await this.tokensRepository.count({
       where: {
         created_at: LessThan(endOfDay),
       },
     });
 
-    // total unique users
-    const totalUniqueUsers = new Set(
-      transactions.map((transaction) => transaction.address),
-    );
-
-    const totalTransactions = transactions.length;
     const totalMarketCap = await this.getMarketCapSum(endOfDay);
-    const totalVolume = transactions.reduce(
-      (acc, transaction) => acc.plus(transaction.amount?.ae ?? 0),
-      new BigNumber(0),
-    );
-    const totalCreatedTokens = transactions.filter(
-      (transaction) => transaction.tx_type === TX_FUNCTIONS.create_community,
-    ).length;
-    const totalActiveAccounts = totalUniqueUsers.size;
 
     return {
       date: moment(startOfDay).format('YYYY-MM-DD'),
       total_market_cap_sum: totalMarketCap,
-      total_volume_sum: totalVolume,
+      total_volume_sum: new BigNumber(txAgg.total_volume || 0),
       total_tokens: totalTokens,
-      total_transactions: totalTransactions,
-      total_created_tokens: totalCreatedTokens,
-      total_active_accounts: totalActiveAccounts,
+      total_transactions: txAgg.total_transactions,
+      total_created_tokens: txAgg.total_created_tokens,
+      total_active_accounts: txAgg.total_active_accounts,
     };
   }
 
-  private async getMarketCapSum(date: Date) {
-    const $date = moment(date);
-    const smartTransactionQuery = this.transactionsRepository
-      .createQueryBuilder('transaction')
-      .select(
-        'DISTINCT ON (transaction.sale_address) transaction.sale_address',
-        'sale_address',
-      )
-      .addSelect("transaction.market_cap->>'ae'", 'market_cap')
-      .where("transaction.market_cap->>'ae' IS NOT NULL")
-      .andWhere('transaction.created_at <= :start_date', {
-        start_date: $date.toDate(),
-      })
-      .orderBy('transaction.sale_address')
-      .addOrderBy('transaction.created_at', 'DESC');
-    const smartTokens = await smartTransactionQuery.getRawMany();
-
-    // Calculate total market cap sum
-    return smartTokens.reduce((sum, token) => {
-      const marketCap = parseFloat(token.market_cap);
-      return sum + (isNaN(marketCap) ? 0 : marketCap);
-    }, 0);
+  private async getMarketCapSum(date: Date): Promise<BigNumber> {
+    const [result] = await this.transactionsRepository.query(
+      `SELECT COALESCE(SUM(cap.market_cap), 0) AS total
+       FROM (
+         SELECT DISTINCT ON (sale_address)
+           CAST(NULLIF(market_cap->>'ae', 'NaN') AS decimal) AS market_cap
+         FROM transactions
+         WHERE market_cap->>'ae' IS NOT NULL
+           AND created_at <= $1
+         ORDER BY sale_address, created_at DESC
+       ) cap`,
+      [date],
+    );
+    return new BigNumber(result.total || 0);
   }
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -41,6 +41,7 @@ import { AddressLinksModule } from './plugins/address-links/address-links.module
     ConfigModule.forRoot(),
     CacheModule.register({
       isGlobal: true,
+      ttl: 60_000,
     }),
     BullModule.forRoot({
       redis: REDIS_CONFIG,

--- a/src/bcl/controllers/debug-failed-transactions.controller.ts
+++ b/src/bcl/controllers/debug-failed-transactions.controller.ts
@@ -14,7 +14,10 @@ export class DebugFailedTransactionsController {
 
   @Get('failed-transactions')
   async getFailedTransactions() {
-    const failedTransactions = await this.failedTransactionsRepository.find();
+    const failedTransactions = await this.failedTransactionsRepository.find({
+      order: { created_at: 'DESC' },
+      take: 500,
+    });
     return failedTransactions;
   }
 }

--- a/src/bcl/services/fast-pull-tokens.service.ts
+++ b/src/bcl/services/fast-pull-tokens.service.ts
@@ -5,7 +5,6 @@ import {
   WAIT_TIME_WHEN_REQUEST_FAILED,
 } from '@/configs/constants';
 import { ACTIVE_NETWORK } from '@/configs/network';
-import { Token } from '@/tokens/entities/token.entity';
 import {
   PULL_TOKEN_INFO_QUEUE,
   SYNC_TOKEN_HOLDERS_QUEUE,
@@ -14,7 +13,6 @@ import { TokensService } from '@/tokens/tokens.service';
 import { TransactionService } from '@/transactions/services/transaction.service';
 import { SyncState } from '@/mdw-sync/entities/sync-state.entity';
 import { fetchJson } from '@/utils/common';
-import { ICommunityFactorySchema } from '@/utils/types';
 import { InjectQueue } from '@nestjs/bull';
 import { Injectable, Logger } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
@@ -91,7 +89,7 @@ export class FastPullTokensService {
       }).toString();
 
       const url = `${ACTIVE_NETWORK.middlewareUrl}/v3/transactions?${queryString}`;
-      await this.loadCreatedCommunityFromMdw(url, factory);
+      await this.loadCreatedCommunityFromMdw(url);
     } finally {
       this.isPullingLatestCreatedTokens = false;
     }
@@ -122,7 +120,7 @@ export class FastPullTokensService {
       }).toString();
       const url = `${ACTIVE_NETWORK.middlewareUrl}/v3/transactions?${queryString}`;
 
-      await this.loadCreatedCommunityFromMdw(url, factory);
+      await this.loadCreatedCommunityFromMdw(url);
     } catch (error: any) {
       this.logger.error(
         `FastPullTokensService->fastPullTokens: ${error.message}`,
@@ -133,72 +131,60 @@ export class FastPullTokensService {
     this.pullingTokens = false;
   }
 
-  /**
-   * @param url
-   * @param factory
-   * @param saleAddresses
-   * @returns
-   */
-  private async loadCreatedCommunityFromMdw(
-    url: string,
-    factory: ICommunityFactorySchema,
-    tokens: Token[] = [],
-    totalRetries = 0,
-  ): Promise<Token[]> {
-    this.logger.log('loadCreatedCommunityFromMdw->url::', url);
-    let result: any;
-    try {
-      result = await fetchJson(url);
-    } catch (error) {
-      if (totalRetries < MAX_RETRIES_WHEN_REQUEST_FAILED) {
-        totalRetries++;
-        await new Promise((resolve) =>
-          setTimeout(resolve, WAIT_TIME_WHEN_REQUEST_FAILED),
-        );
-        return this.loadCreatedCommunityFromMdw(
-          url,
-          factory,
-          tokens,
-          totalRetries,
-        );
-      }
-      this.logger.error('loadCreatedCommunityFromMdw->error::', error);
-      return tokens;
-    }
+  private async loadCreatedCommunityFromMdw(url: string): Promise<void> {
+    let nextUrl: string | null = url;
 
-    if (result?.data?.length) {
-      for (const transaction of result.data) {
+    while (nextUrl) {
+      this.logger.log('loadCreatedCommunityFromMdw->url::', nextUrl);
+
+      let result: any;
+      let retries = 0;
+      while (true) {
         try {
-          const token =
-            await this.tokensService.createTokenFromRawTransaction(transaction);
-          if (!token) {
-            continue;
+          result = await fetchJson(nextUrl);
+          break;
+        } catch (error) {
+          if (retries < MAX_RETRIES_WHEN_REQUEST_FAILED) {
+            retries++;
+            await new Promise((resolve) =>
+              setTimeout(resolve, WAIT_TIME_WHEN_REQUEST_FAILED),
+            );
+          } else {
+            this.logger.error('loadCreatedCommunityFromMdw->error::', error);
+            return;
           }
-          await this.transactionService.saveTransaction(
-            camelcaseKeysDeep(transaction),
-            token,
-          );
-          tokens.push(token);
-        } catch (error: any) {
-          this.logger.error(
-            `loadCreatedCommunityFromMdw->error:: for tx: ${transaction?.tx?.hash}`,
-            error?.message,
-            error?.stack,
-          );
         }
       }
-    } else {
-      this.logger.log('loadCreatedCommunityFromMdw->no data::', url);
-    }
 
-    if (result.next) {
-      return await this.loadCreatedCommunityFromMdw(
-        `${ACTIVE_NETWORK.middlewareUrl}${result.next}`,
-        factory,
-        tokens,
-        0,
-      );
+      if (result?.data?.length) {
+        for (const transaction of result.data) {
+          try {
+            const token =
+              await this.tokensService.createTokenFromRawTransaction(
+                transaction,
+              );
+            if (!token) {
+              continue;
+            }
+            await this.transactionService.saveTransaction(
+              camelcaseKeysDeep(transaction),
+              token,
+            );
+          } catch (error: any) {
+            this.logger.error(
+              `loadCreatedCommunityFromMdw->error:: for tx: ${transaction?.tx?.hash}`,
+              error?.message,
+              error?.stack,
+            );
+          }
+        }
+      } else {
+        this.logger.log('loadCreatedCommunityFromMdw->no data::', nextUrl);
+      }
+
+      nextUrl = result.next
+        ? `${ACTIVE_NETWORK.middlewareUrl}${result.next}`
+        : null;
     }
-    return tokens;
   }
 }

--- a/src/bcl/services/fix-failed-transactions.service.ts
+++ b/src/bcl/services/fix-failed-transactions.service.ts
@@ -31,7 +31,8 @@ export class FixFailedTransactionsService {
     this.fixingFailedTransactions = true;
     try {
       const failedTransactions = await this.failedTransactionsRepository.find({
-        where: {},
+        order: { retries: 'ASC', created_at: 'ASC' },
+        take: 100,
       });
       for (const failedTransaction of failedTransactions) {
         await this.fixFailedTransaction(failedTransaction);

--- a/src/bcl/services/fix-tokens.service.ts
+++ b/src/bcl/services/fix-tokens.service.ts
@@ -38,6 +38,7 @@ export class FixTokensService {
       order: {
         total_supply: 'DESC',
       },
+      take: 100,
     });
     for (const token of tokens) {
       try {

--- a/src/dex/services/dex-sync.service.ts
+++ b/src/dex/services/dex-sync.service.ts
@@ -6,7 +6,7 @@ import { IMiddlewareRequestConfig } from '@/social/interfaces/post.interfaces';
 import { fetchJson } from '@/utils/common';
 import { ITransaction } from '@/utils/types';
 import { Contract } from '@aeternity/aepp-sdk';
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import moment from 'moment';
 import { Repository } from 'typeorm';
@@ -26,6 +26,7 @@ type ContractInstance = Awaited<ReturnType<typeof Contract.initialize>>;
 
 @Injectable()
 export class DexSyncService {
+  private readonly logger = new Logger(DexSyncService.name);
   routerContract: ContractInstance;
   factoryContract: ContractInstance;
   constructor(
@@ -88,40 +89,63 @@ export class DexSyncService {
     await this.pairService.pullPairData(pairInfo);
   }
 
+  private static readonly SYNC_BATCH_SIZE = 100;
+
   async syncTokenPrices() {
-    const pairs = await this.dexPairRepository
-      .createQueryBuilder('pair')
-      .leftJoinAndSelect('pair.token0', 'token0')
-      .leftJoinAndSelect('pair.token1', 'token1')
-      .getMany();
-    const tokens = await this.dexTokenRepository.find();
-    for (const token of tokens) {
-      try {
-        const priceAnalysis =
-          await this.dexTokenService.getTokenPriceWithLiquidityAnalysis(
-            token.address,
-            DEX_CONTRACTS.wae,
+    const batchSize = DexSyncService.SYNC_BATCH_SIZE;
+
+    let tokenSkip = 0;
+    while (true) {
+      const tokens = await this.dexTokenRepository.find({
+        order: { address: 'ASC' },
+        take: batchSize,
+        skip: tokenSkip,
+      });
+      if (!tokens.length) break;
+
+      for (const token of tokens) {
+        try {
+          const priceAnalysis =
+            await this.dexTokenService.getTokenPriceWithLiquidityAnalysis(
+              token.address,
+              DEX_CONTRACTS.wae,
+            );
+
+          if (!priceAnalysis || !priceAnalysis.medianPrice) {
+            continue;
+          }
+
+          const price_data = await this.aePricingService.getPriceData(
+            new BigNumber(priceAnalysis.medianPrice),
           );
-
-        if (!priceAnalysis || !priceAnalysis.medianPrice) {
-          continue; // Skip tokens without price analysis
+          await this.dexTokenRepository.update(token.address, {
+            price: price_data,
+          });
+          await this.tokenSummaryService.createOrUpdateSummary(token.address);
+        } catch (error) {
+          this.logger.error(`Error syncing token ${token.address}:`, error);
+          continue;
         }
-
-        const price_data = await this.aePricingService.getPriceData(
-          new BigNumber(priceAnalysis.medianPrice),
-        );
-        await this.dexTokenRepository.update(token.address, {
-          price: price_data,
-        });
-        await this.tokenSummaryService.createOrUpdateSummary(token.address);
-      } catch (error) {
-        // Log error but continue processing other tokens
-        console.error(`Error syncing token ${token.address}:`, error);
-        continue;
       }
+      tokenSkip += batchSize;
     }
-    for (const pair of pairs) {
-      await this.pairSummaryService.createOrUpdateSummary(pair);
+
+    let pairSkip = 0;
+    while (true) {
+      const pairs = await this.dexPairRepository
+        .createQueryBuilder('pair')
+        .leftJoinAndSelect('pair.token0', 'token0')
+        .leftJoinAndSelect('pair.token1', 'token1')
+        .orderBy('pair.address', 'ASC')
+        .take(batchSize)
+        .skip(pairSkip)
+        .getMany();
+      if (!pairs.length) break;
+
+      for (const pair of pairs) {
+        await this.pairSummaryService.createOrUpdateSummary(pair);
+      }
+      pairSkip += batchSize;
     }
   }
 
@@ -145,24 +169,24 @@ export class DexSyncService {
   }
 
   async pullDexPairsFromMdw(url: string) {
-    const result = await fetchJson(url);
-    const data = result?.data ?? [];
-    for (const transaction of camelcaseKeysDeep(data)) {
-      if (
-        transaction.tx.result !== 'ok' ||
-        transaction.tx.return == 'invalid' ||
-        !transaction.tx.function
-      ) {
-        continue;
+    let nextUrl: string | null = url;
+    while (nextUrl) {
+      const result = await fetchJson(nextUrl);
+      const data = result?.data ?? [];
+      for (const transaction of camelcaseKeysDeep(data)) {
+        if (
+          transaction.tx.result !== 'ok' ||
+          transaction.tx.return == 'invalid' ||
+          !transaction.tx.function
+        ) {
+          continue;
+        }
+        await this.saveTransaction(transaction);
       }
-      await this.saveTransaction(transaction);
+      nextUrl = result.next
+        ? `${ACTIVE_NETWORK.middlewareUrl}${result.next}`
+        : null;
     }
-    if (result.next) {
-      return await this.pullDexPairsFromMdw(
-        `${ACTIVE_NETWORK.middlewareUrl}${result.next}`,
-      );
-    }
-    return result;
   }
 
   async saveTransaction(transaction: ITransaction): Promise<PairTransaction> {

--- a/src/dex/services/dex-token.service.ts
+++ b/src/dex/services/dex-token.service.ts
@@ -13,6 +13,10 @@ import { DEX_CONTRACTS } from '../config/dex-contracts.config';
 
 @Injectable()
 export class DexTokenService {
+  private cachedPairs: Pair[] | null = null;
+  private pairsCacheTime = 0;
+  private static readonly PAIRS_CACHE_TTL_MS = 30_000;
+
   constructor(
     @InjectRepository(DexToken)
     private readonly dexTokenRepository: Repository<DexToken>,
@@ -20,6 +24,23 @@ export class DexTokenService {
     @InjectRepository(Pair)
     private readonly pairRepository: Repository<Pair>,
   ) {}
+
+  private async getAllPairsWithTokens(): Promise<Pair[]> {
+    const now = Date.now();
+    if (
+      this.cachedPairs &&
+      now - this.pairsCacheTime < DexTokenService.PAIRS_CACHE_TTL_MS
+    ) {
+      return this.cachedPairs;
+    }
+    this.cachedPairs = await this.pairRepository
+      .createQueryBuilder('pair')
+      .leftJoinAndSelect('pair.token0', 'token0')
+      .leftJoinAndSelect('pair.token1', 'token1')
+      .getMany();
+    this.pairsCacheTime = now;
+    return this.cachedPairs;
+  }
 
   async findAll(
     options: IPaginationOptions,
@@ -173,12 +194,7 @@ export class DexTokenService {
       };
     }
 
-    // Get all pairs to build the complete graph
-    const allPairs = await this.pairRepository
-      .createQueryBuilder('pair')
-      .leftJoinAndSelect('pair.token0', 'token0')
-      .leftJoinAndSelect('pair.token1', 'token1')
-      .getMany();
+    const allPairs = await this.getAllPairsWithTokens();
 
     // Build edges for path finding
     const edges = allPairs.map((pair) => ({

--- a/src/plugins/governance/services/governance-delegation.service.ts
+++ b/src/plugins/governance/services/governance-delegation.service.ts
@@ -5,7 +5,7 @@ import {
   paginate,
   Pagination,
 } from 'nestjs-typeorm-paginate';
-import { Repository } from 'typeorm';
+import { In, Repository } from 'typeorm';
 import {
   GovernanceDelegationHistoryItemDto,
   GovernanceDelegationWithRevokedDto,
@@ -32,10 +32,16 @@ export class GovernanceDelegationService {
 
     const paginatedResult = await paginate(query, options);
 
-    // Get all revoked delegations for efficient lookup
-    const revokedDelegations = await this.revokedDelegationRepository.find({
-      order: { created_at: 'ASC' },
-    });
+    const delegatorAddresses = [
+      ...new Set(paginatedResult.items.map((d) => d.delegator).filter(Boolean)),
+    ];
+
+    const revokedDelegations = delegatorAddresses.length
+      ? await this.revokedDelegationRepository.find({
+          where: { delegator: In(delegatorAddresses) },
+          order: { created_at: 'ASC' },
+        })
+      : [];
 
     // Map delegations and attach revocation info
     const items: GovernanceDelegationWithRevokedDto[] = paginatedResult.items

--- a/src/tokens/account-tokens.controller.ts
+++ b/src/tokens/account-tokens.controller.ts
@@ -78,22 +78,25 @@ export class AccountTokensController {
         page,
         limit,
       });
-      // get the token holders for each token
-      const tokenHoldersQueryBuilder =
-        await this.tokenHolderRepository.createQueryBuilder('token_holder');
-      tokenHoldersQueryBuilder.where('token_holder.address = :address', {
-        address: owner_address || creator_address,
-      });
-
-      const tokenIds = tokensQueryResult.items
-        .map((holder) => holder.address)
-        .filter((address): address is string => address !== undefined);
+      const tokenAddresses = tokensQueryResult.items
+        .map((t) => t.address)
+        .filter((addr): addr is string => addr !== undefined);
 
       const tokenRanks = await this.tokensService.getTokenRanksByAex9Address(
-        tokenIds as any,
+        tokenAddresses as any,
       );
 
-      const holdings = await tokenHoldersQueryBuilder.getMany();
+      const holdings = tokenAddresses.length
+        ? await this.tokenHolderRepository
+            .createQueryBuilder('token_holder')
+            .where('token_holder.address = :address', {
+              address: owner_address || creator_address,
+            })
+            .andWhere('token_holder.aex9_address IN (:...tokenAddresses)', {
+              tokenAddresses,
+            })
+            .getMany()
+        : [];
       return {
         ...tokensQueryResult,
         items: tokensQueryResult.items?.map((token) => ({

--- a/src/tokens/tokens.controller.spec.ts
+++ b/src/tokens/tokens.controller.spec.ts
@@ -203,6 +203,19 @@ describe('TokensController', () => {
     );
   });
 
+  it('should filter owner holdings with EXISTS instead of a distinct IN subquery', async () => {
+    await controller.listAll(undefined, undefined, undefined, 'ak_owner');
+
+    expect(tokensQueryBuilder.andWhere).toHaveBeenCalledWith(
+      expect.stringContaining('EXISTS ('),
+      { owner_address: 'ak_owner' },
+    );
+    expect(tokensQueryBuilder.andWhere).toHaveBeenCalledWith(
+      expect.stringContaining('token_holder.aex9_address = token.address'),
+      { owner_address: 'ak_owner' },
+    );
+  });
+
   it('should apply eligibility filters only for trending score ordering', async () => {
     await controller.listAll(
       undefined,

--- a/src/tokens/tokens.controller.ts
+++ b/src/tokens/tokens.controller.ts
@@ -234,7 +234,7 @@ export class TokensController {
     description: 'Token address or name',
   })
   @Get(':address/trending-eligibility')
-  @CacheTTL(3)
+  @CacheTTL(3_000)
   async getTrendingEligibility(@Param('address') address: string) {
     return this.tokensService.getTrendingEligibilityBreakdown(address);
   }
@@ -246,7 +246,7 @@ export class TokensController {
     description: 'Token address or name',
   })
   @Get(':address')
-  @CacheTTL(3)
+  @CacheTTL(3_000)
   @ApiResponse({
     type: TokenDto,
   })
@@ -265,7 +265,7 @@ export class TokensController {
   @ApiQuery({ name: 'limit', type: 'number', required: false })
   @ApiOperation({ operationId: 'listTokenHolders' })
   @ApiOkResponsePaginated(TokenHolderDto)
-  @CacheTTL(10)
+  @CacheTTL(10_000)
   @Get(':address/holders')
   async listTokenHolders(
     @Param('address') address: string,
@@ -321,7 +321,7 @@ export class TokensController {
   @ApiQuery({ name: 'limit', type: 'number', required: false })
   @ApiOperation({ operationId: 'listTokenRankings' })
   @ApiOkResponsePaginated(TokenDto)
-  @CacheTTL(10)
+  @CacheTTL(10_000)
   @Get(':address/rankings')
   async listTokenRankings(
     @Param('address') address: string,
@@ -406,7 +406,7 @@ export class TokensController {
     description: 'Token address or name',
   })
   @ApiOperation({ operationId: 'getTokenScore' })
-  @CacheTTL(1)
+  @CacheTTL(1_000)
   @Get(':address/score')
   async getTokenScore(@Param('address') address: string): Promise<any> {
     const token = await this.tokensService.findByAddress(address);

--- a/src/tokens/tokens.controller.ts
+++ b/src/tokens/tokens.controller.ts
@@ -199,10 +199,12 @@ export class TokensController {
 
     if (owner_address) {
       queryBuilder.andWhere(
-        `token.address IN (
-          SELECT DISTINCT "aex9_address"
+        `EXISTS (
+          SELECT 1
           FROM token_holder
-          WHERE address = :owner_address AND balance > 0
+          WHERE token_holder.aex9_address = token.address
+            AND token_holder.address = :owner_address
+            AND token_holder.balance > 0
         )`,
         { owner_address },
       );

--- a/src/tokens/tokens.controller.ts
+++ b/src/tokens/tokens.controller.ts
@@ -198,20 +198,14 @@ export class TokensController {
     }
 
     if (owner_address) {
-      const ownedTokens = await this.tokenHolderRepository
-        .createQueryBuilder('token_holder')
-        .where('token_holder.address = :owner_address', { owner_address })
-        .andWhere('token_holder.balance > 0')
-        .select('token_holder."aex9_address"')
-        .distinct(true)
-        .getRawMany()
-        .then((res) => res.map((r) => r.aex9_address));
-
-      // queryBuilder.andWhereInIds(ownedTokens);
-
-      queryBuilder.andWhere('token.address IN (:...aex9_addresses)', {
-        aex9_addresses: ownedTokens,
-      });
+      queryBuilder.andWhere(
+        `token.address IN (
+          SELECT DISTINCT "aex9_address"
+          FROM token_holder
+          WHERE address = :owner_address AND balance > 0
+        )`,
+        { owner_address },
+      );
     }
 
     const result = await this.tokensService.queryTokensWithRanks(

--- a/src/tokens/tokens.service.spec.ts
+++ b/src/tokens/tokens.service.spec.ts
@@ -296,6 +296,85 @@ describe('TokensService', () => {
     );
   });
 
+  it('executes a single query for ranked token pages and preserves pagination metadata', async () => {
+    const queryBuilder = {
+      getQueryAndParameters: jest
+        .fn()
+        .mockReturnValue([
+          'SELECT token.* FROM token WHERE token.unlisted = false AND token.name ILIKE $1',
+          ['%alpha%'],
+        ]),
+    } as any;
+
+    tokensRepository.query.mockResolvedValue([
+      { sale_address: 'ct_1', name: 'Alpha', total_items: 2 },
+      { sale_address: 'ct_2', name: 'Beta', total_items: 2 },
+    ]);
+
+    const result = await service.queryTokensWithRanks(
+      queryBuilder,
+      2,
+      1,
+      'market_cap',
+      'DESC',
+    );
+
+    expect(tokensRepository.query).toHaveBeenCalledTimes(1);
+    const [sql, params] = tokensRepository.query.mock.calls[0];
+    expect(sql).toContain('WITH all_ranked_tokens AS');
+    expect(sql).toContain('filtered_count AS');
+    expect(sql).toContain('RIGHT JOIN filtered_count ON TRUE');
+    expect(params).toEqual(['%alpha%', 2, 0]);
+    expect(result).toEqual({
+      items: [
+        { sale_address: 'ct_1', name: 'Alpha' },
+        { sale_address: 'ct_2', name: 'Beta' },
+      ],
+      meta: {
+        currentPage: 1,
+        itemCount: 2,
+        itemsPerPage: 2,
+        totalItems: 2,
+        totalPages: 1,
+      },
+    });
+  });
+
+  it('returns empty items with the correct total when a ranked page is out of range', async () => {
+    const queryBuilder = {
+      getQueryAndParameters: jest
+        .fn()
+        .mockReturnValue([
+          'SELECT token.* FROM token WHERE token.unlisted = false',
+          [],
+        ]),
+    } as any;
+
+    tokensRepository.query.mockResolvedValue([
+      { sale_address: null, total_items: 7 },
+    ]);
+
+    const result = await service.queryTokensWithRanks(
+      queryBuilder,
+      5,
+      3,
+      'rank',
+      'ASC',
+    );
+
+    expect(tokensRepository.query).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      items: [],
+      meta: {
+        currentPage: 3,
+        itemCount: 0,
+        itemsPerPage: 5,
+        totalItems: 7,
+        totalPages: 2,
+      },
+    });
+  });
+
   it('returns a trending eligibility breakdown for a token', async () => {
     jest.spyOn(service, 'findByAddress').mockResolvedValue({
       sale_address: 'ct_sale',

--- a/src/tokens/tokens.service.ts
+++ b/src/tokens/tokens.service.ts
@@ -611,36 +611,14 @@ export class TokensService {
   }
 
   async queryTokensWithRanks(
-    queryBuilder: any,
+    queryBuilder: SelectQueryBuilder<Token>,
     limit: number = 20,
     page: number = 1,
     orderBy: string = 'rank',
     orderDirection: 'ASC' | 'DESC' = 'ASC',
   ) {
-    // Get the base query and parameters
-    const subQuery = queryBuilder.getQuery();
-    const parameters = queryBuilder.getParameters();
-
-    // Replace all parameter placeholders with actual values
-    let finalSubQuery = subQuery;
-    Object.entries(parameters).forEach(([key, value]) => {
-      if (Array.isArray(value)) {
-        // Handle array parameters by joining them with commas and wrapping in quotes
-        if (value.length === 0) {
-          // Handle empty arrays by replacing with a condition that always evaluates to false
-          finalSubQuery = finalSubQuery.replace(
-            `IN (:...${key})`,
-            "IN (SELECT '' WHERE 1 = 0)",
-          );
-          finalSubQuery = finalSubQuery.replace(`:...${key}`, 'NULL');
-        } else {
-          const arrayValues = value.map((v) => `'${v}'`).join(',');
-          finalSubQuery = finalSubQuery.replace(`:...${key}`, arrayValues);
-        }
-      } else {
-        finalSubQuery = finalSubQuery.replace(`:${key}`, `'${value}'`);
-      }
-    });
+    const [filteredTokensQuery, parameters] =
+      queryBuilder.getQueryAndParameters();
 
     if (orderBy === 'market_cap') {
       orderBy = 'rank';
@@ -648,29 +626,20 @@ export class TokensService {
       orderDirection = orderDirection === 'ASC' ? 'DESC' : 'ASC';
     }
 
-    // Get total count of filtered items
-    const countQuery = `
-      WITH filtered_tokens AS (
-        ${finalSubQuery}
-      )
-      SELECT COUNT(*) as total
-      FROM filtered_tokens
-    `;
-    const [{ total }] = await this.tokensRepository.query(countQuery);
-    const totalItems = parseInt(total, 10);
-    const totalPages = Math.ceil(totalItems / limit);
-    const orderClause =
-      orderBy === 'trending_score'
-        ? `all_ranked_tokens.trending_score ${orderDirection},
-           CASE
-             WHEN all_ranked_tokens.trending_score = 0
-               THEN all_ranked_tokens.created_at
-             ELSE NULL
-           END DESC,
-           all_ranked_tokens.created_at DESC`
-        : `all_ranked_tokens.${orderBy} ${orderDirection}`;
+    const offset = (page - 1) * limit;
+    const pagedOrderClause = this.buildTokensOrderClause(
+      'all_ranked_tokens',
+      orderBy,
+      orderDirection,
+    );
+    const resultOrderClause = this.buildTokensOrderClause(
+      'paged_tokens',
+      orderBy,
+      orderDirection,
+    );
+    const limitPlaceholder = `$${parameters.length + 1}`;
+    const offsetPlaceholder = `$${parameters.length + 2}`;
 
-    // Create a new query that includes the rank
     const rankedQuery = `
       WITH all_ranked_tokens AS (
         SELECT 
@@ -685,20 +654,42 @@ export class TokensService {
         WHERE token.unlisted = false
       ),
       filtered_tokens AS (
-        ${finalSubQuery}
+        ${filteredTokensQuery}
+      ),
+      filtered_count AS (
+        SELECT COUNT(*)::int AS total_items
+        FROM filtered_tokens
+      ),
+      paged_tokens AS (
+        SELECT 
+          all_ranked_tokens.*,
+          row_to_json(token_performance_view.*) as performance
+        FROM all_ranked_tokens
+        INNER JOIN filtered_tokens ON all_ranked_tokens.sale_address = filtered_tokens.sale_address
+        LEFT JOIN token_performance_view ON all_ranked_tokens.sale_address = token_performance_view.sale_address
+        ORDER BY ${pagedOrderClause}
+        LIMIT ${limitPlaceholder}
+        OFFSET ${offsetPlaceholder}
       )
       SELECT 
-        all_ranked_tokens.*,
-        row_to_json(token_performance_view.*) as performance
-      FROM all_ranked_tokens
-      INNER JOIN filtered_tokens ON all_ranked_tokens.sale_address = filtered_tokens.sale_address
-      LEFT JOIN token_performance_view ON all_ranked_tokens.sale_address = token_performance_view.sale_address
-      ORDER BY ${orderClause}
-      LIMIT ${limit}
-      OFFSET ${(page - 1) * limit}
+        paged_tokens.*,
+        filtered_count.total_items
+      FROM paged_tokens
+      RIGHT JOIN filtered_count ON TRUE
+      ORDER BY ${resultOrderClause}
     `;
 
-    const result = await this.tokensRepository.query(rankedQuery);
+    const rows = await this.tokensRepository.query(rankedQuery, [
+      ...parameters,
+      limit,
+      offset,
+    ]);
+    const totalItems = Number(rows[0]?.total_items ?? 0);
+    const totalPages = Math.ceil(totalItems / limit);
+    const result = rows
+      .filter((row) => row.sale_address !== null)
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      .map(({ total_items, ...item }) => item);
 
     return {
       items: result,
@@ -710,6 +701,24 @@ export class TokensService {
         totalPages,
       },
     };
+  }
+
+  private buildTokensOrderClause(
+    alias: string,
+    orderBy: string,
+    orderDirection: 'ASC' | 'DESC',
+  ): string {
+    if (orderBy === 'trending_score') {
+      return `${alias}.trending_score ${orderDirection},
+         CASE
+           WHEN ${alias}.trending_score = 0
+             THEN ${alias}.created_at
+           ELSE NULL
+         END DESC,
+         ${alias}.created_at DESC`;
+    }
+
+    return `${alias}.${orderBy} ${orderDirection}`;
   }
 
   private buildEligibilityTradeCountsSubquery(): string {

--- a/src/tokens/tokens.service.ts
+++ b/src/tokens/tokens.service.ts
@@ -182,8 +182,8 @@ export class TokensService {
     }
   }
 
-  findAll(): Promise<Token[]> {
-    return this.tokensRepository.find();
+  findAll(limit = 1000, offset = 0): Promise<Token[]> {
+    return this.tokensRepository.find({ take: limit, skip: offset });
   }
 
   async update(token: Token, data): Promise<Token> {

--- a/src/transactions/controllers/analytics-transactions.controller.ts
+++ b/src/transactions/controllers/analytics-transactions.controller.ts
@@ -194,7 +194,7 @@ export class AnalyticsTransactionsController {
     description: 'Returns the sum of market caps for all tokens per day',
     type: [DailyMarketCapSumDto],
   })
-  @CacheTTL(20)
+  @CacheTTL(20_000)
   @Get('daily-market-cap-sum')
   async listDailyMarketCapSum(
     @Query('start_date') start_date?: string,

--- a/src/transactions/controllers/analytics-transactions.controller.ts
+++ b/src/transactions/controllers/analytics-transactions.controller.ts
@@ -205,50 +205,53 @@ export class AnalyticsTransactionsController {
       token_sale_addresses = [token_sale_addresses];
     }
 
-    const startDate = start_date ? new Date(start_date) : new Date();
-    const endDate = end_date ? new Date(end_date) : new Date();
-    const dateRange = [];
-    const currentDate = new Date(startDate);
-    while (currentDate <= endDate) {
-      dateRange.push(new Date(currentDate));
-      currentDate.setDate(currentDate.getDate() + 1);
+    const endDate = end_date ? moment(end_date) : moment();
+    let startDate = start_date ? moment(start_date) : moment();
+
+    const maxDays = 365;
+    if (endDate.diff(startDate, 'days') > maxDays) {
+      startDate = endDate.clone().subtract(maxDays, 'days');
     }
 
-    const results = await Promise.all(
-      dateRange.map((date) =>
-        this.getMarketCapSum(date.toISOString().split('T')[0]),
-      ),
-    );
+    const dates: string[] = [];
+    const current = startDate.clone();
+    while (current.isSameOrBefore(endDate, 'day')) {
+      dates.push(current.format('YYYY-MM-DD'));
+      current.add(1, 'day');
+    }
+
+    const batchSize = 20;
+    const results: DailyMarketCapSumDto[] = [];
+    for (let i = 0; i < dates.length; i += batchSize) {
+      const batch = dates.slice(i, i + batchSize);
+      const batchResults = await Promise.all(
+        batch.map((date) => this.getMarketCapSum(date)),
+      );
+      results.push(...batchResults);
+    }
 
     return results.sort((a, b) => a.date.localeCompare(b.date));
   }
 
-  private async getMarketCapSum(date: string) {
-    const $date = moment(date);
-    const smartTransactionQuery = this.transactionsRepository
-      .createQueryBuilder('transaction')
-      .select(
-        'DISTINCT ON (transaction.sale_address) transaction.sale_address',
-        'sale_address',
-      )
-      .addSelect("transaction.market_cap->>'ae'", 'market_cap')
-      .where("transaction.market_cap->>'ae' IS NOT NULL")
-      .andWhere('transaction.created_at <= :start_date', {
-        start_date: $date.toDate(),
-      })
-      .orderBy('transaction.sale_address')
-      .addOrderBy('transaction.created_at', 'DESC');
-    const smartTokens = await smartTransactionQuery.getRawMany();
+  private async getMarketCapSum(date: string): Promise<DailyMarketCapSumDto> {
+    const endOfDay = moment(date).endOf('day').toDate();
 
-    // Calculate total market cap sum
-    const totalMarketCapSum = smartTokens.reduce((sum, token) => {
-      const marketCap = parseFloat(token.market_cap);
-      return sum + (isNaN(marketCap) ? 0 : marketCap);
-    }, 0);
+    const [result] = await this.transactionsRepository.query(
+      `SELECT COALESCE(SUM(cap.market_cap), 0) AS total
+       FROM (
+         SELECT DISTINCT ON (sale_address)
+           CAST(NULLIF(market_cap->>'ae', 'NaN') AS decimal) AS market_cap
+         FROM transactions
+         WHERE market_cap->>'ae' IS NOT NULL
+           AND created_at <= $1
+         ORDER BY sale_address, created_at DESC
+       ) cap`,
+      [endOfDay],
+    );
 
     return {
-      date: $date.format('YYYY-MM-DD'),
-      sum: totalMarketCapSum,
+      date,
+      sum: parseFloat(result.total) || 0,
     } as any;
   }
 }

--- a/src/transactions/controllers/historical.controller.ts
+++ b/src/transactions/controllers/historical.controller.ts
@@ -57,7 +57,7 @@ export class HistoricalController {
     type: 'string',
     description: 'Token address or name',
   })
-  @CacheTTL(1000)
+  @CacheTTL(60_000)
   @Get(':address/transactions')
   async findByAddress(
     @Param('address') address: string,
@@ -100,7 +100,7 @@ export class HistoricalController {
   })
   @ApiQuery({ name: 'page', type: 'number', required: false })
   @ApiQuery({ name: 'limit', type: 'number', required: false })
-  @CacheTTL(5)
+  @CacheTTL(5_000)
   @Get(':address/history')
   async getPaginatedHistory(
     @Param('address') address: string,
@@ -131,7 +131,7 @@ export class HistoricalController {
     required: false,
     example: '7d',
   })
-  @CacheTTL(5)
+  @CacheTTL(5_000)
   @Get('/preview/:address')
   async getForPreview(
     @Param('address') address: string,
@@ -168,7 +168,7 @@ export class HistoricalController {
   })
   @Header('Content-Type', 'image/svg+xml')
   @Header('Content-Disposition', 'inline; filename="sparkline.svg"')
-  @CacheTTL(60)
+  @CacheTTL(60_000)
   @Get('/preview/:address/sparkline.svg')
   async getSparklineSvg(
     @Param('address') address: string,

--- a/src/transactions/services/transaction-history.service.ts
+++ b/src/transactions/services/transaction-history.service.ts
@@ -1,6 +1,6 @@
 import { TX_FUNCTIONS } from '@/configs';
 import { Token } from '@/tokens/entities/token.entity';
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
 import BigNumber from 'bignumber.js';
 import type { Moment } from 'moment';
@@ -41,6 +41,8 @@ export interface ITransactionPreview {
 
 @Injectable()
 export class TransactionHistoryService {
+  private readonly logger = new Logger(TransactionHistoryService.name);
+
   constructor(
     @InjectRepository(Transaction)
     private readonly transactionsRepository: Repository<Transaction>,
@@ -165,6 +167,8 @@ export class TransactionHistoryService {
     });
   }
 
+  private static readonly MAX_HISTORICAL_ROWS = 50_000;
+
   async getHistoricalData(
     props: IGetHistoricalDataProps,
   ): Promise<HistoricalDataDto[]> {
@@ -182,7 +186,14 @@ export class TransactionHistoryService {
         endDate: endDate.toDate(),
       })
       .orderBy('transactions.created_at', 'ASC')
+      .take(TransactionHistoryService.MAX_HISTORICAL_ROWS)
       .getMany();
+
+    if (data.length >= TransactionHistoryService.MAX_HISTORICAL_ROWS) {
+      this.logger.warn(
+        `Historical data for ${props.token.sale_address} truncated at ${TransactionHistoryService.MAX_HISTORICAL_ROWS} rows`,
+      );
+    }
 
     const firstBefore =
       props.mode === 'aggregated'
@@ -215,23 +226,41 @@ export class TransactionHistoryService {
   ): HistoricalDataDto[] {
     const { startDate, endDate, interval } = props;
 
+    // Pre-filter invalid records once (data is already sorted by created_at ASC)
+    const validData = data.filter(
+      (record) =>
+        record?.buy_price?.ae && (record?.buy_price?.ae as any) != 'NaN',
+    );
+
     const result: HistoricalDataDto[] = [];
     let intervalStart = startDate.toDate().getTime();
     const endTimestamp = endDate.toDate().getTime();
     const intervalDuration = interval * 1000;
-    // const intervalDuration = this.getIntervalDuration(interval);
 
     let previousData: Transaction | undefined = initialPreviousData;
+    let pointer = 0;
 
     while (intervalStart < endTimestamp) {
       const intervalEnd = intervalStart + intervalDuration;
-      const intervalData = data.filter((record) => {
-        if (!record?.buy_price?.ae || (record?.buy_price?.ae as any) == 'NaN') {
-          return false;
-        }
-        const recordTime = record.created_at.getTime();
-        return recordTime >= intervalStart && recordTime < intervalEnd;
-      });
+
+      // Advance pointer past records before the current interval
+      while (
+        pointer < validData.length &&
+        validData[pointer].created_at.getTime() < intervalStart
+      ) {
+        pointer++;
+      }
+
+      // Collect records within [intervalStart, intervalEnd)
+      const intervalData: Transaction[] = [];
+      let scan = pointer;
+      while (
+        scan < validData.length &&
+        validData[scan].created_at.getTime() < intervalEnd
+      ) {
+        intervalData.push(validData[scan]);
+        scan++;
+      }
 
       if (intervalData.length) {
         const aggregatedData = this.aggregateIntervalData(
@@ -253,9 +282,6 @@ export class TransactionHistoryService {
             props,
           ),
         );
-      } else {
-        // Handle the case where there's no previous data and no interval data.
-        // For example, set a default value or continue.
       }
 
       intervalStart = intervalEnd;
@@ -268,7 +294,6 @@ export class TransactionHistoryService {
       }
       return item;
     });
-    // return result;
   }
 
   private aggregateIntervalData(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Multiple endpoints/services switch from per-row ORM loops to raw SQL aggregation and batched pagination, which is performance-positive but risks subtle query/ordering/count differences. Cache TTL semantics are also changed globally and across controllers, so incorrect units could impact caching behavior.
> 
> **Overview**
> **Performance-focused refactor across API + background jobs.** Several hot paths replace N+1 ORM loops with aggregated SQL and batched processing (e.g., account backfill, daily analytics, token ranking pages, DEX token/pair sync), and add stricter limits (`take`/batch sizes) on debug/fixup jobs.
> 
> **Token/account query improvements.** Token list owner filtering now uses a correlated `EXISTS` instead of building an `IN (...)` list, account token holdings fetch only queries relevant `aex9_address` rows, and `queryTokensWithRanks` now returns items + total count via a single CTE query while preserving pagination metadata.
> 
> **Portfolio/history + websocket robustness.** Portfolio price-history loading is extracted and parallelized with address/height resolution, transaction history caps rows and avoids repeated filtering via a single-pass pointer, and the websocket service adds proper teardown (`OnModuleDestroy`), bound handlers, `removeAllListeners()`, and structured logging.
> 
> **Caching updates.** Cache TTL values are normalized to millisecond-style constants across controllers and a global cache default TTL is set in `AppModule`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79e6541665e92822dd78ddfa5b8a0fd129940ce5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->