### PR TITLE
fix: return correct aeternity price

### DIFF
--- a/src/account/controllers/accounts.controller.ts
+++ b/src/account/controllers/accounts.controller.ts
@@ -77,6 +77,7 @@ export class AccountsController {
   })
   @ApiQuery({ name: 'order_direction', enum: ['ASC', 'DESC'], required: false })
   @ApiOperation({ operationId: 'listAll' })
+  @CacheTTL(60_000)
   @Get()
   async listAll(
     @Query('search') search: string | undefined,

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -46,7 +46,7 @@ import { AddressLinksModule } from './plugins/address-links/address-links.module
       useFactory: () => ({
         stores: [
           new Keyv({
-            store: new LRUCache<string, any>({ max: 2000, ttl: 60_000 }),
+            store: new LRUCache<string, any>({ max: 2000 }),
           }),
         ],
       }),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes global caching behavior by removing the shared LRU TTL, which can increase staleness or memory retention if other routes rely on implicit expiry. Limited code churn, but impacts cache semantics across the app.
> 
> **Overview**
> Adds a `@CacheTTL(60_000)` to the `AccountsController.listAll` endpoint so `GET /accounts` responses are cached for 60s.
> 
> Updates the global `CacheModule` Keyv/LRU configuration to remove the LRU-level `ttl`, shifting expiry control away from the cache store and onto per-endpoint TTL settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e23b05d5217a54a21c08218a375ca39a796371c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->