### PR TITLE
Release

### DIFF
--- a/src/account/controllers/accounts.controller.ts
+++ b/src/account/controllers/accounts.controller.ts
@@ -77,6 +77,7 @@ export class AccountsController {
   })
   @ApiQuery({ name: 'order_direction', enum: ['ASC', 'DESC'], required: false })
   @ApiOperation({ operationId: 'listAll' })
+  @CacheTTL(60_000)
   @Get()
   async listAll(
     @Query('search') search: string | undefined,

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -46,7 +46,7 @@ import { AddressLinksModule } from './plugins/address-links/address-links.module
       useFactory: () => ({
         stores: [
           new Keyv({
-            store: new LRUCache<string, any>({ max: 2000, ttl: 60_000 }),
+            store: new LRUCache<string, any>({ max: 2000 }),
           }),
         ],
       }),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes cache expiration behavior by removing the global in-memory LRU TTL and adding a per-endpoint TTL for `GET /accounts`, which could affect response freshness and memory usage under load.
> 
> **Overview**
> Adds a 60s cache TTL to the `AccountsController.listAll` (`GET /accounts`) endpoint.
> 
> Updates global cache configuration to remove the default `ttl` on the in-memory `LRUCache`, shifting expiration control away from the global store and toward per-route TTLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d6165ae2ebc5075139a45c4451659b33b76c112. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->