### PR TITLE
feat: be able to customize popular post feed

### DIFF
--- a/src/configs/constants.ts
+++ b/src/configs/constants.ts
@@ -210,6 +210,10 @@ export const TOKEN_LIST_ELIGIBILITY_CONFIG = {
   MIN_TRADES_ALL_TIME: 3,
 } as const;
 
+export const POPULAR_RANKING_WEIGHT_SCALES = ['low', 'med', 'high'] as const;
+export type PopularRankingWeightScale =
+  (typeof POPULAR_RANKING_WEIGHT_SCALES)[number];
+
 /**
  * Popular posts ranking configuration — "Top" style (no time decay).
  * Posts are ranked purely by accumulated engagement within the selected window.
@@ -228,6 +232,18 @@ export const POPULAR_RANKING_CONFIG = {
     trendingBoost: 0.5, // w_tr (topical relevance)
     contentQuality: 0.3, // w_q (anti-spam)
     reads: 1.5, // w_reads (common passive signal)
+  },
+
+  // user-facing scale controls tune relative importance instead of exposing raw weights
+  CUSTOMIZATION: {
+    SCALE_MULTIPLIERS: {
+      low: 0.6,
+      med: 1,
+      high: 1.5,
+    },
+    ADDITIONAL_SIGNAL_WEIGHTS: {
+      interactionsPerHour: 1.1,
+    },
   },
 
   // content quality params

--- a/src/social/controllers/posts.controller.ts
+++ b/src/social/controllers/posts.controller.ts
@@ -20,7 +20,7 @@ import { paginate } from 'nestjs-typeorm-paginate';
 import { Repository } from 'typeorm';
 import { Post } from '../entities/post.entity';
 import { PopularRankingService } from '../services/popular-ranking.service';
-import { PostDto } from '../dto';
+import { PopularPostsQueryDto, PostDto } from '../dto';
 import type { Request } from 'express';
 import { ReadsService } from '../services/reads.service';
 import { ApiOkResponsePaginated } from '@/utils/api-type';
@@ -368,41 +368,53 @@ export class PostsController {
     };
   }
 
-  @ApiQuery({ name: 'window', enum: ['24h', '7d', 'all'], required: false })
-  @ApiQuery({
-    name: 'debug',
-    type: 'number',
-    required: false,
-    description: 'Return feature breakdown when set to 1',
-  })
-  @ApiQuery({ name: 'page', type: 'number', required: false })
-  @ApiQuery({ name: 'limit', type: 'number', required: false })
   @ApiOperation({
     operationId: 'popular',
     summary: 'Popular posts',
     description:
-      'Returns top posts for selected time window (24h, 7d, all). Ranked by accumulated engagement — no time decay.',
+      'Returns top posts for selected time window (24h, 7d, all). Ranked by accumulated engagement — no time decay. Optional scale params let clients personalize signal importance.',
   })
   @ApiOkResponsePaginated(PostDto)
   @Get('popular')
-  async popular(
-    @Query('window') window: '24h' | '7d' | 'all' = '24h',
-    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page = 1,
-    @Query('limit', new DefaultValuePipe(50), ParseIntPipe) limit = 50,
-    @Query('debug') debug?: number,
-  ) {
+  async popular(@Query() query: PopularPostsQueryDto) {
+    const {
+      window = '24h',
+      page = 1,
+      limit = 50,
+      debug,
+      comments,
+      tipsAmountAE,
+      tipsCount,
+      uniqueTippers,
+      trendingBoost,
+      contentQuality,
+      reads,
+      interactionsPerHour,
+    } = query;
     const offset = (page - 1) * limit;
+    const weightOverrides = {
+      comments,
+      tipsAmountAE,
+      tipsCount,
+      uniqueTippers,
+      trendingBoost,
+      contentQuality,
+      reads,
+      interactionsPerHour,
+    };
     try {
-      // Get total count of popular posts for the given window
-      const totalItems =
-        await this.popularRankingService.getTotalPostsCount(window);
-      const totalPages = Math.ceil(totalItems / limit);
-
-      const rankedItems = await this.popularRankingService.getPopularPosts(
+      const {
+        items: rankedItems,
+        totalItems,
+        scoredItems,
+      } = await this.popularRankingService.getPopularPostsPage(
         window,
         limit,
         offset,
+        undefined,
+        weightOverrides,
       );
+      const totalPages = Math.ceil(totalItems / limit);
 
       const rankedPostIds = rankedItems
         .filter((item) => !this.isPluginContentItem(item))
@@ -451,10 +463,12 @@ export class PostsController {
         },
       };
       if (debug === 1) {
-        response.debug = await (this.popularRankingService as any).explain(
+        response.debug = await this.popularRankingService.explain(
           window,
           limit,
           offset,
+          weightOverrides,
+          scoredItems,
         );
       }
       return response;

--- a/src/social/dto/index.ts
+++ b/src/social/dto/index.ts
@@ -2,3 +2,4 @@ export { PostDto } from './post.dto';
 export { TopicDto } from './topic.dto';
 export { PostSenderDto } from './post-sender.dto';
 export { GiphyGifDto, GiphySearchResponseDto } from './giphy.dto';
+export { PopularPostsQueryDto } from './popular-posts-query.dto';

--- a/src/social/dto/popular-posts-query.dto.ts
+++ b/src/social/dto/popular-posts-query.dto.ts
@@ -1,0 +1,126 @@
+import { Type } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsIn, IsNumber, IsOptional, Max, Min } from 'class-validator';
+import {
+  POPULAR_RANKING_WEIGHT_SCALES,
+  type PopularRankingWeightScale,
+} from '@/configs/constants';
+import type { PopularWindow } from '../services/popular-ranking.service';
+
+export class PopularPostsQueryDto {
+  @ApiPropertyOptional({
+    enum: ['24h', '7d', 'all'],
+    description: 'Popular ranking time window',
+    default: '24h',
+  })
+  @IsOptional()
+  @IsIn(['24h', '7d', 'all'])
+  window?: PopularWindow = '24h';
+
+  @ApiPropertyOptional({
+    type: Number,
+    description: 'Page number',
+    default: 1,
+    minimum: 1,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  @Type(() => Number)
+  page?: number = 1;
+
+  @ApiPropertyOptional({
+    type: Number,
+    description: 'Page size',
+    default: 50,
+    minimum: 1,
+    maximum: 100,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  @Max(100)
+  @Type(() => Number)
+  limit?: number = 50;
+
+  @ApiPropertyOptional({
+    type: Number,
+    description: 'Return debug info when set to 1',
+  })
+  @IsOptional()
+  @IsNumber()
+  @Type(() => Number)
+  debug?: number;
+
+  @ApiPropertyOptional({
+    enum: POPULAR_RANKING_WEIGHT_SCALES,
+    description:
+      'Scale for comment impact (low = reduce, med = default, high = boost)',
+  })
+  @IsOptional()
+  @IsIn(POPULAR_RANKING_WEIGHT_SCALES)
+  comments?: PopularRankingWeightScale;
+
+  @ApiPropertyOptional({
+    enum: POPULAR_RANKING_WEIGHT_SCALES,
+    description:
+      'Scale for tipped amount impact (low = reduce, med = default, high = boost)',
+  })
+  @IsOptional()
+  @IsIn(POPULAR_RANKING_WEIGHT_SCALES)
+  tipsAmountAE?: PopularRankingWeightScale;
+
+  @ApiPropertyOptional({
+    enum: POPULAR_RANKING_WEIGHT_SCALES,
+    description:
+      'Scale for tip count impact (low = reduce, med = default, high = boost)',
+  })
+  @IsOptional()
+  @IsIn(POPULAR_RANKING_WEIGHT_SCALES)
+  tipsCount?: PopularRankingWeightScale;
+
+  @ApiPropertyOptional({
+    enum: POPULAR_RANKING_WEIGHT_SCALES,
+    description:
+      'Scale for unique tippers impact (low = reduce, med = default, high = boost)',
+  })
+  @IsOptional()
+  @IsIn(POPULAR_RANKING_WEIGHT_SCALES)
+  uniqueTippers?: PopularRankingWeightScale;
+
+  @ApiPropertyOptional({
+    enum: POPULAR_RANKING_WEIGHT_SCALES,
+    description:
+      'Scale for trending topic boost (low = reduce, med = default, high = boost)',
+  })
+  @IsOptional()
+  @IsIn(POPULAR_RANKING_WEIGHT_SCALES)
+  trendingBoost?: PopularRankingWeightScale;
+
+  @ApiPropertyOptional({
+    enum: POPULAR_RANKING_WEIGHT_SCALES,
+    description:
+      'Scale for content quality impact (low = reduce, med = default, high = boost)',
+  })
+  @IsOptional()
+  @IsIn(POPULAR_RANKING_WEIGHT_SCALES)
+  contentQuality?: PopularRankingWeightScale;
+
+  @ApiPropertyOptional({
+    enum: POPULAR_RANKING_WEIGHT_SCALES,
+    description:
+      'Scale for reads impact (low = reduce, med = default, high = boost)',
+  })
+  @IsOptional()
+  @IsIn(POPULAR_RANKING_WEIGHT_SCALES)
+  reads?: PopularRankingWeightScale;
+
+  @ApiPropertyOptional({
+    enum: POPULAR_RANKING_WEIGHT_SCALES,
+    description:
+      'Scale for active-engagement velocity using comments, tips, and unique tippers per hour (low = reduce, med = default, high = boost)',
+  })
+  @IsOptional()
+  @IsIn(POPULAR_RANKING_WEIGHT_SCALES)
+  interactionsPerHour?: PopularRankingWeightScale;
+}

--- a/src/social/services/popular-ranking.service.spec.ts
+++ b/src/social/services/popular-ranking.service.spec.ts
@@ -79,6 +79,7 @@ describe('PopularRankingService', () => {
         .fn()
         .mockReturnValueOnce(candidateQueryBuilder)
         .mockReturnValueOnce(commentQueryBuilder),
+      findBy: jest.fn().mockResolvedValue([]),
     };
     tipRepository = {
       createQueryBuilder: jest.fn().mockReturnValue(tipQueryBuilder),
@@ -165,5 +166,588 @@ describe('PopularRankingService', () => {
       'post.created_at >= :since',
       expect.objectContaining({ since: expect.any(Date) }),
     );
+  });
+
+  it('reorders personalized popular results by interactions per hour', async () => {
+    const now = Date.now();
+    const fastPost = {
+      id: 'post-fast',
+      sender_address: 'ak_fast',
+      created_at: new Date(now - 1 * 60 * 60 * 1000).toISOString(),
+      total_comments: 0,
+      content: 'fast',
+      topics: [],
+    };
+    const oldPost = {
+      id: 'post-old',
+      sender_address: 'ak_old',
+      created_at: new Date(now - 12 * 60 * 60 * 1000).toISOString(),
+      total_comments: 0,
+      content: 'old',
+      topics: [],
+    };
+    const candidateQueryBuilder = {
+      leftJoinAndSelect: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      getMany: jest.fn().mockResolvedValue([oldPost, fastPost]),
+    };
+    const tipQueryBuilder = {
+      select: jest.fn().mockReturnThis(),
+      innerJoin: jest.fn().mockReturnThis(),
+      addSelect: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      groupBy: jest.fn().mockReturnThis(),
+      getRawMany: jest.fn().mockResolvedValue([
+        {
+          post_id: 'post-old',
+          amount_sum: '0',
+          count: '2',
+          unique_tippers: '2',
+        },
+        {
+          post_id: 'post-fast',
+          amount_sum: '0',
+          count: '2',
+          unique_tippers: '2',
+        },
+      ]),
+    };
+    const commentQueryBuilder = {
+      innerJoin: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnThis(),
+      addSelect: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      groupBy: jest.fn().mockReturnThis(),
+      getRawMany: jest.fn().mockResolvedValue([
+        { parent_id: 'post-old', count: '4' },
+        { parent_id: 'post-fast', count: '4' },
+      ]),
+    };
+    const readsQueryBuilder = {
+      select: jest.fn().mockReturnThis(),
+      addSelect: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      groupBy: jest.fn().mockReturnThis(),
+      getRawMany: jest.fn().mockResolvedValue([
+        { post_id: 'post-old', reads: '10' },
+        { post_id: 'post-fast', reads: '10' },
+      ]),
+    };
+
+    postRepository = {
+      createQueryBuilder: jest
+        .fn()
+        .mockReturnValueOnce(candidateQueryBuilder)
+        .mockReturnValueOnce(commentQueryBuilder),
+      findBy: jest.fn().mockResolvedValue([oldPost, fastPost]),
+    };
+    tipRepository = {
+      createQueryBuilder: jest.fn().mockReturnValue(tipQueryBuilder),
+    };
+    postReadsRepository = {
+      createQueryBuilder: jest.fn().mockReturnValue(readsQueryBuilder),
+    };
+    service = new PopularRankingService(
+      postRepository as any,
+      tipRepository as any,
+      trendingTagRepository as any,
+      postReadsRepository as any,
+      [],
+    );
+
+    const result = await service.getPopularPostsPage('24h', 10, 0, undefined, {
+      interactionsPerHour: 'high',
+    });
+
+    expect(result.items.map((item) => item.id)).toEqual([
+      'post-fast',
+      'post-old',
+    ]);
+    expect(result.totalItems).toBe(2);
+  });
+
+  describe('getPopularPostsPage without overrides (Redis path)', () => {
+    it('delegates to the cached Redis path and returns totalItems', async () => {
+      const postA = {
+        id: 'post-a',
+        sender_address: 'ak_a',
+        content: 'a',
+        is_hidden: false,
+        post_id: null,
+      };
+      const postB = {
+        id: 'post-b',
+        sender_address: 'ak_b',
+        content: 'b',
+        is_hidden: false,
+        post_id: null,
+      };
+
+      redisMock.zcard.mockResolvedValue(2);
+      (redisMock as any).zrevrange = jest
+        .fn()
+        .mockResolvedValue(['post-a', '10', 'post-b', '5']);
+      postRepository.findBy = jest.fn().mockResolvedValue([postA, postB]);
+
+      const result = await service.getPopularPostsPage(
+        '24h',
+        10,
+        0,
+        undefined,
+        {},
+      );
+
+      expect(result.items.length).toBe(2);
+      expect(result.scoredItems).toBeUndefined();
+
+      redisMock.zcard.mockResolvedValue(1);
+    });
+  });
+
+  describe('resolveWeights', () => {
+    function buildServiceForWeightTests() {
+      const now = Date.now();
+      const post = {
+        id: 'post-w',
+        sender_address: 'ak_w',
+        created_at: new Date(now - 2 * 60 * 60 * 1000).toISOString(),
+        total_comments: 0,
+        content: 'weight test content that is long enough',
+        topics: [],
+      };
+      const candidateQB = {
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([post]),
+      };
+      const commentQB = {
+        innerJoin: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: jest
+          .fn()
+          .mockResolvedValue([{ parent_id: 'post-w', count: '5' }]),
+      };
+      const tipQB = {
+        select: jest.fn().mockReturnThis(),
+        innerJoin: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([
+          {
+            post_id: 'post-w',
+            amount_sum: '100',
+            count: '3',
+            unique_tippers: '2',
+          },
+        ]),
+      };
+      const readsQB = {
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: jest
+          .fn()
+          .mockResolvedValue([{ post_id: 'post-w', reads: '20' }]),
+      };
+
+      const repo = {
+        createQueryBuilder: jest
+          .fn()
+          .mockReturnValueOnce(candidateQB)
+          .mockReturnValueOnce(commentQB),
+        findBy: jest.fn().mockResolvedValue([post]),
+      };
+      const tipRepo = { createQueryBuilder: jest.fn().mockReturnValue(tipQB) };
+      const readsRepo = {
+        createQueryBuilder: jest.fn().mockReturnValue(readsQB),
+      };
+
+      return new PopularRankingService(
+        repo as any,
+        tipRepo as any,
+        trendingTagRepository as any,
+        readsRepo as any,
+        [],
+      );
+    }
+
+    it('applies multiple simultaneous overrides (comments=high, reads=low)', async () => {
+      const svc = buildServiceForWeightTests();
+      const result = await svc.getPopularPostsPage('24h', 10, 0, undefined, {
+        comments: 'high',
+        reads: 'low',
+      });
+
+      expect(result.totalItems).toBe(1);
+      expect(result.scoredItems).toBeDefined();
+      expect(result.scoredItems![0].score).toBeGreaterThan(0);
+    });
+
+    it('returns default ranking when all override values are undefined', async () => {
+      const svc = buildServiceForWeightTests();
+      const postW = { id: 'post-w', sender_address: 'ak_w', content: 'w' };
+      redisMock.zcard.mockResolvedValue(1);
+      (redisMock as any).zrevrange = jest
+        .fn()
+        .mockResolvedValue(['post-w', '10']);
+      (svc as any).postRepository.findBy = jest.fn().mockResolvedValue([postW]);
+
+      const result = await svc.getPopularPostsPage('24h', 10, 0, undefined, {
+        comments: undefined,
+        reads: undefined,
+      });
+
+      expect(result.scoredItems).toBeUndefined();
+
+      redisMock.zcard.mockResolvedValue(1);
+    });
+  });
+
+  describe('computeInteractionsPerHour edge cases', () => {
+    function buildServiceWith(post: any) {
+      const candidateQB = {
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([post]),
+      };
+      const commentQB = {
+        innerJoin: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: jest
+          .fn()
+          .mockResolvedValue([{ parent_id: post.id, count: '3' }]),
+      };
+      const tipQB = {
+        select: jest.fn().mockReturnThis(),
+        innerJoin: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([
+          {
+            post_id: post.id,
+            amount_sum: '0',
+            count: '1',
+            unique_tippers: '1',
+          },
+        ]),
+      };
+      const readsQB = {
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([]),
+      };
+
+      return new PopularRankingService(
+        {
+          createQueryBuilder: jest
+            .fn()
+            .mockReturnValueOnce(candidateQB)
+            .mockReturnValueOnce(commentQB),
+          findBy: jest.fn().mockResolvedValue([post]),
+        } as any,
+        { createQueryBuilder: jest.fn().mockReturnValue(tipQB) } as any,
+        { find: jest.fn().mockResolvedValue([]) } as any,
+        { createQueryBuilder: jest.fn().mockReturnValue(readsQB) } as any,
+        [],
+      );
+    }
+
+    it('handles future createdAt without negative scores', async () => {
+      const futurePost = {
+        id: 'post-future',
+        sender_address: 'ak_f',
+        created_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+        content: 'from the future',
+        topics: [],
+      };
+      const svc = buildServiceWith(futurePost);
+      const result = await svc.getPopularPostsPage('24h', 10, 0, undefined, {
+        interactionsPerHour: 'high',
+      });
+
+      expect(result.totalItems).toBe(1);
+      expect(result.scoredItems![0].score).toBeGreaterThanOrEqual(0);
+    });
+
+    it('handles invalid date string gracefully (interactionsPerHour = 0)', async () => {
+      const badDatePost = {
+        id: 'post-bad-date',
+        sender_address: 'ak_bad',
+        created_at: 'not-a-date',
+        content: 'bad date content',
+        topics: [],
+      };
+      const svc = buildServiceWith(badDatePost);
+      const result = await svc.getPopularPostsPage('24h', 10, 0, undefined, {
+        interactionsPerHour: 'high',
+      });
+
+      expect(result.totalItems).toBe(1);
+      expect(result.scoredItems![0].score).toBeGreaterThanOrEqual(0);
+    });
+
+    it('caps effectiveHours to window size for 24h window', async () => {
+      const now = Date.now();
+      const very_old_post = {
+        id: 'post-capped',
+        sender_address: 'ak_capped',
+        created_at: new Date(now - 48 * 60 * 60 * 1000).toISOString(),
+        content: 'old post that should be capped at 24h',
+        topics: [],
+      };
+      const recent_post = {
+        id: 'post-recent',
+        sender_address: 'ak_recent',
+        created_at: new Date(now - 2 * 60 * 60 * 1000).toISOString(),
+        content: 'recent post within window',
+        topics: [],
+      };
+
+      const candidateQB = {
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([very_old_post, recent_post]),
+      };
+      const commentQB = {
+        innerJoin: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([
+          { parent_id: 'post-capped', count: '5' },
+          { parent_id: 'post-recent', count: '5' },
+        ]),
+      };
+      const tipQB = {
+        select: jest.fn().mockReturnThis(),
+        innerJoin: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([
+          {
+            post_id: 'post-capped',
+            amount_sum: '0',
+            count: '2',
+            unique_tippers: '2',
+          },
+          {
+            post_id: 'post-recent',
+            amount_sum: '0',
+            count: '2',
+            unique_tippers: '2',
+          },
+        ]),
+      };
+      const readsQB = {
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([
+          { post_id: 'post-capped', reads: '10' },
+          { post_id: 'post-recent', reads: '10' },
+        ]),
+      };
+
+      const svc = new PopularRankingService(
+        {
+          createQueryBuilder: jest
+            .fn()
+            .mockReturnValueOnce(candidateQB)
+            .mockReturnValueOnce(commentQB),
+          findBy: jest.fn().mockResolvedValue([very_old_post, recent_post]),
+        } as any,
+        { createQueryBuilder: jest.fn().mockReturnValue(tipQB) } as any,
+        { find: jest.fn().mockResolvedValue([]) } as any,
+        { createQueryBuilder: jest.fn().mockReturnValue(readsQB) } as any,
+        [],
+      );
+
+      const result = await svc.getPopularPostsPage('24h', 10, 0, undefined, {
+        interactionsPerHour: 'high',
+      });
+
+      expect(result.scoredItems).toBeDefined();
+      expect(
+        result.scoredItems!.find((s) => s.postId === 'post-recent')!.score,
+      ).toBeGreaterThan(
+        result.scoredItems!.find((s) => s.postId === 'post-capped')!.score,
+      );
+    });
+  });
+
+  describe('pagination edge cases', () => {
+    it('returns empty items when offset exceeds total candidates', async () => {
+      const result = await service.getPopularPostsPage(
+        '24h',
+        10,
+        9999,
+        undefined,
+        {
+          comments: 'high',
+        },
+      );
+
+      expect(result.items).toEqual([]);
+      expect(result.totalItems).toBe(1);
+    });
+  });
+
+  describe('explain', () => {
+    it('returns unified shape with personalized flag for default path', async () => {
+      const post = {
+        id: 'post-explain',
+        tx_hash: 'tx_123',
+        sender_address: 'ak_explain',
+      };
+      (redisMock as any).zrevrange = jest
+        .fn()
+        .mockResolvedValue(['post-explain']);
+      postRepository.findBy = jest.fn().mockResolvedValue([post]);
+
+      const result = await service.explain('24h', 10, 0);
+
+      expect(result).toEqual([
+        expect.objectContaining({
+          id: 'post-explain',
+          tx: 'tx_123',
+          author: 'ak_explain',
+          personalized: false,
+          appliedWeights: expect.objectContaining({
+            comments: expect.any(Number),
+          }),
+        }),
+      ]);
+    });
+
+    it('returns unified shape with personalized flag for override path', async () => {
+      const post = {
+        id: 'post-p',
+        sender_address: 'ak_p',
+        tx_hash: 'tx_p',
+        created_at: new Date().toISOString(),
+        content: 'personalized',
+        topics: [],
+      };
+      const candidateQB = {
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([post]),
+      };
+      const commentQB = {
+        innerJoin: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([]),
+      };
+      const tipQB = {
+        select: jest.fn().mockReturnThis(),
+        innerJoin: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([]),
+      };
+      const readsQB = {
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([]),
+      };
+
+      const svc = new PopularRankingService(
+        {
+          createQueryBuilder: jest
+            .fn()
+            .mockReturnValueOnce(candidateQB)
+            .mockReturnValueOnce(commentQB),
+          findBy: jest.fn().mockResolvedValue([post]),
+        } as any,
+        { createQueryBuilder: jest.fn().mockReturnValue(tipQB) } as any,
+        { find: jest.fn().mockResolvedValue([]) } as any,
+        { createQueryBuilder: jest.fn().mockReturnValue(readsQB) } as any,
+        [],
+      );
+
+      const result = await svc.explain('24h', 10, 0, { comments: 'high' });
+
+      expect(result).toEqual([
+        expect.objectContaining({
+          id: 'post-p',
+          personalized: true,
+          appliedWeights: expect.objectContaining({
+            comments: expect.any(Number),
+            interactionsPerHour: expect.any(Number),
+          }),
+        }),
+      ]);
+    });
+
+    it('accepts precomputed scored items to avoid redundant computation', async () => {
+      const precomputed = [{ postId: 'post-1', score: 42, type: 'post' }];
+      postRepository.findBy = jest
+        .fn()
+        .mockResolvedValue([
+          { id: 'post-1', tx_hash: 'tx_1', sender_address: 'ak_1' },
+        ]);
+
+      const result = await service.explain(
+        '24h',
+        10,
+        0,
+        { comments: 'high' },
+        precomputed,
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('post-1');
+      expect(postRepository.createQueryBuilder).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/social/services/popular-ranking.service.ts
+++ b/src/social/services/popular-ranking.service.ts
@@ -4,7 +4,10 @@ import { In, Repository } from 'typeorm';
 import { Post } from '../entities/post.entity';
 import { Tip } from '@/tipping/entities/tip.entity';
 import { TrendingTag } from '@/trending-tags/entities/trending-tags.entity';
-import { POPULAR_RANKING_CONFIG } from '@/configs/constants';
+import {
+  POPULAR_RANKING_CONFIG,
+  type PopularRankingWeightScale,
+} from '@/configs/constants';
 import Redis from 'ioredis';
 import { REDIS_CONFIG } from '@/configs/redis';
 import { PostReadsDaily } from '../entities/post-reads.entity';
@@ -24,11 +27,51 @@ interface PopularScoreItem {
   metadata?: Record<string, any>;
 }
 
+type PopularCustomizableWeightKey =
+  | 'comments'
+  | 'tipsAmountAE'
+  | 'tipsCount'
+  | 'uniqueTippers'
+  | 'trendingBoost'
+  | 'contentQuality'
+  | 'reads'
+  | 'interactionsPerHour';
+
+export type PopularRankingWeightOverrides = Partial<
+  Record<PopularCustomizableWeightKey, PopularRankingWeightScale | undefined>
+>;
+
+type Mutable<T> = {
+  -readonly [K in keyof T]: T[K];
+};
+
+type PopularRankingResolvedWeights = Mutable<
+  typeof POPULAR_RANKING_CONFIG.WEIGHTS
+> & {
+  interactionsPerHour: number;
+};
+
+interface PopularScoreInput {
+  content: string;
+  comments: number;
+  tipsAmountAE: number;
+  tipsCount: number;
+  uniqueTippers: number;
+  reads: number;
+  topics?: Array<{ name?: string }>;
+  createdAt?: Date | string;
+}
+
 @Injectable()
 export class PopularRankingService {
   private readonly logger = new Logger(PopularRankingService.name);
   private readonly redis = new Redis(REDIS_CONFIG);
   private readonly recomputeInFlight = new Map<PopularWindow, Promise<void>>();
+  private trendingTagCache: {
+    map: Map<string, number>;
+    expiresAt: number;
+  } | null = null;
+  private static readonly TRENDING_CACHE_TTL_MS = 30_000;
 
   constructor(
     @InjectRepository(Post)
@@ -52,6 +95,51 @@ export class PopularRankingService {
       return POPULAR_RANKING_CONFIG.WINDOW_7D_HOURS;
     }
     return Number.MAX_SAFE_INTEGER;
+  }
+
+  private getDefaultMaxCandidates(window: PopularWindow): number {
+    return window === 'all'
+      ? POPULAR_RANKING_CONFIG.MAX_CANDIDATES_ALL
+      : window === '7d'
+        ? POPULAR_RANKING_CONFIG.MAX_CANDIDATES_7D
+        : POPULAR_RANKING_CONFIG.MAX_CANDIDATES_24H;
+  }
+
+  private hasWeightOverrides(
+    overrides?: PopularRankingWeightOverrides,
+  ): overrides is PopularRankingWeightOverrides {
+    return !!overrides && Object.values(overrides).some((value) => !!value);
+  }
+
+  private resolveWeights(
+    overrides?: PopularRankingWeightOverrides,
+  ): PopularRankingResolvedWeights {
+    const resolved: PopularRankingResolvedWeights = {
+      ...POPULAR_RANKING_CONFIG.WEIGHTS,
+      interactionsPerHour: 0,
+    };
+
+    if (!this.hasWeightOverrides(overrides)) {
+      return resolved;
+    }
+
+    const multipliers = POPULAR_RANKING_CONFIG.CUSTOMIZATION.SCALE_MULTIPLIERS;
+    for (const [key, value] of Object.entries(overrides)) {
+      if (!value) {
+        continue;
+      }
+
+      const multiplier = multipliers[value];
+      if (key === 'interactionsPerHour') {
+        resolved.interactionsPerHour =
+          POPULAR_RANKING_CONFIG.CUSTOMIZATION.ADDITIONAL_SIGNAL_WEIGHTS
+            .interactionsPerHour * multiplier;
+      } else if (key in resolved) {
+        (resolved as Record<string, number>)[key] *= multiplier;
+      }
+    }
+
+    return resolved;
   }
 
   private getRedisKey(window: PopularWindow): string {
@@ -214,12 +302,7 @@ export class PopularRankingService {
       return;
     }
 
-    const fallbackMax =
-      window === 'all'
-        ? POPULAR_RANKING_CONFIG.MAX_CANDIDATES_ALL
-        : window === '7d'
-          ? POPULAR_RANKING_CONFIG.MAX_CANDIDATES_7D
-          : POPULAR_RANKING_CONFIG.MAX_CANDIDATES_24H;
+    const fallbackMax = this.getDefaultMaxCandidates(window);
 
     const task = this.recompute(window, maxCandidates ?? fallbackMax)
       .catch((error) =>
@@ -231,27 +314,17 @@ export class PopularRankingService {
     await task;
   }
 
-  async getPopularPosts(
+  private async hydrateRankedItems(
     window: PopularWindow,
-    limit = 50,
-    offset = 0,
-    maxCandidates?: number,
+    ids: string[],
   ): Promise<(Post | PopularRankingContentItem)[]> {
-    const verifiedIds = await this.getVerifiedPopularIds(window, maxCandidates);
-
-    if (verifiedIds.length === 0) {
-      return this.fetchRecentFallback(window, limit, offset);
-    }
-
-    const paginatedIds = verifiedIds.slice(offset, offset + limit);
-
-    if (paginatedIds.length === 0) {
+    if (ids.length === 0) {
       return [];
     }
 
     const postIds: string[] = [];
     const pluginContentIds: string[] = [];
-    for (const id of paginatedIds) {
+    for (const id of ids) {
       if (id.includes(':')) {
         pluginContentIds.push(id);
       } else {
@@ -279,17 +352,18 @@ export class PopularRankingService {
         itemsByType.get(type)!.push(id);
       }
 
+      const since =
+        window === 'all'
+          ? null
+          : new Date(Date.now() - this.getWindowHours(window) * 60 * 60 * 1000);
+
       for (const contributor of this.rankingContributors) {
         const typeIds = itemsByType.get(contributor.name);
         if (typeIds && typeIds.length > 0) {
           try {
             const allItems = await contributor.getRankingCandidates(
               window,
-              window === 'all'
-                ? null
-                : new Date(
-                    Date.now() - this.getWindowHours(window) * 60 * 60 * 1000,
-                  ),
+              since,
               10000,
             );
             const requestedItems = allItems.filter((item) =>
@@ -308,21 +382,77 @@ export class PopularRankingService {
 
     const postsMap = new Map(posts.map((p) => [p.id, p]));
     const pluginItemsMap = new Map(pluginItems.map((item) => [item.id, item]));
-
     const result: (Post | PopularRankingContentItem)[] = [];
-    for (const id of paginatedIds) {
+    for (const id of ids) {
       const post = postsMap.get(id);
       if (post) {
         result.push(post);
-      } else {
-        const item = pluginItemsMap.get(id);
-        if (item) {
-          result.push(item);
-        }
+        continue;
+      }
+
+      const item = pluginItemsMap.get(id);
+      if (item) {
+        result.push(item);
       }
     }
 
     return result;
+  }
+
+  async getPopularPosts(
+    window: PopularWindow,
+    limit = 50,
+    offset = 0,
+    maxCandidates?: number,
+  ): Promise<(Post | PopularRankingContentItem)[]> {
+    const verifiedIds = await this.getVerifiedPopularIds(window, maxCandidates);
+
+    if (verifiedIds.length === 0) {
+      return this.fetchRecentFallback(window, limit, offset);
+    }
+
+    return this.hydrateRankedItems(
+      window,
+      verifiedIds.slice(offset, offset + limit),
+    );
+  }
+
+  async getPopularPostsPage(
+    window: PopularWindow,
+    limit = 50,
+    offset = 0,
+    maxCandidates?: number,
+    weightOverrides?: PopularRankingWeightOverrides,
+  ): Promise<{
+    items: (Post | PopularRankingContentItem)[];
+    totalItems: number;
+    scoredItems?: PopularScoreItem[];
+  }> {
+    if (!this.hasWeightOverrides(weightOverrides)) {
+      const totalItems = await this.getTotalPostsCount(window);
+      const items = await this.getPopularPosts(
+        window,
+        limit,
+        offset,
+        maxCandidates,
+      );
+      return { items, totalItems };
+    }
+
+    const scored = await this.buildScoredItems(
+      window,
+      maxCandidates ?? this.getDefaultMaxCandidates(window),
+      weightOverrides,
+    );
+    const paginatedIds = scored
+      .slice(offset, offset + limit)
+      .map((item) => item.postId);
+
+    return {
+      items: await this.hydrateRankedItems(window, paginatedIds),
+      totalItems: scored.length,
+      scoredItems: scored,
+    };
   }
 
   async getTotalCached(window: PopularWindow): Promise<number | undefined> {
@@ -350,21 +480,13 @@ export class PopularRankingService {
     }
   }
 
-  async recompute(window: PopularWindow, maxCandidates = 10000): Promise<void> {
-    const key = this.getRedisKey(window);
+  private async buildScoredItems(
+    window: PopularWindow,
+    maxCandidates = 10000,
+    weightOverrides?: PopularRankingWeightOverrides,
+  ): Promise<PopularScoreItem[]> {
     const hours = this.getWindowHours(window);
     const since = new Date(Date.now() - hours * 60 * 60 * 1000);
-
-    this.logger.log(
-      `Starting recompute for window ${window} with maxCandidates ${maxCandidates}, key=${key}`,
-    );
-
-    try {
-      await this.redis.ping();
-    } catch (error) {
-      this.logger.error(`Redis connection error:`, error);
-      throw error;
-    }
 
     const candidates = await this.postRepository
       .createQueryBuilder('post')
@@ -408,14 +530,6 @@ export class PopularRankingService {
       `Found ${pluginContentItems.length} plugin content items for window ${window}`,
     );
 
-    if (candidates.length === 0 && pluginContentItems.length === 0) {
-      await this.redis.del(key);
-      this.logger.warn(
-        `No candidates found for window ${window}, deleted Redis key`,
-      );
-      return;
-    }
-
     if (candidates.length > 0) {
       this.logger.log(
         `First 5 candidate IDs: ${candidates
@@ -425,126 +539,163 @@ export class PopularRankingService {
       );
     }
 
-    // Preload tips per post
     const ids = candidates.map((c) => c.id);
-    const tipsRaw = await this.tipRepository
-      .createQueryBuilder('tip')
-      .select('tip.post_id', 'post_id')
-      .innerJoin(Post, 'post', 'post.id = tip.post_id')
-      .addSelect('COALESCE(SUM(CAST(tip.amount AS numeric)), 0)', 'amount_sum')
-      .addSelect('COUNT(*)', 'count')
-      .addSelect('COUNT(DISTINCT tip.sender_address)', 'unique_tippers')
-      .where('tip.post_id IN (:...ids)', { ids })
-      .andWhere('tip.sender_address != post.sender_address')
-      .groupBy('tip.post_id')
-      .getRawMany<{
-        post_id: string;
-        amount_sum: string;
-        count: string;
-        unique_tippers: string;
-      }>();
-    const tipsByPost = new Map(tipsRaw.map((t) => [t.post_id, t] as const));
+    let tipsByPost = new Map<string, any>();
+    let commentsByPost = new Map<string, number>();
+    let readsByPost = new Map<string, number>();
 
-    // Preload comment counts excluding the post author's own replies
-    const commentsRaw = await this.postRepository
-      .createQueryBuilder('comment')
-      .innerJoin(Post, 'parent', 'parent.id = comment.post_id')
-      .select('comment.post_id', 'parent_id')
-      .addSelect('COUNT(*)', 'count')
-      .where('comment.post_id IN (:...ids)', { ids })
-      .andWhere('comment.is_hidden = false')
-      .andWhere('comment.sender_address != parent.sender_address')
-      .groupBy('comment.post_id')
-      .getRawMany<{ parent_id: string; count: string }>();
-    const commentsByPost = new Map(
-      commentsRaw.map(
-        (r) => [r.parent_id, parseInt(r.count || '0', 10)] as const,
-      ),
-    );
+    if (ids.length > 0) {
+      const tipsRaw = await this.tipRepository
+        .createQueryBuilder('tip')
+        .select('tip.post_id', 'post_id')
+        .innerJoin(Post, 'post', 'post.id = tip.post_id')
+        .addSelect(
+          'COALESCE(SUM(CAST(tip.amount AS numeric)), 0)',
+          'amount_sum',
+        )
+        .addSelect('COUNT(*)', 'count')
+        .addSelect('COUNT(DISTINCT tip.sender_address)', 'unique_tippers')
+        .where('tip.post_id IN (:...ids)', { ids })
+        .andWhere('tip.sender_address != post.sender_address')
+        .groupBy('tip.post_id')
+        .getRawMany<{
+          post_id: string;
+          amount_sum: string;
+          count: string;
+          unique_tippers: string;
+        }>();
+      tipsByPost = new Map(tipsRaw.map((t) => [t.post_id, t] as const));
+
+      const commentsRaw = await this.postRepository
+        .createQueryBuilder('comment')
+        .innerJoin(Post, 'parent', 'parent.id = comment.post_id')
+        .select('comment.post_id', 'parent_id')
+        .addSelect('COUNT(*)', 'count')
+        .where('comment.post_id IN (:...ids)', { ids })
+        .andWhere('comment.is_hidden = false')
+        .andWhere('comment.sender_address != parent.sender_address')
+        .groupBy('comment.post_id')
+        .getRawMany<{ parent_id: string; count: string }>();
+      commentsByPost = new Map(
+        commentsRaw.map(
+          (r) => [r.parent_id, parseInt(r.count || '0', 10)] as const,
+        ),
+      );
+
+      const fromDate = new Date(Date.now() - hours * 3600 * 1000);
+      const fromDateOnly = `${fromDate.getUTCFullYear()}-${String(
+        fromDate.getUTCMonth() + 1,
+      ).padStart(2, '0')}-${String(fromDate.getUTCDate()).padStart(2, '0')}`;
+      const readsQB = this.postReadsRepository
+        .createQueryBuilder('r')
+        .select('r.post_id', 'post_id')
+        .addSelect('COALESCE(SUM(r.reads), 0)', 'reads')
+        .where('r.post_id IN (:...ids)', { ids });
+      if (window !== 'all') {
+        readsQB.andWhere('r.date >= :from', { from: fromDateOnly });
+      }
+      const readsRows = await readsQB
+        .groupBy('r.post_id')
+        .getRawMany<{ post_id: string; reads: string }>();
+      readsByPost = new Map(
+        readsRows.map(
+          (r) => [r.post_id, parseInt(r.reads || '0', 10)] as const,
+        ),
+      );
+    }
 
     const trendingByTag = await this.loadTrendingByTagMap();
+    const resolvedWeights = this.resolveWeights(weightOverrides);
 
-    // Preload reads over window per post
-    const fromDate = new Date(Date.now() - hours * 3600 * 1000);
-    const fromDateOnly = `${fromDate.getUTCFullYear()}-${String(
-      fromDate.getUTCMonth() + 1,
-    ).padStart(2, '0')}-${String(fromDate.getUTCDate()).padStart(2, '0')}`;
-    const readsQB = this.postReadsRepository
-      .createQueryBuilder('r')
-      .select('r.post_id', 'post_id')
-      .addSelect('COALESCE(SUM(r.reads), 0)', 'reads')
-      .where('r.post_id IN (:...ids)', { ids });
-    if (window !== 'all') {
-      readsQB.andWhere('r.date >= :from', { from: fromDateOnly });
-    }
-    const readsRows = await readsQB
-      .groupBy('r.post_id')
-      .getRawMany<{ post_id: string; reads: string }>();
-    const readsByPost = new Map(
-      readsRows.map((r) => [r.post_id, parseInt(r.reads || '0', 10)] as const),
-    );
-
-    // Score posts
     const scoredPosts: PopularScoreItem[] = candidates.map((post) => {
       const tipsAgg = tipsByPost.get(post.id);
       return {
         postId: post.id,
-        score: this.computeScore(trendingByTag, {
-          content: post.content,
-          comments: commentsByPost.get(post.id) || 0,
-          tipsAmountAE: tipsAgg ? parseFloat(tipsAgg.amount_sum || '0') : 0,
-          tipsCount: tipsAgg ? parseInt(tipsAgg.count || '0', 10) : 0,
-          uniqueTippers: tipsAgg
-            ? parseInt(tipsAgg.unique_tippers || '0', 10)
-            : 0,
-          reads: readsByPost.get(post.id) || 0,
-          topics: post.topics,
-        }),
+        score: this.computeScore(
+          trendingByTag,
+          {
+            content: post.content,
+            comments: commentsByPost.get(post.id) || 0,
+            tipsAmountAE: tipsAgg ? parseFloat(tipsAgg.amount_sum || '0') : 0,
+            tipsCount: tipsAgg ? parseInt(tipsAgg.count || '0', 10) : 0,
+            uniqueTippers: tipsAgg
+              ? parseInt(tipsAgg.unique_tippers || '0', 10)
+              : 0,
+            reads: readsByPost.get(post.id) || 0,
+            topics: post.topics,
+            createdAt: post.created_at,
+          },
+          resolvedWeights,
+          window,
+        ),
         type: 'post',
       };
     });
 
-    // Score plugin content items
     const scoredPluginItems: PopularScoreItem[] = pluginContentItems.map(
       (item) => ({
         postId: item.id,
-        score: this.computeScore(trendingByTag, {
-          content: item.content,
-          comments: item.total_comments || 0,
-          tipsAmountAE: 0,
-          tipsCount: 0,
-          uniqueTippers: 0,
-          reads: 0,
-          topics: item.topics,
-        }),
+        score: this.computeScore(
+          trendingByTag,
+          {
+            content: item.content,
+            comments: item.total_comments || 0,
+            tipsAmountAE: 0,
+            tipsCount: 0,
+            uniqueTippers: 0,
+            reads: 0,
+            topics: item.topics,
+            createdAt: item.created_at,
+          },
+          resolvedWeights,
+          window,
+        ),
         type: item.type,
         metadata: item.metadata,
       }),
     );
 
-    const scored = [...scoredPosts, ...scoredPluginItems];
+    return [...scoredPosts, ...scoredPluginItems].sort(
+      (a, b) => b.score - a.score,
+    );
+  }
+
+  async recompute(window: PopularWindow, maxCandidates = 10000): Promise<void> {
+    const key = this.getRedisKey(window);
+
+    this.logger.log(
+      `Starting recompute for window ${window} with maxCandidates ${maxCandidates}, key=${key}`,
+    );
+
+    try {
+      await this.redis.ping();
+    } catch (error) {
+      this.logger.error(`Redis connection error:`, error);
+      throw error;
+    }
+
+    const scored = await this.buildScoredItems(window, maxCandidates);
+
+    if (scored.length === 0) {
+      await this.redis.del(key);
+      this.logger.warn(
+        `No candidates found for window ${window}, deleted Redis key`,
+      );
+      return;
+    }
 
     this.logger.log(
       `Window ${window}: ${scored.length} posts scored, all eligible (no score floor)`,
     );
 
-    if (scored.length > 0) {
-      const topScores = scored
-        .sort((a, b) => b.score - a.score)
-        .slice(0, 5)
-        .map((s) => `${s.postId}:${s.score.toFixed(4)}`)
-        .join(', ');
-      this.logger.log(`Top 5 scores: ${topScores}`);
-    }
+    const topScores = scored
+      .slice(0, 5)
+      .map((s) => `${s.postId}:${s.score.toFixed(4)}`)
+      .join(', ');
+    this.logger.log(`Top 5 scores: ${topScores}`);
 
-    // Cache in Redis ZSET
     try {
       await this.redis.del(key);
-
-      if (scored.length === 0) {
-        this.logger.warn(`No posts to cache for window ${window}`);
-        return;
-      }
 
       const pipeline = this.redis.pipeline();
       for (const item of scored) {
@@ -592,28 +743,61 @@ export class PopularRankingService {
   }
 
   private async loadTrendingByTagMap(): Promise<Map<string, number>> {
+    if (this.trendingTagCache && Date.now() < this.trendingTagCache.expiresAt) {
+      return this.trendingTagCache.map;
+    }
+
     let trending: TrendingTag[] = [];
     try {
       trending = await this.trendingTagRepository.find();
     } catch {
       trending = [];
     }
-    return new Map(
+    const map = new Map(
       trending.map((t) => [t.tag.toLowerCase(), t.score] as const),
+    );
+    this.trendingTagCache = {
+      map,
+      expiresAt: Date.now() + PopularRankingService.TRENDING_CACHE_TTL_MS,
+    };
+    return map;
+  }
+
+  private computeInteractionsPerHour(
+    input: PopularScoreInput,
+    window: PopularWindow,
+  ): number {
+    const createdAt =
+      input.createdAt instanceof Date
+        ? input.createdAt
+        : input.createdAt
+          ? new Date(input.createdAt)
+          : null;
+
+    if (!createdAt || Number.isNaN(createdAt.getTime())) {
+      return 0;
+    }
+
+    const ageHours = Math.max(
+      1,
+      (Date.now() - createdAt.getTime()) / (60 * 60 * 1000),
+    );
+    const effectiveHours =
+      window === 'all'
+        ? ageHours
+        : Math.min(ageHours, this.getWindowHours(window));
+
+    return (
+      (input.comments + input.tipsCount + input.uniqueTippers) /
+      Math.max(1, effectiveHours)
     );
   }
 
   private computeScore(
     trendingByTag: Map<string, number>,
-    input: {
-      content: string;
-      comments: number;
-      tipsAmountAE: number;
-      tipsCount: number;
-      uniqueTippers: number;
-      reads: number;
-      topics?: Array<{ name?: string }>;
-    },
+    input: PopularScoreInput,
+    weights: PopularRankingResolvedWeights,
+    window: PopularWindow,
   ): number {
     const { comments, tipsAmountAE, tipsCount, uniqueTippers, reads } = input;
 
@@ -633,35 +817,66 @@ export class PopularRankingService {
     }
 
     const contentQuality = this.computeContentQuality(input.content || '');
-    const w = POPULAR_RANKING_CONFIG.WEIGHTS;
+    const interactionsPerHour = this.computeInteractionsPerHour(input, window);
 
     return (
-      w.comments * Math.log(1 + comments) +
-      w.tipsAmountAE * Math.log(1 + tipsAmountAE) +
-      w.tipsCount * Math.log(1 + tipsCount) +
-      w.uniqueTippers * Math.log(1 + uniqueTippers) +
-      w.reads * Math.log(1 + reads) +
-      w.trendingBoost * trendingBoost +
-      w.contentQuality * contentQuality
+      weights.comments * Math.log(1 + comments) +
+      weights.tipsAmountAE * Math.log(1 + tipsAmountAE) +
+      weights.tipsCount * Math.log(1 + tipsCount) +
+      weights.uniqueTippers * Math.log(1 + uniqueTippers) +
+      weights.reads * Math.log(1 + reads) +
+      weights.trendingBoost * trendingBoost +
+      weights.contentQuality * contentQuality +
+      weights.interactionsPerHour * Math.log(1 + interactionsPerHour)
     );
   }
 
-  async explain(window: PopularWindow, limit = 20, offset = 0) {
-    const key = this.getRedisKey(window);
-    const ids = await this.redis.zrevrange(key, offset, offset + limit - 1);
-    const posts = ids.length
-      ? await this.postRepository.findBy({ id: In(ids) })
-      : await this.postRepository
-          .createQueryBuilder('post')
-          .where('post.is_hidden = false')
-          .andWhere('post.post_id IS NULL')
-          .orderBy('post.created_at', 'DESC')
-          .limit(limit)
-          .getMany();
-    return posts.map((p) => ({
-      id: p.id,
-      tx: p.tx_hash,
-      author: p.sender_address,
+  async explain(
+    window: PopularWindow,
+    limit = 20,
+    offset = 0,
+    weightOverrides?: PopularRankingWeightOverrides,
+    precomputedScored?: PopularScoreItem[],
+  ) {
+    const personalized = this.hasWeightOverrides(weightOverrides);
+    const appliedWeights = personalized
+      ? this.resolveWeights(weightOverrides)
+      : this.resolveWeights();
+
+    let items: (Post | PopularRankingContentItem)[];
+
+    if (personalized) {
+      const scored =
+        precomputedScored ??
+        (await this.buildScoredItems(
+          window,
+          this.getDefaultMaxCandidates(window),
+          weightOverrides,
+        ));
+      const ids = scored
+        .slice(offset, offset + limit)
+        .map((item) => item.postId);
+      items = await this.hydrateRankedItems(window, ids);
+    } else {
+      const key = this.getRedisKey(window);
+      const ids = await this.redis.zrevrange(key, offset, offset + limit - 1);
+      items = ids.length
+        ? await this.postRepository.findBy({ id: In(ids) })
+        : await this.postRepository
+            .createQueryBuilder('post')
+            .where('post.is_hidden = false')
+            .andWhere('post.post_id IS NULL')
+            .orderBy('post.created_at', 'DESC')
+            .limit(limit)
+            .getMany();
+    }
+
+    return items.map((item) => ({
+      id: item.id,
+      tx: 'tx_hash' in item ? item.tx_hash : undefined,
+      author: item.sender_address,
+      personalized,
+      appliedWeights,
     }));
   }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new query parameters that change the popular feed ranking algorithm and pagination behavior when overrides are used, which can affect feed ordering and performance. Risk is moderate due to new scoring logic (including velocity signal) and new code paths bypassing Redis caching.
> 
> **Overview**
> **Popular posts can now be personalized via query params.** The `GET /posts/popular` endpoint switches to a validated `PopularPostsQueryDto` and accepts per-signal scale overrides (`low|med|high`) plus an optional `interactionsPerHour` velocity boost.
> 
> **Ranking computation is extended and conditional.** `PopularRankingService` adds weight resolution/multipliers, a new `getPopularPostsPage` API that returns `totalItems` (and optional `scoredItems`), and a new scoring term based on interactions per hour; when overrides are present it recomputes scores on-demand instead of using the Redis ZSET.
> 
> **Perf/behavior adjustments & tests.** Trending tag lookups are cached briefly in-memory, `explain` now supports override/debug output and can reuse precomputed scores, and the spec suite adds coverage for overrides, velocity edge cases, pagination behavior, and default-vs-personalized paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39750dd862d1f08e2d820f3f4436ced9d3ac6bae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->