### PR TITLE
Release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -156,16 +156,16 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "19.2.22",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.22.tgz",
-      "integrity": "sha512-OqN/Ded+ZKypPZN5+qUFwtnKGl7FKpxJXYO2Vts5vLBojY5goCZd9SGW1CyXeuPnisRUW+vjqBQbWYuEUh36Tw==",
+      "version": "19.2.24",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.24.tgz",
+      "integrity": "sha512-Kd49warf6U/EyWe5BszF/eebN3zQ3bk7tgfEljAw8q/rX95UUtriJubWvp6pgzHfzBA4jwq8f+QiNZB8eBEXPA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "8.18.0",
         "ajv-formats": "3.0.1",
         "jsonc-parser": "3.3.1",
-        "picomatch": "4.0.2",
+        "picomatch": "4.0.4",
         "rxjs": "7.8.1",
         "source-map": "0.7.4"
       },
@@ -194,13 +194,13 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "19.2.22",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-19.2.22.tgz",
-      "integrity": "sha512-tvfu5jhem1o8qidVxvXe5KfCij65ioMLCOFA947DD+zb3yTl5pJyDm2dqzbOehuQw0fmH4XPQukRJsCUy+UwaA==",
+      "version": "19.2.24",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-19.2.24.tgz",
+      "integrity": "sha512-lnw+ZM1Io+cJAkReC0NPDjqObL8NtKzKIkdgEEKC8CUmkhurYhedbicN8Y8NYHgG1uLd2GozW3+/QqPRZaN+Lw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "19.2.22",
+        "@angular-devkit/core": "19.2.24",
         "jsonc-parser": "3.3.1",
         "magic-string": "0.30.17",
         "ora": "5.4.1",
@@ -213,14 +213,14 @@
       }
     },
     "node_modules/@angular-devkit/schematics-cli": {
-      "version": "19.2.22",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics-cli/-/schematics-cli-19.2.22.tgz",
-      "integrity": "sha512-6BvkxDz4nV8B6Ha4n/pYZ503vXgLxMaEpcKsFDao1sl0iSwrIOphlIS1yWprlGdCThIM3aJref1JU13ZvEcBCA==",
+      "version": "19.2.24",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics-cli/-/schematics-cli-19.2.24.tgz",
+      "integrity": "sha512-bsStZQG67J1HBqTmWxtIcobvgrn32L4UOdL7hGyOru5VxDWPNA8pRnDYavT3hnJeBkJYPoQIw8u7Dm0ecoQprw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "19.2.22",
-        "@angular-devkit/schematics": "19.2.22",
+        "@angular-devkit/core": "19.2.24",
+        "@angular-devkit/schematics": "19.2.24",
         "@inquirer/prompts": "7.3.2",
         "ansi-colors": "4.1.3",
         "symbol-observable": "4.0.0",
@@ -1218,36 +1218,36 @@
       }
     },
     "node_modules/@bull-board/api": {
-      "version": "6.20.6",
-      "resolved": "https://registry.npmjs.org/@bull-board/api/-/api-6.20.6.tgz",
-      "integrity": "sha512-B/9OlKWJ/He421Lyuc7htMpKN4R8hcNu5uoIRiyh9y9J0kMOfxfs82GKXdfR9R0595LvAcCOSvjn8EtWHXesTA==",
+      "version": "6.21.3",
+      "resolved": "https://registry.npmjs.org/@bull-board/api/-/api-6.21.3.tgz",
+      "integrity": "sha512-FoQO+0MgZsPrQX9WLZx0KpINamJY48FUU+OyMcZxx9mQWCwsdak45V/uBgQrTYB3GaF5oGA0SxPXEp4RHwj36A==",
       "license": "MIT",
       "dependencies": {
         "redis-info": "^3.1.0"
       },
       "peerDependencies": {
-        "@bull-board/ui": "6.20.6"
+        "@bull-board/ui": "6.21.3"
       }
     },
     "node_modules/@bull-board/express": {
-      "version": "6.20.6",
-      "resolved": "https://registry.npmjs.org/@bull-board/express/-/express-6.20.6.tgz",
-      "integrity": "sha512-QBOjhi3jR4qIJvLCo++DdL0CyG4umiFXBCPJYr74DmRN41m27rDS3NSf7ceHdbQr9Ol8mw3xbVqGLn50x3QdWQ==",
+      "version": "6.21.3",
+      "resolved": "https://registry.npmjs.org/@bull-board/express/-/express-6.21.3.tgz",
+      "integrity": "sha512-9tE5osCSjjDYCJtTt/bOeXGbykPlhiIKtlGG3/YPCuvQ3qkYrjdBiXSzEUXGqqgX6Kf4HVri/UuY8gy99g/A7w==",
       "license": "MIT",
       "dependencies": {
-        "@bull-board/api": "6.20.6",
-        "@bull-board/ui": "6.20.6",
-        "ejs": "^3.1.10",
+        "@bull-board/api": "6.21.3",
+        "@bull-board/ui": "6.21.3",
+        "ejs": "^5.0.2",
         "express": "^5.2.1"
       }
     },
     "node_modules/@bull-board/ui": {
-      "version": "6.20.6",
-      "resolved": "https://registry.npmjs.org/@bull-board/ui/-/ui-6.20.6.tgz",
-      "integrity": "sha512-nEXRgMHHd48ssINgvDqT7b4p/+57XRf3CUcTGQ7UIJb4F7n/kRRj8+ZQvQmMFsYGdNmbNU2eNheQ05vXSYiqdQ==",
+      "version": "6.21.3",
+      "resolved": "https://registry.npmjs.org/@bull-board/ui/-/ui-6.21.3.tgz",
+      "integrity": "sha512-s/PLBJab8cnoQAGVqjQb0v4oGe0KgB4aQ5G5g93doxzXB/D+wkXNL9P9+zLWLldBJXE57jL4CR99ttDCIiyNHw==",
       "license": "MIT",
       "dependencies": {
-        "@bull-board/api": "6.20.6"
+        "@bull-board/api": "6.21.3"
       }
     },
     "node_modules/@cacheable/utils": {
@@ -1366,9 +1366,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1458,12 +1458,13 @@
       }
     },
     "node_modules/@graphql-tools/merge": {
-      "version": "9.1.7",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.1.7.tgz",
-      "integrity": "sha512-Y5E1vTbTabvcXbkakdFUt4zUIzB1fyaEnVmIWN0l0GMed2gdD01TpZWLUm4RNAxpturvolrb24oGLQrBbPLSoQ==",
+      "version": "9.1.8",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.1.8.tgz",
+      "integrity": "sha512-25V7WDrODo1cPrmuUCrqf5qlMA4a/Ow4aHaqJ1MnTUaluwsV3UiqzCHWux3HSLb0H63mkoZiuOrU5xJhxRcoCg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@graphql-tools/utils": "^11.0.0",
+        "@graphql-tools/utils": "^11.0.1",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -1474,13 +1475,14 @@
       }
     },
     "node_modules/@graphql-tools/schema": {
-      "version": "10.0.31",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.31.tgz",
-      "integrity": "sha512-ZewRgWhXef6weZ0WiP7/MV47HXiuFbFpiDUVLQl6mgXsWSsGELKFxQsyUCBos60Qqy1JEFAIu3Ns6GGYjGkqkQ==",
+      "version": "10.0.32",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.32.tgz",
+      "integrity": "sha512-kJ1Qn20MPnlaEVH37639E6rzQ1tEtr6XTUhNdR4EKydl+FijtLhWX2WLZbGnvrYuG8XUcMxsZU9mRRYYNvK02w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@graphql-tools/merge": "^9.1.7",
-        "@graphql-tools/utils": "^11.0.0",
+        "@graphql-tools/merge": "^9.1.8",
+        "@graphql-tools/utils": "^11.0.1",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -1491,10 +1493,11 @@
       }
     },
     "node_modules/@graphql-tools/utils": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-11.0.0.tgz",
-      "integrity": "sha512-bM1HeZdXA2C3LSIeLOnH/bcqSgbQgKEDrjxODjqi3y58xai2TkNrtYcQSoWzGbt9VMN1dORGjR7Vem8SPnUFQA==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-11.0.1.tgz",
+      "integrity": "sha512-pNyCOb95ab/z3zkkiPwIPYxigX7IcpyFVcgD1XACDEvg/7yGnKCESx3k/XHEeneKYx/aWKGzEh/uuf6M6Q8HOw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
         "@whatwg-node/promise-helpers": "^1.0.0",
@@ -1534,9 +1537,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2149,9 +2152,9 @@
       }
     },
     "node_modules/@istanbuljs/schema": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
-      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2346,9 +2349,9 @@
       }
     },
     "node_modules/@jest/reporters/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2564,39 +2567,39 @@
       "license": "MIT"
     },
     "node_modules/@ledgerhq/devices": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-8.13.0.tgz",
-      "integrity": "sha512-hgGn1kpe/rT0EJ0Qs7rG+1TXA4g6HN2t3dB4DndRTqVqC9aSSbME+ajA0QWLZisxOD3zkwvO4Q0mJ2zARAKyag==",
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-8.14.0.tgz",
+      "integrity": "sha512-eMGOaagkMJrqGtqemYNraPg38FA0I/UUEPrbrC+vOZu1qeoG+Sek3gjuJih6rMK4efUfcI4Zs19w/Hv/58fwkQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ledgerhq/errors": "^6.32.0",
-        "@ledgerhq/logs": "^6.16.0",
+        "@ledgerhq/errors": "^6.33.0",
+        "@ledgerhq/logs": "^6.17.0",
         "rxjs": "7.8.2",
         "semver": "7.7.3"
       }
     },
     "node_modules/@ledgerhq/errors": {
-      "version": "6.32.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-6.32.0.tgz",
-      "integrity": "sha512-BjjvhLM6UXYUbhllqAduo9PSneLt9FXZ3TBEUFQ3MMSZOCHt0gAgDySLwul99R8fdYWkXBza4DYQjUNckpN2lg==",
+      "version": "6.33.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-6.33.0.tgz",
+      "integrity": "sha512-9iMdjB0Hfxfd8HGMVM0TDPfxBXhJ4MtGKyFlm8aveSHSXjcTjGtCkcnk4OUZ6ZHopBb69BFR+HC2N/ob9xuNgA==",
       "license": "Apache-2.0"
     },
     "node_modules/@ledgerhq/hw-transport": {
-      "version": "6.34.1",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-6.34.1.tgz",
-      "integrity": "sha512-Bg9Qk2vtm0m0cZn9prZV2Hbvh3b42KBh4uomO00derh+eiwsdg5AXBBptAJiREkew1RVtETRdWxrKchUJfeWvA==",
+      "version": "6.35.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-6.35.0.tgz",
+      "integrity": "sha512-BFk4Zr5gfzT40RT6nj0NQTNB25bxWD3QWhdrOA6Mi/CChFTdGomjOuAhWHla2kH50ft8M5UsiiUeHoR+56J69g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ledgerhq/devices": "8.13.0",
-        "@ledgerhq/errors": "^6.32.0",
-        "@ledgerhq/logs": "^6.16.0",
+        "@ledgerhq/devices": "8.14.0",
+        "@ledgerhq/errors": "^6.33.0",
+        "@ledgerhq/logs": "^6.17.0",
         "events": "^3.3.0"
       }
     },
     "node_modules/@ledgerhq/logs": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-6.16.0.tgz",
-      "integrity": "sha512-v/PLfb1dq1En35kkpbfRWp8jLYgbPUXxGhmd4pmvPSIe0nRGkNTomsZASmWQAv6pRonVGqHIBVlte7j1MBbOww==",
+      "version": "6.17.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-6.17.0.tgz",
+      "integrity": "sha512-yra33g5q/AU7+PwAws+GaVpQGUuxnDREjVBnviJjcaJLVKuLzI4pnj8Bd3nY3fypM5k1yZEYKEXfUuGFUjP2+w==",
       "license": "Apache-2.0"
     },
     "node_modules/@lukeed/csprng": {
@@ -2779,9 +2782,9 @@
       }
     },
     "node_modules/@metamask/utils": {
-      "version": "11.10.0",
-      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-11.10.0.tgz",
-      "integrity": "sha512-+bWmTOANx1MbBW6RFM8Se4ZoigFYGXiuIrkhjj4XnG5Aez8uWaTSZ76yn9srKKClv+PoEVoAuVtcUOogFEMUNA==",
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-11.11.0.tgz",
+      "integrity": "sha512-0nF2CWjWQr/m0Y2t2lJnBTU1/CZPPTvKvcESLplyWe/tyeb8zFOi/FeneDmaFnML6LYRIGZU6f+xR0jKAIUZfw==",
       "license": "ISC",
       "dependencies": {
         "@ethereumjs/tx": "^4.2.0",
@@ -2898,14 +2901,14 @@
       ]
     },
     "node_modules/@nestjs/apollo": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@nestjs/apollo/-/apollo-13.2.4.tgz",
-      "integrity": "sha512-5gKyDQDm+E+AIYofFxXXUhi/4z9YgSjXtjlXUixCj+n6oVcJOilQ7zxlnu3vHiBZz8kEn2ZvVZTJ+i5V2xQ+ew==",
+      "version": "13.2.5",
+      "resolved": "https://registry.npmjs.org/@nestjs/apollo/-/apollo-13.2.5.tgz",
+      "integrity": "sha512-UaBdfpbXMBzSMZOG4eGkTMHyRxaPUx0sw46dOFWAyF/WDmS7xJHd6KR+iRHSa4atQzzMXvtd9ZVYacHxNfuLKA==",
       "license": "MIT",
       "dependencies": {
         "@apollo/server-plugin-landing-page-graphql-playground": "4.0.1",
         "iterall": "1.3.0",
-        "lodash.omit": "4.5.0",
+        "lodash.omit": "4.18.0",
         "tslib": "2.8.1"
       },
       "peerDependencies": {
@@ -2975,15 +2978,15 @@
       }
     },
     "node_modules/@nestjs/cli": {
-      "version": "11.0.17",
-      "resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-11.0.17.tgz",
-      "integrity": "sha512-tOMgoB9k+Zb2WdKYPhbhceROLcDR1BFQZWfkBOGMRgBTo8rnC125E65UvThEA77vp4w+zKjqiSIv0leT+wdpHg==",
+      "version": "11.0.21",
+      "resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-11.0.21.tgz",
+      "integrity": "sha512-F8mV0Sj/zVEouzR3NxBuJy08YHTUOmC5Xdcx3qIIaJWzrm8Vw86CHkhkaPBJ5ewRMHPDCShPmhsfwhpCcjts3A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "19.2.22",
-        "@angular-devkit/schematics": "19.2.22",
-        "@angular-devkit/schematics-cli": "19.2.22",
+        "@angular-devkit/core": "19.2.24",
+        "@angular-devkit/schematics": "19.2.24",
+        "@angular-devkit/schematics-cli": "19.2.24",
         "@inquirer/prompts": "7.10.1",
         "@nestjs/schematics": "^11.0.1",
         "ansis": "4.2.0",
@@ -2997,7 +3000,7 @@
         "tsconfig-paths": "4.2.0",
         "tsconfig-paths-webpack-plugin": "4.2.0",
         "typescript": "5.9.3",
-        "webpack": "5.105.4",
+        "webpack": "5.106.0",
         "webpack-node-externals": "3.0.0"
       },
       "bin": {
@@ -3007,7 +3010,7 @@
         "node": ">= 20.11"
       },
       "peerDependencies": {
-        "@swc/cli": "^0.1.62 || ^0.3.0 || ^0.4.0 || ^0.5.0 || ^0.6.0 || ^0.7.0",
+        "@swc/cli": "^0.1.62 || ^0.3.0 || ^0.4.0 || ^0.5.0 || ^0.6.0 || ^0.7.0 || ^0.8.0",
         "@swc/core": "^1.3.62"
       },
       "peerDependenciesMeta": {
@@ -3020,12 +3023,12 @@
       }
     },
     "node_modules/@nestjs/common": {
-      "version": "11.1.17",
-      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.17.tgz",
-      "integrity": "sha512-hLODw5Abp8OQgA+mUO4tHou4krKgDtUcM9j5Ihxncst9XeyxYBTt2bwZm4e4EQr5E352S4Fyy6V3iFx9ggxKAg==",
+      "version": "11.1.19",
+      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.19.tgz",
+      "integrity": "sha512-qeiTt2tv+e5QyDKqG8HlVZb2wx64FEaSGFJouqTSRs+kG44iTfl3xlz1XqVped+rihx4hmjWgL5gkhtdK3E6+Q==",
       "license": "MIT",
       "dependencies": {
-        "file-type": "21.3.2",
+        "file-type": "21.3.4",
         "iterare": "1.2.1",
         "load-esm": "1.0.3",
         "tslib": "2.8.1",
@@ -3051,14 +3054,14 @@
       }
     },
     "node_modules/@nestjs/config": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@nestjs/config/-/config-4.0.3.tgz",
-      "integrity": "sha512-FQ3M3Ohqfl+nHAn5tp7++wUQw0f2nAk+SFKe8EpNRnIifPqvfJP6JQxPKtFLMOHbyer4X646prFG4zSRYEssQQ==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@nestjs/config/-/config-4.0.4.tgz",
+      "integrity": "sha512-CJPjNitr0bAufSEnRe2N+JbnVmMmDoo6hvKCPzXgZoGwJSmp/dZPk9f/RMbuD/+Q1ZJPjwsRpq0vxna++Knwow==",
       "license": "MIT",
       "dependencies": {
-        "dotenv": "17.2.3",
+        "dotenv": "17.4.1",
         "dotenv-expand": "12.0.3",
-        "lodash": "4.17.23"
+        "lodash": "4.18.1"
       },
       "peerDependencies": {
         "@nestjs/common": "^10.0.0 || ^11.0.0",
@@ -3066,16 +3069,16 @@
       }
     },
     "node_modules/@nestjs/core": {
-      "version": "11.1.17",
-      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.1.17.tgz",
-      "integrity": "sha512-lD5mAYekTTurF3vDaa8C2OKPnjiz4tsfxIc5XlcSUzOhkwWf6Ay3HKvt6FmvuWQam6uIIHX52Clg+e6tAvf/cg==",
+      "version": "11.1.19",
+      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.1.19.tgz",
+      "integrity": "sha512-6nJkWa2efrYi+XlU686J9y5L7OvxpLVjT0T/sxRKE7Jvpffiihelup4WSvLvRhdHDjj/5SuoWEwqReXAaaeHmw==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
         "iterare": "1.2.1",
-        "path-to-regexp": "8.3.0",
+        "path-to-regexp": "8.4.2",
         "tslib": "2.8.1",
         "uid": "2.0.2"
       },
@@ -3120,24 +3123,24 @@
       }
     },
     "node_modules/@nestjs/graphql": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@nestjs/graphql/-/graphql-13.2.4.tgz",
-      "integrity": "sha512-UXtsY4o1gsSG8tlY2HI3NuWyW15eOSG7IX1nG92T5/VtsEsafhtYOnc0H9Z7zFzUn0tPBCcRte1NgVNEIgAAdw==",
+      "version": "13.2.5",
+      "resolved": "https://registry.npmjs.org/@nestjs/graphql/-/graphql-13.2.5.tgz",
+      "integrity": "sha512-CtM24scQtyP5Xgewidd0VIH4H0LS5i1zESrlM2In7QF7snv+ANdCWz6bgVf1qCZwOTl1jKLY4mYnLPgimPGTyQ==",
       "license": "MIT",
       "dependencies": {
         "@graphql-tools/merge": "9.1.7",
         "@graphql-tools/schema": "10.0.31",
         "@graphql-tools/utils": "11.0.0",
-        "@nestjs/mapped-types": "2.1.0",
+        "@nestjs/mapped-types": "2.1.1",
         "chokidar": "4.0.3",
         "fast-glob": "3.3.3",
         "graphql-tag": "2.12.6",
-        "graphql-ws": "6.0.7",
-        "lodash": "4.17.23",
+        "graphql-ws": "6.0.8",
+        "lodash": "4.18.1",
         "normalize-path": "3.0.0",
         "subscriptions-transport-ws": "0.11.0",
         "tslib": "2.8.1",
-        "ws": "8.19.0"
+        "ws": "8.20.0"
       },
       "peerDependencies": {
         "@apollo/subgraph": "^2.9.3",
@@ -3164,36 +3167,66 @@
         }
       }
     },
-    "node_modules/@nestjs/graphql/node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+    "node_modules/@nestjs/graphql/node_modules/@graphql-tools/merge": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.1.7.tgz",
+      "integrity": "sha512-Y5E1vTbTabvcXbkakdFUt4zUIzB1fyaEnVmIWN0l0GMed2gdD01TpZWLUm4RNAxpturvolrb24oGLQrBbPLSoQ==",
       "license": "MIT",
+      "dependencies": {
+        "@graphql-tools/utils": "^11.0.0",
+        "tslib": "^2.4.0"
+      },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@nestjs/graphql/node_modules/@graphql-tools/schema": {
+      "version": "10.0.31",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.31.tgz",
+      "integrity": "sha512-ZewRgWhXef6weZ0WiP7/MV47HXiuFbFpiDUVLQl6mgXsWSsGELKFxQsyUCBos60Qqy1JEFAIu3Ns6GGYjGkqkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-tools/merge": "^9.1.7",
+        "@graphql-tools/utils": "^11.0.0",
+        "tslib": "^2.4.0"
       },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@nestjs/graphql/node_modules/@graphql-tools/utils": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-11.0.0.tgz",
+      "integrity": "sha512-bM1HeZdXA2C3LSIeLOnH/bcqSgbQgKEDrjxODjqi3y58xai2TkNrtYcQSoWzGbt9VMN1dORGjR7Vem8SPnUFQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "@whatwg-node/promise-helpers": "^1.0.0",
+        "cross-inspect": "1.0.1",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@nestjs/mapped-types": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.0.tgz",
-      "integrity": "sha512-W+n+rM69XsFdwORF11UqJahn4J3xi4g/ZEOlJNL6KoW5ygWSmBB2p0S2BZ4FQeS/NDH72e6xIcu35SfJnE8bXw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.1.tgz",
+      "integrity": "sha512-SCCoMEJ6jdeI5h/N+KCVF1+pmg/hmEkNA5nHTS8Gvww7T/LCl4o1gFLinw2iQ60w7slFkszHcGLKGdazVI4F8A==",
       "license": "MIT",
       "peerDependencies": {
         "@nestjs/common": "^10.0.0 || ^11.0.0",
         "class-transformer": "^0.4.0 || ^0.5.0",
-        "class-validator": "^0.13.0 || ^0.14.0",
+        "class-validator": "^0.13.0 || ^0.14.0 || ^0.15.0",
         "reflect-metadata": "^0.1.12 || ^0.2.0"
       },
       "peerDependenciesMeta": {
@@ -3206,15 +3239,15 @@
       }
     },
     "node_modules/@nestjs/platform-express": {
-      "version": "11.1.17",
-      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.17.tgz",
-      "integrity": "sha512-mAf4eOsSBsTOn/VbrUO1gsjW6dVh91qqXPMXun4dN8SnNjf7PTQagM9o8d6ab8ZBpNe6UdZftdrZoDetU+n4Qg==",
+      "version": "11.1.19",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.19.tgz",
+      "integrity": "sha512-Vpdv8jyCQdThfoTx+UTn+DRYr6H6X02YUqcpZ3qP6G3ZUwtVp7eS+hoQPGd4UuCnlnFG8Wqr2J9bGEzQdi1rIg==",
       "license": "MIT",
       "dependencies": {
         "cors": "2.8.6",
         "express": "5.2.1",
         "multer": "2.1.1",
-        "path-to-regexp": "8.3.0",
+        "path-to-regexp": "8.4.2",
         "tslib": "2.8.1"
       },
       "funding": {
@@ -3227,9 +3260,9 @@
       }
     },
     "node_modules/@nestjs/platform-socket.io": {
-      "version": "11.1.17",
-      "resolved": "https://registry.npmjs.org/@nestjs/platform-socket.io/-/platform-socket.io-11.1.17.tgz",
-      "integrity": "sha512-BSOAsENdmTtsnDL0hb4takbWzPy9WoPybjlM57ab3/rQgm0biMFYUupH2uzmCjmmIXJL/EFbAWznVl8xw2Sa6Q==",
+      "version": "11.1.19",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-socket.io/-/platform-socket.io-11.1.19.tgz",
+      "integrity": "sha512-gu1nPIEaP5Qjjg/Cl8wXyvwGpdZGzgbtK4KcH65YRAA+GTKUkIHb4BNpLJ27Ymq/wqLJKNEbCjajfzD0BEjMGA==",
       "license": "MIT",
       "dependencies": {
         "socket.io": "4.8.3",
@@ -3246,9 +3279,9 @@
       }
     },
     "node_modules/@nestjs/schedule": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-6.1.1.tgz",
-      "integrity": "sha512-kQl1RRgi02GJ0uaUGCrXHCcwISsCsJDciCKe38ykJZgnAeeoeVWs8luWtBo4AqAAXm4nS5K8RlV0smHUJ4+2FA==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-6.1.2.tgz",
+      "integrity": "sha512-u3A0loy/65i2rWSmjrYfcIBwLZ1riQFCaN6Oml7nG2k0VgG1jbBvz/pormtXQmROq/7/KSbj7PNIrTA9St3jTw==",
       "license": "MIT",
       "dependencies": {
         "cron": "4.4.0"
@@ -3322,19 +3355,6 @@
         "yarn": ">= 1.13.0"
       }
     },
-    "node_modules/@nestjs/schematics/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/@nestjs/schematics/node_modules/rxjs": {
       "version": "7.8.1",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
@@ -3346,17 +3366,17 @@
       }
     },
     "node_modules/@nestjs/swagger": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.2.6.tgz",
-      "integrity": "sha512-oiXOxMQqDFyv1AKAqFzSo6JPvMEs4uA36Eyz/s2aloZLxUjcLfUMELSLSNQunr61xCPTpwEOShfmO7NIufKXdA==",
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.2.7.tgz",
+      "integrity": "sha512-+e1KWSyZMAQeyZ8nbQSvm3fhzqdxxBNQENvpjO2dVyD7KJmLTTQyXpRb1nM5O04oFdDTUtG3SHMl4+e+zgCK2A==",
       "license": "MIT",
       "dependencies": {
         "@microsoft/tsdoc": "0.16.0",
-        "@nestjs/mapped-types": "2.1.0",
+        "@nestjs/mapped-types": "2.1.1",
         "js-yaml": "4.1.1",
-        "lodash": "4.17.23",
-        "path-to-regexp": "8.3.0",
-        "swagger-ui-dist": "5.31.0"
+        "lodash": "4.18.1",
+        "path-to-regexp": "8.4.2",
+        "swagger-ui-dist": "5.32.2"
       },
       "peerDependencies": {
         "@fastify/static": "^8.0.0 || ^9.0.0",
@@ -3379,9 +3399,9 @@
       }
     },
     "node_modules/@nestjs/testing": {
-      "version": "11.1.17",
-      "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-11.1.17.tgz",
-      "integrity": "sha512-lNffw+z+2USewmw4W0tsK+Rq94A2N4PiHbcqoRUu5y8fnqxQeIWGHhjo5BFCqj7eivqJBhT7WdRydxVq4rAHzg==",
+      "version": "11.1.19",
+      "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-11.1.19.tgz",
+      "integrity": "sha512-/UFNWXvPEdu4v4DlC5oWLbGKmD27LehLK06b8oLzs6D6lf4vAQTdST8LRAXBadyMUQnVEQWMuBo3CtAVtlfXtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3407,22 +3427,22 @@
       }
     },
     "node_modules/@nestjs/typeorm": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@nestjs/typeorm/-/typeorm-11.0.0.tgz",
-      "integrity": "sha512-SOeUQl70Lb2OfhGkvnh4KXWlsd+zA08RuuQgT7kKbzivngxzSo1Oc7Usu5VxCxACQC9wc2l9esOHILSJeK7rJA==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/typeorm/-/typeorm-11.0.1.tgz",
+      "integrity": "sha512-8rw/nKT0S+L+MkzgE9F2/mox7mAgsPlwfzmW9gsESN1lmQtIrVEfiiBwC2O8+guS1jBfQehJIdcdUj2OAp4VUQ==",
       "license": "MIT",
       "peerDependencies": {
         "@nestjs/common": "^10.0.0 || ^11.0.0",
         "@nestjs/core": "^10.0.0 || ^11.0.0",
         "reflect-metadata": "^0.1.13 || ^0.2.0",
         "rxjs": "^7.2.0",
-        "typeorm": "^0.3.0"
+        "typeorm": "^0.3.0 || ^1.0.0-dev"
       }
     },
     "node_modules/@nestjs/websockets": {
-      "version": "11.1.17",
-      "resolved": "https://registry.npmjs.org/@nestjs/websockets/-/websockets-11.1.17.tgz",
-      "integrity": "sha512-YbwQ0QfVj0lxkKQhdIIgk14ZSVWDqGk1J8nNSN6SLjf36sVv58Ma5ro+dtQua8wj3l2Ub7JJCVFixEhKtYc/rQ==",
+      "version": "11.1.19",
+      "resolved": "https://registry.npmjs.org/@nestjs/websockets/-/websockets-11.1.19.tgz",
+      "integrity": "sha512-2qo8jtIwwwgkqAI1BtnJ02EaFLrRkKA39eYXS8IhZCHilhBHCWdjnJ5cLcFq4oF+s+KZ7LcLGD/3stxJy8ijzg==",
       "license": "MIT",
       "dependencies": {
         "iterare": "1.2.1",
@@ -4429,9 +4449,9 @@
       }
     },
     "node_modules/@typespec/ts-http-runtime": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.4.tgz",
-      "integrity": "sha512-CI0NhTrz4EBaa0U+HaaUZrJhPoso8sG7ZFya8uQoBA57fjzrjRSv87ekCjLZOFExN+gXE/z0xuN2QfH4H2HrLQ==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.5.tgz",
+      "integrity": "sha512-yURCknZhvywvQItHMMmFSo+fq5arCUIyz/CVk7jD89MSai7dkaX8ufjCWp3NttLojoTVbcE72ri+be/TnEbMHw==",
       "license": "MIT",
       "dependencies": {
         "http-proxy-agent": "^7.0.0",
@@ -5111,12 +5131,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/async": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
-      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
-      "license": "MIT"
-    },
     "node_modules/async-retry": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
@@ -5323,9 +5337,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.13",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.13.tgz",
-      "integrity": "sha512-BL2sTuHOdy0YT1lYieUxTw/QMtPBC3pmlJC6xk8BBYVv6vcw3SGdKemQ+Xsx9ik2F/lYDO9tqsFQH1r9PFuHKw==",
+      "version": "2.10.19",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.19.tgz",
+      "integrity": "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -5740,9 +5754,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -5927,14 +5941,14 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
         "set-function-length": "^1.2.2"
       },
       "engines": {
@@ -6003,9 +6017,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001784",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001784.tgz",
-      "integrity": "sha512-WU346nBTklUV9YfUl60fqRbU5ZqyXlqvo1SgigE1OAXK5bFL8LL9q1K7aap3N739l4BvNqnkm3YrGHiY9sfUQw==",
+      "version": "1.0.30001788",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
+      "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
       "dev": true,
       "funding": [
         {
@@ -6371,9 +6385,9 @@
       "license": "ISC"
     },
     "node_modules/content-disposition": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
-      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -6810,9 +6824,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.2.3",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
-      "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
+      "version": "17.4.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.1.tgz",
+      "integrity": "sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -6875,24 +6889,21 @@
       "license": "MIT"
     },
     "node_modules/ejs": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
-      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-5.0.2.tgz",
+      "integrity": "sha512-IpbUaI/CAW86l3f+T8zN0iggSc0LmMZLcIW5eRVStLVNCoTXkE0YlncbbH50fp8Cl6zHIky0sW2uUbhBqGw0Jw==",
       "license": "Apache-2.0",
-      "dependencies": {
-        "jake": "^10.8.5"
-      },
       "bin": {
         "ejs": "bin/cli.js"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=0.12.18"
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.330",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.330.tgz",
-      "integrity": "sha512-jFNydB5kFtYUobh4IkWUnXeyDbjf/r9gcUEXe1xcrcUxIGfTdzPXA+ld6zBRbwvgIGVzDll/LTIiDztEtckSnA==",
+      "version": "1.5.336",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.336.tgz",
+      "integrity": "sha512-AbH9q9J455r/nLmdNZes0G0ZKcRX73FicwowalLs6ijwOmCJSRRrLX63lcAlzy9ux3dWK1w1+1nsBJEWN11hcQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -7312,9 +7323,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7756,9 +7767,9 @@
       }
     },
     "node_modules/file-type": {
-      "version": "21.3.2",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.2.tgz",
-      "integrity": "sha512-DLkUvGwep3poOV2wpzbHCOnSKGk1LzyXTv+aHFgN2VFl96wnp8YA9YjO2qPzg5PuL8q/SW9Pdi6WTkYOIh995w==",
+      "version": "21.3.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+      "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
       "license": "MIT",
       "dependencies": {
         "@tokenizer/inflate": "^0.4.1",
@@ -7771,27 +7782,6 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/file-type?sponsor=1"
-      }
-    },
-    "node_modules/filelist": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
-      "integrity": "sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "minimatch": "^5.0.1"
-      }
-    },
-    "node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/fill-range": {
@@ -7942,9 +7932,9 @@
       }
     },
     "node_modules/fork-ts-checker-webpack-plugin/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8419,9 +8409,9 @@
       }
     },
     "node_modules/graphql-ws": {
-      "version": "6.0.7",
-      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-6.0.7.tgz",
-      "integrity": "sha512-yoLRW+KRlDmnnROdAu7sX77VNLC0bsFoZyGQJLy1cF+X/SkLg/fWkRGrEEYQK8o2cafJ2wmEaMqMEZB3U3DYDg==",
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-6.0.8.tgz",
+      "integrity": "sha512-m3EOaNsUBXwAnkBWbzPfe0Nq8pXUfxsWnolC54sru3FzHvhTZL0Ouf/BoQsaGAXqM+YPerXOJ47BUnmgmoupCw==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -8445,13 +8435,13 @@
       }
     },
     "node_modules/handlebars": {
-      "version": "4.7.7",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
-      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5",
-        "neo-async": "^2.6.0",
+        "neo-async": "^2.6.2",
         "source-map": "^0.6.1",
         "wordwrap": "^1.0.0"
       },
@@ -8554,12 +8544,12 @@
       }
     },
     "node_modules/hbs": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/hbs/-/hbs-4.2.0.tgz",
-      "integrity": "sha512-dQwHnrfWlTk5PvG9+a45GYpg0VpX47ryKF8dULVd6DtwOE6TEcYQXQ5QM6nyOx/h7v3bvEQbdn19EDAcfUAgZg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/hbs/-/hbs-4.2.1.tgz",
+      "integrity": "sha512-jkX8bTB17JCUMhyDobTkbMcdZi3xOplVbWjzp8i40O6ZITQhcjGIy11AmF51IyBe80GnJIRhUtKL9dg/ho/uog==",
       "license": "MIT",
       "dependencies": {
-        "handlebars": "4.7.7",
+        "handlebars": "4.7.9",
         "walk": "2.3.15"
       },
       "engines": {
@@ -9067,23 +9057,6 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
-    "node_modules/jake": {
-      "version": "10.9.4",
-      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.4.tgz",
-      "integrity": "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "async": "^3.2.6",
-        "filelist": "^1.0.4",
-        "picocolors": "^1.1.1"
-      },
-      "bin": {
-        "jake": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
@@ -9239,9 +9212,9 @@
       }
     },
     "node_modules/jest-config/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9581,9 +9554,9 @@
       }
     },
     "node_modules/jest-runtime/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9988,9 +9961,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.defaults": {
@@ -10020,10 +9993,9 @@
       "license": "MIT"
     },
     "node_modules/lodash.omit": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
-      "integrity": "sha512-XeqSp49hNGmlkj2EJlfrQFIzQ6lXdNro9sddtQzcJY8QaoC2GO0DT7xaIokHeyM+mIT0mPMlPvkYzg2xCuHdZg==",
-      "deprecated": "This package is deprecated. Use destructuring assignment syntax instead.",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.18.0.tgz",
+      "integrity": "sha512-hZXIupXdHtocTnvIJ2aCd2vxKYtxex6gbiGuPvgBRnFQO9yu3AtmDAbVuCXcSsQx3INo/1g71OktlFFA/ES8Xg==",
       "license": "MIT"
     },
     "node_modules/lodash.sortby": {
@@ -10072,9 +10044,9 @@
       "peer": true
     },
     "node_modules/lru-cache": {
-      "version": "11.2.7",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
-      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -10599,9 +10571,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.36",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
-      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "version": "2.0.37",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
+      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
       "dev": true,
       "license": "MIT"
     },
@@ -10998,9 +10970,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -11110,12 +11082,13 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11282,9 +11255,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
-      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -11401,9 +11374,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -11549,12 +11522,13 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.11",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "es-errors": "^1.3.0",
         "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
@@ -11670,9 +11644,9 @@
       }
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -11995,13 +11969,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -12533,9 +12507,9 @@
       }
     },
     "node_modules/swagger-ui-dist": {
-      "version": "5.31.0",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.31.0.tgz",
-      "integrity": "sha512-zSUTIck02fSga6rc0RZP3b7J7wgHXwLea8ZjgLA3Vgnb8QeOl3Wou2/j5QkzSGeoz6HusP/coYuJl33aQxQZpg==",
+      "version": "5.32.2",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.2.tgz",
+      "integrity": "sha512-t6Ns52nS8LU2hqi0+rezMjFO1ZrCsCrnommXrU7Nfrg2va2dWahdvM6TuSwzdHpG29v6BHJyU1c/UWFhgVZzVQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@scarf/scarf": "=1.4.0"
@@ -12780,9 +12754,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12912,19 +12886,19 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.4.6",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.6.tgz",
-      "integrity": "sha512-fSpWtOO/1AjSNQguk43hb/JCo16oJDnMJf3CdEGNkqsEX3t0KX96xvyX1D7PfLCpVoKu4MfVrqUkFyblYoY4lA==",
+      "version": "29.4.9",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.9.tgz",
+      "integrity": "sha512-LTb9496gYPMCqjeDLdPrKuXtncudeV1yRZnF4Wo5l3SFi0RYEnYRNgMrFIdg+FHvfzjCyQk1cLncWVqiSX+EvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "bs-logger": "^0.2.6",
         "fast-json-stable-stringify": "^2.1.0",
-        "handlebars": "^4.7.8",
+        "handlebars": "^4.7.9",
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
-        "semver": "^7.7.3",
+        "semver": "^7.7.4",
         "type-fest": "^4.41.0",
         "yargs-parser": "^21.1.1"
       },
@@ -12941,7 +12915,7 @@
         "babel-jest": "^29.0.0 || ^30.0.0",
         "jest": "^29.0.0 || ^30.0.0",
         "jest-util": "^29.0.0 || ^30.0.0",
-        "typescript": ">=4.3 <6"
+        "typescript": ">=4.3 <7"
       },
       "peerDependenciesMeta": {
         "@babel/core": {
@@ -12964,36 +12938,17 @@
         }
       }
     },
-    "node_modules/ts-jest/node_modules/handlebars": {
-      "version": "4.7.9",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
-      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+    "node_modules/ts-jest/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.5",
-        "neo-async": "^2.6.2",
-        "source-map": "^0.6.1",
-        "wordwrap": "^1.0.0"
-      },
+      "license": "ISC",
       "bin": {
-        "handlebars": "bin/handlebars"
+        "semver": "bin/semver.js"
       },
       "engines": {
-        "node": ">=0.4.7"
-      },
-      "optionalDependencies": {
-        "uglify-js": "^3.1.4"
-      }
-    },
-    "node_modules/ts-jest/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
+        "node": ">=10"
       }
     },
     "node_modules/ts-jest/node_modules/type-fest": {
@@ -13544,9 +13499,9 @@
       }
     },
     "node_modules/validator": {
-      "version": "13.15.26",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.26.tgz",
-      "integrity": "sha512-spH26xU080ydGggxRyR1Yhcbgx+j3y5jbNXk/8L+iRvdIEQ4uTRH2Sgf2dokud6Q4oAtsbNvJ1Ft+9xmm6IZcA==",
+      "version": "13.15.35",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.35.tgz",
+      "integrity": "sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
@@ -13626,9 +13581,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/webpack": {
-      "version": "5.105.4",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.4.tgz",
-      "integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
+      "version": "5.106.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.106.0.tgz",
+      "integrity": "sha512-Pkx5joZ9RrdgO5LBkyX1L2ZAJeK/Taz3vqZ9CbcP0wS5LEMx5QkKsEwLl29QJfihZ+DKRBFldzy1O30pJ1MDpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/configs/constants.ts
+++ b/src/configs/constants.ts
@@ -210,6 +210,10 @@ export const TOKEN_LIST_ELIGIBILITY_CONFIG = {
   MIN_TRADES_ALL_TIME: 3,
 } as const;
 
+export const POPULAR_RANKING_WEIGHT_SCALES = ['low', 'med', 'high'] as const;
+export type PopularRankingWeightScale =
+  (typeof POPULAR_RANKING_WEIGHT_SCALES)[number];
+
 /**
  * Popular posts ranking configuration — "Top" style (no time decay).
  * Posts are ranked purely by accumulated engagement within the selected window.
@@ -228,6 +232,18 @@ export const POPULAR_RANKING_CONFIG = {
     trendingBoost: 0.5, // w_tr (topical relevance)
     contentQuality: 0.3, // w_q (anti-spam)
     reads: 1.5, // w_reads (common passive signal)
+  },
+
+  // user-facing scale controls tune relative importance instead of exposing raw weights
+  CUSTOMIZATION: {
+    SCALE_MULTIPLIERS: {
+      low: 0.6,
+      med: 1,
+      high: 1.5,
+    },
+    ADDITIONAL_SIGNAL_WEIGHTS: {
+      interactionsPerHour: 1.1,
+    },
   },
 
   // content quality params

--- a/src/social/controllers/posts.controller.ts
+++ b/src/social/controllers/posts.controller.ts
@@ -20,7 +20,7 @@ import { paginate } from 'nestjs-typeorm-paginate';
 import { Repository } from 'typeorm';
 import { Post } from '../entities/post.entity';
 import { PopularRankingService } from '../services/popular-ranking.service';
-import { PostDto } from '../dto';
+import { PopularPostsQueryDto, PostDto } from '../dto';
 import type { Request } from 'express';
 import { ReadsService } from '../services/reads.service';
 import { ApiOkResponsePaginated } from '@/utils/api-type';
@@ -368,41 +368,53 @@ export class PostsController {
     };
   }
 
-  @ApiQuery({ name: 'window', enum: ['24h', '7d', 'all'], required: false })
-  @ApiQuery({
-    name: 'debug',
-    type: 'number',
-    required: false,
-    description: 'Return feature breakdown when set to 1',
-  })
-  @ApiQuery({ name: 'page', type: 'number', required: false })
-  @ApiQuery({ name: 'limit', type: 'number', required: false })
   @ApiOperation({
     operationId: 'popular',
     summary: 'Popular posts',
     description:
-      'Returns top posts for selected time window (24h, 7d, all). Ranked by accumulated engagement — no time decay.',
+      'Returns top posts for selected time window (24h, 7d, all). Ranked by accumulated engagement — no time decay. Optional scale params let clients personalize signal importance.',
   })
   @ApiOkResponsePaginated(PostDto)
   @Get('popular')
-  async popular(
-    @Query('window') window: '24h' | '7d' | 'all' = '24h',
-    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page = 1,
-    @Query('limit', new DefaultValuePipe(50), ParseIntPipe) limit = 50,
-    @Query('debug') debug?: number,
-  ) {
+  async popular(@Query() query: PopularPostsQueryDto) {
+    const {
+      window = '24h',
+      page = 1,
+      limit = 50,
+      debug,
+      comments,
+      tipsAmountAE,
+      tipsCount,
+      uniqueTippers,
+      trendingBoost,
+      contentQuality,
+      reads,
+      interactionsPerHour,
+    } = query;
     const offset = (page - 1) * limit;
+    const weightOverrides = {
+      comments,
+      tipsAmountAE,
+      tipsCount,
+      uniqueTippers,
+      trendingBoost,
+      contentQuality,
+      reads,
+      interactionsPerHour,
+    };
     try {
-      // Get total count of popular posts for the given window
-      const totalItems =
-        await this.popularRankingService.getTotalPostsCount(window);
-      const totalPages = Math.ceil(totalItems / limit);
-
-      const rankedItems = await this.popularRankingService.getPopularPosts(
+      const {
+        items: rankedItems,
+        totalItems,
+        scoredItems,
+      } = await this.popularRankingService.getPopularPostsPage(
         window,
         limit,
         offset,
+        undefined,
+        weightOverrides,
       );
+      const totalPages = Math.ceil(totalItems / limit);
 
       const rankedPostIds = rankedItems
         .filter((item) => !this.isPluginContentItem(item))
@@ -451,10 +463,12 @@ export class PostsController {
         },
       };
       if (debug === 1) {
-        response.debug = await (this.popularRankingService as any).explain(
+        response.debug = await this.popularRankingService.explain(
           window,
           limit,
           offset,
+          weightOverrides,
+          scoredItems,
         );
       }
       return response;

--- a/src/social/dto/index.ts
+++ b/src/social/dto/index.ts
@@ -2,3 +2,4 @@ export { PostDto } from './post.dto';
 export { TopicDto } from './topic.dto';
 export { PostSenderDto } from './post-sender.dto';
 export { GiphyGifDto, GiphySearchResponseDto } from './giphy.dto';
+export { PopularPostsQueryDto } from './popular-posts-query.dto';

--- a/src/social/dto/popular-posts-query.dto.ts
+++ b/src/social/dto/popular-posts-query.dto.ts
@@ -1,0 +1,126 @@
+import { Type } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsIn, IsNumber, IsOptional, Max, Min } from 'class-validator';
+import {
+  POPULAR_RANKING_WEIGHT_SCALES,
+  type PopularRankingWeightScale,
+} from '@/configs/constants';
+import type { PopularWindow } from '../services/popular-ranking.service';
+
+export class PopularPostsQueryDto {
+  @ApiPropertyOptional({
+    enum: ['24h', '7d', 'all'],
+    description: 'Popular ranking time window',
+    default: '24h',
+  })
+  @IsOptional()
+  @IsIn(['24h', '7d', 'all'])
+  window?: PopularWindow = '24h';
+
+  @ApiPropertyOptional({
+    type: Number,
+    description: 'Page number',
+    default: 1,
+    minimum: 1,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  @Type(() => Number)
+  page?: number = 1;
+
+  @ApiPropertyOptional({
+    type: Number,
+    description: 'Page size',
+    default: 50,
+    minimum: 1,
+    maximum: 100,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  @Max(100)
+  @Type(() => Number)
+  limit?: number = 50;
+
+  @ApiPropertyOptional({
+    type: Number,
+    description: 'Return debug info when set to 1',
+  })
+  @IsOptional()
+  @IsNumber()
+  @Type(() => Number)
+  debug?: number;
+
+  @ApiPropertyOptional({
+    enum: POPULAR_RANKING_WEIGHT_SCALES,
+    description:
+      'Scale for comment impact (low = reduce, med = default, high = boost)',
+  })
+  @IsOptional()
+  @IsIn(POPULAR_RANKING_WEIGHT_SCALES)
+  comments?: PopularRankingWeightScale;
+
+  @ApiPropertyOptional({
+    enum: POPULAR_RANKING_WEIGHT_SCALES,
+    description:
+      'Scale for tipped amount impact (low = reduce, med = default, high = boost)',
+  })
+  @IsOptional()
+  @IsIn(POPULAR_RANKING_WEIGHT_SCALES)
+  tipsAmountAE?: PopularRankingWeightScale;
+
+  @ApiPropertyOptional({
+    enum: POPULAR_RANKING_WEIGHT_SCALES,
+    description:
+      'Scale for tip count impact (low = reduce, med = default, high = boost)',
+  })
+  @IsOptional()
+  @IsIn(POPULAR_RANKING_WEIGHT_SCALES)
+  tipsCount?: PopularRankingWeightScale;
+
+  @ApiPropertyOptional({
+    enum: POPULAR_RANKING_WEIGHT_SCALES,
+    description:
+      'Scale for unique tippers impact (low = reduce, med = default, high = boost)',
+  })
+  @IsOptional()
+  @IsIn(POPULAR_RANKING_WEIGHT_SCALES)
+  uniqueTippers?: PopularRankingWeightScale;
+
+  @ApiPropertyOptional({
+    enum: POPULAR_RANKING_WEIGHT_SCALES,
+    description:
+      'Scale for trending topic boost (low = reduce, med = default, high = boost)',
+  })
+  @IsOptional()
+  @IsIn(POPULAR_RANKING_WEIGHT_SCALES)
+  trendingBoost?: PopularRankingWeightScale;
+
+  @ApiPropertyOptional({
+    enum: POPULAR_RANKING_WEIGHT_SCALES,
+    description:
+      'Scale for content quality impact (low = reduce, med = default, high = boost)',
+  })
+  @IsOptional()
+  @IsIn(POPULAR_RANKING_WEIGHT_SCALES)
+  contentQuality?: PopularRankingWeightScale;
+
+  @ApiPropertyOptional({
+    enum: POPULAR_RANKING_WEIGHT_SCALES,
+    description:
+      'Scale for reads impact (low = reduce, med = default, high = boost)',
+  })
+  @IsOptional()
+  @IsIn(POPULAR_RANKING_WEIGHT_SCALES)
+  reads?: PopularRankingWeightScale;
+
+  @ApiPropertyOptional({
+    enum: POPULAR_RANKING_WEIGHT_SCALES,
+    description:
+      'Scale for active-engagement velocity using comments, tips, and unique tippers per hour (low = reduce, med = default, high = boost)',
+  })
+  @IsOptional()
+  @IsIn(POPULAR_RANKING_WEIGHT_SCALES)
+  interactionsPerHour?: PopularRankingWeightScale;
+}

--- a/src/social/services/popular-ranking.service.spec.ts
+++ b/src/social/services/popular-ranking.service.spec.ts
@@ -79,6 +79,7 @@ describe('PopularRankingService', () => {
         .fn()
         .mockReturnValueOnce(candidateQueryBuilder)
         .mockReturnValueOnce(commentQueryBuilder),
+      findBy: jest.fn().mockResolvedValue([]),
     };
     tipRepository = {
       createQueryBuilder: jest.fn().mockReturnValue(tipQueryBuilder),
@@ -165,5 +166,588 @@ describe('PopularRankingService', () => {
       'post.created_at >= :since',
       expect.objectContaining({ since: expect.any(Date) }),
     );
+  });
+
+  it('reorders personalized popular results by interactions per hour', async () => {
+    const now = Date.now();
+    const fastPost = {
+      id: 'post-fast',
+      sender_address: 'ak_fast',
+      created_at: new Date(now - 1 * 60 * 60 * 1000).toISOString(),
+      total_comments: 0,
+      content: 'fast',
+      topics: [],
+    };
+    const oldPost = {
+      id: 'post-old',
+      sender_address: 'ak_old',
+      created_at: new Date(now - 12 * 60 * 60 * 1000).toISOString(),
+      total_comments: 0,
+      content: 'old',
+      topics: [],
+    };
+    const candidateQueryBuilder = {
+      leftJoinAndSelect: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      getMany: jest.fn().mockResolvedValue([oldPost, fastPost]),
+    };
+    const tipQueryBuilder = {
+      select: jest.fn().mockReturnThis(),
+      innerJoin: jest.fn().mockReturnThis(),
+      addSelect: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      groupBy: jest.fn().mockReturnThis(),
+      getRawMany: jest.fn().mockResolvedValue([
+        {
+          post_id: 'post-old',
+          amount_sum: '0',
+          count: '2',
+          unique_tippers: '2',
+        },
+        {
+          post_id: 'post-fast',
+          amount_sum: '0',
+          count: '2',
+          unique_tippers: '2',
+        },
+      ]),
+    };
+    const commentQueryBuilder = {
+      innerJoin: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnThis(),
+      addSelect: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      groupBy: jest.fn().mockReturnThis(),
+      getRawMany: jest.fn().mockResolvedValue([
+        { parent_id: 'post-old', count: '4' },
+        { parent_id: 'post-fast', count: '4' },
+      ]),
+    };
+    const readsQueryBuilder = {
+      select: jest.fn().mockReturnThis(),
+      addSelect: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      groupBy: jest.fn().mockReturnThis(),
+      getRawMany: jest.fn().mockResolvedValue([
+        { post_id: 'post-old', reads: '10' },
+        { post_id: 'post-fast', reads: '10' },
+      ]),
+    };
+
+    postRepository = {
+      createQueryBuilder: jest
+        .fn()
+        .mockReturnValueOnce(candidateQueryBuilder)
+        .mockReturnValueOnce(commentQueryBuilder),
+      findBy: jest.fn().mockResolvedValue([oldPost, fastPost]),
+    };
+    tipRepository = {
+      createQueryBuilder: jest.fn().mockReturnValue(tipQueryBuilder),
+    };
+    postReadsRepository = {
+      createQueryBuilder: jest.fn().mockReturnValue(readsQueryBuilder),
+    };
+    service = new PopularRankingService(
+      postRepository as any,
+      tipRepository as any,
+      trendingTagRepository as any,
+      postReadsRepository as any,
+      [],
+    );
+
+    const result = await service.getPopularPostsPage('24h', 10, 0, undefined, {
+      interactionsPerHour: 'high',
+    });
+
+    expect(result.items.map((item) => item.id)).toEqual([
+      'post-fast',
+      'post-old',
+    ]);
+    expect(result.totalItems).toBe(2);
+  });
+
+  describe('getPopularPostsPage without overrides (Redis path)', () => {
+    it('delegates to the cached Redis path and returns totalItems', async () => {
+      const postA = {
+        id: 'post-a',
+        sender_address: 'ak_a',
+        content: 'a',
+        is_hidden: false,
+        post_id: null,
+      };
+      const postB = {
+        id: 'post-b',
+        sender_address: 'ak_b',
+        content: 'b',
+        is_hidden: false,
+        post_id: null,
+      };
+
+      redisMock.zcard.mockResolvedValue(2);
+      (redisMock as any).zrevrange = jest
+        .fn()
+        .mockResolvedValue(['post-a', '10', 'post-b', '5']);
+      postRepository.findBy = jest.fn().mockResolvedValue([postA, postB]);
+
+      const result = await service.getPopularPostsPage(
+        '24h',
+        10,
+        0,
+        undefined,
+        {},
+      );
+
+      expect(result.items.length).toBe(2);
+      expect(result.scoredItems).toBeUndefined();
+
+      redisMock.zcard.mockResolvedValue(1);
+    });
+  });
+
+  describe('resolveWeights', () => {
+    function buildServiceForWeightTests() {
+      const now = Date.now();
+      const post = {
+        id: 'post-w',
+        sender_address: 'ak_w',
+        created_at: new Date(now - 2 * 60 * 60 * 1000).toISOString(),
+        total_comments: 0,
+        content: 'weight test content that is long enough',
+        topics: [],
+      };
+      const candidateQB = {
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([post]),
+      };
+      const commentQB = {
+        innerJoin: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: jest
+          .fn()
+          .mockResolvedValue([{ parent_id: 'post-w', count: '5' }]),
+      };
+      const tipQB = {
+        select: jest.fn().mockReturnThis(),
+        innerJoin: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([
+          {
+            post_id: 'post-w',
+            amount_sum: '100',
+            count: '3',
+            unique_tippers: '2',
+          },
+        ]),
+      };
+      const readsQB = {
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: jest
+          .fn()
+          .mockResolvedValue([{ post_id: 'post-w', reads: '20' }]),
+      };
+
+      const repo = {
+        createQueryBuilder: jest
+          .fn()
+          .mockReturnValueOnce(candidateQB)
+          .mockReturnValueOnce(commentQB),
+        findBy: jest.fn().mockResolvedValue([post]),
+      };
+      const tipRepo = { createQueryBuilder: jest.fn().mockReturnValue(tipQB) };
+      const readsRepo = {
+        createQueryBuilder: jest.fn().mockReturnValue(readsQB),
+      };
+
+      return new PopularRankingService(
+        repo as any,
+        tipRepo as any,
+        trendingTagRepository as any,
+        readsRepo as any,
+        [],
+      );
+    }
+
+    it('applies multiple simultaneous overrides (comments=high, reads=low)', async () => {
+      const svc = buildServiceForWeightTests();
+      const result = await svc.getPopularPostsPage('24h', 10, 0, undefined, {
+        comments: 'high',
+        reads: 'low',
+      });
+
+      expect(result.totalItems).toBe(1);
+      expect(result.scoredItems).toBeDefined();
+      expect(result.scoredItems![0].score).toBeGreaterThan(0);
+    });
+
+    it('returns default ranking when all override values are undefined', async () => {
+      const svc = buildServiceForWeightTests();
+      const postW = { id: 'post-w', sender_address: 'ak_w', content: 'w' };
+      redisMock.zcard.mockResolvedValue(1);
+      (redisMock as any).zrevrange = jest
+        .fn()
+        .mockResolvedValue(['post-w', '10']);
+      (svc as any).postRepository.findBy = jest.fn().mockResolvedValue([postW]);
+
+      const result = await svc.getPopularPostsPage('24h', 10, 0, undefined, {
+        comments: undefined,
+        reads: undefined,
+      });
+
+      expect(result.scoredItems).toBeUndefined();
+
+      redisMock.zcard.mockResolvedValue(1);
+    });
+  });
+
+  describe('computeInteractionsPerHour edge cases', () => {
+    function buildServiceWith(post: any) {
+      const candidateQB = {
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([post]),
+      };
+      const commentQB = {
+        innerJoin: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: jest
+          .fn()
+          .mockResolvedValue([{ parent_id: post.id, count: '3' }]),
+      };
+      const tipQB = {
+        select: jest.fn().mockReturnThis(),
+        innerJoin: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([
+          {
+            post_id: post.id,
+            amount_sum: '0',
+            count: '1',
+            unique_tippers: '1',
+          },
+        ]),
+      };
+      const readsQB = {
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([]),
+      };
+
+      return new PopularRankingService(
+        {
+          createQueryBuilder: jest
+            .fn()
+            .mockReturnValueOnce(candidateQB)
+            .mockReturnValueOnce(commentQB),
+          findBy: jest.fn().mockResolvedValue([post]),
+        } as any,
+        { createQueryBuilder: jest.fn().mockReturnValue(tipQB) } as any,
+        { find: jest.fn().mockResolvedValue([]) } as any,
+        { createQueryBuilder: jest.fn().mockReturnValue(readsQB) } as any,
+        [],
+      );
+    }
+
+    it('handles future createdAt without negative scores', async () => {
+      const futurePost = {
+        id: 'post-future',
+        sender_address: 'ak_f',
+        created_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+        content: 'from the future',
+        topics: [],
+      };
+      const svc = buildServiceWith(futurePost);
+      const result = await svc.getPopularPostsPage('24h', 10, 0, undefined, {
+        interactionsPerHour: 'high',
+      });
+
+      expect(result.totalItems).toBe(1);
+      expect(result.scoredItems![0].score).toBeGreaterThanOrEqual(0);
+    });
+
+    it('handles invalid date string gracefully (interactionsPerHour = 0)', async () => {
+      const badDatePost = {
+        id: 'post-bad-date',
+        sender_address: 'ak_bad',
+        created_at: 'not-a-date',
+        content: 'bad date content',
+        topics: [],
+      };
+      const svc = buildServiceWith(badDatePost);
+      const result = await svc.getPopularPostsPage('24h', 10, 0, undefined, {
+        interactionsPerHour: 'high',
+      });
+
+      expect(result.totalItems).toBe(1);
+      expect(result.scoredItems![0].score).toBeGreaterThanOrEqual(0);
+    });
+
+    it('caps effectiveHours to window size for 24h window', async () => {
+      const now = Date.now();
+      const very_old_post = {
+        id: 'post-capped',
+        sender_address: 'ak_capped',
+        created_at: new Date(now - 48 * 60 * 60 * 1000).toISOString(),
+        content: 'old post that should be capped at 24h',
+        topics: [],
+      };
+      const recent_post = {
+        id: 'post-recent',
+        sender_address: 'ak_recent',
+        created_at: new Date(now - 2 * 60 * 60 * 1000).toISOString(),
+        content: 'recent post within window',
+        topics: [],
+      };
+
+      const candidateQB = {
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([very_old_post, recent_post]),
+      };
+      const commentQB = {
+        innerJoin: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([
+          { parent_id: 'post-capped', count: '5' },
+          { parent_id: 'post-recent', count: '5' },
+        ]),
+      };
+      const tipQB = {
+        select: jest.fn().mockReturnThis(),
+        innerJoin: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([
+          {
+            post_id: 'post-capped',
+            amount_sum: '0',
+            count: '2',
+            unique_tippers: '2',
+          },
+          {
+            post_id: 'post-recent',
+            amount_sum: '0',
+            count: '2',
+            unique_tippers: '2',
+          },
+        ]),
+      };
+      const readsQB = {
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([
+          { post_id: 'post-capped', reads: '10' },
+          { post_id: 'post-recent', reads: '10' },
+        ]),
+      };
+
+      const svc = new PopularRankingService(
+        {
+          createQueryBuilder: jest
+            .fn()
+            .mockReturnValueOnce(candidateQB)
+            .mockReturnValueOnce(commentQB),
+          findBy: jest.fn().mockResolvedValue([very_old_post, recent_post]),
+        } as any,
+        { createQueryBuilder: jest.fn().mockReturnValue(tipQB) } as any,
+        { find: jest.fn().mockResolvedValue([]) } as any,
+        { createQueryBuilder: jest.fn().mockReturnValue(readsQB) } as any,
+        [],
+      );
+
+      const result = await svc.getPopularPostsPage('24h', 10, 0, undefined, {
+        interactionsPerHour: 'high',
+      });
+
+      expect(result.scoredItems).toBeDefined();
+      expect(
+        result.scoredItems!.find((s) => s.postId === 'post-recent')!.score,
+      ).toBeGreaterThan(
+        result.scoredItems!.find((s) => s.postId === 'post-capped')!.score,
+      );
+    });
+  });
+
+  describe('pagination edge cases', () => {
+    it('returns empty items when offset exceeds total candidates', async () => {
+      const result = await service.getPopularPostsPage(
+        '24h',
+        10,
+        9999,
+        undefined,
+        {
+          comments: 'high',
+        },
+      );
+
+      expect(result.items).toEqual([]);
+      expect(result.totalItems).toBe(1);
+    });
+  });
+
+  describe('explain', () => {
+    it('returns unified shape with personalized flag for default path', async () => {
+      const post = {
+        id: 'post-explain',
+        tx_hash: 'tx_123',
+        sender_address: 'ak_explain',
+      };
+      (redisMock as any).zrevrange = jest
+        .fn()
+        .mockResolvedValue(['post-explain']);
+      postRepository.findBy = jest.fn().mockResolvedValue([post]);
+
+      const result = await service.explain('24h', 10, 0);
+
+      expect(result).toEqual([
+        expect.objectContaining({
+          id: 'post-explain',
+          tx: 'tx_123',
+          author: 'ak_explain',
+          personalized: false,
+          appliedWeights: expect.objectContaining({
+            comments: expect.any(Number),
+          }),
+        }),
+      ]);
+    });
+
+    it('returns unified shape with personalized flag for override path', async () => {
+      const post = {
+        id: 'post-p',
+        sender_address: 'ak_p',
+        tx_hash: 'tx_p',
+        created_at: new Date().toISOString(),
+        content: 'personalized',
+        topics: [],
+      };
+      const candidateQB = {
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([post]),
+      };
+      const commentQB = {
+        innerJoin: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([]),
+      };
+      const tipQB = {
+        select: jest.fn().mockReturnThis(),
+        innerJoin: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([]),
+      };
+      const readsQB = {
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([]),
+      };
+
+      const svc = new PopularRankingService(
+        {
+          createQueryBuilder: jest
+            .fn()
+            .mockReturnValueOnce(candidateQB)
+            .mockReturnValueOnce(commentQB),
+          findBy: jest.fn().mockResolvedValue([post]),
+        } as any,
+        { createQueryBuilder: jest.fn().mockReturnValue(tipQB) } as any,
+        { find: jest.fn().mockResolvedValue([]) } as any,
+        { createQueryBuilder: jest.fn().mockReturnValue(readsQB) } as any,
+        [],
+      );
+
+      const result = await svc.explain('24h', 10, 0, { comments: 'high' });
+
+      expect(result).toEqual([
+        expect.objectContaining({
+          id: 'post-p',
+          personalized: true,
+          appliedWeights: expect.objectContaining({
+            comments: expect.any(Number),
+            interactionsPerHour: expect.any(Number),
+          }),
+        }),
+      ]);
+    });
+
+    it('accepts precomputed scored items to avoid redundant computation', async () => {
+      const precomputed = [{ postId: 'post-1', score: 42, type: 'post' }];
+      postRepository.findBy = jest
+        .fn()
+        .mockResolvedValue([
+          { id: 'post-1', tx_hash: 'tx_1', sender_address: 'ak_1' },
+        ]);
+
+      const result = await service.explain(
+        '24h',
+        10,
+        0,
+        { comments: 'high' },
+        precomputed,
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('post-1');
+      expect(postRepository.createQueryBuilder).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/social/services/popular-ranking.service.ts
+++ b/src/social/services/popular-ranking.service.ts
@@ -4,7 +4,10 @@ import { In, Repository } from 'typeorm';
 import { Post } from '../entities/post.entity';
 import { Tip } from '@/tipping/entities/tip.entity';
 import { TrendingTag } from '@/trending-tags/entities/trending-tags.entity';
-import { POPULAR_RANKING_CONFIG } from '@/configs/constants';
+import {
+  POPULAR_RANKING_CONFIG,
+  type PopularRankingWeightScale,
+} from '@/configs/constants';
 import Redis from 'ioredis';
 import { REDIS_CONFIG } from '@/configs/redis';
 import { PostReadsDaily } from '../entities/post-reads.entity';
@@ -24,11 +27,51 @@ interface PopularScoreItem {
   metadata?: Record<string, any>;
 }
 
+type PopularCustomizableWeightKey =
+  | 'comments'
+  | 'tipsAmountAE'
+  | 'tipsCount'
+  | 'uniqueTippers'
+  | 'trendingBoost'
+  | 'contentQuality'
+  | 'reads'
+  | 'interactionsPerHour';
+
+export type PopularRankingWeightOverrides = Partial<
+  Record<PopularCustomizableWeightKey, PopularRankingWeightScale | undefined>
+>;
+
+type Mutable<T> = {
+  -readonly [K in keyof T]: T[K];
+};
+
+type PopularRankingResolvedWeights = Mutable<
+  typeof POPULAR_RANKING_CONFIG.WEIGHTS
+> & {
+  interactionsPerHour: number;
+};
+
+interface PopularScoreInput {
+  content: string;
+  comments: number;
+  tipsAmountAE: number;
+  tipsCount: number;
+  uniqueTippers: number;
+  reads: number;
+  topics?: Array<{ name?: string }>;
+  createdAt?: Date | string;
+}
+
 @Injectable()
 export class PopularRankingService {
   private readonly logger = new Logger(PopularRankingService.name);
   private readonly redis = new Redis(REDIS_CONFIG);
   private readonly recomputeInFlight = new Map<PopularWindow, Promise<void>>();
+  private trendingTagCache: {
+    map: Map<string, number>;
+    expiresAt: number;
+  } | null = null;
+  private static readonly TRENDING_CACHE_TTL_MS = 30_000;
 
   constructor(
     @InjectRepository(Post)
@@ -52,6 +95,51 @@ export class PopularRankingService {
       return POPULAR_RANKING_CONFIG.WINDOW_7D_HOURS;
     }
     return Number.MAX_SAFE_INTEGER;
+  }
+
+  private getDefaultMaxCandidates(window: PopularWindow): number {
+    return window === 'all'
+      ? POPULAR_RANKING_CONFIG.MAX_CANDIDATES_ALL
+      : window === '7d'
+        ? POPULAR_RANKING_CONFIG.MAX_CANDIDATES_7D
+        : POPULAR_RANKING_CONFIG.MAX_CANDIDATES_24H;
+  }
+
+  private hasWeightOverrides(
+    overrides?: PopularRankingWeightOverrides,
+  ): overrides is PopularRankingWeightOverrides {
+    return !!overrides && Object.values(overrides).some((value) => !!value);
+  }
+
+  private resolveWeights(
+    overrides?: PopularRankingWeightOverrides,
+  ): PopularRankingResolvedWeights {
+    const resolved: PopularRankingResolvedWeights = {
+      ...POPULAR_RANKING_CONFIG.WEIGHTS,
+      interactionsPerHour: 0,
+    };
+
+    if (!this.hasWeightOverrides(overrides)) {
+      return resolved;
+    }
+
+    const multipliers = POPULAR_RANKING_CONFIG.CUSTOMIZATION.SCALE_MULTIPLIERS;
+    for (const [key, value] of Object.entries(overrides)) {
+      if (!value) {
+        continue;
+      }
+
+      const multiplier = multipliers[value];
+      if (key === 'interactionsPerHour') {
+        resolved.interactionsPerHour =
+          POPULAR_RANKING_CONFIG.CUSTOMIZATION.ADDITIONAL_SIGNAL_WEIGHTS
+            .interactionsPerHour * multiplier;
+      } else if (key in resolved) {
+        (resolved as Record<string, number>)[key] *= multiplier;
+      }
+    }
+
+    return resolved;
   }
 
   private getRedisKey(window: PopularWindow): string {
@@ -214,12 +302,7 @@ export class PopularRankingService {
       return;
     }
 
-    const fallbackMax =
-      window === 'all'
-        ? POPULAR_RANKING_CONFIG.MAX_CANDIDATES_ALL
-        : window === '7d'
-          ? POPULAR_RANKING_CONFIG.MAX_CANDIDATES_7D
-          : POPULAR_RANKING_CONFIG.MAX_CANDIDATES_24H;
+    const fallbackMax = this.getDefaultMaxCandidates(window);
 
     const task = this.recompute(window, maxCandidates ?? fallbackMax)
       .catch((error) =>
@@ -231,27 +314,17 @@ export class PopularRankingService {
     await task;
   }
 
-  async getPopularPosts(
+  private async hydrateRankedItems(
     window: PopularWindow,
-    limit = 50,
-    offset = 0,
-    maxCandidates?: number,
+    ids: string[],
   ): Promise<(Post | PopularRankingContentItem)[]> {
-    const verifiedIds = await this.getVerifiedPopularIds(window, maxCandidates);
-
-    if (verifiedIds.length === 0) {
-      return this.fetchRecentFallback(window, limit, offset);
-    }
-
-    const paginatedIds = verifiedIds.slice(offset, offset + limit);
-
-    if (paginatedIds.length === 0) {
+    if (ids.length === 0) {
       return [];
     }
 
     const postIds: string[] = [];
     const pluginContentIds: string[] = [];
-    for (const id of paginatedIds) {
+    for (const id of ids) {
       if (id.includes(':')) {
         pluginContentIds.push(id);
       } else {
@@ -279,17 +352,18 @@ export class PopularRankingService {
         itemsByType.get(type)!.push(id);
       }
 
+      const since =
+        window === 'all'
+          ? null
+          : new Date(Date.now() - this.getWindowHours(window) * 60 * 60 * 1000);
+
       for (const contributor of this.rankingContributors) {
         const typeIds = itemsByType.get(contributor.name);
         if (typeIds && typeIds.length > 0) {
           try {
             const allItems = await contributor.getRankingCandidates(
               window,
-              window === 'all'
-                ? null
-                : new Date(
-                    Date.now() - this.getWindowHours(window) * 60 * 60 * 1000,
-                  ),
+              since,
               10000,
             );
             const requestedItems = allItems.filter((item) =>
@@ -308,21 +382,77 @@ export class PopularRankingService {
 
     const postsMap = new Map(posts.map((p) => [p.id, p]));
     const pluginItemsMap = new Map(pluginItems.map((item) => [item.id, item]));
-
     const result: (Post | PopularRankingContentItem)[] = [];
-    for (const id of paginatedIds) {
+    for (const id of ids) {
       const post = postsMap.get(id);
       if (post) {
         result.push(post);
-      } else {
-        const item = pluginItemsMap.get(id);
-        if (item) {
-          result.push(item);
-        }
+        continue;
+      }
+
+      const item = pluginItemsMap.get(id);
+      if (item) {
+        result.push(item);
       }
     }
 
     return result;
+  }
+
+  async getPopularPosts(
+    window: PopularWindow,
+    limit = 50,
+    offset = 0,
+    maxCandidates?: number,
+  ): Promise<(Post | PopularRankingContentItem)[]> {
+    const verifiedIds = await this.getVerifiedPopularIds(window, maxCandidates);
+
+    if (verifiedIds.length === 0) {
+      return this.fetchRecentFallback(window, limit, offset);
+    }
+
+    return this.hydrateRankedItems(
+      window,
+      verifiedIds.slice(offset, offset + limit),
+    );
+  }
+
+  async getPopularPostsPage(
+    window: PopularWindow,
+    limit = 50,
+    offset = 0,
+    maxCandidates?: number,
+    weightOverrides?: PopularRankingWeightOverrides,
+  ): Promise<{
+    items: (Post | PopularRankingContentItem)[];
+    totalItems: number;
+    scoredItems?: PopularScoreItem[];
+  }> {
+    if (!this.hasWeightOverrides(weightOverrides)) {
+      const totalItems = await this.getTotalPostsCount(window);
+      const items = await this.getPopularPosts(
+        window,
+        limit,
+        offset,
+        maxCandidates,
+      );
+      return { items, totalItems };
+    }
+
+    const scored = await this.buildScoredItems(
+      window,
+      maxCandidates ?? this.getDefaultMaxCandidates(window),
+      weightOverrides,
+    );
+    const paginatedIds = scored
+      .slice(offset, offset + limit)
+      .map((item) => item.postId);
+
+    return {
+      items: await this.hydrateRankedItems(window, paginatedIds),
+      totalItems: scored.length,
+      scoredItems: scored,
+    };
   }
 
   async getTotalCached(window: PopularWindow): Promise<number | undefined> {
@@ -350,21 +480,13 @@ export class PopularRankingService {
     }
   }
 
-  async recompute(window: PopularWindow, maxCandidates = 10000): Promise<void> {
-    const key = this.getRedisKey(window);
+  private async buildScoredItems(
+    window: PopularWindow,
+    maxCandidates = 10000,
+    weightOverrides?: PopularRankingWeightOverrides,
+  ): Promise<PopularScoreItem[]> {
     const hours = this.getWindowHours(window);
     const since = new Date(Date.now() - hours * 60 * 60 * 1000);
-
-    this.logger.log(
-      `Starting recompute for window ${window} with maxCandidates ${maxCandidates}, key=${key}`,
-    );
-
-    try {
-      await this.redis.ping();
-    } catch (error) {
-      this.logger.error(`Redis connection error:`, error);
-      throw error;
-    }
 
     const candidates = await this.postRepository
       .createQueryBuilder('post')
@@ -408,14 +530,6 @@ export class PopularRankingService {
       `Found ${pluginContentItems.length} plugin content items for window ${window}`,
     );
 
-    if (candidates.length === 0 && pluginContentItems.length === 0) {
-      await this.redis.del(key);
-      this.logger.warn(
-        `No candidates found for window ${window}, deleted Redis key`,
-      );
-      return;
-    }
-
     if (candidates.length > 0) {
       this.logger.log(
         `First 5 candidate IDs: ${candidates
@@ -425,126 +539,163 @@ export class PopularRankingService {
       );
     }
 
-    // Preload tips per post
     const ids = candidates.map((c) => c.id);
-    const tipsRaw = await this.tipRepository
-      .createQueryBuilder('tip')
-      .select('tip.post_id', 'post_id')
-      .innerJoin(Post, 'post', 'post.id = tip.post_id')
-      .addSelect('COALESCE(SUM(CAST(tip.amount AS numeric)), 0)', 'amount_sum')
-      .addSelect('COUNT(*)', 'count')
-      .addSelect('COUNT(DISTINCT tip.sender_address)', 'unique_tippers')
-      .where('tip.post_id IN (:...ids)', { ids })
-      .andWhere('tip.sender_address != post.sender_address')
-      .groupBy('tip.post_id')
-      .getRawMany<{
-        post_id: string;
-        amount_sum: string;
-        count: string;
-        unique_tippers: string;
-      }>();
-    const tipsByPost = new Map(tipsRaw.map((t) => [t.post_id, t] as const));
+    let tipsByPost = new Map<string, any>();
+    let commentsByPost = new Map<string, number>();
+    let readsByPost = new Map<string, number>();
 
-    // Preload comment counts excluding the post author's own replies
-    const commentsRaw = await this.postRepository
-      .createQueryBuilder('comment')
-      .innerJoin(Post, 'parent', 'parent.id = comment.post_id')
-      .select('comment.post_id', 'parent_id')
-      .addSelect('COUNT(*)', 'count')
-      .where('comment.post_id IN (:...ids)', { ids })
-      .andWhere('comment.is_hidden = false')
-      .andWhere('comment.sender_address != parent.sender_address')
-      .groupBy('comment.post_id')
-      .getRawMany<{ parent_id: string; count: string }>();
-    const commentsByPost = new Map(
-      commentsRaw.map(
-        (r) => [r.parent_id, parseInt(r.count || '0', 10)] as const,
-      ),
-    );
+    if (ids.length > 0) {
+      const tipsRaw = await this.tipRepository
+        .createQueryBuilder('tip')
+        .select('tip.post_id', 'post_id')
+        .innerJoin(Post, 'post', 'post.id = tip.post_id')
+        .addSelect(
+          'COALESCE(SUM(CAST(tip.amount AS numeric)), 0)',
+          'amount_sum',
+        )
+        .addSelect('COUNT(*)', 'count')
+        .addSelect('COUNT(DISTINCT tip.sender_address)', 'unique_tippers')
+        .where('tip.post_id IN (:...ids)', { ids })
+        .andWhere('tip.sender_address != post.sender_address')
+        .groupBy('tip.post_id')
+        .getRawMany<{
+          post_id: string;
+          amount_sum: string;
+          count: string;
+          unique_tippers: string;
+        }>();
+      tipsByPost = new Map(tipsRaw.map((t) => [t.post_id, t] as const));
+
+      const commentsRaw = await this.postRepository
+        .createQueryBuilder('comment')
+        .innerJoin(Post, 'parent', 'parent.id = comment.post_id')
+        .select('comment.post_id', 'parent_id')
+        .addSelect('COUNT(*)', 'count')
+        .where('comment.post_id IN (:...ids)', { ids })
+        .andWhere('comment.is_hidden = false')
+        .andWhere('comment.sender_address != parent.sender_address')
+        .groupBy('comment.post_id')
+        .getRawMany<{ parent_id: string; count: string }>();
+      commentsByPost = new Map(
+        commentsRaw.map(
+          (r) => [r.parent_id, parseInt(r.count || '0', 10)] as const,
+        ),
+      );
+
+      const fromDate = new Date(Date.now() - hours * 3600 * 1000);
+      const fromDateOnly = `${fromDate.getUTCFullYear()}-${String(
+        fromDate.getUTCMonth() + 1,
+      ).padStart(2, '0')}-${String(fromDate.getUTCDate()).padStart(2, '0')}`;
+      const readsQB = this.postReadsRepository
+        .createQueryBuilder('r')
+        .select('r.post_id', 'post_id')
+        .addSelect('COALESCE(SUM(r.reads), 0)', 'reads')
+        .where('r.post_id IN (:...ids)', { ids });
+      if (window !== 'all') {
+        readsQB.andWhere('r.date >= :from', { from: fromDateOnly });
+      }
+      const readsRows = await readsQB
+        .groupBy('r.post_id')
+        .getRawMany<{ post_id: string; reads: string }>();
+      readsByPost = new Map(
+        readsRows.map(
+          (r) => [r.post_id, parseInt(r.reads || '0', 10)] as const,
+        ),
+      );
+    }
 
     const trendingByTag = await this.loadTrendingByTagMap();
+    const resolvedWeights = this.resolveWeights(weightOverrides);
 
-    // Preload reads over window per post
-    const fromDate = new Date(Date.now() - hours * 3600 * 1000);
-    const fromDateOnly = `${fromDate.getUTCFullYear()}-${String(
-      fromDate.getUTCMonth() + 1,
-    ).padStart(2, '0')}-${String(fromDate.getUTCDate()).padStart(2, '0')}`;
-    const readsQB = this.postReadsRepository
-      .createQueryBuilder('r')
-      .select('r.post_id', 'post_id')
-      .addSelect('COALESCE(SUM(r.reads), 0)', 'reads')
-      .where('r.post_id IN (:...ids)', { ids });
-    if (window !== 'all') {
-      readsQB.andWhere('r.date >= :from', { from: fromDateOnly });
-    }
-    const readsRows = await readsQB
-      .groupBy('r.post_id')
-      .getRawMany<{ post_id: string; reads: string }>();
-    const readsByPost = new Map(
-      readsRows.map((r) => [r.post_id, parseInt(r.reads || '0', 10)] as const),
-    );
-
-    // Score posts
     const scoredPosts: PopularScoreItem[] = candidates.map((post) => {
       const tipsAgg = tipsByPost.get(post.id);
       return {
         postId: post.id,
-        score: this.computeScore(trendingByTag, {
-          content: post.content,
-          comments: commentsByPost.get(post.id) || 0,
-          tipsAmountAE: tipsAgg ? parseFloat(tipsAgg.amount_sum || '0') : 0,
-          tipsCount: tipsAgg ? parseInt(tipsAgg.count || '0', 10) : 0,
-          uniqueTippers: tipsAgg
-            ? parseInt(tipsAgg.unique_tippers || '0', 10)
-            : 0,
-          reads: readsByPost.get(post.id) || 0,
-          topics: post.topics,
-        }),
+        score: this.computeScore(
+          trendingByTag,
+          {
+            content: post.content,
+            comments: commentsByPost.get(post.id) || 0,
+            tipsAmountAE: tipsAgg ? parseFloat(tipsAgg.amount_sum || '0') : 0,
+            tipsCount: tipsAgg ? parseInt(tipsAgg.count || '0', 10) : 0,
+            uniqueTippers: tipsAgg
+              ? parseInt(tipsAgg.unique_tippers || '0', 10)
+              : 0,
+            reads: readsByPost.get(post.id) || 0,
+            topics: post.topics,
+            createdAt: post.created_at,
+          },
+          resolvedWeights,
+          window,
+        ),
         type: 'post',
       };
     });
 
-    // Score plugin content items
     const scoredPluginItems: PopularScoreItem[] = pluginContentItems.map(
       (item) => ({
         postId: item.id,
-        score: this.computeScore(trendingByTag, {
-          content: item.content,
-          comments: item.total_comments || 0,
-          tipsAmountAE: 0,
-          tipsCount: 0,
-          uniqueTippers: 0,
-          reads: 0,
-          topics: item.topics,
-        }),
+        score: this.computeScore(
+          trendingByTag,
+          {
+            content: item.content,
+            comments: item.total_comments || 0,
+            tipsAmountAE: 0,
+            tipsCount: 0,
+            uniqueTippers: 0,
+            reads: 0,
+            topics: item.topics,
+            createdAt: item.created_at,
+          },
+          resolvedWeights,
+          window,
+        ),
         type: item.type,
         metadata: item.metadata,
       }),
     );
 
-    const scored = [...scoredPosts, ...scoredPluginItems];
+    return [...scoredPosts, ...scoredPluginItems].sort(
+      (a, b) => b.score - a.score,
+    );
+  }
+
+  async recompute(window: PopularWindow, maxCandidates = 10000): Promise<void> {
+    const key = this.getRedisKey(window);
+
+    this.logger.log(
+      `Starting recompute for window ${window} with maxCandidates ${maxCandidates}, key=${key}`,
+    );
+
+    try {
+      await this.redis.ping();
+    } catch (error) {
+      this.logger.error(`Redis connection error:`, error);
+      throw error;
+    }
+
+    const scored = await this.buildScoredItems(window, maxCandidates);
+
+    if (scored.length === 0) {
+      await this.redis.del(key);
+      this.logger.warn(
+        `No candidates found for window ${window}, deleted Redis key`,
+      );
+      return;
+    }
 
     this.logger.log(
       `Window ${window}: ${scored.length} posts scored, all eligible (no score floor)`,
     );
 
-    if (scored.length > 0) {
-      const topScores = scored
-        .sort((a, b) => b.score - a.score)
-        .slice(0, 5)
-        .map((s) => `${s.postId}:${s.score.toFixed(4)}`)
-        .join(', ');
-      this.logger.log(`Top 5 scores: ${topScores}`);
-    }
+    const topScores = scored
+      .slice(0, 5)
+      .map((s) => `${s.postId}:${s.score.toFixed(4)}`)
+      .join(', ');
+    this.logger.log(`Top 5 scores: ${topScores}`);
 
-    // Cache in Redis ZSET
     try {
       await this.redis.del(key);
-
-      if (scored.length === 0) {
-        this.logger.warn(`No posts to cache for window ${window}`);
-        return;
-      }
 
       const pipeline = this.redis.pipeline();
       for (const item of scored) {
@@ -592,28 +743,61 @@ export class PopularRankingService {
   }
 
   private async loadTrendingByTagMap(): Promise<Map<string, number>> {
+    if (this.trendingTagCache && Date.now() < this.trendingTagCache.expiresAt) {
+      return this.trendingTagCache.map;
+    }
+
     let trending: TrendingTag[] = [];
     try {
       trending = await this.trendingTagRepository.find();
     } catch {
       trending = [];
     }
-    return new Map(
+    const map = new Map(
       trending.map((t) => [t.tag.toLowerCase(), t.score] as const),
+    );
+    this.trendingTagCache = {
+      map,
+      expiresAt: Date.now() + PopularRankingService.TRENDING_CACHE_TTL_MS,
+    };
+    return map;
+  }
+
+  private computeInteractionsPerHour(
+    input: PopularScoreInput,
+    window: PopularWindow,
+  ): number {
+    const createdAt =
+      input.createdAt instanceof Date
+        ? input.createdAt
+        : input.createdAt
+          ? new Date(input.createdAt)
+          : null;
+
+    if (!createdAt || Number.isNaN(createdAt.getTime())) {
+      return 0;
+    }
+
+    const ageHours = Math.max(
+      1,
+      (Date.now() - createdAt.getTime()) / (60 * 60 * 1000),
+    );
+    const effectiveHours =
+      window === 'all'
+        ? ageHours
+        : Math.min(ageHours, this.getWindowHours(window));
+
+    return (
+      (input.comments + input.tipsCount + input.uniqueTippers) /
+      Math.max(1, effectiveHours)
     );
   }
 
   private computeScore(
     trendingByTag: Map<string, number>,
-    input: {
-      content: string;
-      comments: number;
-      tipsAmountAE: number;
-      tipsCount: number;
-      uniqueTippers: number;
-      reads: number;
-      topics?: Array<{ name?: string }>;
-    },
+    input: PopularScoreInput,
+    weights: PopularRankingResolvedWeights,
+    window: PopularWindow,
   ): number {
     const { comments, tipsAmountAE, tipsCount, uniqueTippers, reads } = input;
 
@@ -633,35 +817,66 @@ export class PopularRankingService {
     }
 
     const contentQuality = this.computeContentQuality(input.content || '');
-    const w = POPULAR_RANKING_CONFIG.WEIGHTS;
+    const interactionsPerHour = this.computeInteractionsPerHour(input, window);
 
     return (
-      w.comments * Math.log(1 + comments) +
-      w.tipsAmountAE * Math.log(1 + tipsAmountAE) +
-      w.tipsCount * Math.log(1 + tipsCount) +
-      w.uniqueTippers * Math.log(1 + uniqueTippers) +
-      w.reads * Math.log(1 + reads) +
-      w.trendingBoost * trendingBoost +
-      w.contentQuality * contentQuality
+      weights.comments * Math.log(1 + comments) +
+      weights.tipsAmountAE * Math.log(1 + tipsAmountAE) +
+      weights.tipsCount * Math.log(1 + tipsCount) +
+      weights.uniqueTippers * Math.log(1 + uniqueTippers) +
+      weights.reads * Math.log(1 + reads) +
+      weights.trendingBoost * trendingBoost +
+      weights.contentQuality * contentQuality +
+      weights.interactionsPerHour * Math.log(1 + interactionsPerHour)
     );
   }
 
-  async explain(window: PopularWindow, limit = 20, offset = 0) {
-    const key = this.getRedisKey(window);
-    const ids = await this.redis.zrevrange(key, offset, offset + limit - 1);
-    const posts = ids.length
-      ? await this.postRepository.findBy({ id: In(ids) })
-      : await this.postRepository
-          .createQueryBuilder('post')
-          .where('post.is_hidden = false')
-          .andWhere('post.post_id IS NULL')
-          .orderBy('post.created_at', 'DESC')
-          .limit(limit)
-          .getMany();
-    return posts.map((p) => ({
-      id: p.id,
-      tx: p.tx_hash,
-      author: p.sender_address,
+  async explain(
+    window: PopularWindow,
+    limit = 20,
+    offset = 0,
+    weightOverrides?: PopularRankingWeightOverrides,
+    precomputedScored?: PopularScoreItem[],
+  ) {
+    const personalized = this.hasWeightOverrides(weightOverrides);
+    const appliedWeights = personalized
+      ? this.resolveWeights(weightOverrides)
+      : this.resolveWeights();
+
+    let items: (Post | PopularRankingContentItem)[];
+
+    if (personalized) {
+      const scored =
+        precomputedScored ??
+        (await this.buildScoredItems(
+          window,
+          this.getDefaultMaxCandidates(window),
+          weightOverrides,
+        ));
+      const ids = scored
+        .slice(offset, offset + limit)
+        .map((item) => item.postId);
+      items = await this.hydrateRankedItems(window, ids);
+    } else {
+      const key = this.getRedisKey(window);
+      const ids = await this.redis.zrevrange(key, offset, offset + limit - 1);
+      items = ids.length
+        ? await this.postRepository.findBy({ id: In(ids) })
+        : await this.postRepository
+            .createQueryBuilder('post')
+            .where('post.is_hidden = false')
+            .andWhere('post.post_id IS NULL')
+            .orderBy('post.created_at', 'DESC')
+            .limit(limit)
+            .getMany();
+    }
+
+    return items.map((item) => ({
+      id: item.id,
+      tx: 'tx_hash' in item ? item.tx_hash : undefined,
+      author: item.sender_address,
+      personalized,
+      appliedWeights,
     }));
   }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the `GET /posts/popular` contract and popular-ranking scoring logic, which can alter feed ordering and load characteristics due to on-demand rescoring when overrides are provided. Dependency bumps in `package-lock.json` also introduce integration risk but are largely patch/minor updates.
> 
> **Overview**
> Adds optional *client-controlled* weight scaling to the `GET /posts/popular` endpoint via a new `PopularPostsQueryDto`, allowing callers to boost/reduce individual engagement signals (comments, tips, reads, etc.) and an additional velocity signal (`interactionsPerHour`).
> 
> Refactors `PopularRankingService` to support per-request rescoring with `getPopularPostsPage`, resolves weight overrides using new config multipliers, adds a short-lived trending-tag cache, and updates `explain`/debug output to reflect personalized vs default ranking (reusing precomputed scores when available). Also updates tests to cover override behavior and edge cases, and bumps multiple npm dependencies in `package-lock.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5385d4b4222dea0f6b6ba5c7bc2e699c9f63687. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->