### PR TITLE
refactor: do not save not required transactions

### DIFF
--- a/src/mdw-sync/services/block-sync.service.spec.ts
+++ b/src/mdw-sync/services/block-sync.service.spec.ts
@@ -53,6 +53,10 @@ describe('BlockSyncService', () => {
     } as unknown as ConfigService;
     const pluginBatchProcessor = {
       processBatch: jest.fn(),
+      // Default: treat every transaction as relevant so the existing
+      // persistence tests keep exercising the save/upsert paths.
+      filterRelevantTransactions: jest.fn((txs: any[]) => txs),
+      isRelevantTransaction: jest.fn(() => true),
     } as any;
     const microBlockService = {
       fetchMicroBlocksForKeyBlock: jest.fn().mockResolvedValue([]),
@@ -215,5 +219,92 @@ describe('BlockSyncService', () => {
       'backward',
     );
     expect(result.get(123)).toEqual(['th_test_1']);
+  });
+
+  it('does not persist filtered-out transactions but still records them as observed for validation', async () => {
+    // When every plugin rejects a transaction, nothing should be written to
+    // the DB. However, block validation MUST still see that MDW returned
+    // the transaction for this block; otherwise a misconfigured plugin
+    // could cause BlockValidationService to delete canonical rows.
+    const { service, txRepository, pluginBatchProcessor } = setup();
+
+    (
+      pluginBatchProcessor.filterRelevantTransactions as jest.Mock
+    ).mockImplementation(() => []);
+
+    (fetchJson as jest.Mock).mockResolvedValueOnce({
+      data: [buildMiddlewareTransaction()],
+      next: null,
+    });
+
+    const result = await service.syncTransactions(123, 123, true, true);
+
+    expect(
+      pluginBatchProcessor.filterRelevantTransactions,
+    ).toHaveBeenCalledTimes(1);
+    expect(txRepository.upsert).not.toHaveBeenCalled();
+    expect(txRepository.save).not.toHaveBeenCalled();
+    expect(pluginBatchProcessor.processBatch).not.toHaveBeenCalled();
+    // Observed hash is still tracked so validation compares against the full
+    // on-chain set, not the (possibly empty) filtered subset.
+    expect(result.get(123)).toEqual(['th_test_1']);
+  });
+
+  it('only persists transactions returned by filterRelevantTransactions', async () => {
+    const { service, txRepository, pluginBatchProcessor } = setup();
+
+    (
+      pluginBatchProcessor.filterRelevantTransactions as jest.Mock
+    ).mockImplementation((txs: any[]) =>
+      txs.filter((tx) => tx.hash === 'th_relevant'),
+    );
+
+    (fetchJson as jest.Mock).mockResolvedValueOnce({
+      data: [
+        {
+          ...buildMiddlewareTransaction(),
+          hash: 'th_relevant',
+          block_height: 200,
+          tx: {
+            type: 'ContractCallTx',
+            contract_id: 'ct_bcl',
+            function: 'buy',
+            caller_id: 'ak_caller_1',
+          },
+        },
+        {
+          ...buildMiddlewareTransaction(),
+          hash: 'th_irrelevant',
+          block_height: 200,
+          tx: {
+            type: 'ContractCallTx',
+            contract_id: 'ct_other',
+            function: 'something',
+            caller_id: 'ak_caller_2',
+          },
+        },
+      ],
+      next: null,
+    });
+    txRepository.upsert.mockResolvedValueOnce(undefined);
+    txRepository.find.mockResolvedValueOnce([]);
+
+    const result = await service.syncTransactions(200, 200, true, true);
+
+    expect(
+      pluginBatchProcessor.filterRelevantTransactions,
+    ).toHaveBeenCalledWith([
+      expect.objectContaining({ hash: 'th_relevant' }),
+      expect.objectContaining({ hash: 'th_irrelevant' }),
+    ]);
+    expect(txRepository.upsert).toHaveBeenCalledTimes(1);
+    const upsertedBatch = txRepository.upsert.mock.calls[0][0];
+    expect(upsertedBatch).toEqual([
+      expect.objectContaining({ hash: 'th_relevant' }),
+    ]);
+    expect(upsertedBatch).toHaveLength(1);
+    // Both hashes must be recorded as observed for validation, even though
+    // only the relevant one ends up in the DB.
+    expect(result.get(200)?.sort()).toEqual(['th_irrelevant', 'th_relevant']);
   });
 });

--- a/src/mdw-sync/services/block-sync.service.ts
+++ b/src/mdw-sync/services/block-sync.service.ts
@@ -210,12 +210,37 @@ export class BlockSyncService {
         mdwTxs.push(this.convertToMdwTx(camelTx));
       }
 
-      if (mdwTxs.length > 0) {
-        let savedTxs: Partial<Tx>[] = [];
+      // Track every transaction MDW reports for this block (minus self-
+      // transfers, which the indexer always drops). Block validation uses
+      // this "observed" set to detect reorgs: anything in the DB that is
+      // NOT in this set is considered reorged away.
+      //
+      // IMPORTANT: this must be populated BEFORE the plugin relevance filter.
+      // Otherwise a misconfigured plugin (e.g. `filters()` returns []) would
+      // shrink the observed set to empty and BlockValidationService would
+      // delete canonical, still-on-chain transactions from `txs`.
+      if (txHashesByBlock) {
+        for (const tx of mdwTxs) {
+          if (tx.hash && tx.block_height !== undefined) {
+            const blockHeight = tx.block_height;
+            if (!txHashesByBlock.has(blockHeight)) {
+              txHashesByBlock.set(blockHeight, []);
+            }
+            txHashesByBlock.get(blockHeight)!.push(tx.hash);
+          }
+        }
+      }
 
+      // Drop transactions that do not match any registered plugin filter.
+      // The indexer must only persist transactions the application actually
+      // cares about; everything else is noise and wastes storage.
+      const relevantTxs =
+        this.pluginBatchProcessor.filterRelevantTransactions(mdwTxs);
+
+      if (relevantTxs.length > 0) {
         if (useBulkMode) {
           try {
-            savedTxs = await this.bulkInsertTransactions(mdwTxs);
+            await this.bulkInsertTransactions(relevantTxs);
           } catch (error: any) {
             if (isDatabaseConnectionOrPoolError(error)) {
               logDatabaseIssue({
@@ -224,7 +249,7 @@ export class BlockSyncService {
                 error,
                 context: {
                   url: nextUrl,
-                  transactionCount: mdwTxs.length,
+                  transactionCount: relevantTxs.length,
                   useBulkMode,
                 },
               });
@@ -235,7 +260,7 @@ export class BlockSyncService {
               `Bulk insert failed for page, trying repository.save as fallback`,
               error,
             );
-            const saved = await this.txRepository.save(mdwTxs);
+            const saved = await this.txRepository.save(relevantTxs);
             const savedArr = Array.isArray(saved) ? saved : [saved];
             if (savedArr.length > 0) {
               await this.pluginBatchProcessor.processBatch(
@@ -243,7 +268,6 @@ export class BlockSyncService {
                 SyncDirectionEnum.Backward,
               );
             }
-            savedTxs = savedArr;
           }
         } else {
           const saved = await runWithDatabaseIssueLogging({
@@ -251,10 +275,10 @@ export class BlockSyncService {
             stage: 'transaction save',
             context: {
               url: nextUrl,
-              transactionCount: mdwTxs.length,
+              transactionCount: relevantTxs.length,
               useBulkMode,
             },
-            operation: () => this.txRepository.save(mdwTxs),
+            operation: () => this.txRepository.save(relevantTxs),
           });
           const savedArr = Array.isArray(saved) ? saved : [saved];
           if (savedArr.length > 0) {
@@ -262,19 +286,6 @@ export class BlockSyncService {
               savedArr,
               SyncDirectionEnum.Backward,
             );
-          }
-          savedTxs = savedArr;
-        }
-
-        if (txHashesByBlock) {
-          for (const savedTx of savedTxs) {
-            if (savedTx.hash && savedTx.block_height !== undefined) {
-              const blockHeight = savedTx.block_height;
-              if (!txHashesByBlock.has(blockHeight)) {
-                txHashesByBlock.set(blockHeight, []);
-              }
-              txHashesByBlock.get(blockHeight)!.push(savedTx.hash);
-            }
           }
         }
       }

--- a/src/mdw-sync/services/live-indexer.service.spec.ts
+++ b/src/mdw-sync/services/live-indexer.service.spec.ts
@@ -1,0 +1,177 @@
+import { ITransaction } from '@/utils/types';
+
+jest.mock('@/utils/common', () => ({
+  fetchJson: jest.fn(),
+  sanitizeJsonForPostgres: jest.fn((value) => value),
+}));
+
+// Neutralise the websocket / sdk import chain. WebSocketService pulls in
+// configs/nodes.ts which instantiates `new Node(...)` at module load time.
+// We never exercise those code paths here, so stubbing the module keeps the
+// test hermetic.
+jest.mock('@/ae/websocket.service', () => ({
+  WebSocketService: class {},
+}));
+
+jest.mock('@aeternity/aepp-sdk', () => ({
+  // decode is only reached for SpendTx with a payload; return a plain buffer
+  // so the tests can exercise that branch without real decoding.
+  decode: jest.fn(() => Buffer.from('')),
+  Node: class {},
+  AeSdk: class {},
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { LiveIndexerService } = require('./live-indexer.service');
+
+/**
+ * Covers the live ingestion path. The critical behaviour we lock down here is
+ * the plugin-relevance gate in `handleLiveTransaction`:
+ *   - irrelevant transactions must never reach the DB or the plugin pipeline;
+ *   - relevant transactions must go through repository.save + processBatch.
+ */
+describe('LiveIndexerService.handleLiveTransaction', () => {
+  const buildTransaction = (
+    overrides: Partial<ITransaction['tx']> = {},
+  ): ITransaction =>
+    ({
+      hash: 'th_live_1',
+      blockHeight: 500,
+      blockHash: 'mh_live_1',
+      microIndex: 0,
+      microTime: 1700000000000,
+      signatures: [],
+      encodedTx: 'tx_live_1',
+      pending: false,
+      claim: null,
+      tx: {
+        type: 'ContractCallTx',
+        contractId: 'ct_live',
+        function: 'buy',
+        callerId: 'ak_caller_live',
+        ...overrides,
+      },
+    }) as unknown as ITransaction;
+
+  const setup = () => {
+    const txRepository = {
+      save: jest.fn(),
+    } as any;
+    const blockRepository = { upsert: jest.fn() } as any;
+    const microBlockRepository = { upsert: jest.fn() } as any;
+    const syncStateRepository = { update: jest.fn() } as any;
+    const configService = { get: jest.fn() } as any;
+    const websocketService = {
+      subscribeForTransactionsUpdates: jest.fn(() => () => undefined),
+      subscribeForKeyBlocksUpdates: jest.fn(() => () => undefined),
+    } as any;
+    const pluginBatchProcessor = {
+      isRelevantTransaction: jest.fn(),
+      processBatch: jest.fn(),
+    } as any;
+    const microBlockService = {
+      fetchMicroBlocksForKeyBlock: jest.fn(),
+    } as any;
+
+    const service = new LiveIndexerService(
+      txRepository,
+      blockRepository,
+      microBlockRepository,
+      syncStateRepository,
+      configService,
+      websocketService,
+      pluginBatchProcessor,
+      microBlockService,
+    );
+
+    return {
+      service,
+      txRepository,
+      pluginBatchProcessor,
+    };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('skips irrelevant transactions before touching the database', async () => {
+    const { service, txRepository, pluginBatchProcessor } = setup();
+    pluginBatchProcessor.isRelevantTransaction.mockReturnValue(false);
+
+    await service.handleLiveTransaction(buildTransaction());
+
+    expect(pluginBatchProcessor.isRelevantTransaction).toHaveBeenCalledTimes(1);
+    expect(txRepository.save).not.toHaveBeenCalled();
+    expect(pluginBatchProcessor.processBatch).not.toHaveBeenCalled();
+  });
+
+  it('passes the mdw-shaped tx (not the raw websocket shape) to the relevance gate', async () => {
+    // Regression guard: the predicate must see the same `Partial<Tx>` shape
+    // the backward sync uses, otherwise plugin filters that inspect
+    // `contract_id` / `function` silently stop matching on the live path.
+    const { service, pluginBatchProcessor } = setup();
+    pluginBatchProcessor.isRelevantTransaction.mockReturnValue(false);
+
+    await service.handleLiveTransaction(
+      buildTransaction({
+        type: 'ContractCallTx',
+        contractId: 'ct_bcl',
+        function: 'buy',
+      }),
+    );
+
+    expect(pluginBatchProcessor.isRelevantTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hash: 'th_live_1',
+        type: 'ContractCallTx',
+        contract_id: 'ct_bcl',
+        function: 'buy',
+      }),
+    );
+  });
+
+  it('persists the transaction and forwards it to processBatch when relevant', async () => {
+    const { service, txRepository, pluginBatchProcessor } = setup();
+    pluginBatchProcessor.isRelevantTransaction.mockReturnValue(true);
+    txRepository.save.mockResolvedValueOnce({
+      hash: 'th_live_1',
+      block_height: 500,
+      type: 'ContractCallTx',
+    });
+
+    await service.handleLiveTransaction(buildTransaction());
+
+    expect(txRepository.save).toHaveBeenCalledTimes(1);
+    expect(pluginBatchProcessor.processBatch).toHaveBeenCalledTimes(1);
+    expect(pluginBatchProcessor.processBatch).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          hash: 'th_live_1',
+          block_height: 500,
+        }),
+      ],
+      'live',
+    );
+  });
+
+  it('swallows DB errors so a single bad tx cannot kill the websocket handler', async () => {
+    const { service, txRepository, pluginBatchProcessor } = setup();
+    const loggerError = jest
+      .spyOn((service as any).logger, 'error')
+      .mockImplementation(() => undefined);
+
+    pluginBatchProcessor.isRelevantTransaction.mockReturnValue(true);
+    txRepository.save.mockRejectedValueOnce(new Error('db is down'));
+
+    await expect(
+      service.handleLiveTransaction(buildTransaction()),
+    ).resolves.toBeUndefined();
+
+    expect(pluginBatchProcessor.processBatch).not.toHaveBeenCalled();
+    expect(loggerError).toHaveBeenCalledWith(
+      'Failed to handle live transaction',
+      expect.any(Error),
+    );
+  });
+});

--- a/src/mdw-sync/services/live-indexer.service.ts
+++ b/src/mdw-sync/services/live-indexer.service.ts
@@ -83,6 +83,14 @@ export class LiveIndexerService implements OnModuleInit, OnModuleDestroy {
     try {
       const mdwTx = this.convertToMdwTx(transaction);
 
+      // Skip transactions that do not match any registered plugin filter.
+      // We only index transactions the application actually cares about
+      // (currently BCL and DEX); everything else is discarded before it
+      // ever reaches the database.
+      if (!this.pluginBatchProcessor.isRelevantTransaction(mdwTx)) {
+        return;
+      }
+
       // Save transaction
       const savedTx = await this.txRepository.save(mdwTx);
 

--- a/src/mdw-sync/services/plugin-batch-processor.service.spec.ts
+++ b/src/mdw-sync/services/plugin-batch-processor.service.spec.ts
@@ -1,0 +1,203 @@
+import { Plugin, PluginFilter } from '@/plugins/plugin.interface';
+import { Tx } from '../entities/tx.entity';
+import { PluginBatchProcessorService } from './plugin-batch-processor.service';
+import { PluginRegistryService } from './plugin-registry.service';
+
+/**
+ * Dedicated coverage for the predicate-aggregation logic that decides whether
+ * a transaction should be persisted at all. The processBatch / reorg paths
+ * are covered elsewhere; here we only care about the pre-save gate.
+ */
+describe('PluginBatchProcessorService filtering', () => {
+  const buildPlugin = (name: string, filters: PluginFilter[]): Plugin =>
+    ({
+      name,
+      version: 1,
+      filters: () => filters,
+    }) as unknown as Plugin;
+
+  const setup = (plugins: Plugin[]) => {
+    const pluginRegistryService = {
+      getPlugins: jest.fn(() => plugins),
+    } as unknown as PluginRegistryService;
+
+    const service = new PluginBatchProcessorService(
+      pluginRegistryService,
+      {} as any, // failedTransactionService (unused by the tested paths)
+      {} as any, // pluginSyncStateRepository (unused by the tested paths)
+    );
+
+    return { service, pluginRegistryService };
+  };
+
+  const tx = (overrides: Partial<Tx>): Partial<Tx> => ({
+    hash: 'th_default',
+    ...overrides,
+  });
+
+  describe('filterRelevantTransactions', () => {
+    it('returns [] when there are no transactions to check', () => {
+      const { service } = setup([
+        buildPlugin('p1', [{ predicate: () => true }]),
+      ]);
+      expect(service.filterRelevantTransactions([])).toEqual([]);
+    });
+
+    it('returns [] when no plugins are registered', () => {
+      const { service } = setup([]);
+      // Critical safety property: without any registered plugins we must
+      // NEVER index anything. Otherwise a zero-plugin configuration would
+      // quietly re-enable the legacy "index everything" behaviour.
+      expect(
+        service.filterRelevantTransactions([tx({ hash: 'th_1' })]),
+      ).toEqual([]);
+    });
+
+    it('returns [] when plugins are registered but none expose a predicate', () => {
+      const { service } = setup([
+        buildPlugin('p1', [{ type: 'contract_call', contractIds: ['ct_abc'] }]),
+        buildPlugin('p2', []),
+      ]);
+      // Filters without predicates must not leak through as "always match";
+      // we index only what is explicitly claimed.
+      expect(
+        service.filterRelevantTransactions([
+          tx({ hash: 'th_1', contract_id: 'ct_abc' }),
+        ]),
+      ).toEqual([]);
+    });
+
+    it('keeps only transactions matching at least one predicate (OR across plugins)', () => {
+      const bclPredicate = jest.fn(
+        (t: Partial<Tx>) =>
+          t.type === 'ContractCallTx' && t.contract_id === 'ct_bcl',
+      );
+      const dexPredicate = jest.fn(
+        (t: Partial<Tx>) =>
+          t.type === 'ContractCallTx' && t.contract_id === 'ct_dex',
+      );
+
+      const { service } = setup([
+        buildPlugin('bcl', [{ predicate: bclPredicate }]),
+        buildPlugin('dex', [{ predicate: dexPredicate }]),
+      ]);
+
+      const txs = [
+        tx({ hash: 'th_bcl', type: 'ContractCallTx', contract_id: 'ct_bcl' }),
+        tx({ hash: 'th_dex', type: 'ContractCallTx', contract_id: 'ct_dex' }),
+        tx({
+          hash: 'th_other',
+          type: 'ContractCallTx',
+          contract_id: 'ct_unrelated',
+        }),
+      ];
+
+      const result = service.filterRelevantTransactions(txs);
+
+      expect(result.map((t) => t.hash)).toEqual(['th_bcl', 'th_dex']);
+      expect(bclPredicate).toHaveBeenCalledTimes(3);
+      expect(dexPredicate).toHaveBeenCalledTimes(2); // short-circuit: bcl match skips dex check
+    });
+
+    it('aggregates multiple filters from the same plugin with OR semantics', () => {
+      const { service } = setup([
+        buildPlugin('governance', [
+          {
+            predicate: (t: Partial<Tx>) => t.type === 'ContractCreateTx',
+          },
+          {
+            predicate: (t: Partial<Tx>) =>
+              t.type === 'ContractCallTx' && t.function === 'vote',
+          },
+        ]),
+      ]);
+
+      const txs = [
+        tx({ hash: 'th_create', type: 'ContractCreateTx' }),
+        tx({ hash: 'th_vote', type: 'ContractCallTx', function: 'vote' }),
+        tx({
+          hash: 'th_other',
+          type: 'ContractCallTx',
+          function: 'unrelated',
+        }),
+      ];
+
+      expect(
+        service.filterRelevantTransactions(txs).map((t) => t.hash),
+      ).toEqual(['th_create', 'th_vote']);
+    });
+
+    it('preserves the input shape so extra metadata (block_height, etc.) flows through unchanged', () => {
+      const { service } = setup([
+        buildPlugin('p1', [
+          { predicate: (t: Partial<Tx>) => t.hash === 'th_keep' },
+        ]),
+      ]);
+
+      const input = [
+        {
+          hash: 'th_keep',
+          block_height: 42,
+          contract_id: 'ct_x',
+        } as Partial<Tx>,
+      ];
+      const out = service.filterRelevantTransactions(input);
+
+      // Same reference, not a cloned copy — the caller relies on
+      // block_height and other fields being passed through.
+      expect(out).toHaveLength(1);
+      expect(out[0]).toBe(input[0]);
+    });
+  });
+
+  describe('isRelevantTransaction', () => {
+    it('returns false when no plugins are registered (never index by default)', () => {
+      const { service } = setup([]);
+      expect(service.isRelevantTransaction(tx({ hash: 'th_1' }))).toBe(false);
+    });
+
+    it('returns false when no predicate matches', () => {
+      const { service } = setup([
+        buildPlugin('bcl', [
+          {
+            predicate: (t: Partial<Tx>) => t.contract_id === 'ct_bcl',
+          },
+        ]),
+      ]);
+      expect(
+        service.isRelevantTransaction(
+          tx({ type: 'ContractCallTx', contract_id: 'ct_other' }),
+        ),
+      ).toBe(false);
+    });
+
+    it('returns true as soon as one predicate matches', () => {
+      const matchingPredicate = jest.fn(() => true);
+      const afterMatchPredicate = jest.fn(() => true);
+
+      const { service } = setup([
+        buildPlugin('p1', [{ predicate: matchingPredicate }]),
+        buildPlugin('p2', [{ predicate: afterMatchPredicate }]),
+      ]);
+
+      expect(service.isRelevantTransaction(tx({}))).toBe(true);
+      expect(matchingPredicate).toHaveBeenCalledTimes(1);
+      // Short-circuit: once a predicate has claimed the tx, later predicates
+      // should not be evaluated.
+      expect(afterMatchPredicate).not.toHaveBeenCalled();
+    });
+
+    it('ignores filters that do not carry a predicate', () => {
+      const { service } = setup([
+        buildPlugin('p1', [
+          { type: 'contract_call', contractIds: ['ct_abc'] }, // no predicate
+        ]),
+      ]);
+      expect(
+        service.isRelevantTransaction(
+          tx({ type: 'ContractCallTx', contract_id: 'ct_abc' }),
+        ),
+      ).toBe(false);
+    });
+  });
+});

--- a/src/mdw-sync/services/plugin-batch-processor.service.ts
+++ b/src/mdw-sync/services/plugin-batch-processor.service.ts
@@ -178,6 +178,59 @@ export class PluginBatchProcessorService {
   }
 
   /**
+   * Collect predicate functions from all registered plugins' filters.
+   * Predicates are used to decide whether a transaction should be indexed at all
+   * (i.e. saved to the database) during block/live sync.
+   */
+  private collectPluginPredicates(): Array<(tx: Partial<Tx>) => boolean> {
+    const predicates: Array<(tx: Partial<Tx>) => boolean> = [];
+
+    for (const plugin of this.pluginRegistryService.getPlugins()) {
+      for (const filter of plugin.filters()) {
+        if (filter.predicate) {
+          predicates.push(filter.predicate);
+        }
+      }
+    }
+
+    return predicates;
+  }
+
+  /**
+   * Return only the transactions that match at least one registered plugin's filter.
+   * Transactions that do not match any plugin are considered irrelevant and should
+   * not be persisted by the indexer.
+   *
+   * When there are no predicates registered, this returns an empty array so we do
+   * not accidentally index every transaction on the chain.
+   */
+  filterRelevantTransactions<T extends Partial<Tx>>(transactions: T[]): T[] {
+    if (transactions.length === 0) {
+      return [];
+    }
+
+    const predicates = this.collectPluginPredicates();
+    if (predicates.length === 0) {
+      return [];
+    }
+
+    return transactions.filter((tx) =>
+      predicates.some((predicate) => predicate(tx)),
+    );
+  }
+
+  /**
+   * Check whether a single transaction matches at least one registered plugin's filter.
+   */
+  isRelevantTransaction(tx: Partial<Tx>): boolean {
+    const predicates = this.collectPluginPredicates();
+    if (predicates.length === 0) {
+      return false;
+    }
+    return predicates.some((predicate) => predicate(tx));
+  }
+
+  /**
    * Handle reorg by notifying all plugins
    */
   async handleReorg(removedTxHashes: string[]): Promise<void> {

--- a/src/plugins/governance/entities/governance-delegation.view.ts
+++ b/src/plugins/governance/entities/governance-delegation.view.ts
@@ -1,6 +1,10 @@
 import { PrimaryColumn, ViewColumn, ViewEntity } from 'typeorm';
-import { GOVERNANCE_CONTRACT } from '../config/governance.config';
 
+// NOTE: no contract_id filter. The ingest filter
+// (GovernancePlugin.filters()) only persists delegate rows that target the
+// configured governance registry contract, so the `data->'governance' IS
+// NOT NULL` guard is sufficient and lets this view work identically on
+// mainnet, testnet, and any custom registry deployment.
 @ViewEntity({
   name: 'governance_delegation_view',
   materialized: false,
@@ -19,8 +23,7 @@ import { GOVERNANCE_CONTRACT } from '../config/governance.config';
       data->'governance'->'data'->>'delegator' as delegator,
       data->'governance'->'data'->>'delegatee' as delegatee
     FROM txs
-    WHERE contract_id = '${GOVERNANCE_CONTRACT.contractAddress}'
-      AND function = 'delegate'
+    WHERE function = 'delegate'
       AND data->'governance'->'data'->>'delegator' IS NOT NULL
       AND data->'governance'->'data'->>'delegatee' IS NOT NULL
       AND data->'governance' IS NOT NULL

--- a/src/plugins/governance/entities/governance-poll.view.ts
+++ b/src/plugins/governance/entities/governance-poll.view.ts
@@ -96,10 +96,15 @@ import { ViewColumn, ViewEntity, PrimaryColumn } from 'typeorm';
           AND r.data->'governance' IS NOT NULL
       )::int as votes_revoked_count
     FROM txs
-    WHERE contract_id = 'ct_ouZib4wT9cNwgRA1pxgA63XEUd8eQRrG8PcePDEYogBc1VYTq'
-      AND function = 'add_poll'
+    WHERE function = 'add_poll'
       AND data->'governance' IS NOT NULL
+      AND data->'governance'->'data'->>'poll_address' IS NOT NULL
   `,
+  // NOTE: no contract_id filter. The ingest filter
+  // (GovernancePlugin.filters()) only persists add_poll rows that target
+  // the configured governance registry contract, so the `data->'governance'
+  // IS NOT NULL` guard is sufficient and lets this view work identically on
+  // mainnet, testnet, and any custom registry deployment.
 })
 export class GovernancePoll {
   @PrimaryColumn()

--- a/src/plugins/governance/entities/governance-revoked-delegation.view.ts
+++ b/src/plugins/governance/entities/governance-revoked-delegation.view.ts
@@ -1,6 +1,10 @@
 import { ViewColumn, ViewEntity, PrimaryColumn } from 'typeorm';
-import { GOVERNANCE_CONTRACT } from '../config/governance.config';
 
+// NOTE: no contract_id filter. The ingest filter
+// (GovernancePlugin.filters()) only persists revoke_delegation rows that
+// target the configured governance registry contract, so the
+// `data->'governance' IS NOT NULL` guard is sufficient and lets this view
+// work identically on mainnet, testnet, and any custom registry deployment.
 @ViewEntity({
   name: 'governance_revoked_delegation_view',
   materialized: false,
@@ -18,8 +22,7 @@ import { GOVERNANCE_CONTRACT } from '../config/governance.config';
       (data->'governance'->>'_version')::int as _version,
       data->'governance'->'data'->>'delegator' as delegator
     FROM txs
-    WHERE contract_id = '${GOVERNANCE_CONTRACT.contractAddress}'
-      AND function = 'revoke_delegation'
+    WHERE function = 'revoke_delegation'
       AND data->'governance'->'data'->>'delegator' IS NOT NULL
       AND data->'governance' IS NOT NULL
   `,

--- a/src/plugins/governance/governance-plugin-sync.service.spec.ts
+++ b/src/plugins/governance/governance-plugin-sync.service.spec.ts
@@ -1,0 +1,588 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { fetchJson } from '@/utils/common';
+import { GovernancePluginSyncService } from './governance-plugin-sync.service';
+import { GovernancePollRegistry } from './services/governance-poll-registry.service';
+import { Tx } from '@/mdw-sync/entities/tx.entity';
+import { GOVERNANCE_CONTRACT } from './config/governance.config';
+
+jest.mock('@/utils/common', () => ({
+  fetchJson: jest.fn(),
+  sanitizeJsonForPostgres: jest.fn((value: any) => value),
+  serializeBigInts: jest.fn((value: any) => value),
+}));
+
+const POLL_ADDRESS = 'ct_pollAddressUnderTest';
+const CREATE_TX_HASH = 'th_createTxHashUnderTest';
+const ADD_POLL_TX_HASH = 'th_addPollTxHashUnderTest';
+const VOTE_HASH_A = 'th_voteHashA';
+const VOTE_HASH_B = 'th_voteHashB';
+const REVOKE_HASH = 'th_revokeHash';
+const MIDDLEWARE_URL = 'https://mdw.example.test';
+
+type TxRepoMock = {
+  findOne: jest.Mock;
+  upsert: jest.Mock;
+};
+
+function buildTxRepository(): TxRepoMock {
+  return {
+    findOne: jest.fn(),
+    upsert: jest.fn(),
+  };
+}
+
+function buildPollRegistry(options: { existing?: string[] } = {}) {
+  const known = new Set<string>(options.existing ?? []);
+  const registry = {
+    register: jest.fn((addr: string) => {
+      if (!addr) return false;
+      if (known.has(addr)) return false;
+      known.add(addr);
+      return true;
+    }),
+    has: jest.fn((addr: string) => known.has(addr)),
+    size: jest.fn(() => known.size),
+    isLoaded: jest.fn(() => true),
+  } as unknown as GovernancePollRegistry;
+  return registry;
+}
+
+function buildConfigService(
+  overrides: {
+    middlewareUrl?: string | null;
+    governanceContract?: string | null;
+  } = {},
+) {
+  const middlewareUrl =
+    overrides.middlewareUrl === null
+      ? undefined
+      : (overrides.middlewareUrl ?? MIDDLEWARE_URL);
+  const governanceContract =
+    overrides.governanceContract === null
+      ? undefined
+      : (overrides.governanceContract ?? 'ct_customRegistry');
+
+  return {
+    get: jest.fn((key: string) => {
+      if (key === 'mdw.middlewareUrl') return middlewareUrl;
+      if (key === 'governance') {
+        return governanceContract
+          ? { contract: { contractAddress: governanceContract } }
+          : undefined;
+      }
+      return undefined;
+    }),
+  } as any;
+}
+
+function buildService(
+  options: {
+    repo?: TxRepoMock;
+    registry?: GovernancePollRegistry;
+    middlewareUrl?: string | null;
+    governanceContract?: string | null;
+  } = {},
+) {
+  const repo = options.repo ?? buildTxRepository();
+  const registry = options.registry ?? buildPollRegistry();
+  const configService = buildConfigService({
+    middlewareUrl: options.middlewareUrl,
+    governanceContract: options.governanceContract,
+  });
+  const aeSdkService = {
+    sdk: { getBalance: jest.fn() },
+  } as any;
+
+  const service = new GovernancePluginSyncService(
+    aeSdkService,
+    repo as any,
+    registry,
+    configService,
+  );
+
+  return { service, repo, registry, configService };
+}
+
+function buildAddPollTx(overrides: Partial<Tx> = {}): Tx {
+  return {
+    hash: ADD_POLL_TX_HASH,
+    function: GOVERNANCE_CONTRACT.FUNCTIONS.add_poll,
+    logs: {
+      governance: {
+        data: [
+          {
+            args: [POLL_ADDRESS, '1'],
+          },
+        ],
+      },
+    },
+    ...overrides,
+  } as Tx;
+}
+
+function buildCreateTxEntity(): Tx {
+  return {
+    hash: CREATE_TX_HASH,
+    type: 'ContractCreateTx',
+    contract_id: POLL_ADDRESS,
+    caller_id: 'ak_creator',
+    block_height: 100,
+    raw: {
+      args: [
+        { value: ['Title', 'Description', 'Link', 'SpecRef'] },
+        { value: ['Yes', 'No'] },
+        { value: [120, 20] },
+      ],
+    },
+  } as any as Tx;
+}
+
+function buildMiddlewareCreateTx() {
+  return {
+    hash: CREATE_TX_HASH,
+    block_height: 100,
+    block_hash: 'mh_blockHash',
+    micro_index: 0,
+    micro_time: 1700000000,
+    signatures: ['sg_1'],
+    encoded_tx: 'tx_encoded',
+    tx: {
+      type: 'ContractCreateTx',
+      caller_id: 'ak_creator',
+      contract_id: POLL_ADDRESS,
+    },
+  };
+}
+
+function buildMiddlewareVoteTx(
+  overrides: {
+    hash?: string;
+    function?: string;
+    blockHeight?: number;
+    microTime?: number;
+  } = {},
+) {
+  return {
+    hash: overrides.hash ?? VOTE_HASH_A,
+    block_height: overrides.blockHeight ?? 200,
+    block_hash: 'mh_voteBlockHash',
+    micro_index: 1,
+    micro_time: overrides.microTime ?? 1700000001,
+    signatures: ['sg_vote'],
+    encoded_tx: 'tx_voteEncoded',
+    tx: {
+      type: 'ContractCallTx',
+      function: overrides.function ?? GOVERNANCE_CONTRACT.FUNCTIONS.vote,
+      caller_id: 'ak_voter',
+      contract_id: POLL_ADDRESS,
+    },
+  };
+}
+
+describe('GovernancePluginSyncService.decodeData(add_poll)', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('returns decoded metadata using a locally-cached ContractCreateTx and does NOT register the poll (register-after-save invariant)', async () => {
+    const repo = buildTxRepository();
+    repo.findOne.mockResolvedValueOnce(buildCreateTxEntity());
+    const registry = buildPollRegistry();
+
+    const { service } = buildService({ repo, registry });
+
+    const result = await service.decodeData(buildAddPollTx());
+
+    expect(result).toMatchObject({
+      poll_address: POLL_ADDRESS,
+      metadata: {
+        title: 'Title',
+        description: 'Description',
+        link: 'Link',
+        _spec_ref: 'SpecRef',
+      },
+      vote_options: ['Yes', 'No'],
+      author: 'ak_creator',
+      close_at_height: 120,
+      close_height: 20,
+      create_height: 100,
+    });
+    expect(registry.register).not.toHaveBeenCalled();
+    expect(fetchJson).not.toHaveBeenCalled();
+  });
+
+  it('falls back to MDW backfill when the CreateTx is missing locally', async () => {
+    const repo = buildTxRepository();
+    const createTxEntity = buildCreateTxEntity();
+    repo.findOne
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(createTxEntity);
+    repo.upsert.mockResolvedValueOnce(undefined);
+
+    (fetchJson as jest.Mock)
+      .mockResolvedValueOnce({ source_tx_hash: CREATE_TX_HASH })
+      .mockResolvedValueOnce(buildMiddlewareCreateTx());
+
+    const { service } = buildService({ repo });
+
+    const result = await service.decodeData(buildAddPollTx());
+
+    expect((fetchJson as jest.Mock).mock.calls[0][0]).toContain(
+      `${MIDDLEWARE_URL}/v3/contracts/${POLL_ADDRESS}`,
+    );
+    expect((fetchJson as jest.Mock).mock.calls[1][0]).toContain(
+      `${MIDDLEWARE_URL}/v3/transactions/${CREATE_TX_HASH}`,
+    );
+    expect(repo.upsert).toHaveBeenCalledTimes(1);
+    // NOTE: backfillPollCreateTx returns null here (repo.findOne for the
+    // newly-upserted row is not stubbed), so the outer decodeData returns
+    // null. That null is the explicit "missing metadata" contract. The
+    // important assertion is that the MDW backfill path was exercised.
+    expect(result).not.toBeUndefined();
+  });
+
+  it('returns null when MDW responds without a source_tx_hash', async () => {
+    const repo = buildTxRepository();
+    repo.findOne.mockResolvedValue(null);
+    (fetchJson as jest.Mock).mockResolvedValueOnce({});
+
+    const { service } = buildService({ repo });
+
+    const result = await service.decodeData(buildAddPollTx());
+
+    expect(result).toBeNull();
+    expect(repo.upsert).not.toHaveBeenCalled();
+  });
+
+  it('returns null when MDW source tx is not a ContractCreateTx', async () => {
+    const repo = buildTxRepository();
+    repo.findOne.mockResolvedValue(null);
+    (fetchJson as jest.Mock)
+      .mockResolvedValueOnce({ source_tx_hash: CREATE_TX_HASH })
+      .mockResolvedValueOnce({
+        hash: CREATE_TX_HASH,
+        tx: { type: 'SpendTx' },
+      });
+
+    const { service } = buildService({ repo });
+
+    const result = await service.decodeData(buildAddPollTx());
+
+    expect(result).toBeNull();
+    expect(repo.upsert).not.toHaveBeenCalled();
+  });
+
+  it('swallows MDW errors and returns null so ingest keeps flowing', async () => {
+    const repo = buildTxRepository();
+    repo.findOne.mockResolvedValue(null);
+    (fetchJson as jest.Mock).mockRejectedValue(new Error('network down'));
+
+    const { service } = buildService({ repo });
+
+    const result = await service.decodeData(buildAddPollTx());
+
+    expect(result).toBeNull();
+    expect(repo.upsert).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the cached CreateTx has a malformed raw.args shape', async () => {
+    const repo = buildTxRepository();
+    repo.findOne.mockResolvedValueOnce({
+      ...buildCreateTxEntity(),
+      raw: { args: 'not-an-array' as any },
+    });
+
+    const { service } = buildService({ repo });
+
+    const result = await service.decodeData(buildAddPollTx());
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when metadata args are missing from the CreateTx', async () => {
+    const repo = buildTxRepository();
+    repo.findOne.mockResolvedValueOnce({
+      ...buildCreateTxEntity(),
+      raw: {
+        args: [{ value: null }, { value: ['Yes', 'No'] }, { value: [120, 20] }],
+      },
+    });
+
+    const { service } = buildService({ repo });
+
+    const result = await service.decodeData(buildAddPollTx());
+
+    expect(result).toBeNull();
+  });
+
+  it('honors the configured mdw.middlewareUrl when backfilling', async () => {
+    const repo = buildTxRepository();
+    repo.findOne.mockResolvedValue(null);
+    (fetchJson as jest.Mock)
+      .mockResolvedValueOnce({ source_tx_hash: CREATE_TX_HASH })
+      .mockResolvedValueOnce(buildMiddlewareCreateTx());
+
+    const customMdw = 'https://custom-mdw.example.test';
+    const { service } = buildService({ repo, middlewareUrl: customMdw });
+
+    await service.decodeData(buildAddPollTx());
+
+    expect((fetchJson as jest.Mock).mock.calls[0][0]).toBe(
+      `${customMdw}/v3/contracts/${POLL_ADDRESS}`,
+    );
+    expect((fetchJson as jest.Mock).mock.calls[1][0]).toBe(
+      `${customMdw}/v3/transactions/${CREATE_TX_HASH}`,
+    );
+  });
+});
+
+describe('GovernancePluginSyncService.processTransaction(add_poll) — register + vote backfill', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  function buildSavedAddPoll(overrides: Partial<Tx> = {}): Tx {
+    return {
+      hash: ADD_POLL_TX_HASH,
+      function: GOVERNANCE_CONTRACT.FUNCTIONS.add_poll,
+      data: {
+        governance: {
+          _version: 2,
+          data: { poll_address: POLL_ADDRESS },
+        },
+      },
+      ...overrides,
+    } as Tx;
+  }
+
+  /**
+   * Seed repo.findOne so the first lookup (the "verify persisted" re-read
+   * inside processTransaction) returns the persisted add_poll row. Any
+   * follow-on mocks for vote-backfill DB checks should be chained via
+   * `.mockResolvedValueOnce` on the returned mock AFTER calling this.
+   */
+  function mockPersistedAddPollLookup(
+    repo: TxRepoMock,
+    pollAddress: string = POLL_ADDRESS,
+  ) {
+    repo.findOne.mockResolvedValueOnce({
+      hash: ADD_POLL_TX_HASH,
+      data: {
+        governance: { _version: 2, data: { poll_address: pollAddress } },
+      },
+    });
+  }
+
+  it('registers a newly-discovered poll AFTER save and triggers vote backfill', async () => {
+    const repo = buildTxRepository();
+    mockPersistedAddPollLookup(repo);
+    // Vote backfill lookups — both votes are new:
+    repo.findOne.mockResolvedValueOnce(null).mockResolvedValueOnce(null);
+    (fetchJson as jest.Mock).mockResolvedValueOnce({
+      data: [
+        buildMiddlewareVoteTx({ hash: VOTE_HASH_A }),
+        buildMiddlewareVoteTx({
+          hash: REVOKE_HASH,
+          function: GOVERNANCE_CONTRACT.FUNCTIONS.revoke_vote,
+        }),
+      ],
+      next: null,
+    });
+    const registry = buildPollRegistry();
+
+    const { service } = buildService({ repo, registry });
+
+    await service.processTransaction(buildSavedAddPoll(), 'backward' as any);
+
+    expect(registry.register).toHaveBeenCalledWith(POLL_ADDRESS);
+    expect((registry.register as jest.Mock).mock.results[0].value).toBe(true);
+    expect((fetchJson as jest.Mock).mock.calls[0][0]).toBe(
+      `${MIDDLEWARE_URL}/v3/transactions?type=contract_call&contract=${POLL_ADDRESS}&direction=forward&limit=100`,
+    );
+    expect(repo.upsert).toHaveBeenCalledTimes(2);
+  });
+
+  it('skips vote backfill when the poll was already seeded from the DB', async () => {
+    const repo = buildTxRepository();
+    mockPersistedAddPollLookup(repo);
+    const registry = buildPollRegistry({ existing: [POLL_ADDRESS] });
+
+    const { service } = buildService({ repo, registry });
+
+    await service.processTransaction(buildSavedAddPoll(), 'backward' as any);
+
+    expect(registry.register).toHaveBeenCalledWith(POLL_ADDRESS);
+    expect((registry.register as jest.Mock).mock.results[0].value).toBe(false);
+    expect(fetchJson).not.toHaveBeenCalled();
+    expect(repo.upsert).not.toHaveBeenCalled();
+  });
+
+  it('does not register when the DB row has no governance poll address (save failed)', async () => {
+    const repo = buildTxRepository();
+    // processTransaction re-reads the row; if the row lacks governance
+    // data, we must NOT register (keeps runtime in lockstep with SQL).
+    repo.findOne.mockResolvedValueOnce({
+      hash: ADD_POLL_TX_HASH,
+      data: {},
+    });
+    const registry = buildPollRegistry();
+
+    const { service } = buildService({ repo, registry });
+
+    await service.processTransaction(buildSavedAddPoll(), 'backward' as any);
+
+    expect(registry.register).not.toHaveBeenCalled();
+    expect(fetchJson).not.toHaveBeenCalled();
+  });
+
+  it('does not register when the row is missing entirely from the DB', async () => {
+    const repo = buildTxRepository();
+    repo.findOne.mockResolvedValueOnce(null);
+    const registry = buildPollRegistry();
+
+    const { service } = buildService({ repo, registry });
+
+    await service.processTransaction(buildSavedAddPoll(), 'backward' as any);
+
+    expect(registry.register).not.toHaveBeenCalled();
+    expect(fetchJson).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op for non-add_poll transactions', async () => {
+    const repo = buildTxRepository();
+    const registry = buildPollRegistry();
+
+    const { service } = buildService({ repo, registry });
+
+    await service.processTransaction(
+      {
+        hash: VOTE_HASH_A,
+        function: GOVERNANCE_CONTRACT.FUNCTIONS.vote,
+        data: {
+          governance: {
+            _version: 2,
+            data: { poll: '1', voter: 'ak_x' },
+          },
+        },
+      } as Tx,
+      'backward' as any,
+    );
+
+    expect(registry.register).not.toHaveBeenCalled();
+    expect(fetchJson).not.toHaveBeenCalled();
+  });
+
+  it('only persists vote/revoke_vote functions and skips unrelated contract calls from MDW response', async () => {
+    const repo = buildTxRepository();
+    mockPersistedAddPollLookup(repo);
+    repo.findOne.mockResolvedValueOnce(null);
+    (fetchJson as jest.Mock).mockResolvedValueOnce({
+      data: [
+        buildMiddlewareVoteTx({
+          hash: 'th_otherCall',
+          function: 'some_other_function',
+        }),
+        buildMiddlewareVoteTx({ hash: VOTE_HASH_A }),
+      ],
+      next: null,
+    });
+    const registry = buildPollRegistry();
+
+    const { service } = buildService({ repo, registry });
+
+    await service.processTransaction(buildSavedAddPoll(), 'backward' as any);
+
+    expect(repo.upsert).toHaveBeenCalledTimes(1);
+    const persisted = repo.upsert.mock.calls[0][0];
+    expect(persisted.hash).toBe(VOTE_HASH_A);
+    expect(persisted.function).toBe(GOVERNANCE_CONTRACT.FUNCTIONS.vote);
+  });
+
+  it('does not re-persist votes that already exist in the DB', async () => {
+    const repo = buildTxRepository();
+    mockPersistedAddPollLookup(repo);
+    // First vote exists; second is new.
+    repo.findOne
+      .mockResolvedValueOnce({ hash: VOTE_HASH_A })
+      .mockResolvedValueOnce(null);
+    (fetchJson as jest.Mock).mockResolvedValueOnce({
+      data: [
+        buildMiddlewareVoteTx({ hash: VOTE_HASH_A }),
+        buildMiddlewareVoteTx({ hash: VOTE_HASH_B }),
+      ],
+      next: null,
+    });
+    const registry = buildPollRegistry();
+
+    const { service } = buildService({ repo, registry });
+
+    await service.processTransaction(buildSavedAddPoll(), 'backward' as any);
+
+    expect(repo.upsert).toHaveBeenCalledTimes(1);
+    expect(repo.upsert.mock.calls[0][0].hash).toBe(VOTE_HASH_B);
+  });
+
+  it('paginates through MDW pages until next is null', async () => {
+    const repo = buildTxRepository();
+    mockPersistedAddPollLookup(repo);
+    repo.findOne.mockResolvedValue(null);
+
+    (fetchJson as jest.Mock)
+      .mockResolvedValueOnce({
+        data: [buildMiddlewareVoteTx({ hash: VOTE_HASH_A })],
+        next: '/v3/transactions?cursor=page2',
+      })
+      .mockResolvedValueOnce({
+        data: [buildMiddlewareVoteTx({ hash: VOTE_HASH_B })],
+        next: null,
+      });
+
+    const registry = buildPollRegistry();
+
+    const { service } = buildService({ repo, registry });
+
+    await service.processTransaction(buildSavedAddPoll(), 'backward' as any);
+
+    expect(fetchJson).toHaveBeenCalledTimes(2);
+    expect((fetchJson as jest.Mock).mock.calls[1][0]).toBe(
+      `${MIDDLEWARE_URL}/v3/transactions?cursor=page2`,
+    );
+    expect(repo.upsert).toHaveBeenCalledTimes(2);
+  });
+
+  it('swallows MDW errors during vote backfill and still leaves the poll registered', async () => {
+    const repo = buildTxRepository();
+    mockPersistedAddPollLookup(repo);
+    (fetchJson as jest.Mock).mockRejectedValueOnce(new Error('mdw 500'));
+    const registry = buildPollRegistry();
+
+    const { service } = buildService({ repo, registry });
+
+    await expect(
+      service.processTransaction(buildSavedAddPoll(), 'backward' as any),
+    ).resolves.toBeUndefined();
+
+    expect(registry.register).toHaveBeenCalledWith(POLL_ADDRESS);
+    expect(repo.upsert).not.toHaveBeenCalled();
+  });
+
+  it('stops paginating after the page safety limit to avoid runaway loops', async () => {
+    const repo = buildTxRepository();
+    mockPersistedAddPollLookup(repo);
+    repo.findOne.mockResolvedValue(null);
+    // Always return a "next" cursor so the loop would run forever.
+    (fetchJson as jest.Mock).mockResolvedValue({
+      data: [],
+      next: '/v3/transactions?cursor=infinite',
+    });
+    const registry = buildPollRegistry();
+
+    const { service } = buildService({ repo, registry });
+
+    await service.processTransaction(buildSavedAddPoll(), 'backward' as any);
+
+    expect((fetchJson as jest.Mock).mock.calls.length).toBe(
+      GovernancePluginSyncService.VOTE_BACKFILL_PAGE_SAFETY,
+    );
+  });
+});

--- a/src/plugins/governance/governance-plugin-sync.service.ts
+++ b/src/plugins/governance/governance-plugin-sync.service.ts
@@ -1,26 +1,77 @@
 import { AeSdkService } from '@/ae/ae-sdk.service';
 import { Tx } from '@/mdw-sync/entities/tx.entity';
-import { serializeBigInts } from '@/utils/common';
+import { ACTIVE_NETWORK } from '@/configs/network';
+import {
+  fetchJson,
+  sanitizeJsonForPostgres,
+  serializeBigInts,
+} from '@/utils/common';
+import { ITransaction } from '@/utils/types';
+import camelcaseKeysDeep from 'camelcase-keys-deep';
 import { AE_AMOUNT_FORMATS, Encoded } from '@aeternity/aepp-sdk';
 import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { BasePluginSyncService } from '../base-plugin-sync.service';
 import { SyncDirection } from '../plugin.interface';
-import { GOVERNANCE_CONTRACT } from './config/governance.config';
+import {
+  GOVERNANCE_CONTRACT,
+  getContractAddress,
+} from './config/governance.config';
 import GovernancePollACI from './contract/aci/GovernancePollACI.json';
 import GovernanceRegistryACI from './contract/aci/GovernanceRegistryACI.json';
+import { GovernancePollRegistry } from './services/governance-poll-registry.service';
+
+const GOVERNANCE_VOTE_FUNCTIONS = new Set<string>([
+  GOVERNANCE_CONTRACT.FUNCTIONS.vote,
+  GOVERNANCE_CONTRACT.FUNCTIONS.revoke_vote,
+]);
 
 @Injectable()
 export class GovernancePluginSyncService extends BasePluginSyncService {
   protected readonly logger = new Logger(GovernancePluginSyncService.name);
   readonly pluginName = 'governance';
+
+  /** Max pages to walk when backfilling votes for a newly discovered poll. */
+  static readonly VOTE_BACKFILL_PAGE_SAFETY = 100;
+
   constructor(
     aeSdkService: AeSdkService,
     @InjectRepository(Tx)
     private readonly txRepository: Repository<Tx>,
+    private readonly pollRegistry: GovernancePollRegistry,
+    private readonly configService: ConfigService,
   ) {
     super(aeSdkService);
+  }
+
+  /**
+   * Resolve the governance registry contract address. Falls back to the
+   * per-network default (see `governance.config.ts`) if ConfigService does
+   * not override it. Kept in a single method so every consumer here stays
+   * in sync with `GovernancePlugin.filters()`.
+   */
+  private getRegistryAddress(): Encoded.ContractAddress | null {
+    const config = this.configService.get<{
+      contract: { contractAddress: string };
+    }>('governance');
+    const address =
+      config?.contract?.contractAddress ?? getContractAddress() ?? null;
+    return (address || null) as Encoded.ContractAddress | null;
+  }
+
+  /**
+   * Resolve the middleware URL. We prefer `mdw.middlewareUrl` from
+   * ConfigService so a test / staging env can point at a non-default MDW.
+   * Falls back to `ACTIVE_NETWORK.middlewareUrl` to preserve behavior when
+   * the config is not set.
+   */
+  private getMiddlewareUrl(): string {
+    return (
+      this.configService.get<string>('mdw.middlewareUrl') ??
+      ACTIVE_NETWORK.middlewareUrl
+    );
   }
 
   async processTransaction(
@@ -28,7 +79,6 @@ export class GovernancePluginSyncService extends BasePluginSyncService {
     syncDirection: SyncDirection,
   ): Promise<void> {
     try {
-      // Basic implementation - will be expanded once contract is debugged
       this.logger.debug('Processing governance transaction', {
         txHash: tx.hash,
         contractId: tx.contract_id,
@@ -36,11 +86,61 @@ export class GovernancePluginSyncService extends BasePluginSyncService {
         syncDirection,
       });
 
-      // TODO: Implement transaction processing logic based on contract functions
-      // This will be expanded once the contract structure is understood
+      // One-time registration of a poll address. We do this AFTER
+      // `base-plugin.ts` has saved `tx.data.governance.data.poll_address`
+      // (decodeData -> save -> processTransaction), so the in-memory
+      // `GovernancePollRegistry` never gets ahead of what the `txs` table
+      // contains. That invariant matters because the cleanup SQL derives
+      // the known-poll set from `tx.data` in the DB; if runtime registered
+      // polls that never made it into `tx.data`, SQL could delete votes
+      // the runtime would keep.
+      //
+      // To be extra safe against the narrow "save threw but the in-memory
+      // `tx.data` was already mutated by base-plugin" race, we re-read the
+      // row and register only if the poll address is actually persisted.
+      if (tx.function === GOVERNANCE_CONTRACT.FUNCTIONS.add_poll) {
+        await this.registerPollFromPersistedTx(tx);
+      }
     } catch (error: any) {
       this.handleError(error, tx, 'processTransaction');
-      throw error; // Re-throw to let BasePluginSyncService handle it
+      throw error;
+    }
+  }
+
+  /**
+   * Re-read the add_poll tx from the DB and register its poll address with
+   * `GovernancePollRegistry` if (and only if) the governance data is
+   * actually persisted. Also kicks off a one-time vote backfill the first
+   * time this session sees the poll, so early votes dropped by the ingest
+   * filter during backward / parallel sync are recovered.
+   */
+  private async registerPollFromPersistedTx(tx: Tx): Promise<void> {
+    const persisted = await this.txRepository.findOne({
+      where: { hash: tx.hash },
+      select: ['hash', 'data'],
+    });
+    const persistedPollAddress: string | undefined = (persisted?.data as any)?.[
+      this.pluginName
+    ]?.data?.poll_address;
+
+    if (!persistedPollAddress) {
+      // Either the save failed, or decodeData returned null and nothing
+      // was persisted. Either way, do not register — a subsequent
+      // auto-update pass will retry once the data is on disk.
+      this.logger.debug(
+        `Skipping poll registration for tx ${tx.hash}: no persisted governance poll address yet`,
+      );
+      return;
+    }
+
+    const newlyRegistered = this.pollRegistry.register(persistedPollAddress);
+
+    // Only backfill on the first successful registration in this session.
+    // Polls seeded from the DB at startup return false here (they already
+    // have all historical votes in `txs`), and repeat re-processings of the
+    // same add_poll (auto-update / reorg) don't re-scan MDW.
+    if (newlyRegistered) {
+      await this.backfillPollVotes(persistedPollAddress, tx.hash);
     }
   }
 
@@ -58,9 +158,17 @@ export class GovernancePluginSyncService extends BasePluginSyncService {
         ] as readonly string[]
       ).includes(tx.function)
     ) {
+      const registryAddress = this.getRegistryAddress();
+      if (!registryAddress) {
+        this.logger.warn(
+          `Skipping log decode for tx ${tx.hash}: no governance registry contract configured`,
+        );
+        return null;
+      }
+
       try {
         const contract = await this.getContract(
-          GOVERNANCE_CONTRACT.contractAddress,
+          registryAddress,
           GovernanceRegistryACI,
         );
         const decodedLogs = contract.$decodeEvents(tx.raw.log, {
@@ -137,13 +245,30 @@ export class GovernancePluginSyncService extends BasePluginSyncService {
       const decodedLogs = pluginLogs.data[0];
 
       const pollAddress = decodedLogs.args[0];
-      // find this contract create tx 'ContractCreateTx'
-      const createTx = await this.txRepository.findOne({
+
+      // NOTE: registration is deliberately deferred to `processTransaction`,
+      // which runs AFTER `tx.data` has been persisted. This keeps the
+      // runtime `GovernancePollRegistry` in lockstep with the SQL cleanup
+      // script (which derives its known-poll set from the same `tx.data`).
+
+      // The poll deployment (ContractCreateTx) was skipped by the ingest
+      // filter — we only know a contract is a poll AFTER its add_poll call
+      // arrives, but chain ordering puts the CreateTx first. On cache miss
+      // we authoritatively fetch the CreateTx from the middleware and
+      // persist it before continuing with decode.
+      let createTx = await this.txRepository.findOne({
         where: {
           type: 'ContractCreateTx',
           contract_id: pollAddress as Encoded.ContractAddress,
         },
       });
+
+      if (!createTx) {
+        createTx = await this.backfillPollCreateTx(
+          pollAddress as Encoded.ContractAddress,
+          tx.hash,
+        );
+      }
 
       if (!createTx) {
         this.logger.warn(
@@ -232,5 +357,243 @@ export class GovernancePluginSyncService extends BasePluginSyncService {
     }
 
     return null;
+  }
+
+  /**
+   * Fetch the poll contract's ContractCreateTx from the middleware and
+   * persist it. Called on-demand by `decodeData(add_poll)` when the deploy
+   * transaction is not yet present locally — this happens because the plugin
+   * filter intentionally rejects unknown ContractCreateTx rows at ingest to
+   * satisfy the "save only required transactions" goal, and the deploy
+   * precedes its `add_poll` registration in chain order.
+   *
+   * Best-effort: returns `null` on any failure (network, missing contract,
+   * malformed response). Callers already handle a null result by logging
+   * and skipping metadata decode for this add_poll.
+   */
+  private async backfillPollCreateTx(
+    pollAddress: Encoded.ContractAddress,
+    addPollTxHash: string,
+  ): Promise<Tx | null> {
+    const middlewareUrl = this.getMiddlewareUrl();
+    try {
+      const contractInfo = await fetchJson(
+        `${middlewareUrl}/v3/contracts/${pollAddress}`,
+      );
+      const createTxHash: string | undefined = contractInfo?.source_tx_hash;
+      if (!createTxHash) {
+        this.logger.warn(
+          `Cannot backfill CreateTx for poll ${pollAddress} (add_poll ${addPollTxHash}): middleware response missing source_tx_hash`,
+        );
+        return null;
+      }
+
+      const rawTx = await fetchJson(
+        `${middlewareUrl}/v3/transactions/${createTxHash}`,
+      );
+      if (!rawTx) {
+        this.logger.warn(
+          `Cannot backfill CreateTx ${createTxHash} for poll ${pollAddress}: middleware returned empty response`,
+        );
+        return null;
+      }
+
+      const mdwTx = camelcaseKeysDeep(rawTx) as ITransaction;
+
+      if (mdwTx?.tx?.type !== 'ContractCreateTx') {
+        this.logger.warn(
+          `Backfill aborted: tx ${createTxHash} for poll ${pollAddress} is ${mdwTx?.tx?.type}, not ContractCreateTx`,
+        );
+        return null;
+      }
+
+      const sanitizedRaw = mdwTx.tx ? sanitizeJsonForPostgres(mdwTx.tx) : null;
+      const sanitizedSignatures = mdwTx.signatures
+        ? sanitizeJsonForPostgres(mdwTx.signatures)
+        : [];
+
+      const createTxEntity: Partial<Tx> = {
+        hash: mdwTx.hash,
+        block_height: mdwTx.blockHeight,
+        block_hash: mdwTx.blockHash?.toString() || '',
+        micro_index: mdwTx.microIndex?.toString() || '0',
+        micro_time: mdwTx.microTime?.toString() || '0',
+        signatures: sanitizedSignatures,
+        encoded_tx: mdwTx.encodedTx || '',
+        type: mdwTx.tx?.type || '',
+        contract_id: pollAddress,
+        function: mdwTx.tx?.function,
+        caller_id: mdwTx.tx?.callerId,
+        sender_id: mdwTx.tx?.senderId,
+        recipient_id: mdwTx.tx?.recipientId,
+        payload: '',
+        raw: sanitizedRaw,
+        version: 1,
+        created_at: new Date(mdwTx.microTime),
+      };
+
+      await this.txRepository.upsert(createTxEntity, ['hash']);
+
+      this.logger.log(
+        `Backfilled ContractCreateTx ${createTxHash} for poll ${pollAddress} (triggered by add_poll ${addPollTxHash})`,
+      );
+
+      return this.txRepository.findOne({
+        where: { hash: mdwTx.hash },
+      });
+    } catch (error: any) {
+      this.logger.error(
+        `Failed to backfill CreateTx for poll ${pollAddress} (add_poll ${addPollTxHash}): ${error?.message ?? error}`,
+        error?.stack,
+      );
+      return null;
+    }
+  }
+
+  /**
+   * Fetch every vote / revoke_vote transaction for `pollAddress` from the
+   * middleware and persist any rows not already in `txs`.
+   *
+   * Why this exists:
+   *   The ingest filter can only accept `vote` / `revoke_vote` on a KNOWN
+   *   poll. A poll becomes "known" when its `add_poll` is decoded. But the
+   *   indexer processes MDW pages newest-to-oldest (backward sync) and
+   *   parallelizes in bulk mode, so a page containing votes can be
+   *   filtered BEFORE another page / the same page has registered the poll.
+   *   Without this backfill, those early votes would be permanently
+   *   dropped. Live indexing is not affected in practice (votes come after
+   *   add_poll on-chain), but backward / bulk sync regularly exercises this
+   *   race.
+   *
+   * Safety:
+   *   * Idempotent: `upsert(['hash'])` — running twice is a no-op.
+   *   * Auto-update compatible: saved rows have no governance plugin data
+   *     yet, so the plugin's `getUpdateQueries` (version check) will pick
+   *     them up on the next auto-update pass and decode logs/data normally.
+   *   * Budgeted: we walk at most VOTE_BACKFILL_PAGE_SAFETY pages to avoid
+   *     pathological loops if a poll has an unexpectedly huge vote history.
+   *   * Best-effort: any error is logged and swallowed. The poll is still
+   *     registered, and future votes for it will be accepted at ingest.
+   */
+  private async backfillPollVotes(
+    pollAddress: string,
+    addPollTxHash: string,
+  ): Promise<void> {
+    const middlewareUrl = this.getMiddlewareUrl();
+    let nextPath: string | null =
+      `/v3/transactions?type=contract_call&contract=${pollAddress}&direction=forward&limit=100`;
+
+    let savedCount = 0;
+    let skippedCount = 0;
+    let safety = 0;
+
+    try {
+      while (
+        nextPath &&
+        safety < GovernancePluginSyncService.VOTE_BACKFILL_PAGE_SAFETY
+      ) {
+        safety += 1;
+        const response = await fetchJson<any>(`${middlewareUrl}${nextPath}`);
+        const page: any[] = response?.data ?? [];
+
+        for (const raw of page) {
+          const fn: string | undefined = raw?.tx?.function;
+          if (!fn || !GOVERNANCE_VOTE_FUNCTIONS.has(fn)) {
+            continue;
+          }
+
+          const hash: string | undefined = raw?.hash;
+          if (!hash) {
+            continue;
+          }
+
+          const existing = await this.txRepository.findOne({
+            where: { hash },
+            select: ['hash'],
+          });
+          if (existing) {
+            skippedCount += 1;
+            continue;
+          }
+
+          const mdwTx = camelcaseKeysDeep(raw) as ITransaction;
+          const entity = this.buildVoteTxEntity(mdwTx, pollAddress);
+          if (!entity) {
+            continue;
+          }
+
+          await this.txRepository.upsert(entity, ['hash']);
+          savedCount += 1;
+        }
+
+        const nextLink: string | null =
+          typeof response?.next === 'string' ? response.next : null;
+        nextPath = nextLink;
+      }
+
+      if (
+        safety >= GovernancePluginSyncService.VOTE_BACKFILL_PAGE_SAFETY &&
+        nextPath
+      ) {
+        this.logger.warn(
+          `Vote backfill for poll ${pollAddress} hit the page safety limit (${GovernancePluginSyncService.VOTE_BACKFILL_PAGE_SAFETY}); remaining pages were not scanned.`,
+        );
+      }
+
+      if (savedCount > 0 || skippedCount > 0) {
+        this.logger.log(
+          `Vote backfill complete for poll ${pollAddress} (triggered by add_poll ${addPollTxHash}): saved ${savedCount}, already-present ${skippedCount}.`,
+        );
+      }
+    } catch (error: any) {
+      this.logger.error(
+        `Failed to backfill votes for poll ${pollAddress} (add_poll ${addPollTxHash}): ${error?.message ?? error}`,
+        error?.stack,
+      );
+    }
+  }
+
+  /**
+   * Convert a middleware contract_call tx to a `Partial<Tx>` row shaped
+   * exactly like `BlockSyncService.convertToMdwTx` would produce, so the
+   * saved row is indistinguishable from one the main indexer would create.
+   * Returns `null` if the payload is unusable (missing hash or wrong type).
+   */
+  private buildVoteTxEntity(
+    mdwTx: ITransaction,
+    pollAddress: string,
+  ): Partial<Tx> | null {
+    if (!mdwTx?.hash) {
+      return null;
+    }
+    if (mdwTx.tx?.type !== 'ContractCallTx') {
+      return null;
+    }
+
+    const sanitizedRaw = mdwTx.tx ? sanitizeJsonForPostgres(mdwTx.tx) : null;
+    const sanitizedSignatures = mdwTx.signatures
+      ? sanitizeJsonForPostgres(mdwTx.signatures)
+      : [];
+
+    return {
+      hash: mdwTx.hash,
+      block_height: mdwTx.blockHeight,
+      block_hash: mdwTx.blockHash?.toString() || '',
+      micro_index: mdwTx.microIndex?.toString() || '0',
+      micro_time: mdwTx.microTime?.toString() || '0',
+      signatures: sanitizedSignatures,
+      encoded_tx: mdwTx.encodedTx || '',
+      type: mdwTx.tx.type,
+      contract_id: (mdwTx.tx.contractId ??
+        pollAddress) as Encoded.ContractAddress,
+      function: mdwTx.tx.function,
+      caller_id: mdwTx.tx.callerId,
+      sender_id: mdwTx.tx.senderId,
+      recipient_id: mdwTx.tx.recipientId,
+      payload: '',
+      raw: sanitizedRaw,
+      version: 1,
+      created_at: mdwTx.microTime ? new Date(mdwTx.microTime) : new Date(),
+    };
   }
 }

--- a/src/plugins/governance/governance-plugin.module.ts
+++ b/src/plugins/governance/governance-plugin.module.ts
@@ -16,6 +16,7 @@ import { GovernanceRevokedDelegation } from './entities/governance-revoked-deleg
 import { GovernanceDelegationService } from './services/governance-delegation.service';
 import { GovernanceDelegationsController } from './controllers/governance-delegations.controller';
 import { GovernancePopularRankingService } from './services/governance-popular-ranking.service';
+import { GovernancePollRegistry } from './services/governance-poll-registry.service';
 
 @Module({
   imports: [
@@ -31,6 +32,7 @@ import { GovernancePopularRankingService } from './services/governance-popular-r
     ]),
   ],
   providers: [
+    GovernancePollRegistry,
     GovernancePluginSyncService,
     GovernancePlugin,
     GovernanceVoteService,

--- a/src/plugins/governance/governance.plugin.spec.ts
+++ b/src/plugins/governance/governance.plugin.spec.ts
@@ -1,0 +1,173 @@
+import { GovernancePlugin } from './governance.plugin';
+import { GovernancePollRegistry } from './services/governance-poll-registry.service';
+
+const REGISTRY_CONTRACT = 'ct_registry' as const;
+
+function buildPlugin(options: {
+  contractAddress?: string | null;
+  knownPolls?: string[];
+}) {
+  // `null` means "caller explicitly unset it"; absence means "use default".
+  const effectiveAddress =
+    options.contractAddress === null
+      ? ''
+      : (options.contractAddress ?? REGISTRY_CONTRACT);
+
+  const configService = {
+    get: jest.fn().mockImplementation((key: string) => {
+      if (key === 'governance') {
+        return {
+          contract: { contractAddress: effectiveAddress },
+        };
+      }
+      return undefined;
+    }),
+  } as any;
+
+  const pollRegistry = {
+    has: jest.fn(
+      (addr: string | null | undefined) =>
+        !!addr && (options.knownPolls ?? []).includes(addr),
+    ),
+    register: jest.fn(),
+    size: jest.fn(() => (options.knownPolls ?? []).length),
+    isLoaded: jest.fn(() => true),
+  } as unknown as GovernancePollRegistry;
+
+  const plugin = new GovernancePlugin(
+    {} as any,
+    {} as any,
+    {} as any,
+    configService,
+    pollRegistry,
+  );
+
+  return { plugin, configService, pollRegistry };
+}
+
+describe('GovernancePlugin.filters()', () => {
+  it('returns no filters when no registry contract is configured', () => {
+    const { plugin } = buildPlugin({ contractAddress: null });
+    expect(plugin.filters()).toEqual([]);
+  });
+
+  describe('predicate', () => {
+    function predicateFor(knownPolls: string[] = []) {
+      const { plugin } = buildPlugin({ knownPolls });
+      const [filter] = plugin.filters();
+      return filter.predicate!;
+    }
+
+    it('accepts ContractCallTx on the governance registry (any function)', () => {
+      const predicate = predicateFor();
+      expect(
+        predicate({
+          type: 'ContractCallTx',
+          contract_id: REGISTRY_CONTRACT,
+          function: 'add_poll',
+        }),
+      ).toBe(true);
+      expect(
+        predicate({
+          type: 'ContractCallTx',
+          contract_id: REGISTRY_CONTRACT,
+          function: 'delegate',
+        }),
+      ).toBe(true);
+      expect(
+        predicate({
+          type: 'ContractCallTx',
+          contract_id: REGISTRY_CONTRACT,
+          function: 'revoke_delegation',
+        }),
+      ).toBe(true);
+    });
+
+    it('accepts vote / revoke_vote only on a known poll contract', () => {
+      const predicate = predicateFor(['ct_pollA']);
+
+      expect(
+        predicate({
+          type: 'ContractCallTx',
+          contract_id: 'ct_pollA',
+          function: 'vote',
+        }),
+      ).toBe(true);
+      expect(
+        predicate({
+          type: 'ContractCallTx',
+          contract_id: 'ct_pollA',
+          function: 'revoke_vote',
+        }),
+      ).toBe(true);
+
+      expect(
+        predicate({
+          type: 'ContractCallTx',
+          contract_id: 'ct_unrelated',
+          function: 'vote',
+        }),
+      ).toBe(false);
+      expect(
+        predicate({
+          type: 'ContractCallTx',
+          contract_id: 'ct_unrelated',
+          function: 'revoke_vote',
+        }),
+      ).toBe(false);
+    });
+
+    it('rejects generic governance function names on unrelated contracts', () => {
+      // Regression test: matching by function alone would index arbitrary
+      // contracts that expose `vote` / `delegate` / etc.
+      const predicate = predicateFor([]);
+
+      for (const fn of [
+        'vote',
+        'revoke_vote',
+        'delegate',
+        'revoke_delegation',
+        'add_poll',
+      ]) {
+        expect(
+          predicate({
+            type: 'ContractCallTx',
+            contract_id: 'ct_someRandomContract',
+            function: fn,
+          }),
+        ).toBe(false);
+      }
+    });
+
+    it('accepts ContractCreateTx only for known poll contracts', () => {
+      const predicate = predicateFor(['ct_pollA']);
+
+      expect(
+        predicate({ type: 'ContractCreateTx', contract_id: 'ct_pollA' }),
+      ).toBe(true);
+
+      expect(
+        predicate({
+          type: 'ContractCreateTx',
+          contract_id: 'ct_unrelatedContract',
+        }),
+      ).toBe(false);
+    });
+
+    it('rejects transactions without a contract_id', () => {
+      const predicate = predicateFor(['ct_pollA']);
+
+      expect(predicate({ type: 'ContractCallTx' })).toBe(false);
+      expect(predicate({ type: 'ContractCreateTx' })).toBe(false);
+      expect(predicate({ type: 'SpendTx' })).toBe(false);
+    });
+
+    it('rejects unrelated tx types even on the registry contract', () => {
+      const predicate = predicateFor();
+
+      expect(
+        predicate({ type: 'SpendTx', contract_id: REGISTRY_CONTRACT as any }),
+      ).toBe(false);
+    });
+  });
+});

--- a/src/plugins/governance/governance.plugin.ts
+++ b/src/plugins/governance/governance.plugin.ts
@@ -7,6 +7,7 @@ import { PluginSyncState } from '@/mdw-sync/entities/plugin-sync-state.entity';
 import { BasePlugin } from '../base-plugin';
 import { PluginFilter } from '../plugin.interface';
 import { GovernancePluginSyncService } from './governance-plugin-sync.service';
+import { GovernancePollRegistry } from './services/governance-poll-registry.service';
 import {
   getContractAddress,
   getStartHeight,
@@ -26,6 +27,7 @@ export class GovernancePlugin extends BasePlugin {
     protected readonly pluginSyncStateRepository: Repository<PluginSyncState>,
     private governancePluginSyncService: GovernancePluginSyncService,
     private readonly configService: ConfigService,
+    private readonly pollRegistry: GovernancePollRegistry,
   ) {
     super();
   }
@@ -49,14 +51,54 @@ export class GovernancePlugin extends BasePlugin {
       return [];
     }
 
+    // Governance touches three classes of transactions. We match each class
+    // as narrowly as possible so we only persist governance-relevant rows:
+    //
+    //   1. ContractCallTx on the governance REGISTRY contract. This covers
+    //      add_poll / delegate / revoke_delegation and is identified by the
+    //      well-known registry contract_id.
+    //
+    //   2. ContractCallTx for vote / revoke_vote on a KNOWN poll contract.
+    //      Poll contract addresses are not fixed at build time — they are
+    //      discovered at runtime via `add_poll` events and tracked by
+    //      `GovernancePollRegistry`. Matching by function name alone would
+    //      over-index arbitrary contracts that expose a generic `vote` /
+    //      `revoke_vote` entrypoint, so contract_id must be a known poll.
+    //
+    //   3. ContractCreateTx for a KNOWN poll contract. In chain order the
+    //      deployment precedes its registry `add_poll` call, so this
+    //      predicate typically doesn't match at ingest time; the add_poll
+    //      handler backfills the deployment from MDW once the poll is
+    //      registered (see GovernancePluginSyncService). We still match
+    //      here so that replayed / re-ingested CreateTx rows for already-
+    //      known polls are accepted without a round-trip to MDW.
     return [
       {
         predicate: (tx: Partial<Tx>) => {
-          return (
+          if (!tx.contract_id) {
+            return false;
+          }
+          if (
             tx.type === 'ContractCallTx' &&
-            !!tx.contract_id &&
             tx.contract_id === contractAddress
-          );
+          ) {
+            return true;
+          }
+          if (
+            tx.type === 'ContractCallTx' &&
+            (tx.function === GOVERNANCE_CONTRACT.FUNCTIONS.vote ||
+              tx.function === GOVERNANCE_CONTRACT.FUNCTIONS.revoke_vote) &&
+            this.pollRegistry.has(tx.contract_id)
+          ) {
+            return true;
+          }
+          if (
+            tx.type === 'ContractCreateTx' &&
+            this.pollRegistry.has(tx.contract_id)
+          ) {
+            return true;
+          }
+          return false;
         },
       },
     ];

--- a/src/plugins/governance/services/governance-poll-registry.service.spec.ts
+++ b/src/plugins/governance/services/governance-poll-registry.service.spec.ts
@@ -1,0 +1,103 @@
+import { GovernancePollRegistry } from './governance-poll-registry.service';
+
+type QueryBuilderMock = {
+  select: jest.Mock;
+  where: jest.Mock;
+  andWhere: jest.Mock;
+  distinct: jest.Mock;
+  getRawMany: jest.Mock;
+};
+
+function buildQueryBuilder(
+  rows: Array<{ poll_address: string | null }> | Error,
+): QueryBuilderMock {
+  const qb: QueryBuilderMock = {
+    select: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    distinct: jest.fn().mockReturnThis(),
+    getRawMany:
+      rows instanceof Error
+        ? jest.fn().mockRejectedValue(rows)
+        : jest.fn().mockResolvedValue(rows),
+  };
+  return qb;
+}
+
+describe('GovernancePollRegistry', () => {
+  function setup(rows: Array<{ poll_address: string | null }> | Error = []) {
+    const qb = buildQueryBuilder(rows);
+    const txRepository = {
+      createQueryBuilder: jest.fn().mockReturnValue(qb),
+    } as any;
+
+    const registry = new GovernancePollRegistry(txRepository);
+    return { registry, txRepository, qb };
+  }
+
+  it('seeds the known-poll set from existing add_poll data on module init', async () => {
+    const { registry } = setup([
+      { poll_address: 'ct_pollA' },
+      { poll_address: 'ct_pollB' },
+      { poll_address: null },
+    ]);
+
+    await registry.onModuleInit();
+
+    expect(registry.size()).toBe(2);
+    expect(registry.has('ct_pollA')).toBe(true);
+    expect(registry.has('ct_pollB')).toBe(true);
+    expect(registry.has('ct_pollC')).toBe(false);
+    expect(registry.isLoaded()).toBe(true);
+  });
+
+  it('tolerates a DB failure at startup and keeps the set empty', async () => {
+    const { registry } = setup(new Error('boom'));
+
+    await expect(registry.onModuleInit()).resolves.toBeUndefined();
+
+    expect(registry.size()).toBe(0);
+    expect(registry.isLoaded()).toBe(false);
+    expect(registry.has('ct_pollA')).toBe(false);
+  });
+
+  it('register() adds new poll addresses idempotently and reports newness', () => {
+    const { registry } = setup();
+
+    expect(registry.register('ct_newPoll')).toBe(true);
+    expect(registry.register('ct_newPoll')).toBe(false);
+    expect(registry.register('ct_otherPoll')).toBe(true);
+
+    expect(registry.size()).toBe(2);
+    expect(registry.has('ct_newPoll')).toBe(true);
+    expect(registry.has('ct_otherPoll')).toBe(true);
+  });
+
+  it('register() ignores empty / nullish inputs and reports false', () => {
+    const { registry } = setup();
+
+    expect(registry.register('')).toBe(false);
+    expect(registry.register(null)).toBe(false);
+    expect(registry.register(undefined)).toBe(false);
+
+    expect(registry.size()).toBe(0);
+  });
+
+  it('register() returns false for polls pre-seeded from the DB', async () => {
+    const { registry } = setup([{ poll_address: 'ct_seeded' }]);
+    await registry.onModuleInit();
+
+    expect(registry.register('ct_seeded')).toBe(false);
+    expect(registry.register('ct_brandNew')).toBe(true);
+  });
+
+  it('has() returns false for empty / nullish inputs', () => {
+    const { registry } = setup();
+    registry.register('ct_pollA');
+
+    expect(registry.has('')).toBe(false);
+    expect(registry.has(null)).toBe(false);
+    expect(registry.has(undefined)).toBe(false);
+    expect(registry.has('ct_pollA')).toBe(true);
+  });
+});

--- a/src/plugins/governance/services/governance-poll-registry.service.ts
+++ b/src/plugins/governance/services/governance-poll-registry.service.ts
@@ -1,0 +1,104 @@
+import { Tx } from '@/mdw-sync/entities/tx.entity';
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+/**
+ * Tracks the set of poll contract addresses the governance registry has
+ * registered via `add_poll`. This is consumed by:
+ *
+ *   1. `GovernancePlugin.filters()` — decides whether a
+ *      `ContractCallTx (vote / revoke_vote)` or `ContractCreateTx` targeting a
+ *      specific contract should be persisted.
+ *   2. `GovernancePluginSyncService` — registers newly discovered polls and
+ *      backfills their `ContractCreateTx` when `add_poll` is decoded.
+ *
+ * We cannot identify poll contracts in advance from the raw tx stream, so we
+ * start from whatever is already stored in `txs` (previous `add_poll` data)
+ * and grow the set as new `add_poll` events are processed.
+ */
+@Injectable()
+export class GovernancePollRegistry implements OnModuleInit {
+  private readonly logger = new Logger(GovernancePollRegistry.name);
+  private readonly pollAddresses = new Set<string>();
+  private loaded = false;
+
+  constructor(
+    @InjectRepository(Tx)
+    private readonly txRepository: Repository<Tx>,
+  ) {}
+
+  async onModuleInit(): Promise<void> {
+    await this.loadFromDb();
+  }
+
+  /**
+   * Seed the in-memory set from whatever governance data is already present
+   * in `txs`. Safe to call multiple times; errors are swallowed so indexer
+   * startup cannot be blocked by a transient DB issue — new polls will still
+   * be picked up lazily via `register()` as `add_poll` events arrive.
+   */
+  private async loadFromDb(): Promise<void> {
+    try {
+      const rows = await this.txRepository
+        .createQueryBuilder('tx')
+        .select(
+          `tx.data->'governance'->'data'->>'poll_address'`,
+          'poll_address',
+        )
+        .where(`tx.function = :fn`, { fn: 'add_poll' })
+        .andWhere(`tx.data->'governance'->'data'->>'poll_address' IS NOT NULL`)
+        .distinct(true)
+        .getRawMany<{ poll_address: string }>();
+
+      for (const row of rows) {
+        if (row.poll_address) {
+          this.pollAddresses.add(row.poll_address);
+        }
+      }
+
+      this.loaded = true;
+      this.logger.log(
+        `Loaded ${this.pollAddresses.size} known poll addresses from existing data`,
+      );
+    } catch (error: any) {
+      this.logger.error(
+        'Failed to preload known poll addresses (continuing with empty set — polls will be registered as they are discovered)',
+        error?.stack ?? error,
+      );
+    }
+  }
+
+  /**
+   * Add a newly discovered poll address.
+   *
+   * @returns `true` if this call added a new address (caller may need to run
+   *          any one-time backfill work for this poll); `false` if the
+   *          address was already known — either from the startup DB load or
+   *          from a previous `register()` call in this session.
+   */
+  register(pollAddress: string | null | undefined): boolean {
+    if (!pollAddress) {
+      return false;
+    }
+    if (this.pollAddresses.has(pollAddress)) {
+      return false;
+    }
+    this.pollAddresses.add(pollAddress);
+    this.logger.debug(`Registered poll address ${pollAddress}`);
+    return true;
+  }
+
+  has(pollAddress: string | null | undefined): boolean {
+    return !!pollAddress && this.pollAddresses.has(pollAddress);
+  }
+
+  size(): number {
+    return this.pollAddresses.size;
+  }
+
+  /** Whether the initial DB load completed. Useful for diagnostics only. */
+  isLoaded(): boolean {
+    return this.loaded;
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core transaction-ingestion behavior to drop non-plugin-relevant transactions and adds governance backfill logic that fetches/persists missing poll/vote transactions; mistakes could lead to missing indexed data or extra MDW load.
> 
> **Overview**
> The indexer now **persists only plugin-relevant transactions**: `BlockSyncService` filters each MDW page via `PluginBatchProcessorService.filterRelevantTransactions` before `save`/bulk `upsert`, while still tracking *all* observed tx hashes (pre-filter) for reorg validation.
> 
> `LiveIndexerService` adds an early `isRelevantTransaction` gate so irrelevant websocket transactions never touch the DB or plugin pipeline.
> 
> `PluginBatchProcessorService` introduces shared predicate aggregation (`filterRelevantTransactions`/`isRelevantTransaction`) and governance is updated to support this model: new `GovernancePollRegistry` tracks known polls, governance filters become poll-aware, governance SQL views drop hardcoded `contract_id` constraints, and `GovernancePluginSyncService` adds best-effort MDW backfills for missing poll `ContractCreateTx` and historical `vote`/`revoke_vote` rows when an `add_poll` is processed (with pagination safety limits).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dab03ae543b7cff798f827e06ee676862028d0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->