### PR TITLE
feat(tokens): add new order_by option

### DIFF
--- a/src/tokens/tokens.controller.spec.ts
+++ b/src/tokens/tokens.controller.spec.ts
@@ -203,6 +203,29 @@ describe('TokensController', () => {
     );
   });
 
+  it('should allow ordering tokens by treasury', async () => {
+    await controller.listAll(
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      1,
+      100,
+      'treasury',
+      'DESC',
+      'all',
+    );
+
+    expect(tokensService.applyListEligibilityFilters).not.toHaveBeenCalled();
+    expect(tokensService.queryTokensWithRanks).toHaveBeenCalledWith(
+      tokensQueryBuilder,
+      100,
+      1,
+      'treasury',
+      'DESC',
+    );
+  });
+
   it('should filter owner holdings with EXISTS instead of a distinct IN subquery', async () => {
     await controller.listAll(undefined, undefined, undefined, 'ak_owner');
 

--- a/src/tokens/tokens.controller.ts
+++ b/src/tokens/tokens.controller.ts
@@ -99,6 +99,7 @@ export class TokensController {
       'created_at',
       'holders_count',
       'rank',
+      'treasury',
       'trending_score',
     ],
     required: false,
@@ -132,6 +133,7 @@ export class TokensController {
       'name',
       'price',
       'created_at',
+      'treasury',
       'trending_score',
       'holders_count',
     ];

--- a/src/tokens/tokens.service.spec.ts
+++ b/src/tokens/tokens.service.spec.ts
@@ -340,6 +340,25 @@ describe('TokensService', () => {
     });
   });
 
+  it('orders ranked token pages by treasury using dao balance', async () => {
+    const queryBuilder = {
+      getQueryAndParameters: jest
+        .fn()
+        .mockReturnValue([
+          'SELECT token.* FROM token WHERE token.unlisted = false',
+          [],
+        ]),
+    } as any;
+
+    tokensRepository.query.mockResolvedValue([]);
+
+    await service.queryTokensWithRanks(queryBuilder, 20, 1, 'treasury', 'DESC');
+
+    const [sql] = tokensRepository.query.mock.calls[0];
+    expect(sql).toContain('ORDER BY all_ranked_tokens.dao_balance DESC');
+    expect(sql).toContain('ORDER BY paged_tokens.dao_balance DESC');
+  });
+
   it('returns empty items with the correct total when a ranked page is out of range', async () => {
     const queryBuilder = {
       getQueryAndParameters: jest

--- a/src/tokens/tokens.service.ts
+++ b/src/tokens/tokens.service.ts
@@ -735,7 +735,9 @@ export class TokensService {
          ${alias}.created_at DESC`;
     }
 
-    return `${alias}.${orderBy} ${orderDirection}`;
+    const orderColumn = orderBy === 'treasury' ? 'dao_balance' : orderBy;
+
+    return `${alias}.${orderColumn} ${orderDirection}`;
   }
 
   private buildEligibilityTradeCountsSubquery(): string {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this only adds a new allowed `order_by` value and maps it to an existing column (`dao_balance`) in the generated ORDER BY clause, with test coverage to validate the SQL.
> 
> **Overview**
> Adds a new `order_by=treasury` option to `GET /tokens` (Swagger + sort allowlist), enabling clients to sort token list pages by treasury value.
> 
> Implements treasury sorting by translating `treasury` to the `dao_balance` column inside `buildTokensOrderClause`, and extends controller/service specs to verify the controller passes the new sort through and the ranked-page SQL orders by `dao_balance`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83cffdb013d9143065d8af59d74774ba298835ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->