### PR TITLE
fix: return correct ae price

### DIFF
--- a/src/ae-pricing/ae-pricing.service.spec.ts
+++ b/src/ae-pricing/ae-pricing.service.spec.ts
@@ -1,0 +1,133 @@
+import { CURRENCIES } from '@/configs';
+import { CurrencyRates } from '@/utils/types';
+import BigNumber from 'bignumber.js';
+import { AePricingService } from './ae-pricing.service';
+
+const buildCompleteRates = (
+  overrides: Partial<CurrencyRates> = {},
+): CurrencyRates =>
+  ({
+    ...Object.fromEntries(
+      CURRENCIES.map(({ code }, index) => [code, (index + 1) / 100]),
+    ),
+    ...overrides,
+  }) as CurrencyRates;
+
+describe('AePricingService', () => {
+  let service: AePricingService;
+  let coinGeckoService: { getAeternityRates: jest.Mock };
+  let coinPriceRepository: { query: jest.Mock; save: jest.Mock };
+
+  beforeEach(() => {
+    coinGeckoService = {
+      getAeternityRates: jest.fn(),
+    };
+    coinPriceRepository = {
+      query: jest.fn(),
+      save: jest.fn(),
+    };
+    service = new AePricingService(
+      coinGeckoService as any,
+      coinPriceRepository as any,
+    );
+  });
+
+  it('should return complete CoinGecko rates', async () => {
+    const rates = buildCompleteRates({ usd: 0.1 });
+    coinGeckoService.getAeternityRates.mockResolvedValue(rates);
+
+    await expect(service.getCurrencyRates()).resolves.toEqual(rates);
+    expect(coinPriceRepository.query).not.toHaveBeenCalled();
+  });
+
+  it('should fall back to latest complete DB rates', async () => {
+    const olderCompleteRates = buildCompleteRates({ usd: 0.1 });
+    coinGeckoService.getAeternityRates.mockRejectedValue(
+      new Error('cache miss'),
+    );
+    coinPriceRepository.query.mockResolvedValue([
+      {
+        id: 1,
+        rates: olderCompleteRates,
+        created_at: new Date('2026-04-27T00:00:00Z'),
+      },
+    ]);
+
+    await expect(service.getCurrencyRates()).resolves.toEqual(
+      olderCompleteRates,
+    );
+    expect(coinPriceRepository.query).toHaveBeenCalledWith(
+      expect.stringContaining('rates::jsonb ?& $1::text[]'),
+      [CURRENCIES.map(({ code }) => code)],
+    );
+  });
+
+  it('should rely on the DB to skip any number of incomplete newer snapshots', async () => {
+    const completeRates = buildCompleteRates({ usd: 0.1 });
+    coinGeckoService.getAeternityRates.mockRejectedValue(
+      new Error('cache miss'),
+    );
+    coinPriceRepository.query.mockResolvedValue([
+      {
+        id: 1,
+        rates: completeRates,
+        created_at: new Date('2026-04-26T00:00:00Z'),
+      },
+    ]);
+
+    await expect(service.getCurrencyRates()).resolves.toEqual(completeRates);
+    const [sql] = coinPriceRepository.query.mock.calls[0];
+    expect(sql).not.toContain('LIMIT 10');
+  });
+
+  it('should throw when no complete rates are available', async () => {
+    coinGeckoService.getAeternityRates.mockRejectedValue(
+      new Error('cache miss'),
+    );
+    coinPriceRepository.query.mockResolvedValue([
+      {
+        id: 1,
+        rates: { usd: 0.1 },
+        created_at: new Date(),
+      },
+    ]);
+
+    await expect(service.getCurrencyRates()).rejects.toThrow(
+      'Aeternity rates are temporarily unavailable',
+    );
+  });
+
+  it('should not save incomplete rates snapshots', async () => {
+    const dbRates = buildCompleteRates({ usd: 0.1 });
+    coinGeckoService.getAeternityRates.mockResolvedValue({ usd: 0.2 });
+    coinPriceRepository.query.mockResolvedValue([
+      {
+        id: 1,
+        rates: dbRates,
+        created_at: new Date(),
+      },
+    ]);
+
+    const result = await service.pullAndSaveCoinCurrencyRates();
+
+    expect(result?.rates).toEqual(dbRates);
+    expect(coinPriceRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should price all supported currencies from the latest DB snapshot', async () => {
+    const rates = buildCompleteRates({ usd: 0.1, eur: 0.09 });
+    coinPriceRepository.query.mockResolvedValue([
+      {
+        id: 1,
+        rates,
+        created_at: new Date(),
+      },
+    ]);
+
+    const result = await service.getPriceData(new BigNumber(2));
+
+    expect(result.ae).toEqual(new BigNumber(2));
+    expect(result.usd).toEqual(new BigNumber(0.2));
+    expect(result.eur).toEqual(new BigNumber(0.18));
+  });
+});

--- a/src/ae-pricing/ae-pricing.service.ts
+++ b/src/ae-pricing/ae-pricing.service.ts
@@ -1,9 +1,11 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, ServiceUnavailableException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import BigNumber from 'bignumber.js';
 import { CoinGeckoService } from '@/ae/coin-gecko.service';
 import { CURRENCIES } from '@/configs';
 import { IPriceDto } from '@/tokens/dto/price.dto';
+import { CurrencyRates } from '@/utils/types';
+import { isCompleteCurrencyRates } from '@/utils/currency-rates.util';
 import { Repository } from 'typeorm';
 import { CoinPrice } from './entities/coin-price.entity';
 
@@ -16,6 +18,27 @@ export class AePricingService {
     @InjectRepository(CoinPrice)
     private coinPriceRepository: Repository<CoinPrice>,
   ) {}
+
+  async getCurrencyRates(): Promise<CurrencyRates> {
+    try {
+      const rates = await this.coinGeckoService.getAeternityRates();
+      if (isCompleteCurrencyRates(rates)) {
+        return rates;
+      }
+    } catch (_err) {
+      // Use the DB snapshot below when the in-memory/Redis cache is unavailable.
+    }
+
+    const latestRates = await this.findLatestCompleteRatesSnapshot();
+    if (latestRates) {
+      this.latestRates = latestRates;
+      return latestRates.rates as unknown as CurrencyRates;
+    }
+
+    throw new ServiceUnavailableException(
+      'Aeternity rates are temporarily unavailable',
+    );
+  }
 
   /**
    * Reads the latest rates from the CoinGeckoService in-memory / Redis cache
@@ -31,13 +54,8 @@ export class AePricingService {
       // Rates unavailable — fall back to latest DB row below
     }
 
-    if (!rates) {
-      this.latestRates = await this.coinPriceRepository.findOne({
-        where: {},
-        order: {
-          created_at: 'DESC',
-        },
-      });
+    if (!isCompleteCurrencyRates(rates)) {
+      this.latestRates = await this.findLatestCompleteRatesSnapshot();
       return this.latestRates;
     }
 
@@ -46,12 +64,7 @@ export class AePricingService {
         rates,
       });
     } catch (error) {
-      this.latestRates = await this.coinPriceRepository.findOne({
-        where: {},
-        order: {
-          created_at: 'DESC',
-        },
-      });
+      this.latestRates = await this.findLatestCompleteRatesSnapshot();
     }
     return this.latestRates;
   }
@@ -64,28 +77,22 @@ export class AePricingService {
    * @returns An object containing the price data for AE and other currencies.
    */
   async getPriceData(price: BigNumber): Promise<IPriceDto> {
-    let latestRates: CoinPrice | null = null;
-    try {
-      latestRates = await this.coinPriceRepository.findOne({
-        where: {},
-        order: {
-          created_at: 'DESC',
-        },
-      });
-    } catch (error) {
-      //
-    }
+    let latestRates = await this.findLatestCompleteRatesSnapshot();
 
     // Populate latestRates from cache if not yet in DB (first startup before cron runs)
     if (!latestRates) {
       latestRates = await this.pullAndSaveCoinCurrencyRates();
     }
+    this.latestRates = latestRates;
 
-    const prices = {
+    const prices: Record<string, BigNumber | null> = {
       ae: price,
     };
 
-    if (!this.latestRates) {
+    if (!this.latestRates || !isCompleteCurrencyRates(this.latestRates.rates)) {
+      CURRENCIES.forEach(({ code }) => {
+        prices[code] = null;
+      });
       return prices as any;
     }
 
@@ -98,5 +105,27 @@ export class AePricingService {
     });
 
     return prices as any;
+  }
+
+  private async findLatestCompleteRatesSnapshot(): Promise<CoinPrice | null> {
+    try {
+      const snapshots = await this.coinPriceRepository.query(
+        `
+          SELECT *
+          FROM coin_prices
+          WHERE rates::jsonb ?& $1::text[]
+          ORDER BY created_at DESC
+          LIMIT 1
+        `,
+        [CURRENCIES.map(({ code }) => code)],
+      );
+      const latestSnapshot = snapshots[0] as CoinPrice | undefined;
+
+      return latestSnapshot && isCompleteCurrencyRates(latestSnapshot.rates)
+        ? latestSnapshot
+        : null;
+    } catch (error) {
+      return null;
+    }
   }
 }

--- a/src/ae-pricing/controllers/price-feed.controller.ts
+++ b/src/ae-pricing/controllers/price-feed.controller.ts
@@ -9,13 +9,17 @@ import {
   CoinGeckoService,
   CoinGeckoMarketResponse,
 } from '@/ae/coin-gecko.service';
+import { AePricingService } from '../ae-pricing.service';
 import { CurrencyRates } from '@/utils/types';
 import { AETERNITY_COIN_ID } from '@/configs';
 
 @Controller('coins')
 @ApiTags('Coins')
 export class PriceFeedController {
-  constructor(private readonly coinGeckoService: CoinGeckoService) {}
+  constructor(
+    private readonly coinGeckoService: CoinGeckoService,
+    private readonly aePricingService: AePricingService,
+  ) {}
 
   @ApiOperation({
     operationId: 'getCurrencyRates',
@@ -43,7 +47,7 @@ export class PriceFeedController {
   @Get('aeternity/rates')
   async getCurrencyRates(): Promise<CurrencyRates> {
     // Serve best-available (cached/last-known-good) rates to avoid intermittent {}
-    return this.coinGeckoService.getAeternityRates();
+    return this.aePricingService.getCurrencyRates();
   }
 
   @ApiOperation({

--- a/src/ae/coin-gecko.service.spec.ts
+++ b/src/ae/coin-gecko.service.spec.ts
@@ -1,4 +1,4 @@
-import { AETERNITY_COIN_ID } from '@/configs';
+import { AETERNITY_COIN_ID, CURRENCIES } from '@/configs';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { fetchJson } from '@/utils/common';
 import { CurrencyRates } from '@/utils/types';
@@ -11,6 +11,16 @@ import { CoinGeckoService } from './coin-gecko.service';
 jest.mock('@/utils/common', () => ({
   fetchJson: jest.fn(),
 }));
+
+const buildCompleteRates = (
+  overrides: Partial<CurrencyRates> = {},
+): CurrencyRates =>
+  ({
+    ...Object.fromEntries(
+      CURRENCIES.map(({ code }, index) => [code, (index + 1) / 100]),
+    ),
+    ...overrides,
+  }) as CurrencyRates;
 
 describe('CoinGeckoService', () => {
   let service: CoinGeckoService;
@@ -51,7 +61,7 @@ describe('CoinGeckoService', () => {
   });
 
   it('should fetch coin currency rates correctly', async () => {
-    const mockRates: CurrencyRates = { usd: 0.1, eur: 0.09 } as any;
+    const mockRates = buildCompleteRates({ usd: 0.1, eur: 0.09 });
     (fetchJson as jest.Mock).mockResolvedValue({
       [AETERNITY_COIN_ID]: mockRates,
     });
@@ -63,6 +73,18 @@ describe('CoinGeckoService', () => {
       expect.stringContaining('/simple/price'),
     );
     expect(rates).toEqual(mockRates);
+  });
+
+  it('should reject incomplete coin currency rates', async () => {
+    (fetchJson as jest.Mock).mockResolvedValue({
+      [AETERNITY_COIN_ID]: { usd: 0.1 },
+    });
+
+    const rates = await (service as any).fetchCoinCurrencyRates(
+      AETERNITY_COIN_ID,
+    );
+
+    expect(rates).toBeNull();
   });
 
   it('should return null when fetching coin currency rates fails', async () => {
@@ -103,6 +125,21 @@ describe('CoinGeckoService', () => {
     expect(result.eur).toBeNull(); // Ensure unsupported currencies return null
   });
 
+  it('should return cached rates only when all supported currencies are present', async () => {
+    const cachedRates = buildCompleteRates({ usd: 0.1 });
+    (cacheManager.get as jest.Mock).mockResolvedValue(cachedRates);
+
+    await expect(service.getAeternityRates()).resolves.toEqual(cachedRates);
+  });
+
+  it('should not return incomplete cached rates', async () => {
+    (cacheManager.get as jest.Mock).mockResolvedValue({ usd: 0.1 });
+
+    await expect(service.getAeternityRates()).rejects.toThrow(
+      'Aeternity rates are temporarily unavailable',
+    );
+  });
+
   it('should fetch data from API correctly', async () => {
     (fetchJson as jest.Mock).mockResolvedValue({ data: 'mockData' });
 
@@ -128,6 +165,50 @@ describe('CoinGeckoService', () => {
     const result = await service.getCoinMarketData(AETERNITY_COIN_ID, 'usd');
 
     expect(result).toEqual(cachedMarket.data);
+    expect(fetchJson).not.toHaveBeenCalled();
+  });
+
+  it('should return fallback market data when market cache is empty', async () => {
+    (cacheManager.get as jest.Mock).mockResolvedValue(null);
+    jest.spyOn(service as any, 'readFallbackPricingData').mockReturnValue({
+      prices: [
+        [1000, 0.1],
+        [2000, 0.12],
+      ],
+      market_caps: [
+        [1000, 100],
+        [2000, 120],
+      ],
+      total_volumes: [
+        [1000, 10],
+        [2000, 12],
+      ],
+    });
+
+    const result = await service.getCoinMarketData(AETERNITY_COIN_ID, 'usd');
+
+    expect(result).toMatchObject({
+      id: AETERNITY_COIN_ID,
+      currentPrice: 0.12,
+      marketCap: 120,
+      totalVolume: 12,
+      marketCapChange24h: 20,
+      dataSource: 'fallback',
+      isFallback: true,
+    });
+    expect(result.priceChange24h).toBeCloseTo(0.02);
+    expect(cacheManager.set).toHaveBeenCalledWith(
+      `coingecko:market:v1:${AETERNITY_COIN_ID}:usd`,
+      expect.objectContaining({
+        data: expect.objectContaining({
+          currentPrice: 0.12,
+          dataSource: 'fallback',
+          isFallback: true,
+        }),
+        fetchedAt: expect.any(Number),
+      }),
+      60 * 60 * 1000,
+    );
     expect(fetchJson).not.toHaveBeenCalled();
   });
 });

--- a/src/ae/coin-gecko.service.ts
+++ b/src/ae/coin-gecko.service.ts
@@ -17,10 +17,16 @@ import { AETERNITY_COIN_ID, CURRENCIES } from '@/configs';
 import { IPriceDto } from '@/tokens/dto/price.dto';
 import { fetchJson } from '@/utils/common';
 import { CurrencyRates } from '@/utils/types';
+import {
+  getMissingCurrencyCodes,
+  isCompleteCurrencyRates,
+} from '@/utils/currency-rates.util';
 import { CoinHistoricalPriceService } from '@/ae-pricing/services/coin-historical-price.service';
 
 const COIN_GECKO_API_URL = 'https://api.coingecko.com/api/v3';
 const DEFAULT_MARKET_DATA_MAX_AGE_MS = 3 * 60 * 1000;
+const FALLBACK_MARKET_DATA_CACHE_TTL_MS = 60 * 60 * 1000;
+const RATES_CACHE_KEY = 'coingecko:rates';
 
 export interface CoinGeckoMarketResponse {
   ath: number;
@@ -49,6 +55,14 @@ export interface CoinGeckoMarketResponse {
   symbol: string;
   totalSupply: number;
   totalVolume: number;
+  dataSource?: 'coingecko' | 'fallback';
+  isFallback?: boolean;
+}
+
+interface FallbackPriceData {
+  prices?: Array<[number, number]>;
+  market_caps?: Array<[number, number]>;
+  total_volumes?: Array<[number, number]>;
 }
 
 @Injectable()
@@ -143,32 +157,33 @@ export class CoinGeckoService {
    * Never triggers a live CoinGecko API call — data is kept fresh by syncAllFromApi().
    */
   async getAeternityRates(): Promise<CurrencyRates> {
-    if (this.rates && !this.isPullTimeExpired()) {
+    if (
+      this.rates &&
+      !this.isPullTimeExpired() &&
+      isCompleteCurrencyRates(this.rates)
+    ) {
       return this.rates;
     }
 
     // Try Redis cache
     try {
       const cachedRates =
-        await this.cacheManager.get<CurrencyRates>('coingecko:rates');
-      if (cachedRates) {
+        await this.cacheManager.get<CurrencyRates>(RATES_CACHE_KEY);
+      if (isCompleteCurrencyRates(cachedRates)) {
         this.rates = cachedRates;
         this.last_pull_time = moment();
         return cachedRates;
+      }
+      if (cachedRates) {
+        this.logger.warn(
+          `Ignoring incomplete cached rates; missing: ${getMissingCurrencyCodes(cachedRates).join(', ')}`,
+        );
       }
     } catch (error) {
       this.logger.warn(
         'Failed to read cached rates in getAeternityRates:',
         error,
       );
-    }
-
-    // Try fallback JSON
-    const fallbackRates = this.getFallbackRates();
-    if (fallbackRates) {
-      this.rates = fallbackRates;
-      this.last_pull_time = moment();
-      return fallbackRates;
     }
 
     throw new ServiceUnavailableException(
@@ -178,7 +193,7 @@ export class CoinGeckoService {
 
   /**
    * Retrieves the price data for a given amount of AE tokens.
-   * Reads rates from memory / Redis / fallback — never triggers a live API call.
+   * Reads rates from memory / Redis — never triggers a live API call.
    * The cron (syncAllFromApi) keeps rates fresh; here we only warm up if rates are null.
    * @param price - The amount of AE tokens.
    * @returns An object containing the price data for AE and other currencies.
@@ -189,19 +204,17 @@ export class CoinGeckoService {
     if (this.rates === null) {
       try {
         const cachedRates =
-          await this.cacheManager.get<CurrencyRates>('coingecko:rates');
-        if (cachedRates) {
+          await this.cacheManager.get<CurrencyRates>(RATES_CACHE_KEY);
+        if (isCompleteCurrencyRates(cachedRates)) {
           this.rates = cachedRates;
           this.last_pull_time = moment();
-        } else {
-          const fallbackRates = this.getFallbackRates();
-          if (fallbackRates) {
-            this.rates = fallbackRates;
-            this.last_pull_time = moment();
-          }
+        } else if (cachedRates) {
+          this.logger.warn(
+            `Ignoring incomplete cached rates in getPriceData; missing: ${getMissingCurrencyCodes(cachedRates).join(', ')}`,
+          );
         }
       } catch (error) {
-        this.logger.warn('Failed to get cached or fallback rates:', error);
+        this.logger.warn('Failed to get cached rates:', error);
       }
     }
 
@@ -272,6 +285,26 @@ export class CoinGeckoService {
       }
     } catch (error) {
       this.logger.warn(`Failed to read market cache (${cacheKey}):`, error);
+    }
+
+    const fallbackMarketData = this.getFallbackMarketData(coinId, currencyCode);
+    if (fallbackMarketData) {
+      try {
+        await this.cacheManager.set(
+          cacheKey,
+          {
+            data: fallbackMarketData,
+            fetchedAt: Date.now(),
+          } satisfies CachedMarket,
+          FALLBACK_MARKET_DATA_CACHE_TTL_MS,
+        );
+      } catch (error) {
+        this.logger.warn(
+          `Failed to cache fallback market data (${cacheKey}):`,
+          error,
+        );
+      }
+      return fallbackMarketData;
     }
 
     throw new ServiceUnavailableException(
@@ -349,11 +382,11 @@ export class CoinGeckoService {
    */
   private async pullData() {
     const rates = await this.fetchCoinCurrencyRates(AETERNITY_COIN_ID);
-    if (rates) {
+    if (isCompleteCurrencyRates(rates)) {
       this.rates = rates;
       this.last_pull_time = moment();
       try {
-        await this.cacheManager.set('coingecko:rates', rates, 600 * 1000);
+        await this.cacheManager.set(RATES_CACHE_KEY, rates, 600 * 1000);
         this.logger.debug('Cached currency rates');
       } catch (error) {
         this.logger.warn('Failed to cache currency rates:', error);
@@ -362,55 +395,131 @@ export class CoinGeckoService {
       // If API fails, try to use cached rates
       try {
         const cachedRates =
-          await this.cacheManager.get<CurrencyRates>('coingecko:rates');
-        if (cachedRates) {
+          await this.cacheManager.get<CurrencyRates>(RATES_CACHE_KEY);
+        if (isCompleteCurrencyRates(cachedRates)) {
           this.logger.log('Using cached currency rates due to API failure');
           this.rates = cachedRates;
           this.last_pull_time = moment();
         } else {
-          const fallbackRates = this.getFallbackRates();
-          if (fallbackRates) {
-            this.logger.log('Using fallback rates from JSON file');
-            this.rates = fallbackRates;
-            this.last_pull_time = moment();
+          if (cachedRates) {
+            this.logger.warn(
+              `Ignoring incomplete cached rates after API failure; missing: ${getMissingCurrencyCodes(cachedRates).join(', ')}`,
+            );
+          }
+          if (isCompleteCurrencyRates(this.rates)) {
+            this.logger.log(
+              'Keeping previous in-memory currency rates due to API failure',
+            );
           } else {
-            this.logger.warn('No rates available from API, cache, or fallback');
+            this.logger.warn('No complete rates available from API or cache');
           }
         }
       } catch (error) {
         this.logger.warn('Failed to read cached rates:', error);
-        const fallbackRates = this.getFallbackRates();
-        if (fallbackRates) {
-          this.logger.log('Using fallback rates from JSON file');
-          this.rates = fallbackRates;
-          this.last_pull_time = moment();
-        }
       }
     }
   }
 
-  /**
-   * Gets fallback rates from the JSON file (uses latest USD price).
-   * @returns CurrencyRates object with USD rate, or null if unavailable
-   */
-  private getFallbackRates(): CurrencyRates | null {
-    try {
-      const priceData = this.readFallbackPriceData();
-      if (priceData && priceData.length > 0) {
-        const sortedByTime = [...priceData].sort((a, b) => b[0] - a[0]);
-        const latestPrice = sortedByTime[0][1];
-        if (latestPrice && typeof latestPrice === 'number') {
-          this.logger.log(`Using fallback USD rate from JSON: ${latestPrice}`);
-          return {
-            usd: latestPrice,
-          } as CurrencyRates;
-        }
-      }
-      return null;
-    } catch (error) {
-      this.logger.error('Failed to get fallback rates:', error);
+  private getFallbackMarketData(
+    coinId: string,
+    currencyCode: string,
+  ): CoinGeckoMarketResponse | null {
+    if (coinId !== AETERNITY_COIN_ID || currencyCode !== 'usd') {
       return null;
     }
+
+    try {
+      const fallbackData = this.readFallbackPricingData();
+      const latestPrice = this.getLatestFallbackValue(fallbackData.prices);
+      if (!latestPrice) {
+        return null;
+      }
+
+      const previousPrice = this.getPreviousFallbackValue(fallbackData.prices);
+      const priceChange24h = previousPrice
+        ? latestPrice[1] - previousPrice[1]
+        : 0;
+      const priceChangePercentage24h =
+        previousPrice && previousPrice[1] !== 0
+          ? (priceChange24h / previousPrice[1]) * 100
+          : 0;
+      const latestMarketCap = this.getLatestFallbackValue(
+        fallbackData.market_caps,
+      );
+      const previousMarketCap = this.getPreviousFallbackValue(
+        fallbackData.market_caps,
+      );
+      const marketCapChange24h =
+        latestMarketCap && previousMarketCap
+          ? latestMarketCap[1] - previousMarketCap[1]
+          : 0;
+      const marketCapChangePercentage24h =
+        previousMarketCap && previousMarketCap[1] !== 0
+          ? (marketCapChange24h / previousMarketCap[1]) * 100
+          : 0;
+
+      this.logger.warn(
+        `Using fallback market data from JSON for ${coinId}/${currencyCode}`,
+      );
+
+      return {
+        ath: latestPrice[1],
+        athChangePercentage: 0,
+        athDate: new Date(latestPrice[0]).toISOString(),
+        atl: latestPrice[1],
+        atlChangePercentage: 0,
+        atlDate: new Date(latestPrice[0]).toISOString(),
+        circulatingSupply: 0,
+        currentPrice: latestPrice[1],
+        fullyDilutedValuation: null,
+        high24h: Math.max(latestPrice[1], previousPrice?.[1] ?? latestPrice[1]),
+        id: coinId,
+        image: '',
+        lastUpdated: new Date(latestPrice[0]).toISOString(),
+        low24h: Math.min(latestPrice[1], previousPrice?.[1] ?? latestPrice[1]),
+        marketCap: latestMarketCap?.[1] ?? 0,
+        marketCapChange24h,
+        marketCapChangePercentage24h,
+        marketCapRank: 0,
+        maxSupply: null,
+        name: 'Aeternity',
+        priceChange24h,
+        priceChangePercentage24h,
+        roi: null,
+        symbol: 'ae',
+        totalSupply: 0,
+        totalVolume:
+          this.getLatestFallbackValue(fallbackData.total_volumes)?.[1] ?? 0,
+        dataSource: 'fallback',
+        isFallback: true,
+      };
+    } catch (error) {
+      this.logger.error('Failed to get fallback market data:', error);
+      return null;
+    }
+  }
+
+  private getLatestFallbackValue(
+    values?: Array<[number, number]>,
+  ): [number, number] | null {
+    if (!values?.length) {
+      return null;
+    }
+
+    return values.reduce((latest, current) =>
+      current[0] > latest[0] ? current : latest,
+    );
+  }
+
+  private getPreviousFallbackValue(
+    values?: Array<[number, number]>,
+  ): [number, number] | null {
+    if (!values || values.length < 2) {
+      return null;
+    }
+
+    const sortedByTime = [...values].sort((a, b) => b[0] - a[0]);
+    return sortedByTime[1];
   }
 
   /**
@@ -444,12 +553,18 @@ export class CoinGeckoService {
       }
 
       const rates = response?.[coinId];
-      if (rates) {
+      if (isCompleteCurrencyRates(rates)) {
         this.logger.debug(
           `Fetched CoinGecko rates for ${coinId}:`,
           JSON.stringify(rates),
         );
         return rates;
+      }
+      if (rates) {
+        this.logger.warn(
+          `Incomplete CoinGecko rates for ${coinId}; missing: ${getMissingCurrencyCodes(rates).join(', ')}`,
+        );
+        return null;
       }
       this.logger.warn(`No rates found in CoinGecko response for ${coinId}`);
       return null;
@@ -514,9 +629,7 @@ export class CoinGeckoService {
    */
   private readFallbackPriceData(): Array<[number, number]> {
     try {
-      const filePath = join(process.cwd(), 'src', 'data', 'ae-pricing.json');
-      const fileContent = readFileSync(filePath, 'utf-8');
-      const data = JSON.parse(fileContent);
+      const data = this.readFallbackPricingData();
 
       if (data?.prices && Array.isArray(data.prices)) {
         this.logger.log(
@@ -536,6 +649,12 @@ export class CoinGeckoService {
       );
       return [];
     }
+  }
+
+  private readFallbackPricingData(): FallbackPriceData {
+    const filePath = join(process.cwd(), 'src', 'data', 'ae-pricing.json');
+    const fileContent = readFileSync(filePath, 'utf-8');
+    return JSON.parse(fileContent) as FallbackPriceData;
   }
 
   /**

--- a/src/utils/currency-rates.util.spec.ts
+++ b/src/utils/currency-rates.util.spec.ts
@@ -1,0 +1,46 @@
+import { CURRENCIES } from '@/configs';
+import { CurrencyRates } from './types';
+import {
+  getMissingCurrencyCodes,
+  isCompleteCurrencyRates,
+} from './currency-rates.util';
+
+const buildCompleteRates = (
+  overrides: Partial<CurrencyRates> = {},
+): CurrencyRates =>
+  ({
+    ...Object.fromEntries(
+      CURRENCIES.map(({ code }, index) => [code, (index + 1) / 100]),
+    ),
+    ...overrides,
+  }) as CurrencyRates;
+
+describe('currency rates utils', () => {
+  it('should accept finite numeric rates for every supported currency', () => {
+    expect(isCompleteCurrencyRates(buildCompleteRates())).toBe(true);
+  });
+
+  it('should reject null and non-object values', () => {
+    expect(isCompleteCurrencyRates(null)).toBe(false);
+    expect(isCompleteCurrencyRates(undefined)).toBe(false);
+    expect(isCompleteCurrencyRates('usd')).toBe(false);
+  });
+
+  it('should reject rates missing any supported currency', () => {
+    expect(isCompleteCurrencyRates({ usd: 0.1 })).toBe(false);
+    expect(getMissingCurrencyCodes({ usd: 0.1 })).toEqual(
+      CURRENCIES.filter(({ code }) => code !== 'usd').map(({ code }) => code),
+    );
+  });
+
+  it('should reject non-finite and non-numeric rates', () => {
+    const rates = buildCompleteRates({
+      eur: Number.NaN,
+      gbp: Number.POSITIVE_INFINITY,
+      xau: '0.1' as any,
+    });
+
+    expect(isCompleteCurrencyRates(rates)).toBe(false);
+    expect(getMissingCurrencyCodes(rates)).toEqual(['eur', 'gbp', 'xau']);
+  });
+});

--- a/src/utils/currency-rates.util.ts
+++ b/src/utils/currency-rates.util.ts
@@ -1,0 +1,24 @@
+import { CURRENCIES } from '@/configs';
+import { CurrencyRates } from './types';
+
+export function isCompleteCurrencyRates(
+  rates: unknown,
+): rates is CurrencyRates {
+  if (!rates || typeof rates !== 'object') {
+    return false;
+  }
+
+  return CURRENCIES.every(({ code }) => {
+    const rate = (rates as Partial<CurrencyRates>)[code];
+    return typeof rate === 'number' && Number.isFinite(rate);
+  });
+}
+
+export function getMissingCurrencyCodes(
+  rates: Partial<CurrencyRates>,
+): string[] {
+  return CURRENCIES.filter(({ code }) => {
+    const rate = rates[code];
+    return typeof rate !== 'number' || !Number.isFinite(rate);
+  }).map(({ code }) => code);
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes affect price/rate retrieval and fallback paths (cache/DB/JSON) and introduce a new raw SQL query for selecting complete snapshots, so errors could impact pricing availability or correctness across endpoints.
> 
> **Overview**
> AE spot-rate serving is hardened to **only accept complete rate snapshots** for all supported currencies, avoiding intermittent `{}`/partial responses and incorrect conversions.
> 
> `AePricingService` now provides `getCurrencyRates()` used by `/coins/aeternity/rates`, falls back to the **latest complete** `coin_prices` snapshot when cache misses occur, and avoids persisting incomplete snapshots; pricing conversion returns `null` for all fiat codes when a complete snapshot isn’t available.
> 
> `CoinGeckoService` now validates cached/API rates with new `currency-rates` utilities (and logs missing codes), removes the previous “fallback USD rate” path, and adds a **fallback market-data** response (from bundled JSON) when the market cache is empty, caching that fallback for 1 hour.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88beee6c1f03430edb360e7f87da7692c5566564. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->