### PR TITLE
Add new filter to leaderboard endpoint

### DIFF
--- a/docs/leaderboard-time-filter-manual-migration.sql
+++ b/docs/leaderboard-time-filter-manual-migration.sql
@@ -1,0 +1,137 @@
+-- =============================================================================
+-- Leaderboard time-filter feature — manual migration & deploy runbook
+-- =============================================================================
+--
+-- The TypeORM entity decorators added in this change describe the desired
+-- index shape, but production runs with `synchronize=false`. Apply this DDL
+-- BEFORE shipping the new code path or the time-filtered query will fall back
+-- to a sequential scan over `transactions` (potentially millions of rows) and
+-- the per-metric ORDER BYs on the snapshot table will not be index-backed.
+--
+-- All statements are idempotent (`IF EXISTS` / `IF NOT EXISTS`) so the script
+-- can be re-run safely.
+--
+-- IMPORTANT: `CREATE INDEX CONCURRENTLY` and `DROP INDEX CONCURRENTLY` cannot
+-- run inside a transaction block, so do NOT wrap this script in BEGIN/COMMIT.
+-- Run it with autocommit on, e.g.:
+--   psql -v ON_ERROR_STOP=1 -f docs/leaderboard-time-filter-manual-migration.sql
+--
+-- -----------------------------------------------------------------------------
+-- Pre-deploy checklist
+-- -----------------------------------------------------------------------------
+-- 1. Apply this script against production (or staging first) with the OLD
+--    application version still serving traffic. The DDL is purely additive:
+--    it only adds indexes and drops one anonymous, no-longer-referenced index.
+-- 2. Wait for `CREATE INDEX CONCURRENTLY` to finish on `transactions` before
+--    rolling out the new code. On large `transactions` tables this can take
+--    minutes to hours.
+-- 3. Verify each new index reports `indisvalid = true`:
+--      SELECT indexrelid::regclass AS index, indisvalid, indisready
+--      FROM pg_index
+--      WHERE indexrelid::regclass::text IN (
+--        'IDX_TRANSACTION_CREATED_AT_ADDRESS_TYPE',
+--        'IDX_ACCOUNT_LEADERBOARD_SNAPSHOTS_WINDOW_ADDRESS',
+--        'IDX_ACCOUNT_LEADERBOARD_SNAPSHOTS_WINDOW_AUM',
+--        'IDX_ACCOUNT_LEADERBOARD_SNAPSHOTS_WINDOW_PNL',
+--        'IDX_ACCOUNT_LEADERBOARD_SNAPSHOTS_WINDOW_ROI',
+--        'IDX_ACCOUNT_LEADERBOARD_SNAPSHOTS_WINDOW_MDD'
+--      );
+-- 4. Only after every index is valid, deploy the new application version that
+--    accepts `timePeriod` / `timeUnit` query params.
+--
+-- -----------------------------------------------------------------------------
+-- Post-deploy verification
+-- -----------------------------------------------------------------------------
+-- Run these EXPLAIN ANALYZE checks against production (or a recent prod-like
+-- snapshot) to confirm the planner picks up the new indexes.
+--
+-- A) Time-window scan over transactions (drives the active_accounts CTE):
+--      EXPLAIN (ANALYZE, BUFFERS)
+--      SELECT 1 FROM transactions
+--      WHERE created_at >= now() - interval '2 hours'
+--        AND created_at <  now()
+--        AND tx_type IN ('buy','sell');
+--    Expected plan node: `Index Scan using IDX_TRANSACTION_CREATED_AT_ADDRESS_TYPE`
+--    (or a Bitmap Index Scan on the same index).
+--    Red flag: `Seq Scan on transactions` — index not deployed or not selected.
+--
+-- B) Snapshot ORDER BY (drives the read service main query):
+--      EXPLAIN (ANALYZE, BUFFERS)
+--      SELECT * FROM account_leaderboard_snapshots
+--      WHERE window = '7d' AND aum_usd >= 1
+--      ORDER BY pnl_usd DESC LIMIT 18;
+--    Expected: `Index Scan using IDX_ACCOUNT_LEADERBOARD_SNAPSHOTS_WINDOW_PNL`
+--    or a Sort node fed from one of the snapshot indexes (acceptable — the
+--    table is small, ≤100 rows per window). Repeat for sortBy=roi/mdd/aum.
+--
+-- C) Hit a real time-filtered request and inspect the duration:
+--      curl 'https://<host>/api/accounts/leaderboard?window=7d&sortBy=pnl&timePeriod=30&timeUnit=minutes'
+--    p95 should be well under 500ms. If it is not, capture the plan via
+--    `auto_explain` (or run the underlying query manually with EXPLAIN ANALYZE)
+--    and check that `IDX_TRANSACTION_CREATED_AT_ADDRESS_TYPE` is being used.
+--
+-- -----------------------------------------------------------------------------
+-- Rollback
+-- -----------------------------------------------------------------------------
+-- The new indexes are additive and safe to leave in place even if the
+-- application is rolled back. To fully revert:
+--   DROP INDEX CONCURRENTLY IF EXISTS "IDX_TRANSACTION_CREATED_AT_ADDRESS_TYPE";
+--   DROP INDEX CONCURRENTLY IF EXISTS "IDX_ACCOUNT_LEADERBOARD_SNAPSHOTS_WINDOW_ADDRESS";
+--   DROP INDEX CONCURRENTLY IF EXISTS "IDX_ACCOUNT_LEADERBOARD_SNAPSHOTS_WINDOW_AUM";
+--   DROP INDEX CONCURRENTLY IF EXISTS "IDX_ACCOUNT_LEADERBOARD_SNAPSHOTS_WINDOW_PNL";
+--   DROP INDEX CONCURRENTLY IF EXISTS "IDX_ACCOUNT_LEADERBOARD_SNAPSHOTS_WINDOW_ROI";
+--   DROP INDEX CONCURRENTLY IF EXISTS "IDX_ACCOUNT_LEADERBOARD_SNAPSHOTS_WINDOW_MDD";
+--
+-- If a `CREATE INDEX CONCURRENTLY` failed partway through, it leaves an INVALID
+-- index that still consumes write overhead but cannot be used by the planner:
+--   SELECT indexrelid::regclass FROM pg_index WHERE NOT indisvalid;
+-- Drop any such row before retrying:
+--   DROP INDEX CONCURRENTLY IF EXISTS "<name>";
+--
+-- =============================================================================
+
+-- 1. Snapshot table indexes ---------------------------------------------------
+
+-- Old anonymous index that was previously declared as @Index(['window','aum_usd']).
+-- TypeORM does not drop it automatically because the new declaration carries an
+-- explicit name. Discover its actual name in the target environment first:
+--   SELECT indexname FROM pg_indexes
+--   WHERE tablename = 'account_leaderboard_snapshots'
+--     AND indexdef LIKE '%(window, aum_usd)%';
+-- Then drop it:
+DROP INDEX CONCURRENTLY IF EXISTS "IDX_43a3f2eb87e4dca4dd1a59ba7c";
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
+  "IDX_ACCOUNT_LEADERBOARD_SNAPSHOTS_WINDOW_ADDRESS"
+  ON account_leaderboard_snapshots (window, address);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
+  "IDX_ACCOUNT_LEADERBOARD_SNAPSHOTS_WINDOW_AUM"
+  ON account_leaderboard_snapshots (window, aum_usd);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
+  "IDX_ACCOUNT_LEADERBOARD_SNAPSHOTS_WINDOW_PNL"
+  ON account_leaderboard_snapshots (window, pnl_usd);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
+  "IDX_ACCOUNT_LEADERBOARD_SNAPSHOTS_WINDOW_ROI"
+  ON account_leaderboard_snapshots (window, roi_pct);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
+  "IDX_ACCOUNT_LEADERBOARD_SNAPSHOTS_WINDOW_MDD"
+  ON account_leaderboard_snapshots (window, mdd_pct);
+
+-- 2. Transactions table index ------------------------------------------------
+
+-- Backs the time-window scan in the active_accounts CTE:
+--   WHERE t.tx_type IN ('buy','sell')
+--     AND t.created_at >= $start AND t.created_at < $end
+--     AND EXISTS (... eligible.address = t.address)
+--
+-- `transactions` is large; the build can take a long time. CONCURRENTLY avoids
+-- blocking writes. Monitor with:
+--   SELECT phase, blocks_done, blocks_total, tuples_done, tuples_total
+--   FROM pg_stat_progress_create_index;
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
+  "IDX_TRANSACTION_CREATED_AT_ADDRESS_TYPE"
+  ON transactions (created_at, address, tx_type);

--- a/src/account/controllers/leaderboard.controller.spec.ts
+++ b/src/account/controllers/leaderboard.controller.spec.ts
@@ -1,0 +1,144 @@
+import { LeaderboardController } from './leaderboard.controller';
+import { LeaderboardService } from '../services/leaderboard.service';
+
+describe('LeaderboardController', () => {
+  const buildService = (
+    result: Awaited<ReturnType<LeaderboardService['getLeaders']>>,
+  ) => {
+    const getLeaders = jest.fn().mockResolvedValue(result);
+    return {
+      service: { getLeaders } as unknown as LeaderboardService,
+      getLeaders,
+    };
+  };
+
+  it('reports totalPages = 0 when there are no candidates', async () => {
+    const { service } = buildService({
+      items: [],
+      totalCandidates: 0,
+      page: 1,
+      limit: 10,
+      window: '7d',
+      sortBy: 'pnl',
+      sortDir: 'DESC',
+    });
+    const controller = new LeaderboardController(service);
+
+    const response = await controller.getLeaderboard({});
+
+    expect(response.items).toEqual([]);
+    expect(response.meta).toMatchObject({
+      page: 1,
+      limit: 10,
+      totalItems: 0,
+      totalPages: 0,
+      window: '7d',
+      sortBy: 'pnl',
+      sortDir: 'DESC',
+    });
+    expect(response.meta.timeFilter).toBeUndefined();
+  });
+
+  it('rounds totalPages up for partial last pages', async () => {
+    const { service } = buildService({
+      items: [],
+      totalCandidates: 31,
+      page: 1,
+      limit: 10,
+      window: '7d',
+      sortBy: 'pnl',
+      sortDir: 'DESC',
+    });
+    const controller = new LeaderboardController(service);
+
+    const response = await controller.getLeaderboard({});
+
+    expect(response.meta.totalPages).toBe(4);
+    expect(response.meta.totalItems).toBe(31);
+  });
+
+  it('forwards the query DTO straight to the service', async () => {
+    const { service, getLeaders } = buildService({
+      items: [],
+      totalCandidates: 0,
+      page: 3,
+      limit: 5,
+      window: '30d',
+      sortBy: 'roi',
+      sortDir: 'ASC',
+    });
+    const controller = new LeaderboardController(service);
+
+    await controller.getLeaderboard({
+      window: '30d',
+      sortBy: 'roi',
+      sortDir: 'ASC',
+      page: 3,
+      limit: 5,
+      timePeriod: 30,
+      timeUnit: 'minutes',
+    });
+
+    expect(getLeaders).toHaveBeenCalledWith({
+      window: '30d',
+      sortBy: 'roi',
+      sortDir: 'ASC',
+      page: 3,
+      limit: 5,
+      timePeriod: 30,
+      timeUnit: 'minutes',
+    });
+  });
+
+  it('serializes timeFilter dates as ISO strings and surfaces active_period on items', async () => {
+    const start = new Date('2026-04-28T10:00:00.000Z');
+    const end = new Date('2026-04-28T12:00:00.000Z');
+    const { service } = buildService({
+      items: [
+        {
+          address: 'ak_test',
+          chain_name: 'alice',
+          aum_usd: 100,
+          pnl_usd: 5,
+          roi_pct: 7,
+          mdd_pct: 3,
+          buy_count: 50,
+          sell_count: 40,
+          created_tokens_count: 0,
+          owned_trends_count: 0,
+          portfolio_value_usd_sparkline: [],
+          active_period: { buy_count: 4, sell_count: 2 },
+        },
+      ],
+      totalCandidates: 1,
+      page: 1,
+      limit: 18,
+      window: '30d',
+      sortBy: 'aum',
+      sortDir: 'DESC',
+      timeFilter: { value: 2, unit: 'hours', start, end },
+    });
+    const controller = new LeaderboardController(service);
+
+    const response = await controller.getLeaderboard({
+      window: '30d',
+      sortBy: 'aum',
+      timePeriod: 2,
+      timeUnit: 'hours',
+    });
+
+    expect(response.meta.timeFilter).toEqual({
+      value: 2,
+      unit: 'hours',
+      start: '2026-04-28T10:00:00.000Z',
+      end: '2026-04-28T12:00:00.000Z',
+    });
+    expect(response.meta.totalPages).toBe(1);
+    expect(response.items[0].active_period).toEqual({
+      buy_count: 4,
+      sell_count: 2,
+    });
+    expect(response.items[0].buy_count).toBe(50);
+    expect(response.items[0].sell_count).toBe(40);
+  });
+});

--- a/src/account/controllers/leaderboard.controller.ts
+++ b/src/account/controllers/leaderboard.controller.ts
@@ -1,26 +1,15 @@
-import {
-  Controller,
-  Get,
-  Query,
-  UseInterceptors,
-  DefaultValuePipe,
-  ParseIntPipe,
-} from '@nestjs/common';
-import {
-  ApiOkResponse,
-  ApiOperation,
-  ApiQuery,
-  ApiTags,
-} from '@nestjs/swagger';
+import { Controller, Get, Query, UseInterceptors } from '@nestjs/common';
+import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { CacheInterceptor, CacheTTL } from '@nestjs/cache-manager';
+import { LeaderboardService } from '../services/leaderboard.service';
 import {
-  GetLeadersParams,
   LeaderboardItem,
-  LeaderboardService,
   LeaderboardSortBy,
   LeaderboardSortDir,
+  LeaderboardTimeUnit,
   LeaderboardWindow,
-} from '../services/leaderboard.service';
+} from '../services/leaderboard.types';
+import { GetLeaderboardQueryDto } from '../dto/get-leaderboard-query.dto';
 
 class LeaderboardResponseDto {
   items!: LeaderboardItem[];
@@ -32,6 +21,12 @@ class LeaderboardResponseDto {
     window: LeaderboardWindow;
     sortBy: LeaderboardSortBy;
     sortDir: LeaderboardSortDir;
+    timeFilter?: {
+      value: number;
+      unit: LeaderboardTimeUnit;
+      start: string;
+      end: string;
+    };
   };
 }
 
@@ -44,87 +39,43 @@ export class LeaderboardController {
   @ApiOperation({
     operationId: 'getAccountsLeaderboard',
     description:
-      'Returns paginated trading leaders with metrics (AUM, PNL, ROI, MDD), activity counters, and portfolio sparkline.',
+      'Returns paginated trading leaders with metrics (AUM, PNL, ROI, MDD), activity counters, and a portfolio sparkline. ' +
+      'Metrics are precomputed per window (7d / 30d / all). ' +
+      'When timePeriod + timeUnit are supplied, the response is restricted to leaders that traded (buy or sell) within that recent window, ' +
+      'and each item gains an `active_period` block with buy/sell counts scoped to the recent window. ' +
+      'The window-scoped `buy_count` / `sell_count` fields on each item remain unchanged. ' +
+      'Note: responses are cached for up to 60 seconds, so `meta.timeFilter.start` and `meta.timeFilter.end` reflect the time the cache entry was filled, not strictly the time of the current request.',
   })
   @ApiOkResponse({ type: LeaderboardResponseDto })
-  @ApiQuery({
-    name: 'window',
-    required: false,
-    enum: ['7d', '30d', 'all'],
-    example: '7d',
-  })
-  @ApiQuery({
-    name: 'sortBy',
-    required: false,
-    enum: ['pnl', 'roi', 'mdd', 'aum'],
-    example: 'pnl',
-  })
-  @ApiQuery({
-    name: 'sortDir',
-    required: false,
-    enum: ['ASC', 'DESC'],
-    example: 'DESC',
-  })
-  @ApiQuery({ name: 'page', required: false, example: 1 })
-  @ApiQuery({ name: 'limit', required: false, example: 18 })
-  @ApiQuery({
-    name: 'points',
-    required: false,
-    example: 30,
-    description: 'Approximate number of sparkline points',
-  })
-  @ApiQuery({
-    name: 'minAumUsd',
-    required: false,
-    example: 1,
-    description: 'Exclude leaders with AUM below this USD value',
-  })
-  @ApiQuery({
-    name: 'maxCandidates',
-    required: false,
-    example: 36,
-    description: 'Upper bound of candidate addresses to evaluate',
-  })
   @CacheTTL(60_000)
   @Get()
   async getLeaderboard(
-    @Query('window') window: LeaderboardWindow = '7d',
-    @Query('sortBy') sortBy: LeaderboardSortBy = 'pnl',
-    @Query('sortDir')
-    sortDir: LeaderboardSortDir = (sortBy === 'mdd'
-      ? 'ASC'
-      : 'DESC') as LeaderboardSortDir,
-    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page = 1,
-    @Query('limit', new DefaultValuePipe(18), ParseIntPipe) limit = 18,
-    @Query('points', new DefaultValuePipe(30), ParseIntPipe) points = 30,
-    @Query('minAumUsd', new DefaultValuePipe(1), ParseIntPipe) minAumUsd = 1,
-    @Query('maxCandidates', new DefaultValuePipe(36), ParseIntPipe)
-    maxCandidates = 36,
+    @Query() query: GetLeaderboardQueryDto,
   ): Promise<LeaderboardResponseDto> {
-    const params: GetLeadersParams = {
-      window,
-      sortBy,
-      sortDir,
-      page,
-      limit,
-      points,
-      minAumUsd,
-      maxCandidates,
-    };
-    const result = await this.leaderboardService.getLeaders(params);
+    const result = await this.leaderboardService.getLeaders(query);
+    const totalPages =
+      result.totalCandidates === 0
+        ? 0
+        : Math.ceil(result.totalCandidates / result.limit);
+
     return {
       items: result.items,
       meta: {
         page: result.page,
         limit: result.limit,
         totalItems: result.totalCandidates,
-        totalPages: Math.max(
-          1,
-          Math.ceil(result.totalCandidates / result.limit),
-        ),
-        window,
-        sortBy,
-        sortDir,
+        totalPages,
+        window: result.window,
+        sortBy: result.sortBy,
+        sortDir: result.sortDir,
+        timeFilter: result.timeFilter
+          ? {
+              value: result.timeFilter.value,
+              unit: result.timeFilter.unit,
+              start: result.timeFilter.start.toISOString(),
+              end: result.timeFilter.end.toISOString(),
+            }
+          : undefined,
       },
     };
   }

--- a/src/account/dto/get-leaderboard-query.dto.ts
+++ b/src/account/dto/get-leaderboard-query.dto.ts
@@ -1,0 +1,110 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform, Type } from 'class-transformer';
+import { IsIn, IsInt, IsOptional, Max, Min } from 'class-validator';
+import {
+  LeaderboardSortBy,
+  LeaderboardSortDir,
+  LeaderboardTimeUnit,
+  LeaderboardWindow,
+} from '../services/leaderboard.types';
+
+const WINDOWS: LeaderboardWindow[] = ['7d', '30d', 'all'];
+const SORT_BYS: LeaderboardSortBy[] = ['pnl', 'roi', 'mdd', 'aum'];
+const SORT_DIRS: LeaderboardSortDir[] = ['ASC', 'DESC'];
+const TIME_UNITS: LeaderboardTimeUnit[] = ['minutes', 'hours'];
+
+export class GetLeaderboardQueryDto {
+  @ApiPropertyOptional({ enum: WINDOWS, example: '7d' })
+  @IsOptional()
+  @IsIn(WINDOWS)
+  window?: LeaderboardWindow;
+
+  @ApiPropertyOptional({ enum: SORT_BYS, example: 'pnl' })
+  @IsOptional()
+  @IsIn(SORT_BYS)
+  sortBy?: LeaderboardSortBy;
+
+  @ApiPropertyOptional({
+    enum: SORT_DIRS,
+    example: 'DESC',
+    description:
+      'Defaults to DESC, except for sortBy=mdd which defaults to ASC.',
+  })
+  @IsOptional()
+  @Transform(({ value }) =>
+    typeof value === 'string' ? value.toUpperCase() : value,
+  )
+  @IsIn(SORT_DIRS)
+  sortDir?: LeaderboardSortDir;
+
+  @ApiPropertyOptional({ example: 1, minimum: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number;
+
+  @ApiPropertyOptional({ example: 18, minimum: 1, maximum: 50 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(50)
+  limit?: number;
+
+  @ApiPropertyOptional({
+    example: 1,
+    minimum: 0,
+    description: 'Exclude leaders with AUM below this USD value.',
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  minAumUsd?: number;
+
+  @ApiPropertyOptional({
+    example: 30,
+    minimum: 1,
+    description:
+      'Optional recent activity period. Must be provided together with timeUnit.',
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  timePeriod?: number;
+
+  @ApiPropertyOptional({
+    enum: TIME_UNITS,
+    example: 'minutes',
+    description:
+      'Unit for timePeriod. Filters to leaders active in the last N minutes or hours.',
+  })
+  @IsOptional()
+  @IsIn(TIME_UNITS)
+  timeUnit?: LeaderboardTimeUnit;
+
+  @ApiPropertyOptional({
+    example: 30,
+    description: 'Approximate number of sparkline points (currently ignored).',
+    deprecated: true,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  points?: number;
+
+  @ApiPropertyOptional({
+    example: 36,
+    description:
+      'Upper bound of candidate addresses to evaluate (ignored in snapshot mode).',
+    deprecated: true,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  maxCandidates?: number;
+}

--- a/src/account/entities/account-leaderboard-snapshot.entity.ts
+++ b/src/account/entities/account-leaderboard-snapshot.entity.ts
@@ -6,10 +6,17 @@ import {
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
-import { LeaderboardWindow } from '../services/leaderboard.service';
+import { LeaderboardWindow } from '../services/leaderboard.types';
 
 @Entity({ name: 'account_leaderboard_snapshots' })
-@Index(['window', 'aum_usd'])
+@Index('IDX_ACCOUNT_LEADERBOARD_SNAPSHOTS_WINDOW_ADDRESS', [
+  'window',
+  'address',
+])
+@Index('IDX_ACCOUNT_LEADERBOARD_SNAPSHOTS_WINDOW_AUM', ['window', 'aum_usd'])
+@Index('IDX_ACCOUNT_LEADERBOARD_SNAPSHOTS_WINDOW_PNL', ['window', 'pnl_usd'])
+@Index('IDX_ACCOUNT_LEADERBOARD_SNAPSHOTS_WINDOW_ROI', ['window', 'roi_pct'])
+@Index('IDX_ACCOUNT_LEADERBOARD_SNAPSHOTS_WINDOW_MDD', ['window', 'mdd_pct'])
 export class AccountLeaderboardSnapshot {
   @PrimaryGeneratedColumn()
   id: number;

--- a/src/account/services/leaderboard-snapshot.service.spec.ts
+++ b/src/account/services/leaderboard-snapshot.service.spec.ts
@@ -1,6 +1,43 @@
 import { LeaderboardSnapshotService } from './leaderboard-snapshot.service';
+import { LEADERBOARD_SNAPSHOT_MAX_CANDIDATES } from './leaderboard.types';
 
 describe('LeaderboardSnapshotService', () => {
+  it('pins LEADERBOARD_SNAPSHOT_MAX_CANDIDATES to its expected ceiling', () => {
+    // The read path's inline `COUNT(*) OVER()` is O(≤N) only because each
+    // leaderboard window is materialized at most this many rows. Bumping this
+    // value means revisiting the read service's docs and (possibly) switching
+    // to cursor pagination — see leaderboard.service.ts comments.
+    expect(LEADERBOARD_SNAPSHOT_MAX_CANDIDATES).toBe(100);
+  });
+
+  it('passes LEADERBOARD_SNAPSHOT_MAX_CANDIDATES into computeWindow for every window', async () => {
+    const service = new LeaderboardSnapshotService(
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {
+        manager: {
+          transaction: jest.fn(),
+        },
+      } as any,
+      {} as any,
+      {} as any,
+    );
+
+    const computeSpy = jest
+      .spyOn(service as any, 'computeWindow')
+      .mockResolvedValue([]);
+
+    await service.refreshAllWindows();
+
+    const observedWindows = computeSpy.mock.calls.map((call) => call[0]);
+    expect(observedWindows).toEqual(['7d', '30d', 'all']);
+    for (const call of computeSpy.mock.calls) {
+      expect(call[1]).toBe(LEADERBOARD_SNAPSHOT_MAX_CANDIDATES);
+    }
+  });
+
   it('reuses cached pnl promises for the same address and block height', async () => {
     const pnlResult = {
       pnls: {},

--- a/src/account/services/leaderboard-snapshot.service.ts
+++ b/src/account/services/leaderboard-snapshot.service.ts
@@ -6,7 +6,11 @@ import { Transaction } from '@/transactions/entities/transaction.entity';
 import { Account } from '../entities/account.entity';
 import { Token } from '@/tokens/entities/token.entity';
 import { TokenHolder } from '@/tokens/entities/token-holders.entity';
-import { LeaderboardItem, LeaderboardWindow } from './leaderboard.service';
+import {
+  LEADERBOARD_SNAPSHOT_MAX_CANDIDATES,
+  LeaderboardItem,
+  LeaderboardWindow,
+} from './leaderboard.types';
 import { AccountLeaderboardSnapshot } from '../entities/account-leaderboard-snapshot.entity';
 import { BclPnlService, TokenPnlResult } from './bcl-pnl.service';
 import { timestampToAeHeight } from '@/utils/getBlochHeight';
@@ -59,7 +63,12 @@ export class LeaderboardSnapshotService {
     pnlCache: Map<string, Promise<TokenPnlResult>>,
   ): Promise<void> {
     this.logger.log(`Recomputing leaderboard snapshots for window=${window}`);
-    const items = await this.computeWindow(window, 100, referenceEnd, pnlCache);
+    const items = await this.computeWindow(
+      window,
+      LEADERBOARD_SNAPSHOT_MAX_CANDIDATES,
+      referenceEnd,
+      pnlCache,
+    );
 
     await this.snapshotRepository.manager.transaction(async (manager) => {
       const repo = manager.getRepository(AccountLeaderboardSnapshot);

--- a/src/account/services/leaderboard.service.spec.ts
+++ b/src/account/services/leaderboard.service.spec.ts
@@ -1,0 +1,319 @@
+import { BadRequestException } from '@nestjs/common';
+import { LeaderboardService } from './leaderboard.service';
+
+describe('LeaderboardService', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  type MockRow = Record<string, unknown>;
+
+  const createService = (
+    rows: MockRow[] = [],
+    totalCount: number | string = 0,
+  ) => {
+    const query = jest.fn((sql: string) => {
+      const isCount =
+        sql.includes('SELECT COUNT(*)::int AS total_count') &&
+        !sql.includes('snap.address,');
+      if (isCount) {
+        return Promise.resolve([{ total_count: String(totalCount) }]);
+      }
+      return Promise.resolve(
+        rows.map((row) => ({ total_count: String(totalCount), ...row })),
+      );
+    });
+
+    return {
+      service: new LeaderboardService({ query } as never),
+      snapshotRepository: { query },
+    };
+  };
+
+  const findCall = (
+    query: jest.Mock,
+    matcher: (sql: string) => boolean,
+  ): [string, unknown[]] => {
+    const call = query.mock.calls.find(([sql]) => matcher(sql as string));
+    if (!call) {
+      throw new Error('No matching query call found');
+    }
+    return [call[0] as string, call[1] as unknown[]];
+  };
+
+  const isRowsQuery = (sql: string) => sql.includes('snap.address,');
+  const isFallbackCountQuery = (sql: string) =>
+    sql.includes('SELECT COUNT(*)::int AS total_count') &&
+    !sql.includes('snap.address,');
+
+  it('reads leaderboard snapshots in a single query carrying the inline total', async () => {
+    const { service, snapshotRepository } = createService(
+      [
+        {
+          address: 'ak_test',
+          chain_name: null,
+          aum_usd: '10',
+          pnl_usd: '2',
+          roi_pct: '20',
+          mdd_pct: '5',
+          buy_count: '3',
+          sell_count: '1',
+          created_tokens_count: '0',
+          owned_trends_count: '2',
+          portfolio_value_usd_sparkline: [[1, 10]],
+          active_buy_count: null,
+          active_sell_count: null,
+        },
+      ],
+      7,
+    );
+
+    const result = await service.getLeaders({
+      window: '7d',
+      sortBy: 'pnl',
+      sortDir: 'DESC',
+      page: 2,
+      limit: 10,
+    });
+
+    expect(snapshotRepository.query).toHaveBeenCalledTimes(1);
+
+    const [rowsSql, rowsParams] = findCall(
+      snapshotRepository.query,
+      isRowsQuery,
+    );
+    expect(rowsSql).not.toContain('active_accounts');
+    expect(rowsSql).toContain('(COUNT(*) OVER())::int AS total_count');
+    expect(rowsSql).toContain('ORDER BY snap.pnl_usd DESC, snap.address ASC');
+    expect(rowsParams).toEqual(['7d', 1, 10, 10]);
+
+    expect(result.totalCandidates).toBe(7);
+    expect(result.window).toBe('7d');
+    expect(result.sortBy).toBe('pnl');
+    expect(result.sortDir).toBe('DESC');
+    expect(result.timeFilter).toBeUndefined();
+    expect(result.items[0]).toMatchObject({
+      address: 'ak_test',
+      aum_usd: 10,
+      pnl_usd: 2,
+      buy_count: 3,
+      sell_count: 1,
+    });
+    expect(result.items[0].active_period).toBeUndefined();
+  });
+
+  it('reports total = 0 with no fallback query when the first page is empty', async () => {
+    const { service, snapshotRepository } = createService([], 0);
+
+    const result = await service.getLeaders({
+      window: '7d',
+      sortBy: 'pnl',
+      page: 1,
+      limit: 10,
+    });
+
+    expect(result.items).toEqual([]);
+    expect(result.totalCandidates).toBe(0);
+    expect(snapshotRepository.query).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to a COUNT query only when paginating past the end', async () => {
+    const { service, snapshotRepository } = createService([], 7);
+
+    const result = await service.getLeaders({
+      window: '7d',
+      sortBy: 'pnl',
+      page: 99,
+      limit: 10,
+    });
+
+    expect(result.items).toEqual([]);
+    expect(result.totalCandidates).toBe(7);
+    expect(snapshotRepository.query).toHaveBeenCalledTimes(2);
+
+    const [, rowsParams] = findCall(snapshotRepository.query, isRowsQuery);
+    expect(rowsParams).toEqual(['7d', 1, 10, 980]);
+
+    const [countSql, countParams] = findCall(
+      snapshotRepository.query,
+      isFallbackCountQuery,
+    );
+    expect(countSql).toContain('SELECT COUNT(*)::int AS total_count');
+    expect(countParams).toEqual(['7d', 1]);
+  });
+
+  it('defaults sortDir to ASC for sortBy=mdd', async () => {
+    const { service, snapshotRepository } = createService([], 0);
+
+    const result = await service.getLeaders({ window: '7d', sortBy: 'mdd' });
+
+    expect(result.sortDir).toBe('ASC');
+    const [rowsSql] = findCall(snapshotRepository.query, isRowsQuery);
+    expect(rowsSql).toContain('ORDER BY snap.mdd_pct ASC, snap.address ASC');
+  });
+
+  it('joins recent activity and emits active_period when a time filter is supplied', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-04-28T12:00:00.000Z'));
+    const { service, snapshotRepository } = createService(
+      [
+        {
+          address: 'ak_test',
+          chain_name: 'alice',
+          aum_usd: '100',
+          pnl_usd: '5',
+          roi_pct: '7',
+          mdd_pct: '3',
+          buy_count: '50',
+          sell_count: '40',
+          created_tokens_count: '0',
+          owned_trends_count: '0',
+          portfolio_value_usd_sparkline: null,
+          active_buy_count: '4',
+          active_sell_count: '2',
+        },
+      ],
+      1,
+    );
+
+    const result = await service.getLeaders({
+      window: '30d',
+      sortBy: 'aum',
+      timePeriod: 2,
+      timeUnit: 'hours',
+    });
+
+    expect(snapshotRepository.query).toHaveBeenCalledTimes(1);
+
+    const [rowsSql, rowsParams] = findCall(
+      snapshotRepository.query,
+      isRowsQuery,
+    );
+    expect(rowsSql).toContain('WITH active_accounts AS');
+    expect(rowsSql).toContain("t.tx_type IN ('buy', 'sell')");
+    expect(rowsSql).toContain('INNER JOIN active_accounts active');
+    expect(rowsSql).toContain('AND EXISTS');
+    expect(rowsSql).toContain('AS active_buy_count');
+    expect(rowsSql).toContain('(COUNT(*) OVER())::int AS total_count');
+    expect(rowsParams).toEqual([
+      '30d',
+      1,
+      new Date('2026-04-28T10:00:00.000Z'),
+      new Date('2026-04-28T12:00:00.000Z'),
+      18,
+      0,
+    ]);
+
+    expect(result.timeFilter).toEqual({
+      value: 2,
+      unit: 'hours',
+      start: new Date('2026-04-28T10:00:00.000Z'),
+      end: new Date('2026-04-28T12:00:00.000Z'),
+    });
+    expect(result.items[0].buy_count).toBe(50);
+    expect(result.items[0].sell_count).toBe(40);
+    expect(result.items[0].active_period).toEqual({
+      buy_count: 4,
+      sell_count: 2,
+    });
+  });
+
+  it('accepts the 168-hour upper bound', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-04-28T12:00:00.000Z'));
+    const { service } = createService([], 0);
+
+    const result = await service.getLeaders({
+      window: '7d',
+      sortBy: 'pnl',
+      timePeriod: 168,
+      timeUnit: 'hours',
+    });
+
+    expect(result.timeFilter?.start).toEqual(
+      new Date('2026-04-21T12:00:00.000Z'),
+    );
+    expect(result.timeFilter?.end).toEqual(
+      new Date('2026-04-28T12:00:00.000Z'),
+    );
+  });
+
+  it('accepts the 10080-minute upper bound', async () => {
+    const { service } = createService([], 0);
+
+    await expect(
+      service.getLeaders({
+        window: '7d',
+        sortBy: 'pnl',
+        timePeriod: 10080,
+        timeUnit: 'minutes',
+      }),
+    ).resolves.toBeTruthy();
+  });
+
+  it.each([
+    [{ timePeriod: 30 }, 'timePeriod and timeUnit must be provided together'],
+    [
+      { timeUnit: 'hours' as const },
+      'timePeriod and timeUnit must be provided together',
+    ],
+    [
+      { timePeriod: 0, timeUnit: 'hours' as const },
+      'timePeriod must be a positive integer',
+    ],
+    [
+      { timePeriod: 1.5, timeUnit: 'hours' as const },
+      'timePeriod must be a positive integer',
+    ],
+    [
+      { timePeriod: 169, timeUnit: 'hours' as const },
+      'timePeriod cannot exceed 7 days',
+    ],
+    [
+      { timePeriod: 10081, timeUnit: 'minutes' as const },
+      'timePeriod cannot exceed 7 days',
+    ],
+    [
+      { timePeriod: 1, timeUnit: 'days' as unknown as 'minutes' },
+      'timeUnit must be one of: minutes, hours',
+    ],
+  ])('rejects invalid time filters: %o', async (timeParams, message) => {
+    const { service, snapshotRepository } = createService();
+
+    await expect(
+      service.getLeaders({
+        window: '7d',
+        sortBy: 'pnl',
+        ...timeParams,
+      }),
+    ).rejects.toThrow(new BadRequestException(message));
+    expect(snapshotRepository.query).not.toHaveBeenCalled();
+  });
+
+  it('defends against an unexpected sortBy value reaching the service', async () => {
+    const { service, snapshotRepository } = createService();
+
+    await expect(
+      service.getLeaders({
+        window: '7d',
+        sortBy: 'volume' as never,
+      }),
+    ).rejects.toThrow(
+      new BadRequestException('sortBy must be one of: pnl, roi, mdd, aum'),
+    );
+    expect(snapshotRepository.query).not.toHaveBeenCalled();
+  });
+
+  it('defends against an unexpected sortDir value reaching the service', async () => {
+    const { service, snapshotRepository } = createService();
+
+    await expect(
+      service.getLeaders({
+        window: '7d',
+        sortBy: 'pnl',
+        sortDir: 'sideways' as never,
+      }),
+    ).rejects.toThrow(
+      new BadRequestException('sortDir must be one of: ASC, DESC'),
+    );
+    expect(snapshotRepository.query).not.toHaveBeenCalled();
+  });
+});

--- a/src/account/services/leaderboard.service.ts
+++ b/src/account/services/leaderboard.service.ts
@@ -1,39 +1,57 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { AccountLeaderboardSnapshot } from '../entities/account-leaderboard-snapshot.entity';
+import {
+  GetLeadersParams,
+  LeaderboardItem,
+  LeaderboardSortBy,
+  LeaderboardSortDir,
+  LeaderboardTimeFilter,
+  LeaderboardTimeUnit,
+  LeaderboardWindow,
+} from './leaderboard.types';
 
-export type LeaderboardWindow = '7d' | '30d' | 'all';
-export type LeaderboardSortBy = 'pnl' | 'roi' | 'mdd' | 'aum';
-export type LeaderboardSortDir = 'ASC' | 'DESC';
-
-export interface GetLeadersParams {
-  window: LeaderboardWindow;
-  sortBy: LeaderboardSortBy;
-  sortDir?: LeaderboardSortDir;
-  page?: number;
-  limit?: number;
-  points?: number;
-  minAumUsd?: number;
-  maxCandidates?: number; // kept for API compatibility, ignored in snapshot mode
-}
-
-export interface LeaderboardItem {
+interface LeaderboardRow {
   address: string;
-  chain_name?: string | null;
-  // metrics
-  aum_usd: number;
-  pnl_usd: number;
-  roi_pct: number;
-  mdd_pct: number;
-  // activity
-  buy_count: number;
-  sell_count: number;
-  created_tokens_count: number;
-  owned_trends_count: number;
-  // chart
-  portfolio_value_usd_sparkline: Array<[number, number]>;
+  chain_name: string | null;
+  aum_usd: number | string;
+  pnl_usd: number | string;
+  roi_pct: number | string;
+  mdd_pct: number | string;
+  buy_count: number | string;
+  sell_count: number | string;
+  created_tokens_count: number | string;
+  owned_trends_count: number | string;
+  portfolio_value_usd_sparkline: Array<[number, number]> | null;
+  active_buy_count?: number | string | null;
+  active_sell_count?: number | string | null;
+  total_count: number | string;
 }
+
+interface LeaderboardCountRow {
+  total_count: number | string;
+}
+
+const SORT_COLUMNS: Record<LeaderboardSortBy, string> = {
+  pnl: 'snap.pnl_usd',
+  roi: 'snap.roi_pct',
+  mdd: 'snap.mdd_pct',
+  aum: 'snap.aum_usd',
+};
+
+const VALID_SORT_DIRECTIONS: ReadonlySet<LeaderboardSortDir> = new Set([
+  'ASC',
+  'DESC',
+]);
+const VALID_TIME_UNITS: ReadonlySet<LeaderboardTimeUnit> = new Set([
+  'minutes',
+  'hours',
+]);
+const MAX_TIME_FILTER_DAYS = 7;
+const MAX_TIME_FILTER_MS = MAX_TIME_FILTER_DAYS * 24 * 60 * 60 * 1000;
+const DEFAULT_LIMIT = 18;
+const MAX_LIMIT = 50;
 
 @Injectable()
 export class LeaderboardService {
@@ -47,53 +65,271 @@ export class LeaderboardService {
     totalCandidates: number;
     page: number;
     limit: number;
+    window: LeaderboardWindow;
+    sortBy: LeaderboardSortBy;
+    sortDir: LeaderboardSortDir;
+    timeFilter?: LeaderboardTimeFilter;
   }> {
     const window = params.window ?? '7d';
     const sortBy = params.sortBy ?? 'pnl';
-    const sortDir = params.sortDir ?? (sortBy === 'mdd' ? 'ASC' : 'DESC');
-    const page = Math.max(1, params.page || 1);
-    const limit = Math.max(1, Math.min(params.limit || 18, 50));
+    const sortDir = this.resolveSortDir(params.sortDir, sortBy);
+    const page = Math.max(1, params.page ?? 1);
+    const limit = Math.max(
+      1,
+      Math.min(params.limit ?? DEFAULT_LIMIT, MAX_LIMIT),
+    );
     const minAumUsd = params.minAumUsd ?? 1; // default: exclude ~0 AUM
-    const qb = this.snapshotRepository
-      .createQueryBuilder('snap')
-      .where('snap.window = :window', { window })
-      .andWhere('snap.aum_usd >= :minAumUsd', { minAumUsd });
+    const timeFilter = this.normalizeTimeFilter(params);
+    const offset = (page - 1) * limit;
 
-    const sortColumn =
-      sortBy === 'pnl'
-        ? 'snap.pnl_usd'
-        : sortBy === 'roi'
-          ? 'snap.roi_pct'
-          : sortBy === 'mdd'
-            ? 'snap.mdd_pct'
-            : 'snap.aum_usd';
+    const { rows, total } = await this.queryLeaderboardRows({
+      window,
+      sortBy,
+      sortDir,
+      minAumUsd,
+      limit,
+      offset,
+      timeFilter,
+    });
 
-    qb.orderBy(sortColumn, sortDir);
-
-    const [rows, total] = await qb
-      .skip((page - 1) * limit)
-      .take(limit)
-      .getManyAndCount();
-
-    const items: LeaderboardItem[] = rows.map((row) => ({
-      address: row.address,
-      chain_name: row.chain_name ?? null,
-      aum_usd: row.aum_usd,
-      pnl_usd: row.pnl_usd,
-      roi_pct: row.roi_pct,
-      mdd_pct: row.mdd_pct,
-      buy_count: row.buy_count,
-      sell_count: row.sell_count,
-      created_tokens_count: row.created_tokens_count,
-      owned_trends_count: row.owned_trends_count,
-      portfolio_value_usd_sparkline: row.portfolio_value_usd_sparkline || [],
-    }));
+    const items: LeaderboardItem[] = rows.map((row) => {
+      const item: LeaderboardItem = {
+        address: row.address,
+        chain_name: row.chain_name ?? null,
+        aum_usd: Number(row.aum_usd),
+        pnl_usd: Number(row.pnl_usd),
+        roi_pct: Number(row.roi_pct),
+        mdd_pct: Number(row.mdd_pct),
+        buy_count: Number(row.buy_count),
+        sell_count: Number(row.sell_count),
+        created_tokens_count: Number(row.created_tokens_count),
+        owned_trends_count: Number(row.owned_trends_count),
+        portfolio_value_usd_sparkline: row.portfolio_value_usd_sparkline || [],
+      };
+      if (timeFilter) {
+        item.active_period = {
+          buy_count: Number(row.active_buy_count ?? 0),
+          sell_count: Number(row.active_sell_count ?? 0),
+        };
+      }
+      return item;
+    });
 
     return {
       items,
       totalCandidates: total,
       page,
       limit,
+      window,
+      sortBy,
+      sortDir,
+      timeFilter,
+    };
+  }
+
+  /**
+   * Issues a single SQL statement that returns paginated rows and inlines the
+   * unrestricted total via `COUNT(*) OVER()`. Avoids running the (potentially
+   * expensive) `active_accounts` CTE twice on the hot path.
+   *
+   * Cost of the inline COUNT:
+   * `COUNT(*) OVER()` evaluates the full filtered set (post-CTE, pre-LIMIT).
+   * For this endpoint that set is upper-bounded by
+   * `LEADERBOARD_SNAPSHOT_MAX_CANDIDATES` rows per window (snapshot job caps
+   * how many rows it writes), so the COUNT is O(≤N) — essentially free —
+   * regardless of caller pagination. If that ceiling is ever raised beyond
+   * a few thousand, switch to cursor pagination or drop `totalItems` from
+   * the response, otherwise the COUNT will start to dominate.
+   *
+   * Performance prerequisite for the time-filter path:
+   * the `active_accounts` CTE scans `transactions` over a ≤7d window. The
+   * supporting indexes are described in
+   * `docs/leaderboard-time-filter-manual-migration.sql`; that DDL must be
+   * applied **before** the time-filter feature is exposed in production.
+   *
+   * The only case in which we cannot read the total from the rows themselves
+   * is an empty page beyond the end of the result (e.g. `page=99` of a 7-row
+   * result). In that case we issue a single fallback `COUNT(*)` query — which
+   * is the only path that re-evaluates the CTE.
+   */
+  private async queryLeaderboardRows(params: {
+    window: LeaderboardWindow;
+    sortBy: LeaderboardSortBy;
+    sortDir: LeaderboardSortDir;
+    minAumUsd: number;
+    limit: number;
+    offset: number;
+    timeFilter?: LeaderboardTimeFilter;
+  }): Promise<{ rows: LeaderboardRow[]; total: number }> {
+    // Defensive: sortBy/sortDir should already be validated by the controller's
+    // class-validator DTO, but we still look them up via a fixed map / set
+    // because they're string-interpolated into SQL below.
+    const sortColumn = SORT_COLUMNS[params.sortBy];
+    if (!sortColumn) {
+      throw new BadRequestException(
+        'sortBy must be one of: pnl, roi, mdd, aum',
+      );
+    }
+    if (!VALID_SORT_DIRECTIONS.has(params.sortDir)) {
+      throw new BadRequestException('sortDir must be one of: ASC, DESC');
+    }
+
+    const baseQueryParams: Array<string | number | Date> = [];
+    const pushParam = (value: string | number | Date): string => {
+      baseQueryParams.push(value);
+      return `$${baseQueryParams.length}`;
+    };
+
+    const windowParam = pushParam(params.window);
+    const minAumParam = pushParam(params.minAumUsd);
+
+    let activeAccountsCte = '';
+    let activeAccountsJoin = '';
+    let activeBuyCountSelect = 'NULL';
+    let activeSellCountSelect = 'NULL';
+
+    if (params.timeFilter) {
+      const startParam = pushParam(params.timeFilter.start);
+      const endParam = pushParam(params.timeFilter.end);
+      // The EXISTS clause restricts the transactions scan to addresses that are
+      // already eligible (in the window with sufficient AUM). The same window
+      // and minAum predicates are reapplied in the outer query below; if either
+      // is changed, change both places.
+      activeAccountsCte = `
+        WITH active_accounts AS (
+          SELECT
+            t.address,
+            COUNT(*) FILTER (WHERE t.tx_type = 'buy')::int AS buy_count,
+            COUNT(*) FILTER (WHERE t.tx_type = 'sell')::int AS sell_count
+          FROM transactions t
+          WHERE t.tx_type IN ('buy', 'sell')
+            AND t.created_at >= ${startParam}
+            AND t.created_at < ${endParam}
+            AND EXISTS (
+              SELECT 1
+              FROM account_leaderboard_snapshots eligible
+              WHERE eligible.window = ${windowParam}
+                AND eligible.aum_usd >= ${minAumParam}
+                AND eligible.address = t.address
+            )
+          GROUP BY t.address
+        )
+      `;
+      activeAccountsJoin =
+        'INNER JOIN active_accounts active ON active.address = snap.address';
+      activeBuyCountSelect = 'active.buy_count';
+      activeSellCountSelect = 'active.sell_count';
+    }
+
+    const dataQueryParams = [...baseQueryParams, params.limit, params.offset];
+    const limitParam = `$${baseQueryParams.length + 1}`;
+    const offsetParam = `$${baseQueryParams.length + 2}`;
+
+    const rows = (await this.snapshotRepository.query(
+      `
+        ${activeAccountsCte}
+        SELECT
+          snap.address,
+          snap.chain_name,
+          snap.aum_usd,
+          snap.pnl_usd,
+          snap.roi_pct,
+          snap.mdd_pct,
+          snap.buy_count,
+          snap.sell_count,
+          snap.created_tokens_count,
+          snap.owned_trends_count,
+          snap.portfolio_value_usd_sparkline,
+          ${activeBuyCountSelect} AS active_buy_count,
+          ${activeSellCountSelect} AS active_sell_count,
+          (COUNT(*) OVER())::int AS total_count
+        FROM account_leaderboard_snapshots snap
+        ${activeAccountsJoin}
+        WHERE snap.window = ${windowParam}
+          AND snap.aum_usd >= ${minAumParam}
+        ORDER BY ${sortColumn} ${params.sortDir}, snap.address ASC
+        LIMIT ${limitParam}
+        OFFSET ${offsetParam}
+      `,
+      dataQueryParams,
+    )) as LeaderboardRow[];
+
+    if (rows.length > 0) {
+      return { rows, total: Number(rows[0].total_count) };
+    }
+    if (params.offset === 0) {
+      // Empty result set on the first page → total is 0; no fallback required.
+      return { rows, total: 0 };
+    }
+
+    // Empty page beyond the end of the result. Pay for one extra COUNT(*).
+    const countRows = (await this.snapshotRepository.query(
+      `
+        ${activeAccountsCte}
+        SELECT COUNT(*)::int AS total_count
+        FROM account_leaderboard_snapshots snap
+        ${activeAccountsJoin}
+        WHERE snap.window = ${windowParam}
+          AND snap.aum_usd >= ${minAumParam}
+      `,
+      baseQueryParams,
+    )) as LeaderboardCountRow[];
+
+    return {
+      rows,
+      total: countRows.length ? Number(countRows[0].total_count) : 0,
+    };
+  }
+
+  private resolveSortDir(
+    sortDir: LeaderboardSortDir | undefined,
+    sortBy: LeaderboardSortBy,
+  ): LeaderboardSortDir {
+    if (sortDir) {
+      return sortDir;
+    }
+    return sortBy === 'mdd' ? 'ASC' : 'DESC';
+  }
+
+  private normalizeTimeFilter(
+    params: GetLeadersParams,
+  ): LeaderboardTimeFilter | undefined {
+    const hasPeriod = params.timePeriod !== undefined;
+    const hasUnit = params.timeUnit !== undefined && params.timeUnit !== null;
+
+    if (!hasPeriod && !hasUnit) {
+      return undefined;
+    }
+    if (!hasPeriod || !hasUnit) {
+      throw new BadRequestException(
+        'timePeriod and timeUnit must be provided together',
+      );
+    }
+
+    const value = Number(params.timePeriod);
+    const unit = params.timeUnit as LeaderboardTimeUnit;
+
+    if (!Number.isInteger(value) || value < 1) {
+      throw new BadRequestException('timePeriod must be a positive integer');
+    }
+    if (!VALID_TIME_UNITS.has(unit)) {
+      throw new BadRequestException('timeUnit must be one of: minutes, hours');
+    }
+
+    const durationMs =
+      unit === 'minutes' ? value * 60 * 1000 : value * 60 * 60 * 1000;
+    if (durationMs > MAX_TIME_FILTER_MS) {
+      throw new BadRequestException(
+        `timePeriod cannot exceed ${MAX_TIME_FILTER_DAYS} days`,
+      );
+    }
+
+    const end = new Date();
+    return {
+      value,
+      unit,
+      start: new Date(end.getTime() - durationMs),
+      end,
     };
   }
 }

--- a/src/account/services/leaderboard.types.ts
+++ b/src/account/services/leaderboard.types.ts
@@ -1,0 +1,63 @@
+/**
+ * Hard ceiling on rows materialized per leaderboard window. The snapshot job
+ * (`LeaderboardSnapshotService.refreshAllWindows`) only writes the top N
+ * candidates per window, so any read-side query against
+ * `account_leaderboard_snapshots` filtered by `window = $w` returns at most
+ * this many rows. The leaderboard read service relies on this bound so its
+ * inline `COUNT(*) OVER()` stays O(≤N) regardless of caller pagination.
+ *
+ * If this is ever raised beyond a few thousand, revisit the read path: switch
+ * to cursor pagination or drop `totalItems` from the response, otherwise the
+ * COUNT will start to dominate.
+ */
+export const LEADERBOARD_SNAPSHOT_MAX_CANDIDATES = 100;
+
+export type LeaderboardWindow = '7d' | '30d' | 'all';
+export type LeaderboardSortBy = 'pnl' | 'roi' | 'mdd' | 'aum';
+export type LeaderboardSortDir = 'ASC' | 'DESC';
+export type LeaderboardTimeUnit = 'minutes' | 'hours';
+
+export interface LeaderboardTimeFilter {
+  value: number;
+  unit: LeaderboardTimeUnit;
+  start: Date;
+  end: Date;
+}
+
+export interface LeaderboardItemActivePeriod {
+  buy_count: number;
+  sell_count: number;
+}
+
+export interface LeaderboardItem {
+  address: string;
+  chain_name?: string | null;
+  // metrics (window-scoped: 7d / 30d / all)
+  aum_usd: number;
+  pnl_usd: number;
+  roi_pct: number;
+  mdd_pct: number;
+  // activity (window-scoped, from snapshot)
+  buy_count: number;
+  sell_count: number;
+  created_tokens_count: number;
+  owned_trends_count: number;
+  // chart
+  portfolio_value_usd_sparkline: Array<[number, number]>;
+  // present only when timePeriod + timeUnit are supplied;
+  // counts scoped to the recent window
+  active_period?: LeaderboardItemActivePeriod;
+}
+
+export interface GetLeadersParams {
+  window?: LeaderboardWindow;
+  sortBy?: LeaderboardSortBy;
+  sortDir?: LeaderboardSortDir;
+  page?: number;
+  limit?: number;
+  points?: number;
+  minAumUsd?: number;
+  timePeriod?: number;
+  timeUnit?: LeaderboardTimeUnit;
+  maxCandidates?: number; // kept for API compatibility, ignored in snapshot mode
+}

--- a/src/main.validation.spec.ts
+++ b/src/main.validation.spec.ts
@@ -1,5 +1,6 @@
 import { ValidationPipe } from '@nestjs/common';
 import { CreateAffiliationDto } from './affiliation/dto/create-affiliation.dto';
+import { GetLeaderboardQueryDto } from './account/dto/get-leaderboard-query.dto';
 import { GetPnlQueryDto } from './account/dto/get-pnl-query.dto';
 import { GetPortfolioHistoryQueryDto } from './account/dto/get-portfolio-history-query.dto';
 import {
@@ -128,6 +129,28 @@ describe('global ValidationPipe request DTO coverage', () => {
       },
       assertTransformed(result: GetPortfolioHistoryQueryDto) {
         expect(result.interval).toBe(86400);
+      },
+    },
+    {
+      name: 'GetLeaderboardQueryDto',
+      metatype: GetLeaderboardQueryDto,
+      type: 'query' as const,
+      validPayload: {
+        window: '7d',
+        sortBy: 'pnl',
+        sortDir: 'desc',
+        page: '2',
+        limit: '20',
+        minAumUsd: '1',
+        timePeriod: '30',
+        timeUnit: 'minutes',
+      },
+      assertTransformed(result: GetLeaderboardQueryDto) {
+        expect(result.page).toBe(2);
+        expect(result.limit).toBe(20);
+        expect(result.minAumUsd).toBe(1);
+        expect(result.timePeriod).toBe(30);
+        expect(result.sortDir).toBe('DESC');
       },
     },
     {

--- a/src/transactions/entities/transaction.entity.ts
+++ b/src/transactions/entities/transaction.entity.ts
@@ -22,6 +22,11 @@ import {
   'created_at',
 ])
 @Index('IDX_TRANSACTION_ADDRESS_BLOCK_HEIGHT', ['address', 'block_height'])
+@Index('IDX_TRANSACTION_CREATED_AT_ADDRESS_TYPE', [
+  'created_at',
+  'address',
+  'tx_type',
+])
 export class Transaction {
   @Index()
   @PrimaryColumn()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new time-filtered query path that scans `transactions` and changes leaderboard pagination/metadata; correctness and performance depend on deploying new DB indexes first. Some risk of query-planner regressions and API response shape changes (`active_period`, `meta.timeFilter`).
> 
> **Overview**
> Adds optional `timePeriod` + `timeUnit` filtering to `GET /accounts/leaderboard`, restricting results to accounts with recent buy/sell activity and returning per-item `active_period` counts plus `meta.timeFilter` (ISO timestamps).
> 
> Refactors the read path to a raw SQL query that inlines totals via `COUNT(*) OVER()` with a fallback COUNT for out-of-range pages, updates controller query parsing/validation via `GetLeaderboardQueryDto`, and centralizes leaderboard types/constants (including a pinned `LEADERBOARD_SNAPSHOT_MAX_CANDIDATES`).
> 
> Introduces named TypeORM indexes and a manual, concurrent migration/runbook to add snapshot ORDER BY indexes and a `transactions (created_at, address, tx_type)` index required for the new time-filter CTE.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c11cea152e521a468008daee27480e1270e36790. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->