### PR TITLE
perf: remove redundant indexes

### DIFF
--- a/src/mdw-sync/entities/key-block.entity.ts
+++ b/src/mdw-sync/entities/key-block.entity.ts
@@ -13,8 +13,6 @@ import { Searchable } from '@/api-core/decorators/searchable.decorator';
 @Entity({
   name: 'key_blocks',
 })
-@Index(['height'])
-@Index(['hash'])
 @Index(['prev_hash'])
 @Index(['prev_key_hash'])
 @Index(['time'])

--- a/src/mdw-sync/entities/micro-block.entity.ts
+++ b/src/mdw-sync/entities/micro-block.entity.ts
@@ -14,7 +14,6 @@ import { Searchable } from '@/api-core/decorators/searchable.decorator';
   name: 'micro_blocks',
 })
 @Index(['height'])
-@Index(['hash'])
 @Index(['prev_hash'])
 @Index(['prev_key_hash'])
 @ObjectType()

--- a/src/mdw-sync/entities/tx.entity.ts
+++ b/src/mdw-sync/entities/tx.entity.ts
@@ -14,7 +14,6 @@ import { Searchable } from '@/api-core/decorators/searchable.decorator';
 @Entity({
   name: 'txs',
 })
-@Index(['hash'])
 @Index(['block_height'])
 @Index(['type'])
 @Index(['contract_id'])


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Schema/index changes can affect query plans and require safe rollout/migrations, but the removed indexes appear redundant with primary/unique constraints.
> 
> **Overview**
> Removes explicit `@Index` decorators on `hash` (and `height` for `KeyBlock`) in the `KeyBlock`, `MicroBlock`, and `Tx` entities, relying on the existing primary key/unique constraints to provide the needed indexing.
> 
> This reduces redundant index maintenance overhead while keeping the other non-redundant indexes (e.g., `prev_hash`, `prev_key_hash`, `time`, and tx filter fields) unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee2508e05679419fb425c2901a77889f68e033c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->