### PR TITLE
Release

### DIFF
--- a/src/mdw-sync/entities/key-block.entity.ts
+++ b/src/mdw-sync/entities/key-block.entity.ts
@@ -13,8 +13,6 @@ import { Searchable } from '@/api-core/decorators/searchable.decorator';
 @Entity({
   name: 'key_blocks',
 })
-@Index(['height'])
-@Index(['hash'])
 @Index(['prev_hash'])
 @Index(['prev_key_hash'])
 @Index(['time'])

--- a/src/mdw-sync/entities/micro-block.entity.ts
+++ b/src/mdw-sync/entities/micro-block.entity.ts
@@ -14,7 +14,6 @@ import { Searchable } from '@/api-core/decorators/searchable.decorator';
   name: 'micro_blocks',
 })
 @Index(['height'])
-@Index(['hash'])
 @Index(['prev_hash'])
 @Index(['prev_key_hash'])
 @ObjectType()

--- a/src/mdw-sync/entities/tx.entity.ts
+++ b/src/mdw-sync/entities/tx.entity.ts
@@ -14,7 +14,6 @@ import { Searchable } from '@/api-core/decorators/searchable.decorator';
 @Entity({
   name: 'txs',
 })
-@Index(['hash'])
 @Index(['block_height'])
 @Index(['type'])
 @Index(['contract_id'])


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Schema/index changes can affect query performance and may require careful migration coordination if environments already rely on these indexes.
> 
> **Overview**
> Removes TypeORM `@Index` decorators for `hash` on `KeyBlock`, `MicroBlock`, and `Tx`, and also drops the explicit `KeyBlock.height` index annotation.
> 
> This changes the generated/expected database indexing for mdw-sync tables (while keeping other indexes like `prev_hash`, `prev_key_hash`, `time`, and `block_height`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7142c511d274e1981af1affeeddbb90c1462a8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->