### PR TITLE
feat: add params validation

### DIFF
--- a/src/account/controllers/accounts.controller.ts
+++ b/src/account/controllers/accounts.controller.ts
@@ -34,6 +34,10 @@ import { TradingStatsResponseDto } from '../dto/trading-stats-response.dto';
 import { ProfileReadService } from '@/profile/services/profile-read.service';
 import { ProfileCache } from '@/profile/entities/profile-cache.entity';
 import { buildSparklineSvg, sparklineStroke } from '@/utils/sparkline.util';
+import {
+  AeAccountAddressPipe,
+  AeAccountReferencePipe,
+} from '@/common/validation/request-validation';
 
 @UseInterceptors(CacheInterceptor)
 @Controller('accounts')
@@ -176,7 +180,7 @@ export class AccountsController {
   @Get(':address/portfolio/history')
   async getPortfolioHistory(
     //
-    @Param('address') address: string,
+    @Param('address', AeAccountReferencePipe) address: string,
     @Query() query: GetPortfolioHistoryQueryDto,
   ) {
     const start = query.startDate ? moment(query.startDate) : undefined;
@@ -218,7 +222,7 @@ export class AccountsController {
   @CacheTTL(10 * 60_000)
   @Get(':address/portfolio/tokens/history')
   async getTokensPnlHistory(
-    @Param('address') address: string,
+    @Param('address', AeAccountReferencePipe) address: string,
     @Query() query: GetPortfolioHistoryQueryDto,
   ) {
     const start = query.startDate ? moment(query.startDate) : undefined;
@@ -273,7 +277,7 @@ export class AccountsController {
   @CacheTTL(10 * 60_000)
   @Get(':address/portfolio/pnl-chart.svg')
   async getPortfolioPnlChart(
-    @Param('address') address: string,
+    @Param('address', AeAccountReferencePipe) address: string,
     @Query('startDate') startDate?: string,
     @Query('endDate') endDate?: string,
     @Query('convertTo') convertTo: 'ae' | 'usd' = 'ae',
@@ -321,7 +325,7 @@ export class AccountsController {
   @CacheTTL(10 * 60_000)
   @Get(':address/portfolio/stats')
   async getPortfolioStats(
-    @Param('address') address: string,
+    @Param('address', AeAccountReferencePipe) address: string,
     @Query() query: TradingStatsQueryDto,
   ): Promise<TradingStatsResponseDto> {
     const start = query.startDate
@@ -353,7 +357,7 @@ export class AccountsController {
   @ApiParam({ name: 'address', type: 'string' })
   @CacheTTL(10 * 60_000)
   @Get(':address')
-  async getAccount(@Param('address') address: string) {
+  async getAccount(@Param('address', AeAccountAddressPipe) address: string) {
     const account = await this.accountRepository.findOne({
       where: { address },
     });

--- a/src/account/controllers/bcl-pnl.controller.ts
+++ b/src/account/controllers/bcl-pnl.controller.ts
@@ -15,6 +15,7 @@ import { AeSdkService } from '@/ae/ae-sdk.service';
 import { BclPnlService } from '../services/bcl-pnl.service';
 import { GetPnlQueryDto } from '../dto/get-pnl-query.dto';
 import { GetPnlResponseDto } from '../dto/pnl-response.dto';
+import { AeAccountAddressPipe } from '@/common/validation/request-validation';
 
 @Controller('accounts')
 @ApiTags('Accounts')
@@ -29,7 +30,7 @@ export class BclPnlController {
   @ApiOkResponse({ type: GetPnlResponseDto })
   @Get(':address/pnl')
   async getPnl(
-    @Param('address') address: string,
+    @Param('address', AeAccountAddressPipe) address: string,
     @Query() query: GetPnlQueryDto,
   ) {
     // If blockHeight is not provided, get the current block height

--- a/src/account/dto/get-pnl-query.dto.ts
+++ b/src/account/dto/get-pnl-query.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsOptional, IsNumber } from 'class-validator';
+import { IsInt, IsOptional, Min } from 'class-validator';
 import { Type } from 'class-transformer';
 
 export class GetPnlQueryDto {
@@ -11,7 +11,8 @@ export class GetPnlQueryDto {
     example: 12345678,
   })
   @IsOptional()
-  @IsNumber()
+  @IsInt()
+  @Min(0)
   @Type(() => Number)
   blockHeight?: number;
 }

--- a/src/account/dto/get-portfolio-history-query.dto.ts
+++ b/src/account/dto/get-portfolio-history-query.dto.ts
@@ -1,5 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsOptional, IsNumber, IsString, IsIn } from 'class-validator';
+import {
+  IsDateString,
+  IsIn,
+  IsInt,
+  IsOptional,
+  IsString,
+  Min,
+} from 'class-validator';
 import { Type } from 'class-transformer';
 
 export class GetPortfolioHistoryQueryDto {
@@ -11,7 +18,7 @@ export class GetPortfolioHistoryQueryDto {
     example: '2024-01-01T00:00:00.000Z',
   })
   @IsOptional()
-  @IsString()
+  @IsDateString()
   startDate?: string;
 
   @ApiProperty({
@@ -22,7 +29,7 @@ export class GetPortfolioHistoryQueryDto {
     example: '2024-12-31T23:59:59.999Z',
   })
   @IsOptional()
-  @IsString()
+  @IsDateString()
   endDate?: string;
 
   @ApiProperty({
@@ -34,7 +41,8 @@ export class GetPortfolioHistoryQueryDto {
     default: 86400,
   })
   @IsOptional()
-  @IsNumber()
+  @IsInt()
+  @Min(1)
   @Type(() => Number)
   interval?: number;
 

--- a/src/affiliation/controllers/affiliation.controller.ts
+++ b/src/affiliation/controllers/affiliation.controller.ts
@@ -6,6 +6,10 @@ import { CreateAffiliationDto } from '../dto/create-affiliation.dto';
 import { Affiliation } from '../entities/affiliation.entity';
 import { AffiliationCode } from '../entities/affiliation-code.entity';
 import { OAuthService } from '../services/oauth.service';
+import {
+  InviteCodePipe,
+  ProviderParamPipe,
+} from '@/common/validation/request-validation';
 
 @Controller('affiliations')
 @ApiTags('Affiliations')
@@ -25,7 +29,7 @@ export class AffiliationController {
     operationId: 'getJoinInviteInfo',
     summary: 'Get invite link',
   })
-  async getJoinInviteInfo(@Param('code') code: string) {
+  async getJoinInviteInfo(@Param('code', InviteCodePipe) code: string) {
     return this.affiliationRepository.findOne({ where: { code } });
   }
 
@@ -35,8 +39,8 @@ export class AffiliationController {
     summary: 'Get reward code',
   })
   async getRewardCode(
-    @Param('code') code: string,
-    @Param('provider') provider: string,
+    @Param('code', InviteCodePipe) code: string,
+    @Param('provider', ProviderParamPipe) provider: string,
     @Param('access_code') access_code: string,
   ) {
     // Verify the access token with the OAuth provider

--- a/src/affiliation/dto/create-affiliation.dto.ts
+++ b/src/affiliation/dto/create-affiliation.dto.ts
@@ -1,10 +1,11 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { ArrayNotEmpty, IsArray, IsString, Matches } from 'class-validator';
+import { ArrayNotEmpty, IsArray, IsString } from 'class-validator';
+import { IsAeAccountAddress } from '@/common/validation/request-validation';
 
 export class CreateAffiliationDto {
   @ApiProperty({ example: 'ak_2F4ExampleAddress' })
   @IsString()
-  @Matches(/^ak_[1-9A-HJ-NP-Za-km-z]+$/)
+  @IsAeAccountAddress()
   sender_address: string;
 
   @ApiProperty({ example: ['code1', 'code2', 'code3'] })

--- a/src/common/validation/request-validation.spec.ts
+++ b/src/common/validation/request-validation.spec.ts
@@ -1,0 +1,58 @@
+import { BadRequestException } from '@nestjs/common';
+import { Encoding, encode } from '@aeternity/aepp-sdk';
+import {
+  AeAccountAddressPipe,
+  AeAccountReferencePipe,
+  AeContractAddressPipe,
+  AeTransactionHashPipe,
+  OpaqueIdPipe,
+} from './request-validation';
+
+describe('request validation pipes', () => {
+  const accountAddress =
+    'ak_2EZDUTjrzPUikzNereYcBHMYHXaLTn9F6SJJhw6kDEiP4F4Amo';
+  const contractAddress = encode(Buffer.alloc(32, 1), Encoding.ContractAddress);
+  const txHash = encode(Buffer.alloc(32, 2), Encoding.TxHash);
+
+  it('rejects numeric account path values before downstream balance lookups', () => {
+    expect(() =>
+      new AeAccountReferencePipe().transform('100', { data: 'address' }),
+    ).toThrow(BadRequestException);
+  });
+
+  it('accepts account addresses and .chain account references', () => {
+    const pipe = new AeAccountReferencePipe();
+
+    expect(pipe.transform(accountAddress, { data: 'address' })).toBe(
+      accountAddress,
+    );
+    expect(pipe.transform('alice.chain', { data: 'address' })).toBe(
+      'alice.chain',
+    );
+  });
+
+  it('keeps strict account, contract, and transaction hash params separate', () => {
+    expect(
+      new AeAccountAddressPipe().transform(accountAddress, { data: 'address' }),
+    ).toBe(accountAddress);
+    expect(
+      new AeContractAddressPipe().transform(contractAddress, {
+        data: 'address',
+      }),
+    ).toBe(contractAddress);
+    expect(
+      new AeTransactionHashPipe().transform(txHash, { data: 'txHash' }),
+    ).toBe(txHash);
+  });
+
+  it('allows generated post slug characters in opaque IDs', () => {
+    const pipe = new OpaqueIdPipe();
+
+    expect(pipe.transform('olá~mundo-abc123', { data: 'id' })).toBe(
+      'olá~mundo-abc123',
+    );
+    expect(() => pipe.transform('../secret', { data: 'id' })).toThrow(
+      BadRequestException,
+    );
+  });
+});

--- a/src/common/validation/request-validation.ts
+++ b/src/common/validation/request-validation.ts
@@ -1,0 +1,180 @@
+import { Encoding, isEncoded } from '@aeternity/aepp-sdk';
+import { BadRequestException, PipeTransform } from '@nestjs/common';
+import {
+  registerDecorator,
+  ValidationArguments,
+  ValidationOptions,
+} from 'class-validator';
+
+const CHAIN_NAME_PATTERN = /^[a-z0-9][a-z0-9-]{0,62}\.chain$/i;
+const INVITE_CODE_PATTERN = /^[a-z0-9]{1,64}$/i;
+const PROVIDER_PATTERN = /^[a-z][a-z0-9_-]{0,31}$/i;
+const POST_ID_PATTERN = /^[\p{L}\p{N}][\p{L}\p{N}._~:-]{0,127}$/u;
+const TOPIC_PATTERN = /^[A-Za-z0-9][A-Za-z0-9 _.-]{0,127}$/;
+
+type ValidatorFn = (value: string) => boolean;
+
+function propertyName(args: ValidationArguments): string {
+  return args.property;
+}
+
+function registerStringValidator(
+  name: string,
+  validator: ValidatorFn,
+  defaultMessage: (args: ValidationArguments) => string,
+  validationOptions?: ValidationOptions,
+): PropertyDecorator {
+  return (object, propertyName) => {
+    registerDecorator({
+      name,
+      target: object.constructor,
+      propertyName: propertyName as string,
+      options: validationOptions,
+      validator: {
+        validate(value: unknown): boolean {
+          return typeof value === 'string' && validator(value);
+        },
+        defaultMessage,
+      },
+    });
+  };
+}
+
+export function isAeEncoded(
+  value: unknown,
+  encoding: (typeof Encoding)[keyof typeof Encoding],
+): value is string {
+  return typeof value === 'string' && isEncoded(value, encoding);
+}
+
+export function isAeAccountAddress(value: unknown): value is string {
+  return isAeEncoded(value, Encoding.AccountAddress);
+}
+
+export function isAeContractAddress(value: unknown): value is string {
+  return isAeEncoded(value, Encoding.ContractAddress);
+}
+
+export function isAeTransactionHash(value: unknown): value is string {
+  return isAeEncoded(value, Encoding.TxHash);
+}
+
+export function isAeAccountReference(value: unknown): value is string {
+  return (
+    isAeAccountAddress(value) ||
+    (typeof value === 'string' && CHAIN_NAME_PATTERN.test(value))
+  );
+}
+
+export function IsAeAccountAddress(
+  validationOptions?: ValidationOptions,
+): PropertyDecorator {
+  return registerStringValidator(
+    'isAeAccountAddress',
+    isAeAccountAddress,
+    (args) => `${propertyName(args)} must be a valid account address`,
+    validationOptions,
+  );
+}
+
+abstract class StringValidationPipe implements PipeTransform {
+  protected abstract readonly description: string;
+  protected abstract isValid(value: string): boolean;
+
+  transform(value: unknown, metadata?: { data?: string }): string {
+    if (typeof value !== 'string' || !this.isValid(value)) {
+      const name = metadata?.data || 'parameter';
+      throw new BadRequestException(`${name} must be ${this.description}`);
+    }
+    return value;
+  }
+}
+
+abstract class OptionalStringValidationPipe extends StringValidationPipe {
+  transform(value: unknown, metadata?: { data?: string }): string | undefined {
+    if (value === undefined || value === null || value === '') {
+      return undefined;
+    }
+    return super.transform(value, metadata);
+  }
+}
+
+export class AeAccountAddressPipe extends StringValidationPipe {
+  protected readonly description = 'a valid account address';
+
+  protected isValid(value: string): boolean {
+    return isAeAccountAddress(value);
+  }
+}
+
+export class OptionalAeAccountAddressPipe extends OptionalStringValidationPipe {
+  protected readonly description = 'a valid account address';
+
+  protected isValid(value: string): boolean {
+    return isAeAccountAddress(value);
+  }
+}
+
+export class AeAccountReferencePipe extends StringValidationPipe {
+  protected readonly description = 'a valid account address or .chain name';
+
+  protected isValid(value: string): boolean {
+    return isAeAccountReference(value);
+  }
+}
+
+export class AeContractAddressPipe extends StringValidationPipe {
+  protected readonly description = 'a valid contract address';
+
+  protected isValid(value: string): boolean {
+    return isAeContractAddress(value);
+  }
+}
+
+export class OptionalAeContractAddressPipe extends OptionalStringValidationPipe {
+  protected readonly description = 'a valid contract address';
+
+  protected isValid(value: string): boolean {
+    return isAeContractAddress(value);
+  }
+}
+
+export class AeTransactionHashPipe extends StringValidationPipe {
+  protected readonly description = 'a valid transaction hash';
+
+  protected isValid(value: string): boolean {
+    return isAeTransactionHash(value);
+  }
+}
+
+export class InviteCodePipe extends StringValidationPipe {
+  protected readonly description = 'a valid invite code';
+
+  protected isValid(value: string): boolean {
+    return INVITE_CODE_PATTERN.test(value);
+  }
+}
+
+export class ProviderParamPipe extends StringValidationPipe {
+  protected readonly description = 'a valid provider';
+
+  protected isValid(value: string): boolean {
+    return PROVIDER_PATTERN.test(value);
+  }
+}
+
+export class OpaqueIdPipe extends StringValidationPipe {
+  protected readonly description = 'a valid identifier';
+
+  protected isValid(value: string): boolean {
+    return POST_ID_PATTERN.test(value);
+  }
+}
+
+export class TopicParamPipe extends StringValidationPipe {
+  protected readonly description = 'a valid topic';
+
+  protected isValid(value: string): boolean {
+    return TOPIC_PATTERN.test(value);
+  }
+}

--- a/src/dex/controllers/dex-tokens.controller.ts
+++ b/src/dex/controllers/dex-tokens.controller.ts
@@ -21,6 +21,10 @@ import { DexTokenDto, DexTokenSummaryDto } from '../dto';
 import { Pair } from '../entities/pair.entity';
 import { DexTokenSummaryService } from '../services/dex-token-summary.service';
 import { DexTokenService } from '../services/dex-token.service';
+import {
+  AeContractAddressPipe,
+  OptionalAeContractAddressPipe,
+} from '@/common/validation/request-validation';
 
 @Controller('dex/tokens')
 @ApiTags('DEX')
@@ -91,7 +95,7 @@ export class DexTokensController {
   })
   @ApiOkResponse({ type: DexTokenDto })
   @Get(':address')
-  async getByAddress(@Param('address') address: string) {
+  async getByAddress(@Param('address', AeContractAddressPipe) address: string) {
     const token = await this.dexTokenService.findByAddress(address);
     if (!token) {
       throw new NotFoundException(
@@ -113,7 +117,9 @@ export class DexTokensController {
   })
   @ApiOkResponse({ type: DexTokenDto })
   @Get(':address/price')
-  async getTokenPrice(@Param('address') address: string) {
+  async getTokenPrice(
+    @Param('address', AeContractAddressPipe) address: string,
+  ) {
     const token = await this.dexTokenService.findByAddress(address);
     if (!token) {
       throw new NotFoundException(
@@ -180,8 +186,8 @@ export class DexTokensController {
   })
   @Get(':address/price/analysis')
   async getTokenPriceAnalysis(
-    @Param('address') address: string,
-    @Query('base_token') baseToken?: string,
+    @Param('address', AeContractAddressPipe) address: string,
+    @Query('base_token', OptionalAeContractAddressPipe) baseToken?: string,
     @Query('debug') debug?: boolean,
   ) {
     const token = await this.dexTokenService.findByAddress(address);
@@ -218,7 +224,9 @@ export class DexTokensController {
   })
   @ApiOkResponse({ type: DexTokenSummaryDto })
   @Get(':address/summary')
-  async getTokenSummary(@Param('address') address: string) {
+  async getTokenSummary(
+    @Param('address', AeContractAddressPipe) address: string,
+  ) {
     const token = await this.dexTokenService.findByAddress(address);
     if (!token) {
       throw new NotFoundException(

--- a/src/dex/controllers/pair-transactions.controller.ts
+++ b/src/dex/controllers/pair-transactions.controller.ts
@@ -17,6 +17,12 @@ import {
 import { PairTransactionService } from '../services/pair-transaction.service';
 import { PairTransactionDto } from '../dto';
 import { ApiOkResponsePaginated } from '@/utils/api-type';
+import {
+  AeContractAddressPipe,
+  AeTransactionHashPipe,
+  OptionalAeAccountAddressPipe,
+  OptionalAeContractAddressPipe,
+} from '@/common/validation/request-validation';
 
 @Controller('dex/transactions')
 @ApiTags('DEX')
@@ -70,10 +76,12 @@ export class PairTransactionsController {
     @Query('limit', new DefaultValuePipe(100), ParseIntPipe) limit = 100,
     @Query('order_by') orderBy: string = 'created_at',
     @Query('order_direction') orderDirection: 'ASC' | 'DESC' = 'DESC',
-    @Query('pair_address') pairAddress?: string,
-    @Query('token_address') tokenAddress?: string,
+    @Query('pair_address', OptionalAeContractAddressPipe) pairAddress?: string,
+    @Query('token_address', OptionalAeContractAddressPipe)
+    tokenAddress?: string,
     @Query('tx_type') txType?: string,
-    @Query('account_address') account_address?: string,
+    @Query('account_address', OptionalAeAccountAddressPipe)
+    account_address?: string,
   ) {
     return this.pairTransactionService.findAll(
       { page, limit },
@@ -98,7 +106,7 @@ export class PairTransactionsController {
   })
   @ApiOkResponse({ type: PairTransactionDto })
   @Get(':txHash')
-  async getByTxHash(@Param('txHash') txHash: string) {
+  async getByTxHash(@Param('txHash', AeTransactionHashPipe) txHash: string) {
     const pairTransaction =
       await this.pairTransactionService.findByTxHash(txHash);
     if (!pairTransaction) {
@@ -130,7 +138,7 @@ export class PairTransactionsController {
   @ApiOkResponsePaginated(PairTransactionDto)
   @Get('pair/:pairAddress')
   async getByPairAddress(
-    @Param('pairAddress') pairAddress: string,
+    @Param('pairAddress', AeContractAddressPipe) pairAddress: string,
     @Query('page', new DefaultValuePipe(1), ParseIntPipe) page = 1,
     @Query('limit', new DefaultValuePipe(100), ParseIntPipe) limit = 100,
     @Query('order_by') orderBy: string = 'created_at',

--- a/src/dex/controllers/pairs.controller.ts
+++ b/src/dex/controllers/pairs.controller.ts
@@ -23,6 +23,10 @@ import {
   ITransactionPreview,
 } from '../services/pair-history.service';
 import { PairSummaryService } from '../services/pair-summary.service';
+import {
+  AeContractAddressPipe,
+  OptionalAeContractAddressPipe,
+} from '@/common/validation/request-validation';
 
 @Controller('dex/pairs')
 @ApiTags('Dex Pair')
@@ -63,7 +67,8 @@ export class PairsController {
   @Get()
   async listAll(
     @Query('search') search = undefined,
-    @Query('token_address') token_address = undefined,
+    @Query('token_address', OptionalAeContractAddressPipe)
+    token_address = undefined,
     @Query('page', new DefaultValuePipe(1), ParseIntPipe) page = 1,
     @Query('limit', new DefaultValuePipe(100), ParseIntPipe) limit = 100,
     @Query('order_by') orderBy: string = 'created_at',
@@ -90,7 +95,7 @@ export class PairsController {
   })
   @ApiOkResponse({ type: PairDto })
   @Get(':address')
-  async getByAddress(@Param('address') address: string) {
+  async getByAddress(@Param('address', AeContractAddressPipe) address: string) {
     const pair = await this.pairService.findByAddress(address);
     if (!pair) {
       throw new NotFoundException(`Pair with address ${address} not found`);
@@ -116,8 +121,8 @@ export class PairsController {
   @ApiOkResponse({ type: PairDto })
   @Get('from/:from_token/to/:to_token')
   async getPairByFromTokenAndToToken(
-    @Param('from_token') fromToken: string,
-    @Param('to_token') toToken: string,
+    @Param('from_token', AeContractAddressPipe) fromToken: string,
+    @Param('to_token', AeContractAddressPipe) toToken: string,
   ) {
     const pair = await this.pairService.findByFromTokenAndToToken(
       fromToken,
@@ -181,8 +186,8 @@ export class PairsController {
   })
   @Get('from/:from_token/to/:to_token/providers')
   async findPairsForTokens(
-    @Param('from_token') fromToken: string,
-    @Param('to_token') toToken: string,
+    @Param('from_token', AeContractAddressPipe) fromToken: string,
+    @Param('to_token', AeContractAddressPipe) toToken: string,
   ) {
     const result = await this.pairService.findSwapPaths(fromToken, toToken);
 
@@ -225,7 +230,7 @@ export class PairsController {
   @ApiQuery({ name: 'limit', type: 'number', required: false })
   @Get(':address/history')
   async getPaginatedHistory(
-    @Param('address') address: string,
+    @Param('address', AeContractAddressPipe) address: string,
     @Query('interval') interval: number = 3600,
     @Query('from_token') fromToken: string = 'token0',
     @Query('convertTo') convertTo: string = 'ae',
@@ -264,7 +269,7 @@ export class PairsController {
   @ApiOkResponse({ type: PairSummaryDto })
   @Get(':address/summary')
   async getPairSummary(
-    @Param('address') address: string,
+    @Param('address', AeContractAddressPipe) address: string,
     @Query('token') token?: string,
   ) {
     const pair = await this.pairService.findByAddress(address);
@@ -296,7 +301,7 @@ export class PairsController {
   @ApiOkResponse({ type: Object })
   @Get('/:address/preview')
   async getForPreview(
-    @Param('address') address: string,
+    @Param('address', AeContractAddressPipe) address: string,
     @Query('interval') interval: '1d' | '7d' | '30d' = '7d',
   ): Promise<ITransactionPreview> {
     if (!address || address == 'null') {

--- a/src/main.validation.spec.ts
+++ b/src/main.validation.spec.ts
@@ -208,4 +208,28 @@ describe('global ValidationPipe request DTO coverage', () => {
       ]),
     });
   });
+
+  it('rejects invalid SDK-backed account address fields', async () => {
+    await expect(
+      pipe
+        .transform(
+          {
+            sender_address: '100',
+            codes: ['code1'],
+          },
+          {
+            type: 'body',
+            metatype: CreateAffiliationDto,
+            data: '',
+          },
+        )
+        .catch((error: { getResponse?: () => unknown }) => {
+          throw error.getResponse?.() ?? error;
+        }),
+    ).rejects.toMatchObject({
+      message: expect.arrayContaining([
+        expect.stringMatching(/sender_address must be a valid account address/),
+      ]),
+    });
+  });
 });

--- a/src/plugins/address-links/dto/nostr/claim-nostr-link.dto.ts
+++ b/src/plugins/address-links/dto/nostr/claim-nostr-link.dto.ts
@@ -1,8 +1,10 @@
 import { IsString, IsNotEmpty, MaxLength } from 'class-validator';
+import { IsAeAccountAddress } from '@/common/validation/request-validation';
 
 export class ClaimNostrLinkDto {
   @IsString()
   @IsNotEmpty()
+  @IsAeAccountAddress()
   address: string;
 
   /** Nostr npub (bech32-encoded public key). */

--- a/src/plugins/address-links/dto/nostr/submit-nostr-link.dto.ts
+++ b/src/plugins/address-links/dto/nostr/submit-nostr-link.dto.ts
@@ -1,8 +1,10 @@
 import { IsString, IsNotEmpty, IsNumber, MaxLength } from 'class-validator';
+import { IsAeAccountAddress } from '@/common/validation/request-validation';
 
 export class SubmitNostrLinkDto {
   @IsString()
   @IsNotEmpty()
+  @IsAeAccountAddress()
   address: string;
 
   /** Nostr npub (bech32-encoded public key). */

--- a/src/plugins/address-links/dto/nostr/submit-nostr-unlink.dto.ts
+++ b/src/plugins/address-links/dto/nostr/submit-nostr-unlink.dto.ts
@@ -1,8 +1,10 @@
 import { IsString, IsNotEmpty, IsNumber } from 'class-validator';
+import { IsAeAccountAddress } from '@/common/validation/request-validation';
 
 export class SubmitNostrUnlinkDto {
   @IsString()
   @IsNotEmpty()
+  @IsAeAccountAddress()
   address: string;
 
   @IsNumber()

--- a/src/plugins/address-links/dto/nostr/unclaim-nostr-link.dto.ts
+++ b/src/plugins/address-links/dto/nostr/unclaim-nostr-link.dto.ts
@@ -1,7 +1,9 @@
 import { IsString, IsNotEmpty } from 'class-validator';
+import { IsAeAccountAddress } from '@/common/validation/request-validation';
 
 export class UnclaimNostrLinkDto {
   @IsString()
   @IsNotEmpty()
+  @IsAeAccountAddress()
   address: string;
 }

--- a/src/plugins/address-links/dto/x/claim-x-link.dto.ts
+++ b/src/plugins/address-links/dto/x/claim-x-link.dto.ts
@@ -1,8 +1,10 @@
 import { IsString, IsNotEmpty, IsOptional } from 'class-validator';
+import { IsAeAccountAddress } from '@/common/validation/request-validation';
 
 export class ClaimXLinkDto {
   @IsString()
   @IsNotEmpty()
+  @IsAeAccountAddress()
   address: string;
 
   @IsOptional()

--- a/src/plugins/address-links/dto/x/submit-x-link.dto.ts
+++ b/src/plugins/address-links/dto/x/submit-x-link.dto.ts
@@ -1,8 +1,10 @@
 import { IsString, IsNotEmpty, IsNumber, MaxLength } from 'class-validator';
+import { IsAeAccountAddress } from '@/common/validation/request-validation';
 
 export class SubmitXLinkDto {
   @IsString()
   @IsNotEmpty()
+  @IsAeAccountAddress()
   address: string;
 
   @IsString()

--- a/src/plugins/address-links/dto/x/submit-x-unlink.dto.ts
+++ b/src/plugins/address-links/dto/x/submit-x-unlink.dto.ts
@@ -1,8 +1,10 @@
 import { IsString, IsNotEmpty, IsNumber } from 'class-validator';
+import { IsAeAccountAddress } from '@/common/validation/request-validation';
 
 export class SubmitXUnlinkDto {
   @IsString()
   @IsNotEmpty()
+  @IsAeAccountAddress()
   address: string;
 
   @IsNumber()

--- a/src/plugins/address-links/dto/x/unclaim-x-link.dto.ts
+++ b/src/plugins/address-links/dto/x/unclaim-x-link.dto.ts
@@ -1,7 +1,9 @@
 import { IsString, IsNotEmpty } from 'class-validator';
+import { IsAeAccountAddress } from '@/common/validation/request-validation';
 
 export class UnclaimXLinkDto {
   @IsString()
   @IsNotEmpty()
+  @IsAeAccountAddress()
   address: string;
 }

--- a/src/plugins/governance/controllers/governance-delegations.controller.ts
+++ b/src/plugins/governance/controllers/governance-delegations.controller.ts
@@ -15,6 +15,7 @@ import {
 } from '../dto/governance-delegation.dto';
 import { ApiOkResponsePaginated } from '@/utils/api-type';
 import { Pagination } from 'nestjs-typeorm-paginate';
+import { AeAccountAddressPipe } from '@/common/validation/request-validation';
 
 @Controller('governance/delegations')
 @ApiTags('Governance')
@@ -64,7 +65,7 @@ export class GovernanceDelegationsController {
   })
   @Get(':accountAddress')
   async findHistoryByAccount(
-    @Param('accountAddress') accountAddress: string,
+    @Param('accountAddress', AeAccountAddressPipe) accountAddress: string,
   ): Promise<GovernanceDelegationHistoryItemDto[]> {
     return this.governanceDelegationService.findHistoryByAccount(
       accountAddress,

--- a/src/plugins/governance/controllers/governance-votes.controller.ts
+++ b/src/plugins/governance/controllers/governance-votes.controller.ts
@@ -14,6 +14,7 @@ import {
 } from '../dto/governance-vote.dto';
 import { ApiOkResponsePaginated } from '@/utils/api-type';
 import { Pagination } from 'nestjs-typeorm-paginate';
+import { AeContractAddressPipe } from '@/common/validation/request-validation';
 
 @Controller('governance/votes')
 @ApiTags('Governance')
@@ -49,7 +50,7 @@ export class GovernanceVotesController {
   })
   @Get(':pollAddress')
   async findOne(
-    @Param('pollAddress') pollAddress: string,
+    @Param('pollAddress', AeContractAddressPipe) pollAddress: string,
   ): Promise<GovernanceVoteDto> {
     return this.governanceVoteService.findOne(pollAddress);
   }

--- a/src/profile/controllers/profile-chain-name.controller.ts
+++ b/src/profile/controllers/profile-chain-name.controller.ts
@@ -4,6 +4,7 @@ import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { CreateChainNameChallengeDto } from '../dto/create-chain-name-challenge.dto';
 import { RequestChainNameDto } from '../dto/request-chain-name.dto';
 import { ProfileChainNameService } from '../services/profile-chain-name.service';
+import { AeAccountAddressPipe } from '@/common/validation/request-validation';
 
 @Controller('profile')
 @ApiTags('ProfileChainName')
@@ -45,7 +46,9 @@ export class ProfileChainNameController {
     operationId: 'getChainNameClaimStatus',
     summary: 'Get the status of a sponsored chain name claim for an address',
   })
-  async getChainNameClaimStatus(@Param('address') address: string) {
+  async getChainNameClaimStatus(
+    @Param('address', AeAccountAddressPipe) address: string,
+  ) {
     return this.profileChainNameService.getClaimStatus(address);
   }
 }

--- a/src/profile/controllers/profile-rewards.controller.ts
+++ b/src/profile/controllers/profile-rewards.controller.ts
@@ -5,6 +5,7 @@ import { CreateXPostingRecheckChallengeDto } from '../dto/create-x-posting-reche
 import { SubmitXPostingRecheckDto } from '../dto/submit-x-posting-recheck.dto';
 import { ProfileXInviteService } from '../services/profile-x-invite.service';
 import { ProfileXPostingRewardService } from '../services/profile-x-posting-reward.service';
+import { AeAccountAddressPipe } from '@/common/validation/request-validation';
 
 @Controller('profile')
 @ApiTags('ProfileRewards')
@@ -19,7 +20,9 @@ export class ProfileRewardsController {
     operationId: 'getXPostingRewardStatus',
     summary: 'Get X posting reward status for an address',
   })
-  async getXPostingRewardStatus(@Param('address') address: string) {
+  async getXPostingRewardStatus(
+    @Param('address', AeAccountAddressPipe) address: string,
+  ) {
     return this.profileXPostingRewardService.getRewardStatus(address);
   }
 
@@ -45,7 +48,7 @@ export class ProfileRewardsController {
       'Verify wallet ownership and run an on-demand X posting reward recheck',
   })
   async recheckXPostingReward(
-    @Param('address') address: string,
+    @Param('address', AeAccountAddressPipe) address: string,
     @Body() body: SubmitXPostingRecheckDto,
   ) {
     await this.profileXInviteService.verifyPostingRewardRecheckChallenge({

--- a/src/profile/controllers/profile.controller.spec.ts
+++ b/src/profile/controllers/profile.controller.spec.ts
@@ -1,6 +1,9 @@
 import { ProfileController } from './profile.controller';
 
 describe('ProfileController', () => {
+  const validAddress1 = 'ak_2EZDUTjrzPUikzNereYcBHMYHXaLTn9F6SJJhw6kDEiP4F4Amo';
+  const validAddress2 = 'ak_2maNN7AsevCiv546m1TLrSxCFSDeVHif7S7pSsdPS2VXEbkbG';
+
   const getController = (overrides?: {
     profileXInviteService?: any;
     profileXVerificationRewardService?: any;
@@ -41,10 +44,10 @@ describe('ProfileController', () => {
   it('parses addresses query for batch endpoint', async () => {
     const { controller, profileReadService } = getController();
 
-    await controller.getProfiles('ak_1, ak_2', 'false');
+    await controller.getProfiles(`${validAddress1}, ${validAddress2}`, 'false');
 
     expect(profileReadService.getProfilesByAddresses).toHaveBeenCalledWith(
-      ['ak_1', 'ak_2'],
+      [validAddress1, validAddress2],
       { includeOnChain: false },
     );
   });

--- a/src/profile/controllers/profile.controller.ts
+++ b/src/profile/controllers/profile.controller.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   Body,
   Controller,
   DefaultValuePipe,
@@ -21,6 +22,11 @@ import { CreateXInviteChallengeDto } from '../dto/create-x-invite-challenge.dto'
 import { ProfileXVerificationRewardService } from '../services/profile-x-verification-reward.service';
 import { ProfileXPostingRewardService } from '../services/profile-x-posting-reward.service';
 import { Invitation } from '@/affiliation/entities/invitation.entity';
+import {
+  AeAccountAddressPipe,
+  InviteCodePipe,
+  isAeAccountAddress,
+} from '@/common/validation/request-validation';
 
 @Controller('profile')
 @ApiTags('Profile')
@@ -87,7 +93,10 @@ export class ProfileController {
     operationId: 'bindXInviteLink',
     summary: 'Bind invite code to an invitee address',
   })
-  async bindXInvite(@Param('code') code: string, @Body() body: BindXInviteDto) {
+  async bindXInvite(
+    @Param('code', InviteCodePipe) code: string,
+    @Body() body: BindXInviteDto,
+  ) {
     return this.profileXInviteService.bindInvite({
       code,
       inviteeAddress: body.invitee_address,
@@ -134,6 +143,14 @@ export class ProfileController {
       .split(',')
       .map((it) => it.trim())
       .filter(Boolean);
+    const invalidAddress = parsed.find(
+      (address) => !isAeAccountAddress(address),
+    );
+    if (invalidAddress) {
+      throw new BadRequestException(
+        `addresses contains invalid account address ${invalidAddress}`,
+      );
+    }
     return this.profileReadService.getProfilesByAddresses(parsed, {
       includeOnChain: includeOnChain === 'true',
     });
@@ -144,7 +161,9 @@ export class ProfileController {
     operationId: 'getOnChainProfile',
     summary: 'Get profile directly from contract dry-run call',
   })
-  async getOnChainProfile(@Param('address') address: string) {
+  async getOnChainProfile(
+    @Param('address', AeAccountAddressPipe) address: string,
+  ) {
     return this.profileReadService.getOnChainProfile(address);
   }
 
@@ -153,7 +172,9 @@ export class ProfileController {
     operationId: 'getXInviteProgress',
     summary: 'Get X invite progress for inviter',
   })
-  async getXInviteProgress(@Param('address') address: string) {
+  async getXInviteProgress(
+    @Param('address', AeAccountAddressPipe) address: string,
+  ) {
     return this.profileXInviteService.getProgress(address);
   }
 
@@ -162,7 +183,9 @@ export class ProfileController {
     operationId: 'getRewardsProgress',
     summary: 'Get combined progress across all profile reward systems',
   })
-  async getRewardsProgress(@Param('address') address: string) {
+  async getRewardsProgress(
+    @Param('address', AeAccountAddressPipe) address: string,
+  ) {
     const [xVerification, xPosting, xInvite] = await Promise.all([
       this.profileXVerificationRewardService.getRewardStatus(address),
       this.profileXPostingRewardService.getRewardStatus(address),
@@ -238,7 +261,7 @@ export class ProfileController {
       'When true, augments response with fresh on-chain contract read',
   })
   async getProfile(
-    @Param('address') address: string,
+    @Param('address', AeAccountAddressPipe) address: string,
     @Query('includeOnChain') includeOnChain?: string,
   ) {
     return this.profileReadService.getProfile(address, {

--- a/src/profile/dto/ae-account-address.validator.ts
+++ b/src/profile/dto/ae-account-address.validator.ts
@@ -1,4 +1,4 @@
-import { Encoding, isEncoded } from '@aeternity/aepp-sdk';
+import { isAeAccountAddress } from '@/common/validation/request-validation';
 import {
   ValidationArguments,
   ValidatorConstraint,
@@ -8,9 +8,7 @@ import {
 @ValidatorConstraint({ name: 'isAeAccountAddress', async: false })
 export class AeAccountAddressConstraint implements ValidatorConstraintInterface {
   validate(value: unknown): boolean {
-    return (
-      typeof value === 'string' && isEncoded(value, Encoding.AccountAddress)
-    );
+    return isAeAccountAddress(value);
   }
 
   defaultMessage(args: ValidationArguments): string {

--- a/src/profile/dto/bind-x-invite.dto.ts
+++ b/src/profile/dto/bind-x-invite.dto.ts
@@ -1,8 +1,9 @@
 import { IsString, Matches } from 'class-validator';
+import { IsAeAccountAddress } from '@/common/validation/request-validation';
 
 export class BindXInviteDto {
   @IsString()
-  @Matches(/^ak_[1-9A-HJ-NP-Za-km-z]+$/)
+  @IsAeAccountAddress()
   invitee_address: string;
 
   @IsString()

--- a/src/profile/dto/create-chain-name-challenge.dto.ts
+++ b/src/profile/dto/create-chain-name-challenge.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString, Validate } from 'class-validator';
-import { AeAccountAddressConstraint } from './ae-account-address.validator';
+import { IsString } from 'class-validator';
+import { IsAeAccountAddress } from '@/common/validation/request-validation';
 
 export class CreateChainNameChallengeDto {
   @ApiProperty({
@@ -8,6 +8,6 @@ export class CreateChainNameChallengeDto {
     example: 'ak_2519mBsgjJEVEFoRgno1ryDsn3BEaCZGRbXPEjThWYLX9MTpmk',
   })
   @IsString()
-  @Validate(AeAccountAddressConstraint)
+  @IsAeAccountAddress()
   address: string;
 }

--- a/src/profile/dto/create-x-attestation.dto.ts
+++ b/src/profile/dto/create-x-attestation.dto.ts
@@ -1,13 +1,13 @@
 import {
   IsString,
   Length,
-  Matches,
   ValidateIf,
   Validate,
   ValidationArguments,
   ValidatorConstraint,
   ValidatorConstraintInterface,
 } from 'class-validator';
+import { IsAeAccountAddress } from '@/common/validation/request-validation';
 
 @ValidatorConstraint({ name: 'xAttestationAuth', async: false })
 export class XAttestationAuthConstraint implements ValidatorConstraintInterface {
@@ -31,7 +31,7 @@ export class XAttestationAuthConstraint implements ValidatorConstraintInterface 
  */
 export class CreateXAttestationDto {
   @IsString()
-  @Matches(/^ak_[1-9A-HJ-NP-Za-km-z]+$/)
+  @IsAeAccountAddress()
   address: string;
 
   /** When using token flow: provide the X OAuth access token directly */

--- a/src/profile/dto/create-x-invite-challenge.dto.ts
+++ b/src/profile/dto/create-x-invite-challenge.dto.ts
@@ -1,8 +1,9 @@
 import { IsIn, IsString, Matches, ValidateIf } from 'class-validator';
+import { IsAeAccountAddress } from '@/common/validation/request-validation';
 
 export class CreateXInviteChallengeDto {
   @IsString()
-  @Matches(/^ak_[1-9A-HJ-NP-Za-km-z]+$/)
+  @IsAeAccountAddress()
   address: string;
 
   @IsString()

--- a/src/profile/dto/create-x-invite.dto.ts
+++ b/src/profile/dto/create-x-invite.dto.ts
@@ -1,8 +1,9 @@
 import { IsString, Matches } from 'class-validator';
+import { IsAeAccountAddress } from '@/common/validation/request-validation';
 
 export class CreateXInviteDto {
   @IsString()
-  @Matches(/^ak_[1-9A-HJ-NP-Za-km-z]+$/)
+  @IsAeAccountAddress()
   inviter_address: string;
 
   @IsString()

--- a/src/profile/dto/create-x-posting-recheck-challenge.dto.ts
+++ b/src/profile/dto/create-x-posting-recheck-challenge.dto.ts
@@ -1,7 +1,8 @@
-import { IsString, Matches } from 'class-validator';
+import { IsString } from 'class-validator';
+import { IsAeAccountAddress } from '@/common/validation/request-validation';
 
 export class CreateXPostingRecheckChallengeDto {
   @IsString()
-  @Matches(/^ak_[1-9A-HJ-NP-Za-km-z]+$/)
+  @IsAeAccountAddress()
   address: string;
 }

--- a/src/profile/dto/request-chain-name.dto.ts
+++ b/src/profile/dto/request-chain-name.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString, Matches, MinLength, Validate } from 'class-validator';
-import { AeAccountAddressConstraint } from './ae-account-address.validator';
+import { IsString, Matches, MinLength } from 'class-validator';
+import { IsAeAccountAddress } from '@/common/validation/request-validation';
 
 export class RequestChainNameDto {
   @ApiProperty({
@@ -8,7 +8,7 @@ export class RequestChainNameDto {
     example: 'ak_2519mBsgjJEVEFoRgno1ryDsn3BEaCZGRbXPEjThWYLX9MTpmk',
   })
   @IsString()
-  @Validate(AeAccountAddressConstraint)
+  @IsAeAccountAddress()
   address: string;
 
   @ApiProperty({

--- a/src/social/controllers/posts.controller.ts
+++ b/src/social/controllers/posts.controller.ts
@@ -29,6 +29,10 @@ import { TokenPerformanceView } from '@/tokens/entities/tokens-performance.view'
 import { PopularRankingContentItem } from '@/plugins/popular-ranking.interface';
 import { extractTrendMentions } from '../utils/content-parser.util';
 import { ProfileReadService } from '@/profile/services/profile-read.service';
+import {
+  OpaqueIdPipe,
+  OptionalAeAccountAddressPipe,
+} from '@/common/validation/request-validation';
 
 @Controller('posts')
 @ApiTags('Posts')
@@ -214,7 +218,8 @@ export class PostsController {
     @Query('order_by') orderBy: string = 'created_at',
     @Query('order_direction') orderDirection: 'ASC' | 'DESC' = 'DESC',
     @Query('search') search?: string,
-    @Query('account_address') account_address?: string,
+    @Query('account_address', OptionalAeAccountAddressPipe)
+    account_address?: string,
     @Query('topics') topics?: string,
   ) {
     // Build base query for filtering to get distinct post IDs
@@ -534,7 +539,7 @@ export class PostsController {
     description: 'Post retrieved successfully',
   })
   @Get(':id')
-  async getById(@Param('id') id: string, @Req() req: Request) {
+  async getById(@Param('id', OpaqueIdPipe) id: string, @Req() req: Request) {
     const post = await this.postRepository
       .createQueryBuilder('post')
       .where('(post.id = :id OR post.slug = :id)', { id })
@@ -562,7 +567,7 @@ export class PostsController {
   @ApiOkResponsePaginated(PostDto)
   @Get(':id/comments')
   async getComments(
-    @Param('id') id: string,
+    @Param('id', OpaqueIdPipe) id: string,
     @Query('page', new DefaultValuePipe(1), ParseIntPipe) page = 1,
     @Query('limit', new DefaultValuePipe(50), ParseIntPipe) limit = 50,
     @Query('order_direction') orderDirection: 'ASC' | 'DESC' = 'ASC',

--- a/src/social/controllers/topics.controller.ts
+++ b/src/social/controllers/topics.controller.ts
@@ -19,6 +19,7 @@ import { paginate } from 'nestjs-typeorm-paginate';
 import { Repository } from 'typeorm';
 import { Topic } from '../entities/topic.entity';
 import { ApiOkResponsePaginated } from '@/utils/api-type';
+import { TopicParamPipe } from '@/common/validation/request-validation';
 
 @Controller('topics')
 @ApiTags('Topics')
@@ -87,7 +88,7 @@ export class TopicsController {
     description: 'Topic retrieved successfully',
   })
   @Get(':id')
-  async getById(@Param('id') id: string) {
+  async getById(@Param('id', TopicParamPipe) id: string) {
     // Check if the parameter is a valid UUID format
     const isUUID =
       /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
@@ -117,7 +118,7 @@ export class TopicsController {
     description: 'Topic retrieved successfully',
   })
   @Get('name/:name')
-  async getByName(@Param('name') name: string) {
+  async getByName(@Param('name', TopicParamPipe) name: string) {
     const topic = await this.topicRepository.findOne({
       where: { name },
       relations: ['posts'],

--- a/src/tipping/controllers/tips.controller.ts
+++ b/src/tipping/controllers/tips.controller.ts
@@ -15,6 +15,11 @@ import { Tip } from '../entities/tip.entity';
 import { Account } from '@/account/entities/account.entity';
 import { ApiOkResponsePaginated } from '@/utils/api-type';
 import { Post } from '@/social/entities/post.entity';
+import {
+  AeAccountAddressPipe,
+  OpaqueIdPipe,
+  OptionalAeAccountAddressPipe,
+} from '@/common/validation/request-validation';
 
 @Controller('tips')
 @ApiTags('Tips')
@@ -53,8 +58,8 @@ export class TipsController {
     @Query('limit', new DefaultValuePipe(100), ParseIntPipe) limit = 100,
     @Query('order_by') orderBy: 'amount' | 'type' | 'created_at' = 'created_at',
     @Query('order_direction') orderDirection: 'ASC' | 'DESC' = 'DESC',
-    @Query('sender') sender?: string,
-    @Query('receiver') receiver?: string,
+    @Query('sender', OptionalAeAccountAddressPipe) sender?: string,
+    @Query('receiver', OptionalAeAccountAddressPipe) receiver?: string,
     @Query('type') type?: string,
   ) {
     const query = this.tipRepository
@@ -101,7 +106,9 @@ export class TipsController {
     description: 'Returns total tips sent and received for an account',
   })
   @Get('accounts/:address/summary')
-  async getAccountSummary(@Param('address') address: string) {
+  async getAccountSummary(
+    @Param('address', AeAccountAddressPipe) address: string,
+  ) {
     const totals = await this.tipRepository
       .createQueryBuilder('tip')
       .select(
@@ -127,7 +134,7 @@ export class TipsController {
     description: 'Returns total tips amount for a post',
   })
   @Get('posts/:postId/summary')
-  async getPostSummary(@Param('postId') postId: string) {
+  async getPostSummary(@Param('postId', OpaqueIdPipe) postId: string) {
     const post = await this.postRepository.findOne({
       where: { id: postId },
     });

--- a/src/tokens/account-tokens.controller.ts
+++ b/src/tokens/account-tokens.controller.ts
@@ -16,6 +16,11 @@ import { TokenHolderDto } from './dto/token-holder.dto';
 import { TokenHolder } from './entities/token-holders.entity';
 import { Token } from './entities/token.entity';
 import { TokensService } from './tokens.service';
+import {
+  AeAccountAddressPipe,
+  OptionalAeAccountAddressPipe,
+  OptionalAeContractAddressPipe,
+} from '@/common/validation/request-validation';
 
 @Controller('accounts')
 @ApiTags('Account Tokens')
@@ -51,11 +56,14 @@ export class AccountTokensController {
   @ApiOkResponsePaginated(TokenHolderDto)
   @Get(':address/tokens')
   async listAccountTokens(
-    @Param('address') address: string,
+    @Param('address', AeAccountAddressPipe) address: string,
     @Query('search') search = undefined,
-    @Query('factory_address') factory_address = undefined,
-    @Query('creator_address') creator_address = undefined,
-    @Query('owner_address') owner_address = undefined,
+    @Query('factory_address', OptionalAeContractAddressPipe)
+    factory_address = undefined,
+    @Query('creator_address', OptionalAeAccountAddressPipe)
+    creator_address = undefined,
+    @Query('owner_address', OptionalAeAccountAddressPipe)
+    owner_address = undefined,
     @Query('page', new DefaultValuePipe(1), ParseIntPipe) page = 1,
     @Query('limit', new DefaultValuePipe(100), ParseIntPipe) limit = 100,
     @Query('order_by') orderBy: string = 'balance',

--- a/src/tokens/tokens.controller.ts
+++ b/src/tokens/tokens.controller.ts
@@ -35,6 +35,10 @@ import {
 import { Cache } from 'cache-manager';
 import { Queue } from 'bull';
 import { SYNC_TOKEN_HOLDERS_QUEUE } from './queues/constants';
+import {
+  OptionalAeAccountAddressPipe,
+  OptionalAeContractAddressPipe,
+} from '@/common/validation/request-validation';
 
 const TOKENS_LIST_CACHE_TTL_MS = 60 * 1000;
 const TRENDING_TOKENS_LIST_CACHE_TTL_MS = 15 * 60 * 1000;
@@ -116,9 +120,12 @@ export class TokensController {
   @Get()
   async listAll(
     @Query('search') search = undefined,
-    @Query('factory_address') factory_address = undefined,
-    @Query('creator_address') creator_address = undefined,
-    @Query('owner_address') owner_address = undefined,
+    @Query('factory_address', OptionalAeContractAddressPipe)
+    factory_address = undefined,
+    @Query('creator_address', OptionalAeAccountAddressPipe)
+    creator_address = undefined,
+    @Query('owner_address', OptionalAeAccountAddressPipe)
+    owner_address = undefined,
     @Query('page', new DefaultValuePipe(1), ParseIntPipe) page = 1,
     @Query('limit', new DefaultValuePipe(100), ParseIntPipe) limit = 100,
     @Query('order_by') orderBy: string = 'market_cap',

--- a/src/transactions/controllers/transactions.controller.ts
+++ b/src/transactions/controllers/transactions.controller.ts
@@ -24,6 +24,10 @@ import { Repository } from 'typeorm';
 import { TransactionDto } from '../dto/transaction.dto';
 import { Transaction } from '../entities/transaction.entity';
 import { TransactionService } from '../services/transaction.service';
+import {
+  AeTransactionHashPipe,
+  OptionalAeAccountAddressPipe,
+} from '@/common/validation/request-validation';
 
 @Controller('transactions')
 @ApiTags('Transactions')
@@ -77,7 +81,8 @@ export class TransactionsController {
   @Get('')
   async listTransactions(
     @Query('token_address') token_address: string = undefined,
-    @Query('account_address') account_address: string = undefined,
+    @Query('account_address', OptionalAeAccountAddressPipe)
+    account_address: string = undefined,
     @Query('includes') includes: string = undefined,
     @Query('page', new DefaultValuePipe(1), ParseIntPipe) page = 1,
     @Query('limit', new DefaultValuePipe(100), ParseIntPipe) limit = 100,
@@ -148,7 +153,7 @@ export class TransactionsController {
   @ApiOkResponse({ type: TransactionDto })
   @Get('by-hash')
   async getTransactionByHash(
-    @Query('tx_hash') tx_hash: string,
+    @Query('tx_hash', AeTransactionHashPipe) tx_hash: string,
   ): Promise<TransactionDto> {
     const transaction = await this.transactionsRepository
       .createQueryBuilder('transactions')

--- a/src/transactions/dto/analytics-transactions.dto.ts
+++ b/src/transactions/dto/analytics-transactions.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsOptional, IsString } from 'class-validator';
+import { IsDateString, IsOptional, IsString } from 'class-validator';
+import { IsAeAccountAddress } from '@/common/validation/request-validation';
 
 export class DailyTradeVolumeQueryDto {
   @ApiProperty({
@@ -7,7 +8,7 @@ export class DailyTradeVolumeQueryDto {
     required: false,
   })
   @IsOptional()
-  @IsString()
+  @IsDateString()
   start_date?: string;
 
   @ApiProperty({
@@ -15,7 +16,7 @@ export class DailyTradeVolumeQueryDto {
     required: false,
   })
   @IsOptional()
-  @IsString()
+  @IsDateString()
   end_date?: string;
 
   @ApiProperty({
@@ -32,6 +33,7 @@ export class DailyTradeVolumeQueryDto {
   })
   @IsOptional()
   @IsString()
+  @IsAeAccountAddress()
   account_address?: string;
 }
 
@@ -61,7 +63,7 @@ export class DailyUniqueActiveUsersQueryDto {
     required: false,
   })
   @IsOptional()
-  @IsString()
+  @IsDateString()
   start_date?: string;
 
   @ApiProperty({
@@ -69,7 +71,7 @@ export class DailyUniqueActiveUsersQueryDto {
     required: false,
   })
   @IsOptional()
-  @IsString()
+  @IsDateString()
   end_date?: string;
 
   @ApiProperty({

--- a/src/trending-tags/controllers/trending-tags.controller.ts
+++ b/src/trending-tags/controllers/trending-tags.controller.ts
@@ -25,6 +25,7 @@ import { TrendingTag } from '../entities/trending-tags.entity';
 import { CreateTrendingTagsDto } from '../dto/create-trending-tags.dto';
 import { TrendingTagsService } from '../services/trending-tags.service';
 import { ApiKeyGuard } from '../guards/api-key.guard';
+import { TopicParamPipe } from '@/common/validation/request-validation';
 
 @Controller('trending-tags')
 @ApiTags('Trending Tags')
@@ -79,7 +80,7 @@ export class TrendingTagsController {
   @ApiOperation({ operationId: 'getTrendingTag' })
   @ApiParam({ name: 'tag', type: 'string' })
   @Get(':tag')
-  async getTrendingTag(@Param('tag') tag: string) {
+  async getTrendingTag(@Param('tag', TopicParamPipe) tag: string) {
     const trendingTag = await this.trendingTagRepository.findOne({
       where: { tag },
     });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds stricter validation for many path/query/body fields, which can change previously-accepted inputs into `400` responses and potentially affect existing clients. Changes are mostly confined to validation/DTO layers with low risk to core business logic.
> 
> **Overview**
> Adds a centralized `request-validation` module with reusable NestJS pipes and class-validator helpers for AE account/contract/tx identifiers, invite codes/providers, opaque IDs (post slugs), and topic params, plus unit tests.
> 
> Applies these validators across multiple controllers (accounts/portfolio, DEX, transactions, posts/topics, tips, governance, profile) so invalid path/query values are rejected early (including `.chain` references where allowed), and tightens several DTOs (ISO date strings, integer/min constraints, SDK-backed AE address validation). The profile batch `addresses` query now explicitly rejects any invalid address in the list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 438d0acb69664a40e20bf56270b522610d5d1e27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->