### PR TITLE
refactor: adjust popular ranking

### DIFF
--- a/docs/popular-post-ranking.md
+++ b/docs/popular-post-ranking.md
@@ -1,6 +1,6 @@
 ## Popular post ranking
 
-The popular post endpoint ranks content by accumulated engagement — a "Top" style ranking with no time decay. The time window itself acts as the freshness filter.
+The popular post endpoint ranks content all-time, then adds a short-lived live boost so newer posts can surface in a low-activity network. The result is a "Top + fresh" feed: durable engagement still wins over time, but new posts get discovery room during their first day.
 
 The current implementation rewards posts that attract:
 
@@ -13,15 +13,11 @@ The current implementation rewards posts that attract:
 
 It does not simply sort by raw comment count or raw tip amount.
 
-## Endpoint and windows
+## Endpoint
 
 The ranking powers `GET /posts/popular`.
 
-Supported windows:
-
-- `24h` (default)
-- `7d`
-- `all`
+The endpoint no longer exposes timeframes. Clients receive the canonical live popular ranking.
 
 ## Which posts are even eligible
 
@@ -29,23 +25,21 @@ A regular post is considered for ranking only if it is:
 
 - not hidden,
 - a top-level post (`post_id IS NULL`),
-- inside the requested time window for `24h` and `7d`.
+- inside the all-time candidate pool.
 
 Comments are not ranked directly as standalone popular items. Their impact is counted through the parent post's `total_comments`.
 
-For the `all` window, the system does not filter by age, but it still only evaluates the newest candidate set up to the configured cap.
+The system does not filter by age, but it still only evaluates the newest candidate set up to the configured cap.
 
 ## Candidate caps
 
 Before scoring, the service limits how many recent items it evaluates:
 
 ```ts
-MAX_CANDIDATES_24H: 500,
-MAX_CANDIDATES_7D: 3000,
 MAX_CANDIDATES_ALL: 10000,
 ```
 
-This means popularity is computed only within the newest candidate pool for that window, not across every post ever created.
+This means popularity is computed within the newest all-time candidate pool, not across every post ever created.
 
 ## Formula
 
@@ -59,10 +53,20 @@ score =
   w_unique_tippers * log(1 + uniqueTippers) +
   w_reads * log(1 + reads) +
   w_trending * trendingBoost +
-  w_quality * contentQuality
+  w_quality * contentQuality +
+  w_fresh * freshnessFactor +
+  w_velocity * log(1 + interactionsPerHour) * freshnessFactor
 ```
 
-There is no time-decay divisor. The score is purely based on engagement within the selected window.
+There is no time-decay divisor. The live boost is additive and bounded, so it helps new content without permanently overriding all-time engagement.
+
+Freshness is linear over the first 24 hours:
+
+```text
+freshnessFactor = max(0, 1 - ageHours / 24)
+```
+
+After 24 hours, both `freshnessFactor` and the velocity boost are zero. The post then ranks by normal accumulated engagement.
 
 ## Current weights
 
@@ -71,12 +75,14 @@ All weights live in `src/configs/constants.ts` under `POPULAR_RANKING_CONFIG`.
 ```ts
 WEIGHTS: {
   comments: 2.5,
-  tipsAmountAE: 2.0,
+  tipsAmountAE: 1.5,
   tipsCount: 1.0,
   uniqueTippers: 1.5,
   trendingBoost: 0.5,
   contentQuality: 0.3,
   reads: 1.5,
+  freshnessBoost: 0.9,
+  velocityBoost: 0.6,
 }
 ```
 
@@ -85,9 +91,10 @@ WEIGHTS: {
 The biggest direct drivers are:
 
 - `comments`
-- `tipsAmountAE`
 - `uniqueTippers`
 - `reads`
+- `tipsAmountAE`
+- temporary freshness and velocity for posts less than 24 hours old
 
 Because logarithms are used for all count- and amount-based signals, they have diminishing returns. Doubling activity helps, but not linearly forever.
 
@@ -121,7 +128,7 @@ The number of distinct addresses that tipped a post (excluding self-tips). This 
 
 ### 5. Reads
 
-Reads are pulled from `post_reads_daily` and summed across the selected window.
+Reads are pulled from `post_reads_daily` and summed for all available candidate posts.
 
 The ranking uses raw reads:
 
@@ -129,7 +136,7 @@ The ranking uses raw reads:
 log(1 + reads)
 ```
 
-Reads are not normalized by age — the window boundary handles freshness.
+Reads are not normalized by age. Freshness is handled by the bounded new-post boost.
 
 ### 6. Trending topic boost
 
@@ -170,23 +177,31 @@ For polls:
 
 This is why the endpoint can return mixed item types while still ranking them with a comparable scoring model.
 
+## Author diversity
+
+After raw score sorting, each page is reranked to avoid showing the same author twice when there are enough alternatives.
+
+The service:
+
+- oversamples ranked candidates for the requested page,
+- selects the first item from each author,
+- backfills with duplicate authors only when there are not enough unique authors to fill the page.
+
+This keeps each page full while preventing one active user from dominating the popular tab.
+
 ## Caching behavior
 
-Computed rankings are stored in Redis sorted sets for:
-
-- `popular:24h`
-- `popular:7d`
-- `popular:all`
+Computed rankings are stored in the Redis sorted set `popular:all`.
 
 TTL is currently:
 
 ```ts
-REDIS_TTL_SECONDS: 30
+REDIS_TTL_SECONDS: 30;
 ```
 
 So the feed is intentionally refreshed often.
 
-When the cache is empty (cold start or after TTL expiry with no cron), recompute is triggered in the background with a per-window mutex to prevent stampede. The current request falls back to recent posts while the cache is being rebuilt.
+When the cache is empty (cold start or after TTL expiry with no cron), recompute is triggered with a mutex to prevent stampede. The current request falls back to recent posts while the cache is being rebuilt.
 
 ## Practical interpretation
 
@@ -197,17 +212,18 @@ A post is most likely to rank highly when it is:
 - receiving meaningful AE tips from multiple tippers,
 - being read actively,
 - connected to a trending topic,
-- written with enough substance to avoid quality penalties.
+- written with enough substance to avoid quality penalties,
+- less than 24 hours old or gaining early interaction velocity.
 
 ## Files involved
 
-| File | Purpose |
-|------|---------|
-| `src/social/services/popular-ranking.service.ts` | Main candidate selection, scoring, and Redis caching |
-| `src/configs/constants.ts` | Ranking weights and candidate caps |
-| `src/social/controllers/posts.controller.ts` | Exposes `GET /posts/popular` |
-| `src/plugins/popular-ranking.interface.ts` | Plugin contract for non-post content |
-| `src/plugins/governance/services/governance-popular-ranking.service.ts` | Governance poll contribution to popular ranking |
+| File                                                                    | Purpose                                              |
+| ----------------------------------------------------------------------- | ---------------------------------------------------- |
+| `src/social/services/popular-ranking.service.ts`                        | Main candidate selection, scoring, and Redis caching |
+| `src/configs/constants.ts`                                              | Ranking weights and candidate caps                   |
+| `src/social/controllers/posts.controller.ts`                            | Exposes `GET /posts/popular`                         |
+| `src/plugins/popular-ranking.interface.ts`                              | Plugin contract for non-post content                 |
+| `src/plugins/governance/services/governance-popular-ranking.service.ts` | Governance poll contribution to popular ranking      |
 
 ## Design notes
 
@@ -215,9 +231,9 @@ A post is most likely to rank highly when it is:
 
 Most numeric signals use `log(1 + x)` so the ranking favors meaningful activity without letting one giant raw number dominate forever.
 
-### Why there is no time decay
+### Why there is no global time decay
 
-This is a "Top" ranking, not a "Hot" ranking. The time window itself (24h, 7d, all) acts as the freshness filter. Within a window, posts compete purely on accumulated engagement. This is simpler, more transparent, and better suited for a low-activity network where posts need time to gather signals.
+This is not a Hacker News-style feed where every post steadily decays. In a low-activity network, posts need time to gather signal. The algorithm instead uses all-time engagement plus a 24-hour additive boost, so new posts get initial visibility and then settle into the normal ranking.
 
 ### Why there are no score floors
 

--- a/src/configs/constants.ts
+++ b/src/configs/constants.ts
@@ -215,8 +215,8 @@ export type PopularRankingWeightScale =
   (typeof POPULAR_RANKING_WEIGHT_SCALES)[number];
 
 /**
- * Popular posts ranking configuration — "Top" style (no time decay).
- * Posts are ranked purely by accumulated engagement within the selected window.
+ * Popular posts ranking configuration — all-time "Top" style with a short
+ * freshness boost so low-activity feeds still feel alive.
  */
 export const POPULAR_RANKING_CONFIG = {
   // time windows (hours)
@@ -232,6 +232,8 @@ export const POPULAR_RANKING_CONFIG = {
     trendingBoost: 0.5, // w_tr (topical relevance)
     contentQuality: 0.3, // w_q (anti-spam)
     reads: 1.5, // w_reads (common passive signal)
+    freshnessBoost: 0.9, // w_fresh (temporary new-post lift)
+    velocityBoost: 0.6, // w_vel (temporary lift for posts gaining activity quickly)
   },
 
   // user-facing scale controls tune relative importance instead of exposing raw weights
@@ -256,6 +258,14 @@ export const POPULAR_RANKING_CONFIG = {
 
   // trending scaling
   TRENDING_MAX_SCORE: 100, // scale trending tag score to [0..1]
+
+  // live popular behavior
+  FRESHNESS_BOOST_HOURS: 24,
+  AUTHOR_DIVERSITY: {
+    ENABLED: true,
+    OVERSAMPLE_MULTIPLIER: 4,
+    MIN_OVERSAMPLE: 80,
+  },
 
   // redis
   REDIS_KEYS: {

--- a/src/main.validation.spec.ts
+++ b/src/main.validation.spec.ts
@@ -14,6 +14,7 @@ import { BindXInviteDto } from './profile/dto/bind-x-invite.dto';
 import { CreateXPostingRecheckChallengeDto } from './profile/dto/create-x-posting-recheck-challenge.dto';
 import { SubmitXPostingRecheckDto } from './profile/dto/submit-x-posting-recheck.dto';
 import { CreateTrendingTagsDto } from './trending-tags/dto/create-trending-tags.dto';
+import { PopularPostsQueryDto } from './social/dto';
 
 describe('global ValidationPipe request DTO coverage', () => {
   const pipe = new ValidationPipe({
@@ -151,6 +152,21 @@ describe('global ValidationPipe request DTO coverage', () => {
         expect(result.minAumUsd).toBe(1);
         expect(result.timePeriod).toBe(30);
         expect(result.sortDir).toBe('DESC');
+      },
+    },
+    {
+      name: 'PopularPostsQueryDto',
+      metatype: PopularPostsQueryDto,
+      type: 'query' as const,
+      validPayload: {
+        window: '24h',
+        page: '2',
+        limit: '20',
+      },
+      assertTransformed(result: PopularPostsQueryDto) {
+        expect(result.window).toBe('24h');
+        expect(result.page).toBe(2);
+        expect(result.limit).toBe(20);
       },
     },
     {

--- a/src/social/controllers/posts.controller.spec.ts
+++ b/src/social/controllers/posts.controller.spec.ts
@@ -71,4 +71,50 @@ describe('PostsController', () => {
       limit: 100,
     });
   });
+
+  it('uses all-time ranking for popular posts and ignores legacy window queries', async () => {
+    const popularPost = {
+      id: 'post-popular',
+      sender_address: 'ak_author',
+      created_at: new Date().toISOString(),
+      content: 'popular post',
+      total_comments: 0,
+    };
+    const popularRankingService = {
+      getPopularPostsPage: jest.fn().mockResolvedValue({
+        items: [popularPost],
+        totalItems: 1,
+      }),
+    };
+    const hydratedPostQueryBuilder = {
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      getMany: jest.fn().mockResolvedValue([popularPost]),
+    };
+    const popularController = new PostsController(
+      {
+        createQueryBuilder: jest.fn().mockReturnValue(hydratedPostQueryBuilder),
+      } as any,
+      {} as any,
+      popularRankingService as any,
+      {} as any,
+      {
+        getProfilesByAddresses: jest.fn().mockResolvedValue([]),
+      } as any,
+    );
+
+    await popularController.popular({
+      page: 1,
+      limit: 20,
+      window: '24h',
+    } as any);
+
+    expect(popularRankingService.getPopularPostsPage).toHaveBeenCalledWith(
+      'all',
+      20,
+      0,
+      undefined,
+      expect.any(Object),
+    );
+  });
 });

--- a/src/social/controllers/posts.controller.ts
+++ b/src/social/controllers/posts.controller.ts
@@ -377,13 +377,12 @@ export class PostsController {
     operationId: 'popular',
     summary: 'Popular posts',
     description:
-      'Returns top posts for selected time window (24h, 7d, all). Ranked by accumulated engagement — no time decay. Optional scale params let clients personalize signal importance.',
+      'Returns all-time popular posts with a temporary freshness boost for new posts. Optional scale params let clients personalize signal importance.',
   })
   @ApiOkResponsePaginated(PostDto)
   @Get('popular')
   async popular(@Query() query: PopularPostsQueryDto) {
     const {
-      window = '24h',
       page = 1,
       limit = 50,
       debug,
@@ -396,6 +395,7 @@ export class PostsController {
       reads,
       interactionsPerHour,
     } = query;
+    const window = 'all' as const;
     const offset = (page - 1) * limit;
     const weightOverrides = {
       comments,
@@ -478,16 +478,10 @@ export class PostsController {
       }
       return response;
     } catch (error) {
-      const windowHoursMap = { '24h': 24, '7d': 24 * 7, all: 0 } as const;
-      const windowHours = windowHoursMap[window] || 0;
       const fallbackQb = this.postRepository
         .createQueryBuilder('post')
         .where('post.is_hidden = false')
         .andWhere('post.post_id IS NULL');
-      if (windowHours > 0) {
-        const since = new Date(Date.now() - windowHours * 60 * 60 * 1000);
-        fallbackQb.andWhere('post.created_at >= :since', { since });
-      }
       const fallbackBasePosts = await fallbackQb
         .orderBy('post.created_at', 'DESC')
         .offset(offset)

--- a/src/social/dto/popular-posts-query.dto.ts
+++ b/src/social/dto/popular-posts-query.dto.ts
@@ -10,12 +10,13 @@ import type { PopularWindow } from '../services/popular-ranking.service';
 export class PopularPostsQueryDto {
   @ApiPropertyOptional({
     enum: ['24h', '7d', 'all'],
-    description: 'Popular ranking time window',
-    default: '24h',
+    deprecated: true,
+    description:
+      'Deprecated. Popular ranking is now all-time; this value is accepted for backwards compatibility and ignored.',
   })
   @IsOptional()
   @IsIn(['24h', '7d', 'all'])
-  window?: PopularWindow = '24h';
+  window?: PopularWindow;
 
   @ApiPropertyOptional({
     type: Number,

--- a/src/social/services/popular-ranking.service.spec.ts
+++ b/src/social/services/popular-ranking.service.spec.ts
@@ -308,6 +308,64 @@ describe('PopularRankingService', () => {
 
       redisMock.zcard.mockResolvedValue(1);
     });
+
+    it('does not duplicate items across consecutive cached diversified pages', async () => {
+      const posts = [
+        {
+          id: 'post-a-strong',
+          sender_address: 'ak_author_a',
+          content: 'strong post',
+          is_hidden: false,
+          post_id: null,
+        },
+        {
+          id: 'post-a-second',
+          sender_address: 'ak_author_a',
+          content: 'second post',
+          is_hidden: false,
+          post_id: null,
+        },
+        {
+          id: 'post-b',
+          sender_address: 'ak_author_b',
+          content: 'other author post',
+          is_hidden: false,
+          post_id: null,
+        },
+        {
+          id: 'post-c',
+          sender_address: 'ak_author_c',
+          content: 'third author post',
+          is_hidden: false,
+          post_id: null,
+        },
+      ];
+
+      redisMock.zcard.mockResolvedValue(4);
+      (redisMock as any).zrevrange = jest
+        .fn()
+        .mockResolvedValue([
+          'post-a-strong',
+          '10',
+          'post-a-second',
+          '8',
+          'post-b',
+          '1',
+          'post-c',
+          '0',
+        ]);
+      postRepository.findBy = jest.fn().mockResolvedValue(posts);
+
+      const firstPage = await service.getPopularPostsPage('all', 2, 0);
+      const secondPage = await service.getPopularPostsPage('all', 2, 2);
+
+      const firstPageIds = firstPage.items.map((item) => item.id);
+      const secondPageIds = secondPage.items.map((item) => item.id);
+
+      expect(firstPageIds).toEqual(['post-a-strong', 'post-b']);
+      expect(secondPageIds).toEqual(['post-a-second', 'post-c']);
+      expect(firstPageIds.some((id) => secondPageIds.includes(id))).toBe(false);
+    });
   });
 
   describe('resolveWeights', () => {
@@ -627,6 +685,267 @@ describe('PopularRankingService', () => {
 
       expect(result.items).toEqual([]);
       expect(result.totalItems).toBe(1);
+    });
+  });
+
+  describe('live popular behavior', () => {
+    function buildScoredService(
+      posts: any[],
+      comments: Record<string, string>,
+    ) {
+      const candidateQB = {
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue(posts),
+      };
+      const commentQB = {
+        innerJoin: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue(
+          Object.entries(comments).map(([parent_id, count]) => ({
+            parent_id,
+            count,
+          })),
+        ),
+      };
+      const tipQB = {
+        select: jest.fn().mockReturnThis(),
+        innerJoin: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([]),
+      };
+      const readsQB = {
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([]),
+      };
+
+      return new PopularRankingService(
+        {
+          createQueryBuilder: jest
+            .fn()
+            .mockReturnValueOnce(candidateQB)
+            .mockReturnValueOnce(commentQB),
+          findBy: jest.fn().mockResolvedValue(posts),
+        } as any,
+        { createQueryBuilder: jest.fn().mockReturnValue(tipQB) } as any,
+        { find: jest.fn().mockResolvedValue([]) } as any,
+        { createQueryBuilder: jest.fn().mockReturnValue(readsQB) } as any,
+        [],
+      );
+    }
+
+    it('boosts fresh posts and removes that boost after 24 hours', async () => {
+      const now = Date.now();
+      const freshPost = {
+        id: 'post-fresh',
+        sender_address: 'ak_fresh',
+        created_at: new Date(now - 60 * 60 * 1000).toISOString(),
+        content: 'same quality content',
+        topics: [],
+      };
+      const dayOldPost = {
+        id: 'post-day-old',
+        sender_address: 'ak_day_old',
+        created_at: new Date(now - 25 * 60 * 60 * 1000).toISOString(),
+        content: 'same quality content',
+        topics: [],
+      };
+      const olderPost = {
+        id: 'post-older',
+        sender_address: 'ak_older',
+        created_at: new Date(now - 48 * 60 * 60 * 1000).toISOString(),
+        content: 'same quality content',
+        topics: [],
+      };
+      const svc = buildScoredService([dayOldPost, olderPost, freshPost], {});
+
+      const result = await svc.getPopularPostsPage('all', 10, 0, undefined, {
+        comments: 'med',
+      });
+      const scores = new Map(
+        result.scoredItems!.map((item) => [item.postId, item.score]),
+      );
+
+      expect(scores.get('post-fresh')).toBeGreaterThan(
+        scores.get('post-day-old')!,
+      );
+      expect(scores.get('post-day-old')).toBeCloseTo(scores.get('post-older')!);
+    });
+
+    it('avoids duplicate authors within a page when alternatives exist', async () => {
+      const now = Date.now();
+      const posts = [
+        {
+          id: 'post-a-strong',
+          sender_address: 'ak_author_a',
+          created_at: new Date(now - 2 * 60 * 60 * 1000).toISOString(),
+          content: 'strong post',
+          topics: [],
+        },
+        {
+          id: 'post-a-second',
+          sender_address: 'ak_author_a',
+          created_at: new Date(now - 2 * 60 * 60 * 1000).toISOString(),
+          content: 'second post',
+          topics: [],
+        },
+        {
+          id: 'post-b',
+          sender_address: 'ak_author_b',
+          created_at: new Date(now - 2 * 60 * 60 * 1000).toISOString(),
+          content: 'other author post',
+          topics: [],
+        },
+      ];
+      const svc = buildScoredService(posts, {
+        'post-a-strong': '10',
+        'post-a-second': '8',
+        'post-b': '1',
+      });
+
+      const result = await svc.getPopularPostsPage('all', 2, 0, undefined, {
+        comments: 'high',
+      });
+
+      expect(result.items.map((item) => item.id)).toEqual([
+        'post-a-strong',
+        'post-b',
+      ]);
+    });
+
+    it('does not duplicate items across consecutive diversified pages', async () => {
+      const now = Date.now();
+      const posts = [
+        {
+          id: 'post-a-strong',
+          sender_address: 'ak_author_a',
+          created_at: new Date(now - 2 * 60 * 60 * 1000).toISOString(),
+          content: 'strong post',
+          topics: [],
+        },
+        {
+          id: 'post-a-second',
+          sender_address: 'ak_author_a',
+          created_at: new Date(now - 2 * 60 * 60 * 1000).toISOString(),
+          content: 'second post',
+          topics: [],
+        },
+        {
+          id: 'post-b',
+          sender_address: 'ak_author_b',
+          created_at: new Date(now - 2 * 60 * 60 * 1000).toISOString(),
+          content: 'other author post',
+          topics: [],
+        },
+        {
+          id: 'post-c',
+          sender_address: 'ak_author_c',
+          created_at: new Date(now - 2 * 60 * 60 * 1000).toISOString(),
+          content: 'third author post',
+          topics: [],
+        },
+      ];
+
+      const firstPageService = buildScoredService(posts, {
+        'post-a-strong': '10',
+        'post-a-second': '8',
+        'post-b': '1',
+        'post-c': '0',
+      });
+      const secondPageService = buildScoredService(posts, {
+        'post-a-strong': '10',
+        'post-a-second': '8',
+        'post-b': '1',
+        'post-c': '0',
+      });
+
+      const firstPage = await firstPageService.getPopularPostsPage(
+        'all',
+        2,
+        0,
+        undefined,
+        { comments: 'high' },
+      );
+      const secondPage = await secondPageService.getPopularPostsPage(
+        'all',
+        2,
+        2,
+        undefined,
+        { comments: 'high' },
+      );
+
+      const firstPageIds = firstPage.items.map((item) => item.id);
+      const secondPageIds = secondPage.items.map((item) => item.id);
+
+      expect(firstPageIds).toEqual(['post-a-strong', 'post-b']);
+      expect(secondPageIds).toEqual(['post-a-second', 'post-c']);
+      expect(firstPageIds.some((id) => secondPageIds.includes(id))).toBe(false);
+    });
+
+    it('explains the same diversified items returned by personalized ranking', async () => {
+      const now = Date.now();
+      const posts = [
+        {
+          id: 'post-a-strong',
+          sender_address: 'ak_author_a',
+          created_at: new Date(now - 2 * 60 * 60 * 1000).toISOString(),
+          content: 'strong post',
+          topics: [],
+        },
+        {
+          id: 'post-a-second',
+          sender_address: 'ak_author_a',
+          created_at: new Date(now - 2 * 60 * 60 * 1000).toISOString(),
+          content: 'second post',
+          topics: [],
+        },
+        {
+          id: 'post-b',
+          sender_address: 'ak_author_b',
+          created_at: new Date(now - 2 * 60 * 60 * 1000).toISOString(),
+          content: 'other author post',
+          topics: [],
+        },
+      ];
+      const svc = buildScoredService(posts, {
+        'post-a-strong': '10',
+        'post-a-second': '8',
+        'post-b': '1',
+      });
+      const weightOverrides = { comments: 'high' as const };
+
+      const result = await svc.getPopularPostsPage(
+        'all',
+        2,
+        0,
+        undefined,
+        weightOverrides,
+      );
+      const explanation = await svc.explain(
+        'all',
+        2,
+        0,
+        weightOverrides,
+        result.scoredItems,
+      );
+
+      expect(explanation.map((item) => item.id)).toEqual(
+        result.items.map((item) => item.id),
+      );
     });
   });
 

--- a/src/social/services/popular-ranking.service.ts
+++ b/src/social/services/popular-ranking.service.ts
@@ -152,6 +152,93 @@ export class PopularRankingService {
     return POPULAR_RANKING_CONFIG.REDIS_KEYS.popularAll;
   }
 
+  private getDiversityCandidateLimit(limit: number): number {
+    if (!POPULAR_RANKING_CONFIG.AUTHOR_DIVERSITY.ENABLED) {
+      return limit;
+    }
+
+    return Math.max(
+      limit * POPULAR_RANKING_CONFIG.AUTHOR_DIVERSITY.OVERSAMPLE_MULTIPLIER,
+      POPULAR_RANKING_CONFIG.AUTHOR_DIVERSITY.MIN_OVERSAMPLE,
+    );
+  }
+
+  private getDiversityCandidateEnd(offset: number, limit: number): number {
+    if (!POPULAR_RANKING_CONFIG.AUTHOR_DIVERSITY.ENABLED) {
+      return offset + limit;
+    }
+
+    return offset + this.getDiversityCandidateLimit(limit);
+  }
+
+  private getDiversityAuthorKey(
+    item: Post | PopularRankingContentItem,
+  ): string {
+    if (item.sender_address) {
+      return item.sender_address;
+    }
+
+    return `${'type' in item ? item.type : 'post'}:${item.id}`;
+  }
+
+  private diversifyRankedItems<T extends Post | PopularRankingContentItem>(
+    items: T[],
+    limit: number,
+  ): T[] {
+    if (!POPULAR_RANKING_CONFIG.AUTHOR_DIVERSITY.ENABLED || limit <= 0) {
+      return items.slice(0, limit);
+    }
+
+    const selected: T[] = [];
+    const deferred: T[] = [];
+    const selectedAuthors = new Set<string>();
+
+    for (const item of items) {
+      const authorKey = this.getDiversityAuthorKey(item);
+      if (!selectedAuthors.has(authorKey)) {
+        selected.push(item);
+        selectedAuthors.add(authorKey);
+
+        if (selected.length === limit) {
+          return selected;
+        }
+        continue;
+      }
+
+      deferred.push(item);
+    }
+
+    return selected.concat(deferred.slice(0, limit - selected.length));
+  }
+
+  private paginateDiversifiedRankedItems<
+    T extends Post | PopularRankingContentItem,
+  >(items: T[], limit: number, offset: number): T[] {
+    if (!POPULAR_RANKING_CONFIG.AUTHOR_DIVERSITY.ENABLED || limit <= 0) {
+      return items.slice(offset, offset + limit);
+    }
+
+    const targetEnd = offset + limit;
+    const selectedItems: T[] = [];
+    let remainingItems = items;
+
+    while (selectedItems.length < targetEnd && remainingItems.length > 0) {
+      const pageItems = this.diversifyRankedItems(remainingItems, limit);
+      if (pageItems.length === 0) {
+        break;
+      }
+
+      selectedItems.push(...pageItems);
+
+      const selectedIds = new Set(pageItems.map((item) => item.id));
+      remainingItems = remainingItems.filter(
+        (item) => !selectedIds.has(item.id),
+      );
+    }
+
+    return selectedItems.slice(offset, targetEnd);
+  }
+
   /**
    * Get verified popular post IDs from Redis, ensuring they exist in DB
    */
@@ -411,10 +498,13 @@ export class PopularRankingService {
       return this.fetchRecentFallback(window, limit, offset);
     }
 
-    return this.hydrateRankedItems(
+    const candidateEnd = this.getDiversityCandidateEnd(offset, limit);
+    const items = await this.hydrateRankedItems(
       window,
-      verifiedIds.slice(offset, offset + limit),
+      verifiedIds.slice(0, candidateEnd),
     );
+
+    return this.paginateDiversifiedRankedItems(items, limit, offset);
   }
 
   async getPopularPostsPage(
@@ -444,12 +534,14 @@ export class PopularRankingService {
       maxCandidates ?? this.getDefaultMaxCandidates(window),
       weightOverrides,
     );
+    const candidateEnd = this.getDiversityCandidateEnd(offset, limit);
     const paginatedIds = scored
-      .slice(offset, offset + limit)
+      .slice(0, candidateEnd)
       .map((item) => item.postId);
+    const items = await this.hydrateRankedItems(window, paginatedIds);
 
     return {
-      items: await this.hydrateRankedItems(window, paginatedIds),
+      items: this.paginateDiversifiedRankedItems(items, limit, offset),
       totalItems: scored.length,
       scoredItems: scored,
     };
@@ -767,21 +859,11 @@ export class PopularRankingService {
     input: PopularScoreInput,
     window: PopularWindow,
   ): number {
-    const createdAt =
-      input.createdAt instanceof Date
-        ? input.createdAt
-        : input.createdAt
-          ? new Date(input.createdAt)
-          : null;
-
-    if (!createdAt || Number.isNaN(createdAt.getTime())) {
+    const ageHours = this.computeAgeHours(input.createdAt);
+    if (ageHours === null) {
       return 0;
     }
 
-    const ageHours = Math.max(
-      1,
-      (Date.now() - createdAt.getTime()) / (60 * 60 * 1000),
-    );
     const effectiveHours =
       window === 'all'
         ? ageHours
@@ -791,6 +873,41 @@ export class PopularRankingService {
       (input.comments + input.tipsCount + input.uniqueTippers) /
       Math.max(1, effectiveHours)
     );
+  }
+
+  private computeAgeHours(
+    createdAt?: Date | string,
+    minimumHours = 1,
+  ): number | null {
+    const date =
+      createdAt instanceof Date
+        ? createdAt
+        : createdAt
+          ? new Date(createdAt)
+          : null;
+
+    if (!date || Number.isNaN(date.getTime())) {
+      return null;
+    }
+
+    return Math.max(
+      minimumHours,
+      (Date.now() - date.getTime()) / (60 * 60 * 1000),
+    );
+  }
+
+  private computeFreshnessFactor(input: PopularScoreInput): number {
+    const ageHours = this.computeAgeHours(input.createdAt, 0);
+    if (ageHours === null) {
+      return 0;
+    }
+
+    const boostHours = POPULAR_RANKING_CONFIG.FRESHNESS_BOOST_HOURS;
+    if (ageHours >= boostHours) {
+      return 0;
+    }
+
+    return Math.max(0, 1 - ageHours / boostHours);
   }
 
   private computeScore(
@@ -818,6 +935,7 @@ export class PopularRankingService {
 
     const contentQuality = this.computeContentQuality(input.content || '');
     const interactionsPerHour = this.computeInteractionsPerHour(input, window);
+    const freshnessFactor = this.computeFreshnessFactor(input);
 
     return (
       weights.comments * Math.log(1 + comments) +
@@ -827,6 +945,10 @@ export class PopularRankingService {
       weights.reads * Math.log(1 + reads) +
       weights.trendingBoost * trendingBoost +
       weights.contentQuality * contentQuality +
+      weights.freshnessBoost * freshnessFactor +
+      weights.velocityBoost *
+        Math.log(1 + interactionsPerHour) *
+        freshnessFactor +
       weights.interactionsPerHour * Math.log(1 + interactionsPerHour)
     );
   }
@@ -853,22 +975,34 @@ export class PopularRankingService {
           this.getDefaultMaxCandidates(window),
           weightOverrides,
         ));
-      const ids = scored
-        .slice(offset, offset + limit)
-        .map((item) => item.postId);
-      items = await this.hydrateRankedItems(window, ids);
+      const candidateEnd = this.getDiversityCandidateEnd(offset, limit);
+      const ids = scored.slice(0, candidateEnd).map((item) => item.postId);
+      const candidateItems = await this.hydrateRankedItems(window, ids);
+      items = this.paginateDiversifiedRankedItems(
+        candidateItems,
+        limit,
+        offset,
+      );
     } else {
       const key = this.getRedisKey(window);
-      const ids = await this.redis.zrevrange(key, offset, offset + limit - 1);
-      items = ids.length
-        ? await this.postRepository.findBy({ id: In(ids) })
-        : await this.postRepository
-            .createQueryBuilder('post')
-            .where('post.is_hidden = false')
-            .andWhere('post.post_id IS NULL')
-            .orderBy('post.created_at', 'DESC')
-            .limit(limit)
-            .getMany();
+      const candidateEnd = this.getDiversityCandidateEnd(offset, limit);
+      const ids = await this.redis.zrevrange(key, 0, candidateEnd - 1);
+      if (ids.length) {
+        const candidateItems = await this.hydrateRankedItems(window, ids);
+        items = this.paginateDiversifiedRankedItems(
+          candidateItems,
+          limit,
+          offset,
+        );
+      } else {
+        items = await this.postRepository
+          .createQueryBuilder('post')
+          .where('post.is_hidden = false')
+          .andWhere('post.post_id IS NULL')
+          .orderBy('post.created_at', 'DESC')
+          .limit(limit)
+          .getMany();
+      }
     }
 
     return items.map((item) => ({


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core feed-ranking behavior (scoring, pagination, and API semantics), which can materially affect what content users see and how Redis-cached results are served. Risk is moderate due to new freshness/velocity signals and per-page author de-duplication logic that could introduce ordering/pagination edge cases.
> 
> **Overview**
> Updates `GET /posts/popular` to always serve an **all-time** popular ranking (legacy `window` query is now deprecated/ignored) and adjusts the fallback path to no longer apply window-based time filters.
> 
> Evolves the ranking model to a **"Top + fresh"** approach by adding a bounded 24h freshness factor and velocity boost to scoring, tuning weights (notably lowering `tipsAmountAE`), and introducing optional per-page **author diversity** reranking via oversampling + de-duplication across paginated pages.
> 
> Adds/updates tests and docs to cover the new API semantics, validation, freshness behavior, and diversified pagination/explain output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cae8c5ff1953f64674ba8be78b402b828de72bef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->