### PR TITLE
feat: add post analytics functionality and update account entity

### DIFF
--- a/src/account/entities/account.entity.ts
+++ b/src/account/entities/account.entity.ts
@@ -81,6 +81,9 @@ export class Account {
   @Column({ type: 'jsonb', default: {} })
   links: Record<string, string>;
 
+  @Column({ default: false })
+  banned: boolean;
+
   @CreateDateColumn({
     type: 'timestamp',
     default: () => 'CURRENT_TIMESTAMP(6)',

--- a/src/analytics/controllers/analytic.controller.ts
+++ b/src/analytics/controllers/analytic.controller.ts
@@ -11,6 +11,7 @@ import { Analytic } from '../entities/analytic.entity';
 import { ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
 import moment from 'moment';
 import { CacheDailyAnalyticsDataService } from '../services/cache-daily-analytics-data.service';
+import { OptionalAeAccountAddressPipe } from '@/common/validation/request-validation';
 
 @Controller('analytics')
 @ApiTags('Analytics')
@@ -28,6 +29,7 @@ export class AnalyticController {
   @ApiQuery({ name: 'start_date', type: 'string', required: false })
   @ApiQuery({ name: 'end_date', type: 'string', required: false })
   @ApiQuery({ name: 'force_pull', type: 'boolean', required: false })
+  @ApiQuery({ name: 'address', type: 'string', required: false })
   @ApiOperation({
     operationId: 'getAnalyticsData',
   })
@@ -35,6 +37,8 @@ export class AnalyticController {
     @Query('start_date') start_date: string,
     @Query('end_date') end_date: string,
     @Query('force_pull') force_pull: boolean,
+    @Query('address', OptionalAeAccountAddressPipe)
+    address: string | undefined,
   ) {
     const startDate = moment(
       start_date ?? moment().subtract(10, 'day').format('YYYY-MM-DD'),
@@ -46,6 +50,16 @@ export class AnalyticController {
     // if the dates are not valid, return an error
     if (startDate > endDate) {
       throw new BadRequestException('Start date must be before end date');
+    }
+
+    // When filtering by address, always go live so the result reflects the
+    // requested user (the cached `analytics` table only stores global aggregates).
+    if (address) {
+      return this.cacheDailyAnalyticsDataService.getDateRangeAnalyticsLive(
+        startDate,
+        endDate,
+        address,
+      );
     }
 
     if (force_pull) {
@@ -62,17 +76,49 @@ export class AnalyticController {
     return analytics;
   }
 
+  @Get('summary')
+  @ApiQuery({ name: 'start_date', type: 'string', required: false })
+  @ApiQuery({ name: 'end_date', type: 'string', required: false })
+  @ApiQuery({ name: 'address', type: 'string', required: false })
+  @ApiOperation({
+    operationId: 'getAnalyticsSummary',
+  })
+  async getRangeSummary(
+    @Query('start_date') start_date: string,
+    @Query('end_date') end_date: string,
+    @Query('address', OptionalAeAccountAddressPipe)
+    address: string | undefined,
+  ) {
+    const startDate = start_date ? moment(start_date).toDate() : undefined;
+    const endDate = end_date ? moment(end_date).toDate() : undefined;
+
+    if (startDate && endDate && startDate > endDate) {
+      throw new BadRequestException('Start date must be before end date');
+    }
+
+    return this.cacheDailyAnalyticsDataService.getRangeSummary(
+      startDate,
+      endDate,
+      address,
+    );
+  }
+
   @Get('past-24-hours')
+  @ApiQuery({ name: 'address', type: 'string', required: false })
   @ApiOperation({
     operationId: 'getPast24HoursAnalytics',
   })
-  async getPast24HoursAnalytics() {
+  async getPast24HoursAnalytics(
+    @Query('address', OptionalAeAccountAddressPipe)
+    address: string | undefined,
+  ) {
     const startDate = moment().subtract(24, 'hours').toDate();
-    const endDate = moment().add(1, 'day').toDate();
+    const endDate = moment().toDate();
     const analyticsData =
       await this.cacheDailyAnalyticsDataService.getDateAnalytics(
         startDate,
         endDate,
+        address,
       );
     return analyticsData;
   }

--- a/src/analytics/services/cache-daily-analytics-data.service.ts
+++ b/src/analytics/services/cache-daily-analytics-data.service.ts
@@ -105,7 +105,14 @@ export class CacheDailyAnalyticsDataService {
     return analytic;
   }
 
-  async getDateAnalytics(startOfDay: Date, endOfDay: Date) {
+  async getDateAnalytics(startOfDay: Date, endOfDay: Date, address?: string) {
+    const params: any[] = [startOfDay, endOfDay, TX_FUNCTIONS.create_community];
+    let addressFilter = '';
+    if (address) {
+      params.push(address);
+      addressFilter = ' AND address = $4';
+    }
+
     const [txAgg] = await this.transactionsRepository.query(
       `SELECT
          COUNT(*)::int                              AS total_transactions,
@@ -117,17 +124,18 @@ export class CacheDailyAnalyticsDataService {
            WHERE tx_type = $3
          )::int                                     AS total_created_tokens
        FROM transactions
-       WHERE created_at BETWEEN $1 AND $2`,
-      [startOfDay, endOfDay, TX_FUNCTIONS.create_community],
+       WHERE created_at BETWEEN $1 AND $2${addressFilter}`,
+      params,
     );
 
     const totalTokens = await this.tokensRepository.count({
       where: {
         created_at: LessThan(endOfDay),
+        ...(address ? { creator_address: address } : {}),
       },
     });
 
-    const totalMarketCap = await this.getMarketCapSum(endOfDay);
+    const totalMarketCap = await this.getMarketCapSum(endOfDay, address);
 
     return {
       date: moment(startOfDay).format('YYYY-MM-DD'),
@@ -140,7 +148,159 @@ export class CacheDailyAnalyticsDataService {
     };
   }
 
-  private async getMarketCapSum(date: Date): Promise<BigNumber> {
+  /**
+   * Per-day analytics computed live (no cache).
+   * Mirrors the cached `analytics` row shape so the frontend can use it
+   * interchangeably. Used when filtering by address.
+   */
+  async getDateRangeAnalyticsLive(
+    startDate: Date,
+    endDate: Date,
+    address?: string,
+  ) {
+    const startOfRange = moment(startDate).startOf('day').toDate();
+    const endOfRange = moment(endDate).endOf('day').toDate();
+
+    const params: any[] = [
+      startOfRange,
+      endOfRange,
+      TX_FUNCTIONS.create_community,
+    ];
+    let addressFilter = '';
+    if (address) {
+      params.push(address);
+      addressFilter = ' AND address = $4';
+    }
+
+    const rows: Array<{
+      day: Date;
+      total_transactions: string | number;
+      total_active_accounts: string | number;
+      total_volume: string;
+      total_created_tokens: string | number;
+    }> = await this.transactionsRepository.query(
+      `SELECT
+         date_trunc('day', created_at) AS day,
+         COUNT(*)::int                              AS total_transactions,
+         COUNT(DISTINCT address)::int               AS total_active_accounts,
+         COALESCE(SUM(
+           CAST(NULLIF(amount->>'ae', 'NaN') AS decimal)
+         ), 0)                                      AS total_volume,
+         COUNT(*) FILTER (
+           WHERE tx_type = $3
+         )::int                                     AS total_created_tokens
+       FROM transactions
+       WHERE created_at BETWEEN $1 AND $2${addressFilter}
+       GROUP BY day
+       ORDER BY day ASC`,
+      params,
+    );
+
+    if (rows.length === 0) {
+      return [];
+    }
+
+    const enriched = await Promise.all(
+      rows.map(async (row) => {
+        const dayKey = moment(row.day).startOf('day').format('YYYY-MM-DD');
+        const endOfThatDay = moment(dayKey).endOf('day').toDate();
+        const [totalTokens, totalMarketCap] = await Promise.all([
+          this.tokensRepository.count({
+            where: {
+              created_at: LessThan(endOfThatDay),
+              ...(address ? { creator_address: address } : {}),
+            },
+          }),
+          this.getMarketCapSum(endOfThatDay, address),
+        ]);
+        return {
+          date: dayKey,
+          total_market_cap_sum: totalMarketCap,
+          total_volume_sum: new BigNumber(row.total_volume || 0),
+          total_tokens: totalTokens,
+          total_transactions: Number(row.total_transactions ?? 0),
+          total_created_tokens: Number(row.total_created_tokens ?? 0),
+          total_active_accounts: Number(row.total_active_accounts ?? 0),
+        };
+      }),
+    );
+
+    return enriched;
+  }
+
+  /**
+   * Range-aggregated summary stats. Computes the TRUE distinct count of
+   * wallet accounts active in the range (not a sum of per-day distincts,
+   * which over-counts users active on multiple days).
+   *
+   * If `startDate`/`endDate` are omitted, the count is all-time.
+   */
+  async getRangeSummary(
+    startDate: Date | undefined,
+    endDate: Date | undefined,
+    address?: string,
+  ) {
+    const params: any[] = [];
+    const where: string[] = [];
+
+    if (startDate && endDate) {
+      params.push(
+        moment(startDate).startOf('day').toDate(),
+        moment(endDate).endOf('day').toDate(),
+      );
+      where.push(
+        `created_at BETWEEN $${params.length - 1} AND $${params.length}`,
+      );
+    } else if (startDate) {
+      params.push(moment(startDate).startOf('day').toDate());
+      where.push(`created_at >= $${params.length}`);
+    } else if (endDate) {
+      params.push(moment(endDate).endOf('day').toDate());
+      where.push(`created_at <= $${params.length}`);
+    }
+
+    if (address) {
+      params.push(address);
+      where.push(`address = $${params.length}`);
+    }
+
+    const whereClause = where.length > 0 ? `WHERE ${where.join(' AND ')}` : '';
+
+    const [agg] = await this.transactionsRepository.query(
+      `SELECT COUNT(DISTINCT address)::int AS total_unique_accounts
+       FROM transactions
+       ${whereClause}`,
+      params,
+    );
+
+    return {
+      total_unique_accounts: Number(agg?.total_unique_accounts ?? 0),
+    };
+  }
+
+  private async getMarketCapSum(
+    date: Date,
+    address?: string,
+  ): Promise<BigNumber> {
+    if (address) {
+      const [result] = await this.transactionsRepository.query(
+        `SELECT COALESCE(SUM(cap.market_cap), 0) AS total
+         FROM (
+           SELECT DISTINCT ON (sale_address)
+             CAST(NULLIF(market_cap->>'ae', 'NaN') AS decimal) AS market_cap
+           FROM transactions
+           WHERE market_cap->>'ae' IS NOT NULL
+             AND created_at <= $1
+             AND sale_address IN (
+               SELECT sale_address FROM token WHERE creator_address = $2
+             )
+           ORDER BY sale_address, created_at DESC
+         ) cap`,
+        [date, address],
+      );
+      return new BigNumber(result.total || 0);
+    }
+
     const [result] = await this.transactionsRepository.query(
       `SELECT COALESCE(SUM(cap.market_cap), 0) AS total
        FROM (

--- a/src/social/controllers/post-analytics.controller.ts
+++ b/src/social/controllers/post-analytics.controller.ts
@@ -1,0 +1,167 @@
+import {
+  BadRequestException,
+  Controller,
+  DefaultValuePipe,
+  Get,
+  ParseIntPipe,
+  Query,
+  Render,
+} from '@nestjs/common';
+import { ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
+import moment from 'moment';
+import { OptionalAeAccountAddressPipe } from '@/common/validation/request-validation';
+import { ProfileReadService } from '@/profile/services/profile-read.service';
+import {
+  CacheDailyPostAnalyticsService,
+  DatePostAnalyticsRow,
+} from '../services/cache-daily-post-analytics.service';
+
+@Controller('posts/analytics')
+@ApiTags('Posts Analytics')
+export class PostAnalyticsController {
+  constructor(
+    private cacheDailyPostAnalyticsService: CacheDailyPostAnalyticsService,
+    private profileReadService: ProfileReadService,
+  ) {
+    //
+  }
+
+  @Get('')
+  @ApiQuery({ name: 'start_date', type: 'string', required: false })
+  @ApiQuery({ name: 'end_date', type: 'string', required: false })
+  @ApiQuery({ name: 'sender_address', type: 'string', required: false })
+  @ApiOperation({
+    operationId: 'getPostsAnalyticsData',
+  })
+  async getPostsAnalyticsData(
+    @Query('start_date') start_date: string,
+    @Query('end_date') end_date: string,
+    @Query('sender_address', OptionalAeAccountAddressPipe)
+    sender_address: string | undefined,
+  ): Promise<DatePostAnalyticsRow[]> {
+    const startDate = moment(
+      start_date ?? moment().subtract(10, 'day').format('YYYY-MM-DD'),
+    ).toDate();
+    const endDate = moment(
+      end_date ?? moment().format('YYYY-MM-DD'),
+    ).toDate();
+
+    if (startDate > endDate) {
+      throw new BadRequestException('Start date must be before end date');
+    }
+
+    // Always use live aggregation: it's a fast indexed query against `posts`,
+    // and avoids stale/incomplete results while the cron backfills `post_analytics`.
+    return this.cacheDailyPostAnalyticsService.getDateRangeAnalyticsLive(
+      startDate,
+      endDate,
+      sender_address,
+    );
+  }
+
+  @Get('past-24-hours')
+  @ApiQuery({ name: 'sender_address', type: 'string', required: false })
+  @ApiOperation({
+    operationId: 'getPostsPast24HoursAnalytics',
+  })
+  async getPast24HoursAnalytics(
+    @Query('sender_address', OptionalAeAccountAddressPipe)
+    sender_address: string | undefined,
+  ) {
+    const startDate = moment().subtract(24, 'hours').toDate();
+    const endDate = moment().toDate();
+    return this.cacheDailyPostAnalyticsService.getDateAnalytics(
+      startDate,
+      endDate,
+      sender_address,
+    );
+  }
+
+  @Get('top-posters')
+  @ApiQuery({ name: 'start_date', type: 'string', required: false })
+  @ApiQuery({ name: 'end_date', type: 'string', required: false })
+  @ApiQuery({ name: 'limit', type: 'number', required: false })
+  @ApiOperation({
+    operationId: 'getTopPosters',
+  })
+  async getTopPosters(
+    @Query('start_date') start_date: string,
+    @Query('end_date') end_date: string,
+    @Query('limit', new DefaultValuePipe(10), ParseIntPipe) limit: number,
+  ) {
+    const startDate = moment(
+      start_date ?? moment().subtract(10, 'day').format('YYYY-MM-DD'),
+    ).toDate();
+    const endDate = moment(
+      end_date ?? moment().add(1, 'day').format('YYYY-MM-DD'),
+    ).toDate();
+
+    if (startDate > endDate) {
+      throw new BadRequestException('Start date must be before end date');
+    }
+
+    const posters = await this.cacheDailyPostAnalyticsService.getTopPosters(
+      startDate,
+      endDate,
+      limit,
+    );
+
+    if (posters.length === 0) {
+      return [];
+    }
+
+    let profilesByAddress = new Map<string, string>();
+    try {
+      const profiles = await this.profileReadService.getProfilesByAddresses(
+        posters.map((poster) => poster.sender_address),
+      );
+      profilesByAddress = new Map(
+        profiles.map((profile) => [profile.address, profile.public_name]),
+      );
+    } catch {
+      // Profile lookup is best-effort; fall back to address-only display.
+    }
+
+    return posters.map((poster) => ({
+      ...poster,
+      public_name:
+        profilesByAddress.get(poster.sender_address) ?? poster.sender_address,
+    }));
+  }
+
+  @Get('top-topics')
+  @ApiQuery({ name: 'start_date', type: 'string', required: false })
+  @ApiQuery({ name: 'end_date', type: 'string', required: false })
+  @ApiQuery({ name: 'limit', type: 'number', required: false })
+  @ApiOperation({
+    operationId: 'getTopTopics',
+  })
+  async getTopTopics(
+    @Query('start_date') start_date: string,
+    @Query('end_date') end_date: string,
+    @Query('limit', new DefaultValuePipe(10), ParseIntPipe) limit: number,
+  ) {
+    const startDate = moment(
+      start_date ?? moment().subtract(10, 'day').format('YYYY-MM-DD'),
+    ).toDate();
+    const endDate = moment(
+      end_date ?? moment().add(1, 'day').format('YYYY-MM-DD'),
+    ).toDate();
+
+    if (startDate > endDate) {
+      throw new BadRequestException('Start date must be before end date');
+    }
+
+    return this.cacheDailyPostAnalyticsService.getTopTopics(
+      startDate,
+      endDate,
+      limit,
+    );
+  }
+
+  @Get('preview')
+  @Render('posts-analytics')
+  root() {
+    return { message: 'Posts Analytics Dashboard' };
+  }
+}

--- a/src/social/controllers/post-analytics.controller.ts
+++ b/src/social/controllers/post-analytics.controller.ts
@@ -42,9 +42,7 @@ export class PostAnalyticsController {
     const startDate = moment(
       start_date ?? moment().subtract(10, 'day').format('YYYY-MM-DD'),
     ).toDate();
-    const endDate = moment(
-      end_date ?? moment().format('YYYY-MM-DD'),
-    ).toDate();
+    const endDate = moment(end_date ?? moment().format('YYYY-MM-DD')).toDate();
 
     if (startDate > endDate) {
       throw new BadRequestException('Start date must be before end date');

--- a/src/social/entities/post-analytic.entity.ts
+++ b/src/social/entities/post-analytic.entity.ts
@@ -1,0 +1,44 @@
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity({
+  name: 'post_analytics',
+})
+export class PostAnalytic {
+  @PrimaryGeneratedColumn()
+  id: string;
+
+  @Column({
+    type: 'date',
+    unique: true,
+  })
+  public date: Date;
+
+  @Column({ default: 0 })
+  total_posts: number;
+
+  @Column({ default: 0 })
+  total_comments: number;
+
+  @Column({ default: 0 })
+  total_all: number;
+
+  @Column({ default: 0 })
+  total_unique_posters: number;
+
+  @Column({ default: 0 })
+  cumulative_total_posts: number;
+
+  @Column({
+    type: 'numeric',
+    precision: 18,
+    scale: 4,
+    default: 0,
+    transformer: {
+      from: (value: string | null | undefined): number =>
+        value == null ? 0 : Number(value),
+      to: (value: number | null | undefined): number =>
+        value == null ? 0 : value,
+    },
+  })
+  avg_comments_per_post: number;
+}

--- a/src/social/entities/post.entity.ts
+++ b/src/social/entities/post.entity.ts
@@ -15,10 +15,7 @@ import { Topic } from './topic.entity';
   name: 'posts',
 })
 @Index('IDX_POSTS_CREATED_AT', ['created_at'])
-@Index('IDX_POSTS_SENDER_ADDRESS_CREATED_AT', [
-  'sender_address',
-  'created_at',
-])
+@Index('IDX_POSTS_SENDER_ADDRESS_CREATED_AT', ['sender_address', 'created_at'])
 export class Post {
   @PrimaryColumn()
   id: string;

--- a/src/social/entities/post.entity.ts
+++ b/src/social/entities/post.entity.ts
@@ -2,6 +2,7 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  Index,
   JoinColumn,
   JoinTable,
   ManyToMany,
@@ -13,6 +14,11 @@ import { Topic } from './topic.entity';
 @Entity({
   name: 'posts',
 })
+@Index('IDX_POSTS_CREATED_AT', ['created_at'])
+@Index('IDX_POSTS_SENDER_ADDRESS_CREATED_AT', [
+  'sender_address',
+  'created_at',
+])
 export class Post {
   @PrimaryColumn()
   id: string;
@@ -38,6 +44,7 @@ export class Post {
   @Column('json')
   tx_args: any[];
 
+  @Index()
   @Column()
   sender_address: string;
 

--- a/src/social/post.module.ts
+++ b/src/social/post.module.ts
@@ -6,13 +6,16 @@ import { Tip } from '@/tipping/entities/tip.entity';
 import { TrendingTag } from '@/trending-tags/entities/trending-tags.entity';
 import { Token } from '@/tokens/entities/token.entity';
 import { PostReadsDaily } from './entities/post-reads.entity';
+import { PostAnalytic } from './entities/post-analytic.entity';
 import { ReadsService } from './services/reads.service';
 import { PostService } from './services/post.service';
 import { PopularRankingService } from './services/popular-ranking.service';
+import { CacheDailyPostAnalyticsService } from './services/cache-daily-post-analytics.service';
 import { TransactionsModule } from '@/transactions/transactions.module';
 import { PostsController } from './controllers/posts.controller';
 import { TopicsController } from './controllers/topics.controller';
 import { GiphyController } from './controllers/giphy.controller';
+import { PostAnalyticsController } from './controllers/post-analytics.controller';
 import { GovernancePluginModule } from '@/plugins/governance/governance-plugin.module';
 import { getPopularRankingContributorProvider } from '@/plugins';
 import { ProfileModule } from '@/profile/profile.module';
@@ -31,16 +34,25 @@ import { TokensModule } from '@/tokens/tokens.module';
       TrendingTag,
       Token,
       PostReadsDaily,
+      PostAnalytic,
     ]),
   ],
   providers: [
     PostService,
     PopularRankingService,
     ReadsService,
+    CacheDailyPostAnalyticsService,
     getPopularRankingContributorProvider(),
   ],
   exports: [PostService, PopularRankingService, ReadsService, TypeOrmModule],
-  controllers: [PostsController, TopicsController, GiphyController],
+  controllers: [
+    // Register PostAnalyticsController BEFORE PostsController so that its
+    // /posts/analytics/* routes are matched before PostsController's /posts/:id.
+    PostAnalyticsController,
+    PostsController,
+    TopicsController,
+    GiphyController,
+  ],
 })
 export class PostModule {
   //

--- a/src/social/services/cache-daily-post-analytics.service.ts
+++ b/src/social/services/cache-daily-post-analytics.service.ts
@@ -1,0 +1,370 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { InjectRepository } from '@nestjs/typeorm';
+import moment from 'moment';
+import { LessThan, Repository } from 'typeorm';
+import { Post } from '../entities/post.entity';
+import { PostAnalytic } from '../entities/post-analytic.entity';
+
+export interface DatePostAnalyticsRow {
+  date: string;
+  total_posts: number;
+  total_comments: number;
+  total_all: number;
+  total_unique_posters: number;
+  cumulative_total_posts: number;
+  avg_comments_per_post: number;
+}
+
+@Injectable()
+export class CacheDailyPostAnalyticsService {
+  private readonly logger = new Logger(CacheDailyPostAnalyticsService.name);
+
+  constructor(
+    @InjectRepository(PostAnalytic)
+    private postAnalyticsRepository: Repository<PostAnalytic>,
+
+    @InjectRepository(Post)
+    private postsRepository: Repository<Post>,
+  ) {
+    //
+  }
+
+  onModuleInit() {
+    setTimeout(() => this.pullDailyPostAnalyticsData(), 20_000);
+  }
+
+  isPullingDailyPostAnalyticsData = false;
+  @Cron(CronExpression.EVERY_HOUR)
+  async pullDailyPostAnalyticsData() {
+    if (this.isPullingDailyPostAnalyticsData) {
+      return;
+    }
+    this.isPullingDailyPostAnalyticsData = true;
+    try {
+      const latestAnalytic = await this.postAnalyticsRepository.findOne({
+        where: {},
+        order: {
+          date: 'DESC',
+        },
+      });
+
+      let startDate = latestAnalytic?.date;
+
+      if (!startDate) {
+        const firstPost = await this.postsRepository.findOne({
+          where: {},
+          order: {
+            created_at: 'ASC',
+          },
+        });
+        startDate = firstPost?.created_at;
+      } else {
+        // re-pull last 7 days to keep recent data fresh
+        startDate = moment().subtract(7, 'day').toDate();
+      }
+
+      if (!startDate) {
+        return;
+      }
+
+      const endDate = moment().add(1, 'day').toDate();
+
+      await this.pullAnalyticsDataByDateRange(startDate, endDate);
+    } catch (error: any) {
+      this.logger.error(
+        'Error pulling daily post analytics data',
+        error,
+        error?.stack,
+      );
+    } finally {
+      this.isPullingDailyPostAnalyticsData = false;
+    }
+  }
+
+  async pullAnalyticsDataByDateRange(startDate: Date, endDate: Date) {
+    const dateRange: Date[] = [];
+    const currentDate = new Date(startDate);
+    while (currentDate <= endDate) {
+      dateRange.push(new Date(currentDate));
+      currentDate.setDate(currentDate.getDate() + 1);
+    }
+
+    for (const date of dateRange) {
+      try {
+        await this.pullAnalyticsData(date);
+      } catch (error: any) {
+        this.logger.error(
+          `Error pulling post analytics data for date ${date}`,
+          error,
+          error.stack,
+        );
+      }
+    }
+  }
+
+  async pullAnalyticsData(date: Date) {
+    const startOfDay = moment(date).startOf('day').toDate();
+    const endOfDay = moment(date).endOf('day').toDate();
+    const analyticsData = await this.getDateAnalytics(startOfDay, endOfDay);
+    await this.postAnalyticsRepository.delete({
+      date: startOfDay,
+    });
+    return this.postAnalyticsRepository.insert(analyticsData);
+  }
+
+  async getDateAnalytics(
+    startOfDay: Date,
+    endOfDay: Date,
+    senderAddress?: string,
+  ): Promise<DatePostAnalyticsRow> {
+    const params: any[] = [startOfDay, endOfDay];
+    let senderFilter = '';
+    if (senderAddress) {
+      params.push(senderAddress);
+      senderFilter = ' AND sender_address = $3';
+    }
+
+    const [agg] = await this.postsRepository.query(
+      `SELECT
+         COUNT(*) FILTER (WHERE post_id IS NULL)::int                AS total_posts,
+         COUNT(*) FILTER (WHERE post_id IS NOT NULL)::int            AS total_comments,
+         COUNT(*)::int                                               AS total_all,
+         COUNT(DISTINCT sender_address)::int                         AS total_unique_posters,
+         COALESCE(AVG(total_comments) FILTER (WHERE post_id IS NULL), 0) AS avg_comments_per_post
+       FROM posts
+       WHERE created_at BETWEEN $1 AND $2 AND is_hidden = false${senderFilter}`,
+      params,
+    );
+
+    const cumulativeWhere: string[] = [
+      'created_at < $1',
+      'is_hidden = false',
+      'post_id IS NULL',
+    ];
+    const cumulativeParams: any[] = [endOfDay];
+    if (senderAddress) {
+      cumulativeParams.push(senderAddress);
+      cumulativeWhere.push('sender_address = $2');
+    }
+    const [cumulative] = await this.postsRepository.query(
+      `SELECT COUNT(*)::int AS total
+       FROM posts
+       WHERE ${cumulativeWhere.join(' AND ')}`,
+      cumulativeParams,
+    );
+
+    return {
+      date: moment(startOfDay).format('YYYY-MM-DD'),
+      total_posts: Number(agg?.total_posts ?? 0),
+      total_comments: Number(agg?.total_comments ?? 0),
+      total_all: Number(agg?.total_all ?? 0),
+      total_unique_posters: Number(agg?.total_unique_posters ?? 0),
+      cumulative_total_posts: Number(cumulative?.total ?? 0),
+      avg_comments_per_post: Number(agg?.avg_comments_per_post ?? 0),
+    };
+  }
+
+  /**
+   * Compute a per-day series live (no caching) - used when filtering by sender_address
+   * for arbitrary ranges. Uses a single GROUP BY query.
+   */
+  async getDateRangeAnalyticsLive(
+    startDate: Date,
+    endDate: Date,
+    senderAddress?: string,
+  ): Promise<DatePostAnalyticsRow[]> {
+    const startOfRange = moment(startDate).startOf('day').toDate();
+    const endOfRange = moment(endDate).endOf('day').toDate();
+
+    const params: any[] = [startOfRange, endOfRange];
+    let senderFilter = '';
+    if (senderAddress) {
+      params.push(senderAddress);
+      senderFilter = ' AND sender_address = $3';
+    }
+
+    const rows: Array<{
+      day: Date;
+      total_posts: string | number;
+      total_comments: string | number;
+      total_all: string | number;
+      total_unique_posters: string | number;
+      avg_comments_per_post: string | number;
+    }> = await this.postsRepository.query(
+      `SELECT
+         date_trunc('day', created_at) AS day,
+         COUNT(*) FILTER (WHERE post_id IS NULL)::int                AS total_posts,
+         COUNT(*) FILTER (WHERE post_id IS NOT NULL)::int            AS total_comments,
+         COUNT(*)::int                                               AS total_all,
+         COUNT(DISTINCT sender_address)::int                         AS total_unique_posters,
+         COALESCE(AVG(total_comments) FILTER (WHERE post_id IS NULL), 0) AS avg_comments_per_post
+       FROM posts
+       WHERE created_at BETWEEN $1 AND $2 AND is_hidden = false${senderFilter}
+       GROUP BY day
+       ORDER BY day ASC`,
+      params,
+    );
+
+    if (rows.length === 0) {
+      return [];
+    }
+
+    // cumulative totals: one query for the cumulative count up to each day's end
+    const dayKeys = rows.map((row) =>
+      moment(row.day).startOf('day').format('YYYY-MM-DD'),
+    );
+
+    const cumulativeMap = new Map<string, number>();
+    for (const dayKey of dayKeys) {
+      const endOfThatDay = moment(dayKey).endOf('day').toDate();
+      const cumulativeWhere: string[] = [
+        'created_at < $1',
+        'is_hidden = false',
+        'post_id IS NULL',
+      ];
+      const cumulativeParams: any[] = [endOfThatDay];
+      if (senderAddress) {
+        cumulativeParams.push(senderAddress);
+        cumulativeWhere.push('sender_address = $2');
+      }
+      const [cumulative] = await this.postsRepository.query(
+        `SELECT COUNT(*)::int AS total
+         FROM posts
+         WHERE ${cumulativeWhere.join(' AND ')}`,
+        cumulativeParams,
+      );
+      cumulativeMap.set(dayKey, Number(cumulative?.total ?? 0));
+    }
+
+    return rows.map((row) => {
+      const dayKey = moment(row.day).startOf('day').format('YYYY-MM-DD');
+      return {
+        date: dayKey,
+        total_posts: Number(row.total_posts ?? 0),
+        total_comments: Number(row.total_comments ?? 0),
+        total_all: Number(row.total_all ?? 0),
+        total_unique_posters: Number(row.total_unique_posters ?? 0),
+        cumulative_total_posts: cumulativeMap.get(dayKey) ?? 0,
+        avg_comments_per_post: Number(row.avg_comments_per_post ?? 0),
+      };
+    });
+  }
+
+  async getTopPosters(
+    startDate: Date,
+    endDate: Date,
+    limit: number = 10,
+  ): Promise<
+    Array<{
+      sender_address: string;
+      total_posts: number;
+      total_comments: number;
+      total_all: number;
+    }>
+  > {
+    const startOfRange = moment(startDate).startOf('day').toDate();
+    const endOfRange = moment(endDate).endOf('day').toDate();
+
+    const safeLimit = Math.max(1, Math.min(limit, 100));
+
+    const rows: Array<{
+      sender_address: string;
+      total_posts: string | number;
+      total_comments: string | number;
+      total_all: string | number;
+    }> = await this.postsRepository.query(
+      `SELECT
+         sender_address,
+         COUNT(*) FILTER (WHERE post_id IS NULL)::int     AS total_posts,
+         COUNT(*) FILTER (WHERE post_id IS NOT NULL)::int AS total_comments,
+         COUNT(*)::int                                    AS total_all
+       FROM posts
+       WHERE created_at BETWEEN $1 AND $2 AND is_hidden = false
+       GROUP BY sender_address
+       ORDER BY total_all DESC
+       LIMIT $3`,
+      [startOfRange, endOfRange, safeLimit],
+    );
+
+    return rows.map((row) => ({
+      sender_address: row.sender_address,
+      total_posts: Number(row.total_posts ?? 0),
+      total_comments: Number(row.total_comments ?? 0),
+      total_all: Number(row.total_all ?? 0),
+    }));
+  }
+
+  async getTopTopics(
+    startDate: Date,
+    endDate: Date,
+    limit: number = 10,
+  ): Promise<
+    Array<{
+      topic_id: string;
+      topic_name: string;
+      post_count: number;
+    }>
+  > {
+    const startOfRange = moment(startDate).startOf('day').toDate();
+    const endOfRange = moment(endDate).endOf('day').toDate();
+
+    const safeLimit = Math.max(1, Math.min(limit, 100));
+
+    const rows: Array<{
+      topic_id: string;
+      topic_name: string;
+      post_count: string | number;
+    }> = await this.postsRepository.query(
+      `SELECT
+         t.id          AS topic_id,
+         t.name        AS topic_name,
+         COUNT(*)::int AS post_count
+       FROM post_topics pt
+       INNER JOIN topics t ON t.id = pt.topic_id
+       INNER JOIN posts p  ON p.id = pt.post_id
+       WHERE p.created_at BETWEEN $1 AND $2 AND p.is_hidden = false
+       GROUP BY t.id, t.name
+       ORDER BY post_count DESC
+       LIMIT $3`,
+      [startOfRange, endOfRange, safeLimit],
+    );
+
+    return rows.map((row) => ({
+      topic_id: row.topic_id,
+      topic_name: row.topic_name,
+      post_count: Number(row.post_count ?? 0),
+    }));
+  }
+
+  /**
+   * Get the most recent cumulative_total_posts for the unfiltered series, to
+   * surface a "Total Posts (all time, top-level)" stat without scanning the table.
+   */
+  async getLatestCumulativeTotal(): Promise<number> {
+    const latest = await this.postAnalyticsRepository.findOne({
+      where: {},
+      order: { date: 'DESC' },
+    });
+    return latest?.cumulative_total_posts ?? 0;
+  }
+
+  /**
+   * Live count of all top-level posts up to a given date (inclusive end-of-day).
+   * Used as a fallback for filtered/sender-specific cumulative computation.
+   */
+  async countTopLevelPostsBefore(
+    date: Date,
+    senderAddress?: string,
+  ): Promise<number> {
+    const where: any = {
+      created_at: LessThan(moment(date).endOf('day').toDate()),
+      is_hidden: false,
+      post_id: null as any,
+    };
+    if (senderAddress) {
+      where.sender_address = senderAddress;
+    }
+    return this.postsRepository.count({ where });
+  }
+}

--- a/views/analytics.hbs
+++ b/views/analytics.hbs
@@ -161,6 +161,45 @@
         background-color: #2563eb;
       }
 
+      .date-range button.secondary {
+        background-color: #e2e8f0;
+        color: #1e293b;
+      }
+
+      .date-range button.secondary:hover {
+        background-color: #cbd5e1;
+      }
+
+      .date-range > div.address-field {
+        flex: 1;
+        min-width: 280px;
+      }
+
+      .filter-pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        padding: 0.25rem 0.6rem;
+        background: #eff6ff;
+        color: #1d4ed8;
+        border: 1px solid #bfdbfe;
+        border-radius: 999px;
+        font-size: 0.75rem;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+          "Liberation Mono", "Courier New", monospace;
+        margin-bottom: 1rem;
+      }
+
+      .filter-pill .clear {
+        cursor: pointer;
+        color: #1d4ed8;
+        font-weight: 700;
+      }
+
+      .hidden {
+        display: none !important;
+      }
+
       @media (max-width: 1400px) {
         .container {
           padding: 0 1rem;
@@ -209,20 +248,35 @@
           <label for="endDate">End Date:</label>
           <input type="date" id="endDate" />
         </div>
+        <div class="address-field">
+          <label for="addressFilter">Address (optional):</label>
+          <input
+            type="text"
+            id="addressFilter"
+            placeholder="ak_..."
+            autocomplete="off"
+          />
+        </div>
         <button onclick="updateDashboard()">Apply</button>
+        <button class="secondary" onclick="clearAddressFilter()">Clear address</button>
+      </div>
+
+      <div id="filterPill" class="filter-pill hidden">
+        Filtered by <span id="filterPillAddress"></span>
+        <span class="clear" onclick="clearAddressFilter()">&times;</span>
       </div>
 
       <div class="stats-grid">
         <div class="stat-card">
-          <h2>Total Unique Wallet Accounts</h2>
+          <h2 id="totalUsersLabel">Total Unique Wallet Accounts</h2>
           <div class="value" id="totalUsers">-</div>
         </div>
         <div class="stat-card">
-          <h2>Total Created Tokens</h2>
+          <h2 id="totalTokensLabel">Total Created Tokens</h2>
           <div class="value" id="totalTokens">-</div>
         </div>
         <div class="stat-card">
-          <h2>Past 24h Active Accounts</h2>
+          <h2 id="todayActiveUsersLabel">Past 24h Active Accounts</h2>
           <div class="value" id="todayActiveUsers">-</div>
         </div>
         <div class="stat-card">
@@ -235,9 +289,18 @@
           <div class="value" id="todayTokens">-</div>
         </div>
         <div class="stat-card">
-          <h2>Total MarketCap</h2>
+          <h2 id="totalMarketCapLabel">Total MarketCap</h2>
           <div class="value" id="totalMarketCap">-</div>
           <div class="value usd-value" id="totalMarketCapUSD">-</div>
+        </div>
+        <div class="stat-card user-only-card hidden" id="userVolumeCard">
+          <h2>Total Volume (range)</h2>
+          <div class="value" id="userTotalVolume">-</div>
+          <div class="value usd-value" id="userTotalVolumeUSD">-</div>
+        </div>
+        <div class="stat-card user-only-card hidden" id="userTxCard">
+          <h2>Total Transactions (range)</h2>
+          <div class="value" id="userTotalTransactions">-</div>
         </div>
       </div>
 
@@ -271,7 +334,7 @@
         </div>
 
         <div class="chart-container">
-          <h2>Daily Active Accounts</h2>
+          <h2 id="activeUsersChartLabel">Daily Active Accounts</h2>
           <div class="chart-wrapper">
             <canvas id="activeUsersChart"></canvas>
           </div>
@@ -326,6 +389,104 @@
           startDate: moment(startDate).format("YYYY-MM-DD"),
           endDate: moment(endDate).format("YYYY-MM-DD"),
         };
+      }
+
+      function getAddressFilter() {
+        const value = document
+          .getElementById("addressFilter")
+          .value.trim();
+        return value || null;
+      }
+
+      function clearAddressFilter() {
+        document.getElementById("addressFilter").value = "";
+        updateDashboard();
+      }
+
+      function getDefaultDateRange() {
+        return {
+          startDate: moment().subtract(14, "days").format("YYYY-MM-DD"),
+          endDate: moment().format("YYYY-MM-DD"),
+        };
+      }
+
+      function isCustomDateRange() {
+        const def = getDefaultDateRange();
+        const cur = getDateRange();
+        return cur.startDate !== def.startDate || cur.endDate !== def.endDate;
+      }
+
+      function isCustomFilter() {
+        return isCustomDateRange() || !!getAddressFilter();
+      }
+
+      function updateStatLabels() {
+        const custom = isCustomFilter();
+        const customRange = isCustomDateRange();
+        const address = getAddressFilter();
+
+        // Unique Wallet Accounts is ALWAYS platform-wide. When an address is
+        // also set, append (global) to make that explicit; the (range) suffix
+        // is appended whenever the date range is customized.
+        let usersLabel = address
+          ? "Unique Wallet Accounts (global"
+          : custom
+            ? "Unique Wallet Accounts"
+            : "Total Unique Wallet Accounts";
+        if (address) {
+          usersLabel += customRange ? ", range)" : ")";
+        } else if (custom) {
+          usersLabel += " (range)";
+        }
+        document.getElementById("totalUsersLabel").textContent = usersLabel;
+
+        document.getElementById("totalTokensLabel").textContent = custom
+          ? "Created Tokens (range)"
+          : "Total Created Tokens";
+
+        document.getElementById("totalMarketCapLabel").textContent = custom
+          ? "MarketCap (range)"
+          : "Total MarketCap";
+
+        // Past 24h Active Accounts and Daily Active Accounts chart are ALWAYS
+        // platform-wide. Add a (global) hint when an address filter is set so
+        // users understand they are not seeing per-user activity.
+        document.getElementById("todayActiveUsersLabel").textContent = address
+          ? "Past 24h Active Accounts (global)"
+          : "Past 24h Active Accounts";
+        document.getElementById("activeUsersChartLabel").textContent = address
+          ? "Daily Active Accounts (global)"
+          : "Daily Active Accounts";
+      }
+
+      function updateFilterPill() {
+        const address = getAddressFilter();
+        const pill = document.getElementById("filterPill");
+        const pillAddress = document.getElementById("filterPillAddress");
+        if (address) {
+          pillAddress.textContent = address;
+          pill.classList.remove("hidden");
+        } else {
+          pill.classList.add("hidden");
+        }
+      }
+
+      async function fetchJsonOrThrow(url) {
+        const response = await fetch(url);
+        const text = await response.text();
+        let body;
+        try {
+          body = text ? JSON.parse(text) : null;
+        } catch {
+          body = text;
+        }
+        if (!response.ok) {
+          const message =
+            (body && (body.message || body.error)) ||
+            `HTTP ${response.status}`;
+          throw new Error(`${url} -> ${message}`);
+        }
+        return body;
       }
 
       // Set default date range (last 2 weeks)
@@ -410,40 +571,108 @@
         // return (aeAmount / decimals) * aePrice;
       }
 
-      // Fetch analytics data from unified API
-      async function fetchAnalyticsData(startDate, endDate) {
+      // Single-call helper: fetches the per-day analytics rows from the API
+      // and returns them sorted by date. Returns [] on error or non-array.
+      async function fetchAnalyticsRows(startDate, endDate, address) {
         try {
-          const response = await fetch(
-            `${API_URL}/analytics?start_date=${startDate}&end_date=${endDate}`
-          );
-          const data = await response.json();
-          
-          // Sort data by date in ascending order
-          const sortedData = [...data].sort(
-            (a, b) => moment(a.date).valueOf() - moment(b.date).valueOf()
-          );
-          
-          analyticsData = sortedData;
-          return sortedData;
+          const params = new URLSearchParams({
+            start_date: startDate,
+            end_date: endDate,
+          });
+          if (address) {
+            params.set("address", address);
+          }
+          const data = await fetchJsonOrThrow(`${API_URL}/analytics?${params}`);
+          if (!Array.isArray(data)) {
+            console.error(
+              "Unexpected /analytics response (not an array):",
+              data
+            );
+            return [];
+          }
+          return data
+            .slice()
+            .sort(
+              (a, b) => moment(a.date).valueOf() - moment(b.date).valueOf()
+            );
         } catch (error) {
-          console.error("Error fetching analytics data:", error);
+          console.error("Error fetching analytics rows:", error);
           return [];
         }
+      }
+
+      // Fetch analytics data from unified API. When `address` is set, ALSO
+      // fetches the unfiltered series in parallel and overwrites
+      // `total_active_accounts` per day so the Daily Active Accounts chart
+      // continues to show platform-wide context (not 0/1 per day).
+      async function fetchAnalyticsData(startDate, endDate, address) {
+        // Always reset before re-fetch so a failed/empty response can never
+        // leave stale chart data on screen.
+        analyticsData = [];
+        if (address) {
+          const [filtered, global] = await Promise.all([
+            fetchAnalyticsRows(startDate, endDate, address),
+            fetchAnalyticsRows(startDate, endDate, null),
+          ]);
+          const globalByDate = new Map(
+            global.map((row) => [
+              moment(row.date).format("YYYY-MM-DD"),
+              row,
+            ])
+          );
+          analyticsData = filtered.map((row) => {
+            const key = moment(row.date).format("YYYY-MM-DD");
+            const g = globalByDate.get(key);
+            return {
+              ...row,
+              total_active_accounts: g
+                ? parseInt(g.total_active_accounts) || 0
+                : 0,
+            };
+          });
+        } else {
+          analyticsData = await fetchAnalyticsRows(startDate, endDate, null);
+        }
+        return analyticsData;
       }
 
 
 
       // Update total unique users from analytics data
-      function updateTotalUsers() {
-        // Calculate total unique users from all data
-        const uniqueUsers = new Set();
-        analyticsData.forEach(item => {
-          for (let i = 0; i < parseInt(item.total_active_accounts); i++) {
-            uniqueUsers.add(`user_${item.date}_${i}`);
-          }
-        });
-        
-        document.getElementById("totalUsers").textContent = formatNumber(uniqueUsers.size);
+      // Fetches the TRUE distinct count of wallet accounts, either over the
+      // selected range (when a custom filter is active) or all-time (default).
+      async function fetchRangeSummary(startDate, endDate, address) {
+        try {
+          const params = new URLSearchParams();
+          if (startDate) params.set("start_date", startDate);
+          if (endDate) params.set("end_date", endDate);
+          if (address) params.set("address", address);
+          const url = `${API_URL}/analytics/summary${
+            params.toString() ? `?${params}` : ""
+          }`;
+          return await fetchJsonOrThrow(url);
+        } catch (error) {
+          console.error("Error fetching analytics summary:", error);
+          return null;
+        }
+      }
+
+      async function updateTotalUsers() {
+        // This card is ALWAYS platform-wide. If a custom date range is in
+        // effect we scope to that range; otherwise it's an all-time count.
+        // We never pass `address` so the result is meaningful when the user
+        // has filtered the rest of the dashboard to a single wallet.
+        let summary;
+        if (isCustomDateRange()) {
+          const { startDate, endDate } = getDateRange();
+          summary = await fetchRangeSummary(startDate, endDate, null);
+        } else {
+          summary = await fetchRangeSummary(null, null, null);
+        }
+        const value = summary
+          ? parseInt(summary.total_unique_accounts) || 0
+          : 0;
+        document.getElementById("totalUsers").textContent = formatNumber(value);
       }
 
 
@@ -849,59 +1078,124 @@
       }
 
       // Fetch past 24 hours data for today's metrics
-      async function fetchPast24HoursData() {
+      async function fetchPast24HoursData(address) {
         try {
-          const response = await fetch(`${API_URL}/analytics/past-24-hours`);
-          const data = await response.json();
-          console.log('==================');
-          console.log(data);
-          console.log('==================');
-          return data;
+          const params = new URLSearchParams();
+          if (address) {
+            params.set("address", address);
+          }
+          const url = `${API_URL}/analytics/past-24-hours${
+            params.toString() ? `?${params}` : ""
+          }`;
+          return await fetchJsonOrThrow(url);
         } catch (error) {
           console.error("Error fetching past 24 hours data:", error);
           return null;
         }
       }
 
-      // Update today's metrics
-      async function updateTodayMetrics() {
+      // Update today's metrics. When `address` is set, also fetches the
+      // unfiltered past-24h data in parallel so the "Active Accounts" card
+      // can stay platform-wide (not 1/0 for the selected user).
+      async function updateTodayMetrics(address) {
         try {
-          // Fetch past 24 hours data
-          const todayData = await fetchPast24HoursData();
-          if (!todayData) return;
-          
+          const [todayData, todayGlobalData] = await Promise.all([
+            fetchPast24HoursData(address),
+            address
+              ? fetchPast24HoursData(null)
+              : Promise.resolve(null),
+          ]);
+          if (!todayData) {
+            // Reset cards so stale values don't linger when the call fails.
+            document.getElementById("todayTokens").textContent = "0";
+            document.getElementById("todayVolume").textContent = "-";
+            document.getElementById("todayVolumeUSD").textContent = "-";
+            document.getElementById("todayActiveUsers").textContent = "0";
+            return;
+          }
+
           // Get current AE price
           const aePrice = await fetchAEPrice();
-          
+
           // Past 24h tokens
           document.getElementById("todayTokens").textContent = formatNumber(
             parseInt(todayData.total_created_tokens) || 0
           );
-          document.getElementById("totalTokens").textContent = formatNumber(todayData.total_tokens);
 
-          // Past 24h volume
+          // Total Created Tokens card: when a custom filter (range or address)
+          // is active, show the range-scoped sum. Otherwise show the all-time
+          // cumulative count from the past-24h endpoint.
+          if (isCustomFilter()) {
+            const sumInRange = analyticsData.reduce(
+              (acc, item) => acc + (parseInt(item.total_created_tokens) || 0),
+              0
+            );
+            document.getElementById("totalTokens").textContent =
+              formatNumber(sumInRange);
+          } else {
+            document.getElementById("totalTokens").textContent = formatNumber(
+              todayData.total_tokens
+            );
+          }
+
+          // Past 24h volume (filtered to user when address is set)
           const volumeAE = parseFloat(todayData.total_volume_sum) || 0;
           const volumeUSD = convertAEToUSD(volumeAE, aePrice);
           document.getElementById("todayVolume").textContent = formatAEAmount(volumeAE);
           document.getElementById("todayVolumeUSD").textContent = formatUSDAmount(volumeUSD);
 
-          // Past 24h active users
+          // Past 24h active users — always platform-wide context. When
+          // address is set we use the parallel global call; otherwise
+          // todayData itself is already global.
+          const activeAccountsSrc = address ? todayGlobalData : todayData;
           document.getElementById("todayActiveUsers").textContent = formatNumber(
-            parseInt(todayData.total_active_accounts) || 0
+            parseInt(activeAccountsSrc?.total_active_accounts) || 0
           );
+
+          return aePrice;
         } catch (error) {
           console.error("Error updating today's metrics:", error);
+          return 0;
         }
+      }
+
+      // Populate the 2 user-only stat cards (Total Volume / Total
+      // Transactions over the selected range). Hidden when no address filter.
+      function updateUserOnlyCards(address, aePrice) {
+        const cards = document.querySelectorAll(".user-only-card");
+        if (!address) {
+          cards.forEach((c) => c.classList.add("hidden"));
+          return;
+        }
+        cards.forEach((c) => c.classList.remove("hidden"));
+
+        const totalVolume = analyticsData.reduce(
+          (sum, item) => sum + (parseFloat(item.total_volume_sum) || 0),
+          0
+        );
+        const totalTx = analyticsData.reduce(
+          (sum, item) => sum + (parseInt(item.total_transactions) || 0),
+          0
+        );
+        document.getElementById("userTotalVolume").textContent =
+          formatAEAmount(totalVolume);
+        document.getElementById("userTotalVolumeUSD").textContent =
+          formatUSDAmount(totalVolume * (aePrice || 0));
+        document.getElementById("userTotalTransactions").textContent =
+          formatNumber(totalTx);
       }
 
       // Update all charts and metrics
       async function updateDashboard() {
         try {
+          updateFilterPill();
+          updateStatLabels();
           const { startDate, endDate } = getDateRange();
-          
+          const address = getAddressFilter();
+
           // Fetch data from unified API
-          await fetchAnalyticsData(startDate, endDate);
-          
+          await fetchAnalyticsData(startDate, endDate, address);
+
           // Update all charts
           createTokensChart();
           await createVolumeChart();
@@ -909,11 +1203,12 @@
           createTransactionsChart();
           await createMarketCapChart();
           createCumulativeTokensChart();
-          
+
           // Update metrics
-          await updateTodayMetrics();
-          updateTotalUsers();
+          const aePrice = await updateTodayMetrics(address);
+          await updateTotalUsers();
           await updateTotalMarketCap();
+          updateUserOnlyCards(address, aePrice);
         } catch (error) {
           console.error("Error updating dashboard:", error);
         }

--- a/views/main-layout.hbs
+++ b/views/main-layout.hbs
@@ -233,6 +233,18 @@
               </a>
             </div>
           </div>
+
+          <div class="group">
+            <div class="group-title">Social</div>
+            <div class="group-items">
+              <a
+                href="/api/posts/analytics/preview"
+                class="{{#if (eq active 'social-posts')}}active{{/if}}"
+              >
+                Posts
+              </a>
+            </div>
+          </div>
         </div>
       </aside>
 

--- a/views/posts-analytics.hbs
+++ b/views/posts-analytics.hbs
@@ -1,0 +1,880 @@
+{{#> main-layout title="Posts Analytics Dashboard" active="social-posts"}}
+<style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+        font-family: "Inter", sans-serif;
+      }
+
+      body {
+        background-color: #f8fafc;
+        color: #1e293b;
+        padding: 0;
+        min-height: 100vh;
+      }
+
+      .container {
+        max-width: 1400px;
+        margin: 0 auto;
+      }
+
+      .stats-grid {
+        display: grid;
+        grid-template-columns: repeat(6, 1fr);
+        gap: 0.75rem;
+        margin-bottom: 1.5rem;
+      }
+
+      .stat-card {
+        background: white;
+        padding: 0.75rem;
+        border-radius: 0.5rem;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+        min-width: 0;
+      }
+
+      .stat-card h2 {
+        font-size: 0.75rem;
+        margin-bottom: 0.25rem;
+        color: #475569;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      .stat-card .value {
+        font-size: 1.25rem;
+        font-weight: 600;
+        color: #0f172a;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      .charts-grid {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        gap: 1rem;
+      }
+
+      .chart-container {
+        background: white;
+        padding: 1rem;
+        border-radius: 0.5rem;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+        height: 300px;
+      }
+
+      .chart-container.large {
+        grid-column: span 2;
+        height: 400px;
+      }
+
+      .chart-container h2 {
+        font-size: 1rem;
+        margin-bottom: 0.5rem;
+        color: #475569;
+      }
+
+      .chart-wrapper {
+        height: calc(100% - 2rem);
+        position: relative;
+      }
+
+      .filter-bar {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 1rem;
+        align-items: flex-end;
+        margin-bottom: 1.5rem;
+        background: white;
+        padding: 1rem;
+        border-radius: 0.5rem;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+      }
+
+      .filter-bar > div {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        min-width: 150px;
+      }
+
+      .filter-bar > div.address-field {
+        flex: 1;
+        min-width: 280px;
+      }
+
+      .filter-bar label {
+        font-size: 0.875rem;
+        color: #475569;
+      }
+
+      .filter-bar input {
+        padding: 0.5rem;
+        border: 1px solid #e2e8f0;
+        border-radius: 0.25rem;
+        font-size: 0.875rem;
+        color: #1e293b;
+        width: 100%;
+      }
+
+      .filter-bar button {
+        padding: 0.5rem 1rem;
+        background-color: #3b82f6;
+        color: white;
+        border: none;
+        border-radius: 0.25rem;
+        font-size: 0.875rem;
+        cursor: pointer;
+        transition: background-color 0.2s;
+        white-space: nowrap;
+      }
+
+      .filter-bar button:hover {
+        background-color: #2563eb;
+      }
+
+      .filter-bar button.secondary {
+        background-color: #e2e8f0;
+        color: #1e293b;
+      }
+
+      .filter-bar button.secondary:hover {
+        background-color: #cbd5e1;
+      }
+
+      .filter-pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        padding: 0.25rem 0.6rem;
+        background: #eff6ff;
+        color: #1d4ed8;
+        border: 1px solid #bfdbfe;
+        border-radius: 999px;
+        font-size: 0.75rem;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+          "Liberation Mono", "Courier New", monospace;
+        margin-bottom: 1rem;
+      }
+
+      .filter-pill .clear {
+        cursor: pointer;
+        color: #1d4ed8;
+        font-weight: 700;
+      }
+
+      .hidden {
+        display: none !important;
+      }
+
+      @media (max-width: 1400px) {
+        .container {
+          padding: 0 1rem;
+        }
+      }
+
+      @media (max-width: 768px) {
+        .stats-grid {
+          grid-template-columns: repeat(3, 1fr);
+        }
+
+        .charts-grid {
+          grid-template-columns: 1fr;
+        }
+
+        .filter-bar {
+          flex-direction: column;
+          align-items: stretch;
+        }
+
+        .filter-bar > div {
+          width: 100%;
+        }
+
+        .filter-bar button {
+          width: 100%;
+        }
+      }
+
+      @media (max-width: 480px) {
+        .stats-grid {
+          grid-template-columns: repeat(2, 1fr);
+        }
+      }
+    </style>
+
+    <div class="container">
+
+      <div class="filter-bar">
+        <div>
+          <label for="startDate">Start Date:</label>
+          <input type="date" id="startDate" />
+        </div>
+        <div>
+          <label for="endDate">End Date:</label>
+          <input type="date" id="endDate" />
+        </div>
+        <div class="address-field">
+          <label for="senderAddress">Sender Address (optional):</label>
+          <input
+            type="text"
+            id="senderAddress"
+            placeholder="ak_..."
+            autocomplete="off"
+          />
+        </div>
+        <button onclick="updateDashboard()">Apply</button>
+        <button class="secondary" onclick="clearAddressFilter()">Clear address</button>
+      </div>
+
+      <div id="filterPill" class="filter-pill hidden">
+        Filtered by <span id="filterPillAddress"></span>
+        <span class="clear" onclick="clearAddressFilter()">&times;</span>
+      </div>
+
+      <div class="stats-grid">
+        <div class="stat-card">
+          <h2>Total Posts (range)</h2>
+          <div class="value" id="rangeTotalPosts">-</div>
+        </div>
+        <div class="stat-card">
+          <h2>Total Comments (range)</h2>
+          <div class="value" id="rangeTotalComments">-</div>
+        </div>
+        <div class="stat-card">
+          <h2>Unique Posters (range)</h2>
+          <div class="value" id="rangeUniquePosters">-</div>
+        </div>
+        <div class="stat-card">
+          <h2>Past 24h Posts</h2>
+          <div class="value" id="past24Posts">-</div>
+          <div class="value" id="past24Comments" style="font-size: 0.75rem; font-weight: 500; color: #64748b; margin-top: 0.25rem;">-</div>
+        </div>
+        <div class="stat-card">
+          <h2>Past 24h Active Posters</h2>
+          <div class="value" id="past24Posters">-</div>
+        </div>
+        <div class="stat-card">
+          <h2>Cumulative Posts</h2>
+          <div class="value" id="cumulativePosts">-</div>
+        </div>
+      </div>
+
+      <div class="charts-grid">
+        <div class="chart-container">
+          <h2>Daily Posts (Top-level vs Comments)</h2>
+          <div class="chart-wrapper">
+            <canvas id="dailyPostsChart"></canvas>
+          </div>
+        </div>
+
+        <div class="chart-container">
+          <h2>Cumulative Posts</h2>
+          <div class="chart-wrapper">
+            <canvas id="cumulativePostsChart"></canvas>
+          </div>
+        </div>
+
+        <div class="chart-container">
+          <h2>Daily Unique Posters</h2>
+          <div class="chart-wrapper">
+            <canvas id="uniquePostersChart"></canvas>
+          </div>
+        </div>
+
+        <div class="chart-container">
+          <h2>Avg Comments per Post</h2>
+          <div class="chart-wrapper">
+            <canvas id="avgCommentsChart"></canvas>
+          </div>
+        </div>
+
+        <div class="chart-container" id="topPostersContainer">
+          <h2>Top Posters (range)</h2>
+          <div class="chart-wrapper">
+            <canvas id="topPostersChart"></canvas>
+          </div>
+        </div>
+
+        <div class="chart-container">
+          <h2>Top Topics (range)</h2>
+          <div class="chart-wrapper">
+            <canvas id="topTopicsChart"></canvas>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <script>
+      const API_URL = "/api";
+
+      let dailyPostsChart = null;
+      let cumulativePostsChart = null;
+      let uniquePostersChart = null;
+      let avgCommentsChart = null;
+      let topPostersChart = null;
+      let topTopicsChart = null;
+
+      let analyticsData = [];
+
+      function destroyChart(chart) {
+        if (chart) {
+          chart.destroy();
+        }
+      }
+
+      function formatNumber(num) {
+        return Number(num || 0)
+          .toString()
+          .replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+      }
+
+      function formatDate(dateString) {
+        return moment(dateString).format("MMM D");
+      }
+
+      function shortenAddress(address) {
+        if (!address) return "";
+        if (address.length <= 14) return address;
+        return address.slice(0, 8) + "..." + address.slice(-6);
+      }
+
+      function displayPosterLabel(poster) {
+        const address = poster.sender_address || "";
+        const publicName = poster.public_name;
+        if (!publicName || publicName === address) {
+          return shortenAddress(address);
+        }
+        return publicName;
+      }
+
+      function getDateRange() {
+        const startDate = document.getElementById("startDate").value;
+        const endDate = document.getElementById("endDate").value;
+        return {
+          startDate: moment(startDate).format("YYYY-MM-DD"),
+          endDate: moment(endDate).format("YYYY-MM-DD"),
+        };
+      }
+
+      function getSenderAddress() {
+        const value = document.getElementById("senderAddress").value.trim();
+        return value || null;
+      }
+
+      function setDefaultDateRange() {
+        const endDate = moment();
+        const startDate = moment().subtract(14, "days");
+        document.getElementById("startDate").value = startDate.format(
+          "YYYY-MM-DD"
+        );
+        document.getElementById("endDate").value = endDate.format("YYYY-MM-DD");
+      }
+
+      function clearAddressFilter() {
+        document.getElementById("senderAddress").value = "";
+        updateDashboard();
+      }
+
+      function updateFilterPill() {
+        const address = getSenderAddress();
+        const pill = document.getElementById("filterPill");
+        const pillAddress = document.getElementById("filterPillAddress");
+        const topPostersContainer = document.getElementById(
+          "topPostersContainer"
+        );
+        if (address) {
+          pillAddress.textContent = address;
+          pill.classList.remove("hidden");
+          topPostersContainer.classList.add("hidden");
+        } else {
+          pill.classList.add("hidden");
+          topPostersContainer.classList.remove("hidden");
+        }
+      }
+
+      async function fetchJsonOrThrow(url) {
+        const response = await fetch(url);
+        const text = await response.text();
+        let body;
+        try {
+          body = text ? JSON.parse(text) : null;
+        } catch {
+          body = text;
+        }
+        if (!response.ok) {
+          const message =
+            (body && (body.message || body.error)) ||
+            `HTTP ${response.status}`;
+          throw new Error(`${url} -> ${message}`);
+        }
+        return body;
+      }
+
+      async function fetchAnalyticsData(startDate, endDate, senderAddress) {
+        // ALWAYS reset before re-fetch so a failure / empty response can never
+        // leave stale chart data on screen.
+        analyticsData = [];
+        try {
+          const params = new URLSearchParams({
+            start_date: startDate,
+            end_date: endDate,
+          });
+          if (senderAddress) {
+            params.set("sender_address", senderAddress);
+          }
+          const data = await fetchJsonOrThrow(
+            `${API_URL}/posts/analytics?${params}`
+          );
+          if (!Array.isArray(data)) {
+            console.error(
+              "Unexpected posts/analytics response (not an array):",
+              data
+            );
+            return [];
+          }
+          const sortedData = data
+            .slice()
+            .sort(
+              (a, b) => moment(a.date).valueOf() - moment(b.date).valueOf()
+            );
+          analyticsData = sortedData;
+          return sortedData;
+        } catch (error) {
+          console.error("Error fetching posts analytics data:", error);
+          return [];
+        }
+      }
+
+      async function fetchPast24HoursData(senderAddress) {
+        try {
+          const params = new URLSearchParams();
+          if (senderAddress) {
+            params.set("sender_address", senderAddress);
+          }
+          const url = `${API_URL}/posts/analytics/past-24-hours${
+            params.toString() ? `?${params}` : ""
+          }`;
+          return await fetchJsonOrThrow(url);
+        } catch (error) {
+          console.error("Error fetching past-24h data:", error);
+          return null;
+        }
+      }
+
+      async function fetchTopPosters(startDate, endDate) {
+        try {
+          const params = new URLSearchParams({
+            start_date: startDate,
+            end_date: endDate,
+            limit: "10",
+          });
+          const data = await fetchJsonOrThrow(
+            `${API_URL}/posts/analytics/top-posters?${params}`
+          );
+          return Array.isArray(data) ? data : [];
+        } catch (error) {
+          console.error("Error fetching top posters:", error);
+          return [];
+        }
+      }
+
+      async function fetchTopTopics(startDate, endDate) {
+        try {
+          const params = new URLSearchParams({
+            start_date: startDate,
+            end_date: endDate,
+            limit: "10",
+          });
+          const data = await fetchJsonOrThrow(
+            `${API_URL}/posts/analytics/top-topics?${params}`
+          );
+          return Array.isArray(data) ? data : [];
+        } catch (error) {
+          console.error("Error fetching top topics:", error);
+          return [];
+        }
+      }
+
+      function createDailyPostsChart() {
+        try {
+          const labels = analyticsData.map((item) => formatDate(item.date));
+          const topLevel = analyticsData.map(
+            (item) => parseInt(item.total_posts) || 0
+          );
+          const comments = analyticsData.map(
+            (item) => parseInt(item.total_comments) || 0
+          );
+
+          destroyChart(dailyPostsChart);
+          dailyPostsChart = new Chart(
+            document.getElementById("dailyPostsChart"),
+            {
+              type: "bar",
+              data: {
+                labels,
+                datasets: [
+                  {
+                    label: "Top-level Posts",
+                    data: topLevel,
+                    backgroundColor: "#3b82f6",
+                    borderRadius: 4,
+                  },
+                  {
+                    label: "Comments",
+                    data: comments,
+                    backgroundColor: "#a855f7",
+                    borderRadius: 4,
+                  },
+                ],
+              },
+              options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                plugins: { legend: { position: "bottom" } },
+                scales: {
+                  x: {
+                    stacked: true,
+                    grid: { display: false },
+                  },
+                  y: {
+                    stacked: true,
+                    beginAtZero: true,
+                    grid: { color: "rgba(0, 0, 0, 0.05)" },
+                  },
+                },
+              },
+            }
+          );
+        } catch (error) {
+          console.error("Error creating daily posts chart:", error);
+        }
+      }
+
+      function createCumulativePostsChart() {
+        try {
+          destroyChart(cumulativePostsChart);
+          cumulativePostsChart = new Chart(
+            document.getElementById("cumulativePostsChart"),
+            {
+              type: "line",
+              data: {
+                labels: analyticsData.map((item) => formatDate(item.date)),
+                datasets: [
+                  {
+                    label: "Cumulative Posts",
+                    data: analyticsData.map(
+                      (item) => parseInt(item.cumulative_total_posts) || 0
+                    ),
+                    borderColor: "#f43f5e",
+                    backgroundColor: "rgba(244, 63, 94, 0.1)",
+                    tension: 0.4,
+                    fill: true,
+                  },
+                ],
+              },
+              options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                plugins: { legend: { display: false } },
+                scales: {
+                  y: {
+                    beginAtZero: true,
+                    grid: { color: "rgba(0, 0, 0, 0.05)" },
+                  },
+                  x: { grid: { display: false } },
+                },
+              },
+            }
+          );
+        } catch (error) {
+          console.error("Error creating cumulative posts chart:", error);
+        }
+      }
+
+      function createUniquePostersChart() {
+        try {
+          destroyChart(uniquePostersChart);
+          uniquePostersChart = new Chart(
+            document.getElementById("uniquePostersChart"),
+            {
+              type: "line",
+              data: {
+                labels: analyticsData.map((item) => formatDate(item.date)),
+                datasets: [
+                  {
+                    label: "Unique Posters",
+                    data: analyticsData.map(
+                      (item) => parseInt(item.total_unique_posters) || 0
+                    ),
+                    borderColor: "#8b5cf6",
+                    backgroundColor: "rgba(139, 92, 246, 0.1)",
+                    tension: 0.4,
+                    fill: true,
+                  },
+                ],
+              },
+              options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                plugins: { legend: { display: false } },
+                scales: {
+                  y: {
+                    beginAtZero: true,
+                    grid: { color: "rgba(0, 0, 0, 0.05)" },
+                  },
+                  x: { grid: { display: false } },
+                },
+              },
+            }
+          );
+        } catch (error) {
+          console.error("Error creating unique posters chart:", error);
+        }
+      }
+
+      function createAvgCommentsChart() {
+        try {
+          destroyChart(avgCommentsChart);
+          avgCommentsChart = new Chart(
+            document.getElementById("avgCommentsChart"),
+            {
+              type: "line",
+              data: {
+                labels: analyticsData.map((item) => formatDate(item.date)),
+                datasets: [
+                  {
+                    label: "Avg Comments / Post",
+                    data: analyticsData.map((item) =>
+                      Number(item.avg_comments_per_post || 0)
+                    ),
+                    borderColor: "#10b981",
+                    backgroundColor: "rgba(16, 185, 129, 0.1)",
+                    tension: 0.4,
+                    fill: true,
+                  },
+                ],
+              },
+              options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                plugins: { legend: { display: false } },
+                scales: {
+                  y: {
+                    beginAtZero: true,
+                    grid: { color: "rgba(0, 0, 0, 0.05)" },
+                    ticks: {
+                      callback: function (value) {
+                        return Number(value).toFixed(2);
+                      },
+                    },
+                  },
+                  x: { grid: { display: false } },
+                },
+              },
+            }
+          );
+        } catch (error) {
+          console.error("Error creating avg comments chart:", error);
+        }
+      }
+
+      function createTopPostersChart(posters) {
+        try {
+          destroyChart(topPostersChart);
+          if (!posters || posters.length === 0) {
+            return;
+          }
+          const ctx = document.getElementById("topPostersChart");
+          topPostersChart = new Chart(ctx, {
+            type: "bar",
+            data: {
+              labels: posters.map((p) => displayPosterLabel(p)),
+              datasets: [
+                {
+                  label: "Posts",
+                  data: posters.map((p) => parseInt(p.total_posts) || 0),
+                  backgroundColor: "#3b82f6",
+                  borderRadius: 4,
+                  stack: "total",
+                },
+                {
+                  label: "Comments",
+                  data: posters.map((p) => parseInt(p.total_comments) || 0),
+                  backgroundColor: "#a855f7",
+                  borderRadius: 4,
+                  stack: "total",
+                },
+              ],
+            },
+            options: {
+              indexAxis: "y",
+              responsive: true,
+              maintainAspectRatio: false,
+              plugins: {
+                legend: { position: "bottom" },
+                tooltip: {
+                  callbacks: {
+                    afterBody: function (tooltipItems) {
+                      const idx = tooltipItems[0]?.dataIndex;
+                      if (idx == null) return "";
+                      return posters[idx]?.sender_address || "";
+                    },
+                  },
+                },
+              },
+              onClick: function (_evt, elements) {
+                if (!elements || elements.length === 0) return;
+                const idx = elements[0].index;
+                const address = posters[idx]?.sender_address;
+                if (!address) return;
+                document.getElementById("senderAddress").value = address;
+                updateDashboard();
+              },
+              scales: {
+                x: {
+                  stacked: true,
+                  beginAtZero: true,
+                  grid: { color: "rgba(0, 0, 0, 0.05)" },
+                },
+                y: {
+                  stacked: true,
+                  grid: { display: false },
+                },
+              },
+            },
+          });
+        } catch (error) {
+          console.error("Error creating top posters chart:", error);
+        }
+      }
+
+      function createTopTopicsChart(topics) {
+        try {
+          destroyChart(topTopicsChart);
+          if (!topics || topics.length === 0) {
+            return;
+          }
+          topTopicsChart = new Chart(
+            document.getElementById("topTopicsChart"),
+            {
+              type: "bar",
+              data: {
+                labels: topics.map((t) => "#" + t.topic_name),
+                datasets: [
+                  {
+                    label: "Posts",
+                    data: topics.map((t) => parseInt(t.post_count) || 0),
+                    backgroundColor: "#f59e0b",
+                    borderRadius: 4,
+                  },
+                ],
+              },
+              options: {
+                indexAxis: "y",
+                responsive: true,
+                maintainAspectRatio: false,
+                plugins: { legend: { display: false } },
+                scales: {
+                  x: {
+                    beginAtZero: true,
+                    grid: { color: "rgba(0, 0, 0, 0.05)" },
+                  },
+                  y: { grid: { display: false } },
+                },
+              },
+            }
+          );
+        } catch (error) {
+          console.error("Error creating top topics chart:", error);
+        }
+      }
+
+      function updateRangeStats() {
+        const totalPosts = analyticsData.reduce(
+          (sum, item) => sum + (parseInt(item.total_posts) || 0),
+          0
+        );
+        const totalComments = analyticsData.reduce(
+          (sum, item) => sum + (parseInt(item.total_comments) || 0),
+          0
+        );
+        // unique-posters-per-day max approximation; for accuracy we'd need a separate distinct query.
+        const uniquePostersPeak = analyticsData.reduce(
+          (max, item) =>
+            Math.max(max, parseInt(item.total_unique_posters) || 0),
+          0
+        );
+
+        document.getElementById("rangeTotalPosts").textContent =
+          formatNumber(totalPosts);
+        document.getElementById("rangeTotalComments").textContent =
+          formatNumber(totalComments);
+        document.getElementById("rangeUniquePosters").textContent =
+          formatNumber(uniquePostersPeak);
+
+        const last = analyticsData[analyticsData.length - 1];
+        document.getElementById("cumulativePosts").textContent = formatNumber(
+          last ? parseInt(last.cumulative_total_posts) || 0 : 0
+        );
+      }
+
+      async function updatePast24Stats(senderAddress) {
+        const data = await fetchPast24HoursData(senderAddress);
+        const topLevel = data ? parseInt(data.total_posts) || 0 : 0;
+        const comments = data ? parseInt(data.total_comments) || 0 : 0;
+        const posters = data ? parseInt(data.total_unique_posters) || 0 : 0;
+        document.getElementById("past24Posts").textContent =
+          formatNumber(topLevel);
+        document.getElementById("past24Comments").textContent =
+          "+ " + formatNumber(comments) + " comments";
+        document.getElementById("past24Posters").textContent =
+          formatNumber(posters);
+      }
+
+      async function updateDashboard() {
+        try {
+          updateFilterPill();
+
+          const { startDate, endDate } = getDateRange();
+          const senderAddress = getSenderAddress();
+
+          await fetchAnalyticsData(startDate, endDate, senderAddress);
+
+          createDailyPostsChart();
+          createCumulativePostsChart();
+          createUniquePostersChart();
+          createAvgCommentsChart();
+
+          updateRangeStats();
+          await updatePast24Stats(senderAddress);
+
+          if (!senderAddress) {
+            const [posters, topics] = await Promise.all([
+              fetchTopPosters(startDate, endDate),
+              fetchTopTopics(startDate, endDate),
+            ]);
+            createTopPostersChart(posters);
+            createTopTopicsChart(topics);
+          } else {
+            destroyChart(topPostersChart);
+            const topics = await fetchTopTopics(startDate, endDate);
+            createTopTopicsChart(topics);
+          }
+        } catch (error) {
+          console.error("Error updating posts dashboard:", error);
+        }
+      }
+
+      (async function () {
+        setDefaultDateRange();
+        await updateDashboard();
+      })();
+    </script>
+{{/main-layout}}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new analytics endpoints, scheduled aggregation, and new DB columns/tables/indexes; incorrect query logic or index/caching assumptions could impact performance and reported metrics.
> 
> **Overview**
> **Adds address-aware core analytics.** `GET /analytics` and `/analytics/past-24-hours` now accept an optional `address` filter (validated via `OptionalAeAccountAddressPipe`) and switch to live per-day aggregation when filtering; a new `GET /analytics/summary` endpoint returns a true distinct-wallet count over an optional date range.
> 
> **Introduces social post analytics.** Adds `post_analytics` entity + hourly backfill service, new `/posts/analytics/*` endpoints (range, past-24-hours, top posters/topics, preview), and a new `posts-analytics` dashboard view; `posts` gains supporting indexes for the new range queries.
> 
> **Updates dashboards and account schema.** The core analytics UI adds an address filter with clearer global-vs-filtered labeling and extra user-only range cards, and `Account` gains a `banned` boolean flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3643c70a1d1a7a6568fd5365686da4c89799c87c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->