### PR TITLE
refactor: add new leaderboard filter

### DIFF
--- a/docs/leaderboard-time-filter-manual-migration.sql
+++ b/docs/leaderboard-time-filter-manual-migration.sql
@@ -4,7 +4,7 @@
 --
 -- The TypeORM entity decorators added in this change describe the desired
 -- index shape, but production runs with `synchronize=false`. Apply this DDL
--- BEFORE shipping the new code path or rolling-window active trader discovery
+-- BEFORE shipping the new code path or selected-period active trader discovery
 -- will fall back to a sequential scan over `transactions` (potentially
 -- millions of rows) and the per-metric ORDER BYs on the snapshot table will
 -- not be index-backed.
@@ -38,7 +38,7 @@
 --        'IDX_ACCOUNT_LEADERBOARD_SNAPSHOTS_WINDOW_MDD'
 --      );
 -- 4. Only after every index is valid, deploy the new application version that
---    ranks by rolling-window performance when `timePeriod` / `timeUnit` query
+--    ranks by selected-period performance when `startDate` / `endDate` query
 --    params are supplied.
 --
 -- -----------------------------------------------------------------------------
@@ -66,8 +66,8 @@
 --    or a Sort node fed from one of the snapshot indexes (acceptable — the
 --    table is small, ≤100 rows per window). Repeat for sortBy=roi/mdd/aum.
 --
--- C) Hit a real rolling-performance request and inspect the duration:
---      curl 'https://<host>/api/accounts/leaderboard?window=7d&sortBy=pnl&timePeriod=30&timeUnit=minutes'
+-- C) Hit a real selected-period performance request and inspect the duration:
+--      curl 'https://<host>/api/accounts/leaderboard?window=7d&sortBy=pnl&startDate=2026-05-04T10:00:00.000Z&endDate=2026-05-04T18:00:00.000Z'
 --    p95 should be well under 500ms. If it is not, capture the plan via
 --    `auto_explain` (or run the underlying queries manually with EXPLAIN ANALYZE)
 --    and check that `IDX_TRANSACTION_CREATED_AT_ADDRESS_TYPE` is being used.
@@ -125,7 +125,7 @@ CREATE INDEX CONCURRENTLY IF NOT EXISTS
 
 -- 2. Transactions table index ------------------------------------------------
 
--- Backs rolling-window active trader discovery:
+-- Backs selected-period active trader discovery:
 --   WHERE t.tx_type IN ('buy','sell')
 --     AND t.created_at >= $start AND t.created_at < $end
 --

--- a/src/account/controllers/leaderboard.controller.spec.ts
+++ b/src/account/controllers/leaderboard.controller.spec.ts
@@ -75,8 +75,8 @@ describe('LeaderboardController', () => {
       sortDir: 'ASC',
       page: 3,
       limit: 5,
-      timePeriod: 30,
-      timeUnit: 'minutes',
+      startDate: '2026-04-28T10:00:00.000Z',
+      endDate: '2026-04-28T12:00:00.000Z',
     });
 
     expect(getLeaders).toHaveBeenCalledWith({
@@ -85,12 +85,12 @@ describe('LeaderboardController', () => {
       sortDir: 'ASC',
       page: 3,
       limit: 5,
-      timePeriod: 30,
-      timeUnit: 'minutes',
+      startDate: '2026-04-28T10:00:00.000Z',
+      endDate: '2026-04-28T12:00:00.000Z',
     });
   });
 
-  it('serializes timeFilter dates as ISO strings and returns rolling-window metrics', async () => {
+  it('serializes timeFilter dates as ISO strings and returns selected-period metrics', async () => {
     const start = new Date('2026-04-28T10:00:00.000Z');
     const end = new Date('2026-04-28T12:00:00.000Z');
     const { service } = buildService({
@@ -116,20 +116,18 @@ describe('LeaderboardController', () => {
       window: '30d',
       sortBy: 'aum',
       sortDir: 'DESC',
-      timeFilter: { value: 2, unit: 'hours', start, end },
+      timeFilter: { start, end },
     });
     const controller = new LeaderboardController(service);
 
     const response = await controller.getLeaderboard({
       window: '30d',
       sortBy: 'aum',
-      timePeriod: 2,
-      timeUnit: 'hours',
+      startDate: '2026-04-28T10:00:00.000Z',
+      endDate: '2026-04-28T12:00:00.000Z',
     });
 
     expect(response.meta.timeFilter).toEqual({
-      value: 2,
-      unit: 'hours',
       start: '2026-04-28T10:00:00.000Z',
       end: '2026-04-28T12:00:00.000Z',
     });

--- a/src/account/controllers/leaderboard.controller.ts
+++ b/src/account/controllers/leaderboard.controller.ts
@@ -6,7 +6,6 @@ import {
   LeaderboardItem,
   LeaderboardSortBy,
   LeaderboardSortDir,
-  LeaderboardTimeUnit,
   LeaderboardWindow,
 } from '../services/leaderboard.types';
 import { GetLeaderboardQueryDto } from '../dto/get-leaderboard-query.dto';
@@ -22,8 +21,6 @@ class LeaderboardResponseDto {
     sortBy: LeaderboardSortBy;
     sortDir: LeaderboardSortDir;
     timeFilter?: {
-      value: number;
-      unit: LeaderboardTimeUnit;
       start: string;
       end: string;
     };
@@ -40,9 +37,9 @@ export class LeaderboardController {
     operationId: 'getAccountsLeaderboard',
     description:
       'Returns paginated trading leaders with metrics (AUM, PNL, ROI, MDD), activity counters, and a portfolio sparkline. ' +
-      'Without timePeriod + timeUnit, metrics are precomputed per window (7d / 30d / all). ' +
-      'When timePeriod + timeUnit are supplied, leaders are ranked by rolling-window performance among accounts that traded within that recent window. ' +
-      'In that mode, top-level metrics and buy/sell counts are scoped to the requested rolling window. ' +
+      'Without startDate + endDate, metrics are precomputed per window (7d / 30d / all). ' +
+      'When startDate + endDate are supplied, leaders are ranked by selected-period performance among accounts that traded within that time range. ' +
+      'In that mode, top-level metrics and buy/sell counts are scoped to the requested time range. ' +
       'Note: responses are cached for up to 60 seconds, so `meta.timeFilter.start` and `meta.timeFilter.end` reflect the time the cache entry was filled, not strictly the time of the current request.',
   })
   @ApiOkResponse({ type: LeaderboardResponseDto })
@@ -69,8 +66,6 @@ export class LeaderboardController {
         sortDir: result.sortDir,
         timeFilter: result.timeFilter
           ? {
-              value: result.timeFilter.value,
-              unit: result.timeFilter.unit,
               start: result.timeFilter.start.toISOString(),
               end: result.timeFilter.end.toISOString(),
             }

--- a/src/account/dto/get-leaderboard-query.dto.ts
+++ b/src/account/dto/get-leaderboard-query.dto.ts
@@ -1,17 +1,15 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Transform, Type } from 'class-transformer';
-import { IsIn, IsInt, IsOptional, Max, Min } from 'class-validator';
+import { IsISO8601, IsIn, IsInt, IsOptional, Max, Min } from 'class-validator';
 import {
   LeaderboardSortBy,
   LeaderboardSortDir,
-  LeaderboardTimeUnit,
   LeaderboardWindow,
 } from '../services/leaderboard.types';
 
 const WINDOWS: LeaderboardWindow[] = ['7d', '30d', 'all'];
 const SORT_BYS: LeaderboardSortBy[] = ['pnl', 'roi', 'mdd', 'aum'];
 const SORT_DIRS: LeaderboardSortDir[] = ['ASC', 'DESC'];
-const TIME_UNITS: LeaderboardTimeUnit[] = ['minutes', 'hours'];
 
 export class GetLeaderboardQueryDto {
   @ApiPropertyOptional({ enum: WINDOWS, example: '7d' })
@@ -64,26 +62,22 @@ export class GetLeaderboardQueryDto {
   minAumUsd?: number;
 
   @ApiPropertyOptional({
-    example: 30,
-    minimum: 1,
+    example: '2026-05-04T10:00:00.000Z',
     description:
-      'Optional rolling performance period. Must be provided together with timeUnit.',
+      'Optional absolute period start. Must be provided together with endDate.',
   })
   @IsOptional()
-  @Type(() => Number)
-  @IsInt()
-  @Min(1)
-  timePeriod?: number;
+  @IsISO8601({ strict: true })
+  startDate?: string;
 
   @ApiPropertyOptional({
-    enum: TIME_UNITS,
-    example: 'minutes',
+    example: '2026-05-04T18:00:00.000Z',
     description:
-      'Unit for timePeriod. Ranks leaders by performance over the last N minutes or hours.',
+      'Optional absolute period end. Must be provided together with startDate.',
   })
   @IsOptional()
-  @IsIn(TIME_UNITS)
-  timeUnit?: LeaderboardTimeUnit;
+  @IsISO8601({ strict: true })
+  endDate?: string;
 
   @ApiPropertyOptional({
     example: 30,

--- a/src/account/services/leaderboard.service.spec.ts
+++ b/src/account/services/leaderboard.service.spec.ts
@@ -196,8 +196,7 @@ describe('LeaderboardService', () => {
     expect(rowsSql).toContain('ORDER BY snap.mdd_pct ASC, snap.address ASC');
   });
 
-  it('ranks active traders by rolling-window performance when a time filter is supplied', async () => {
-    jest.useFakeTimers().setSystemTime(new Date('2026-04-28T12:00:00.000Z'));
+  it('ranks active traders by selected-period performance when startDate and endDate are supplied', async () => {
     batchTimestampToAeHeightMock.mockImplementation((timestamps: number[]) =>
       Promise.resolve(
         new Map(timestamps.map((timestamp, index) => [timestamp, index + 100])),
@@ -237,8 +236,8 @@ describe('LeaderboardService', () => {
     const result = await service.getLeaders({
       window: '30d',
       sortBy: 'pnl',
-      timePeriod: 2,
-      timeUnit: 'hours',
+      startDate: '2026-04-28T10:00:00.000Z',
+      endDate: '2026-04-28T12:00:00.000Z',
     });
 
     expect(snapshotRepository.query).not.toHaveBeenCalled();
@@ -258,8 +257,6 @@ describe('LeaderboardService', () => {
     expect(bclPnlService.calculateTokenPnlsBatch).toHaveBeenCalledTimes(2);
 
     expect(result.timeFilter).toEqual({
-      value: 2,
-      unit: 'hours',
       start: new Date('2026-04-28T10:00:00.000Z'),
       end: new Date('2026-04-28T12:00:00.000Z'),
     });
@@ -288,7 +285,6 @@ describe('LeaderboardService', () => {
   });
 
   it('sorts and paginates computed event metrics after applying min AUM', async () => {
-    jest.useFakeTimers().setSystemTime(new Date('2026-04-28T12:00:00.000Z'));
     batchTimestampToAeHeightMock.mockImplementation((timestamps: number[]) =>
       Promise.resolve(
         new Map(timestamps.map((timestamp, index) => [timestamp, index + 100])),
@@ -327,8 +323,8 @@ describe('LeaderboardService', () => {
       page: 2,
       limit: 1,
       minAumUsd: 1,
-      timePeriod: 30,
-      timeUnit: 'minutes',
+      startDate: '2026-04-28T11:30:00.000Z',
+      endDate: '2026-04-28T12:00:00.000Z',
     });
 
     expect(result.totalCandidates).toBe(2);
@@ -336,63 +332,50 @@ describe('LeaderboardService', () => {
     expect(result.items[0].address).toBe('ak_second');
   });
 
-  it('accepts the 168-hour upper bound', async () => {
-    jest.useFakeTimers().setSystemTime(new Date('2026-04-28T12:00:00.000Z'));
+  it('accepts a 14-day selected period', async () => {
     const { service } = createService();
 
     const result = await service.getLeaders({
       window: '7d',
       sortBy: 'pnl',
-      timePeriod: 168,
-      timeUnit: 'hours',
+      startDate: '2026-04-14T12:00:00.000Z',
+      endDate: '2026-04-28T12:00:00.000Z',
     });
 
     expect(result.timeFilter?.start).toEqual(
-      new Date('2026-04-21T12:00:00.000Z'),
+      new Date('2026-04-14T12:00:00.000Z'),
     );
     expect(result.timeFilter?.end).toEqual(
       new Date('2026-04-28T12:00:00.000Z'),
     );
   });
 
-  it('accepts the 10080-minute upper bound', async () => {
-    const { service } = createService();
-
-    await expect(
-      service.getLeaders({
-        window: '7d',
-        sortBy: 'pnl',
-        timePeriod: 10080,
-        timeUnit: 'minutes',
-      }),
-    ).resolves.toBeTruthy();
-  });
-
   it.each([
-    [{ timePeriod: 30 }, 'timePeriod and timeUnit must be provided together'],
     [
-      { timeUnit: 'hours' as const },
-      'timePeriod and timeUnit must be provided together',
+      { startDate: '2026-04-28T10:00:00.000Z' },
+      'startDate and endDate must be provided together',
     ],
     [
-      { timePeriod: 0, timeUnit: 'hours' as const },
-      'timePeriod must be a positive integer',
+      { endDate: '2026-04-28T12:00:00.000Z' },
+      'startDate and endDate must be provided together',
     ],
     [
-      { timePeriod: 1.5, timeUnit: 'hours' as const },
-      'timePeriod must be a positive integer',
+      { startDate: 'not-a-date', endDate: '2026-04-28T12:00:00.000Z' },
+      'startDate and endDate must be valid ISO 8601 timestamps',
     ],
     [
-      { timePeriod: 169, timeUnit: 'hours' as const },
-      'timePeriod cannot exceed 7 days',
+      {
+        startDate: '2026-04-28T12:00:00.000Z',
+        endDate: '2026-04-28T10:00:00.000Z',
+      },
+      'endDate must be after startDate',
     ],
     [
-      { timePeriod: 10081, timeUnit: 'minutes' as const },
-      'timePeriod cannot exceed 7 days',
-    ],
-    [
-      { timePeriod: 1, timeUnit: 'days' as unknown as 'minutes' },
-      'timeUnit must be one of: minutes, hours',
+      {
+        startDate: '2026-04-14T11:59:59.999Z',
+        endDate: '2026-04-28T12:00:00.000Z',
+      },
+      'Selected period cannot exceed 14 days',
     ],
   ])('rejects invalid time filters: %o', async (timeParams, message) => {
     const { service, snapshotRepository } = createService();

--- a/src/account/services/leaderboard.service.ts
+++ b/src/account/services/leaderboard.service.ts
@@ -13,7 +13,6 @@ import {
   LeaderboardSortBy,
   LeaderboardSortDir,
   LeaderboardTimeFilter,
-  LeaderboardTimeUnit,
   LeaderboardWindow,
 } from './leaderboard.types';
 
@@ -56,11 +55,7 @@ const VALID_SORT_DIRECTIONS: ReadonlySet<LeaderboardSortDir> = new Set([
   'ASC',
   'DESC',
 ]);
-const VALID_TIME_UNITS: ReadonlySet<LeaderboardTimeUnit> = new Set([
-  'minutes',
-  'hours',
-]);
-const MAX_TIME_FILTER_DAYS = 7;
+const MAX_TIME_FILTER_DAYS = 14;
 const MAX_TIME_FILTER_MS = MAX_TIME_FILTER_DAYS * 24 * 60 * 60 * 1000;
 const DEFAULT_LIMIT = 18;
 const MAX_LIMIT = 50;
@@ -583,41 +578,40 @@ export class LeaderboardService {
   private normalizeTimeFilter(
     params: GetLeadersParams,
   ): LeaderboardTimeFilter | undefined {
-    const hasPeriod = params.timePeriod !== undefined;
-    const hasUnit = params.timeUnit !== undefined && params.timeUnit !== null;
+    const hasStart =
+      params.startDate !== undefined && params.startDate !== null;
+    const hasEnd = params.endDate !== undefined && params.endDate !== null;
 
-    if (!hasPeriod && !hasUnit) {
+    if (!hasStart && !hasEnd) {
       return undefined;
     }
-    if (!hasPeriod || !hasUnit) {
+    if (!hasStart || !hasEnd) {
       throw new BadRequestException(
-        'timePeriod and timeUnit must be provided together',
+        'startDate and endDate must be provided together',
       );
     }
 
-    const value = Number(params.timePeriod);
-    const unit = params.timeUnit as LeaderboardTimeUnit;
+    const start = new Date(params.startDate as string);
+    const end = new Date(params.endDate as string);
 
-    if (!Number.isInteger(value) || value < 1) {
-      throw new BadRequestException('timePeriod must be a positive integer');
-    }
-    if (!VALID_TIME_UNITS.has(unit)) {
-      throw new BadRequestException('timeUnit must be one of: minutes, hours');
+    if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+      throw new BadRequestException(
+        'startDate and endDate must be valid ISO 8601 timestamps',
+      );
     }
 
-    const durationMs =
-      unit === 'minutes' ? value * 60 * 1000 : value * 60 * 60 * 1000;
+    const durationMs = end.getTime() - start.getTime();
+    if (durationMs <= 0) {
+      throw new BadRequestException('endDate must be after startDate');
+    }
     if (durationMs > MAX_TIME_FILTER_MS) {
       throw new BadRequestException(
-        `timePeriod cannot exceed ${MAX_TIME_FILTER_DAYS} days`,
+        `Selected period cannot exceed ${MAX_TIME_FILTER_DAYS} days`,
       );
     }
 
-    const end = new Date();
     return {
-      value,
-      unit,
-      start: new Date(end.getTime() - durationMs),
+      start,
       end,
     };
   }

--- a/src/account/services/leaderboard.types.ts
+++ b/src/account/services/leaderboard.types.ts
@@ -15,11 +15,8 @@ export const LEADERBOARD_SNAPSHOT_MAX_CANDIDATES = 100;
 export type LeaderboardWindow = '7d' | '30d' | 'all';
 export type LeaderboardSortBy = 'pnl' | 'roi' | 'mdd' | 'aum';
 export type LeaderboardSortDir = 'ASC' | 'DESC';
-export type LeaderboardTimeUnit = 'minutes' | 'hours';
 
 export interface LeaderboardTimeFilter {
-  value: number;
-  unit: LeaderboardTimeUnit;
   start: Date;
   end: Date;
 }
@@ -33,8 +30,8 @@ export interface LeaderboardItemActivePeriod {
 export interface LeaderboardItem {
   address: string;
   chain_name?: string | null;
-  // metrics are snapshot-scoped by default; when timePeriod + timeUnit are
-  // supplied, they are computed over that rolling time window.
+  // metrics are snapshot-scoped by default; when startDate + endDate are
+  // supplied, they are computed over that selected time window.
   aum_usd: number;
   pnl_usd: number;
   roi_pct: number;
@@ -46,10 +43,10 @@ export interface LeaderboardItem {
   owned_trends_count: number;
   // chart
   portfolio_value_usd_sparkline: Array<[number, number]>;
-  // Event-window traded volume, present only for time-filtered leaderboards.
+  // Event-window traded volume, present only for selected-period leaderboards.
   volume_usd?: number;
   // Deprecated compatibility field from the first time-filter implementation.
-  // Time-filtered leaderboards now use top-level event-window metrics instead.
+  // Selected-period leaderboards now use top-level event-window metrics instead.
   active_period?: LeaderboardItemActivePeriod;
 }
 
@@ -61,7 +58,7 @@ export interface GetLeadersParams {
   limit?: number;
   points?: number;
   minAumUsd?: number;
-  timePeriod?: number;
-  timeUnit?: LeaderboardTimeUnit;
+  startDate?: string;
+  endDate?: string;
   maxCandidates?: number; // kept for API compatibility, ignored in snapshot mode
 }

--- a/src/main.validation.spec.ts
+++ b/src/main.validation.spec.ts
@@ -143,14 +143,15 @@ describe('global ValidationPipe request DTO coverage', () => {
         page: '2',
         limit: '20',
         minAumUsd: '1',
-        timePeriod: '30',
-        timeUnit: 'minutes',
+        startDate: '2026-04-28T10:00:00.000Z',
+        endDate: '2026-04-28T12:00:00.000Z',
       },
       assertTransformed(result: GetLeaderboardQueryDto) {
         expect(result.page).toBe(2);
         expect(result.limit).toBe(20);
         expect(result.minAumUsd).toBe(1);
-        expect(result.timePeriod).toBe(30);
+        expect(result.startDate).toBe('2026-04-28T10:00:00.000Z');
+        expect(result.endDate).toBe('2026-04-28T12:00:00.000Z');
         expect(result.sortDir).toBe('DESC');
       },
     },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the public leaderboard query contract from relative `timePeriod/timeUnit` to absolute `startDate/endDate` and updates validation/error handling, which could break clients and alters query behavior over large transaction ranges. Adds/relies on indexes for performance; incorrect deploy ordering could cause production slow queries.
> 
> **Overview**
> Switches the leaderboard “time filter” from a rolling window (`timePeriod`/`timeUnit`) to an absolute selected period (`startDate`/`endDate`), updating controller response metadata and service normalization/validation (ISO timestamps, end-after-start, max range now **14 days**).
> 
> Updates tests and DTO validation accordingly, and refreshes the manual migration/runbook docs to reflect the selected-period flow and the required transaction/snapshot indexes for performance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be0f9dadd97dd9cf398c8591a382541efe029eb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->