### PR TITLE
Add traiding only leaderboard flag, increase fresh post boost

### DIFF
--- a/docs/leaderboard-time-filter-manual-migration.sql
+++ b/docs/leaderboard-time-filter-manual-migration.sql
@@ -67,7 +67,7 @@
 --    table is small, ≤100 rows per window). Repeat for sortBy=roi/mdd/aum.
 --
 -- C) Hit a real selected-period performance request and inspect the duration:
---      curl 'https://<host>/api/accounts/leaderboard?window=7d&sortBy=pnl&startDate=2026-05-04T10:00:00.000Z&endDate=2026-05-04T18:00:00.000Z'
+--      curl 'https://<host>/api/accounts/leaderboard?window=7d&sortBy=pnl&startDate=2026-05-04T10:00:00.000Z&endDate=2026-05-04T18:00:00.000Z&tradingOnly=true'
 --    p95 should be well under 500ms. If it is not, capture the plan via
 --    `auto_explain` (or run the underlying queries manually with EXPLAIN ANALYZE)
 --    and check that `IDX_TRANSACTION_CREATED_AT_ADDRESS_TYPE` is being used.

--- a/src/account/controllers/leaderboard.controller.spec.ts
+++ b/src/account/controllers/leaderboard.controller.spec.ts
@@ -77,6 +77,7 @@ describe('LeaderboardController', () => {
       limit: 5,
       startDate: '2026-04-28T10:00:00.000Z',
       endDate: '2026-04-28T12:00:00.000Z',
+      tradingOnly: true,
     });
 
     expect(getLeaders).toHaveBeenCalledWith({
@@ -87,6 +88,7 @@ describe('LeaderboardController', () => {
       limit: 5,
       startDate: '2026-04-28T10:00:00.000Z',
       endDate: '2026-04-28T12:00:00.000Z',
+      tradingOnly: true,
     });
   });
 

--- a/src/account/controllers/leaderboard.controller.ts
+++ b/src/account/controllers/leaderboard.controller.ts
@@ -40,6 +40,7 @@ export class LeaderboardController {
       'Without startDate + endDate, metrics are precomputed per window (7d / 30d / all). ' +
       'When startDate + endDate are supplied, leaders are ranked by selected-period performance among accounts that traded within that time range. ' +
       'In that mode, top-level metrics and buy/sell counts are scoped to the requested time range. ' +
+      'Set tradingOnly=true to base selected-period PNL/ROI on realized token trading PNL, excluding transfer-driven portfolio changes. ' +
       'Note: responses are cached for up to 60 seconds, so `meta.timeFilter.start` and `meta.timeFilter.end` reflect the time the cache entry was filled, not strictly the time of the current request.',
   })
   @ApiOkResponse({ type: LeaderboardResponseDto })

--- a/src/account/dto/get-leaderboard-query.dto.ts
+++ b/src/account/dto/get-leaderboard-query.dto.ts
@@ -1,6 +1,14 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Transform, Type } from 'class-transformer';
-import { IsISO8601, IsIn, IsInt, IsOptional, Max, Min } from 'class-validator';
+import {
+  IsBoolean,
+  IsISO8601,
+  IsIn,
+  IsInt,
+  IsOptional,
+  Max,
+  Min,
+} from 'class-validator';
 import {
   LeaderboardSortBy,
   LeaderboardSortDir,
@@ -78,6 +86,20 @@ export class GetLeaderboardQueryDto {
   @IsOptional()
   @IsISO8601({ strict: true })
   endDate?: string;
+
+  @ApiPropertyOptional({
+    example: true,
+    description:
+      'When true, selected-period PNL/ROI are based only on realized token trading PNL, excluding portfolio value changes caused by transfers.',
+  })
+  @IsOptional()
+  @Transform(({ value }) => {
+    if (value === 'true') return true;
+    if (value === 'false') return false;
+    return value;
+  })
+  @IsBoolean()
+  tradingOnly?: boolean;
 
   @ApiPropertyOptional({
     example: 30,

--- a/src/account/services/leaderboard.service.spec.ts
+++ b/src/account/services/leaderboard.service.spec.ts
@@ -15,10 +15,23 @@ describe('LeaderboardService', () => {
   });
 
   type MockRow = Record<string, unknown>;
+  type MockPnlPoint =
+    | number
+    | {
+        aum: number;
+        gain?: number;
+        cost?: number;
+      };
 
-  const pnlResult = (totalCurrentValueUsd: number) =>
+  const pnlResult = (
+    totalCurrentValueUsd: number,
+    totalGainUsd = 0,
+    totalCostBasisUsd = 0,
+  ) =>
     ({
       totalCurrentValueUsd,
+      totalGainUsd,
+      totalCostBasisUsd,
     }) as never;
 
   const createService = (options?: {
@@ -26,7 +39,7 @@ describe('LeaderboardService', () => {
     totalCount?: number | string;
     activeRows?: MockRow[];
     accounts?: MockRow[];
-    pnlByAddress?: Record<string, number[]>;
+    pnlByAddress?: Record<string, MockPnlPoint[]>;
   }) => {
     const rows = options?.snapshotRows ?? [];
     const totalCount = options?.totalCount ?? 0;
@@ -50,10 +63,15 @@ describe('LeaderboardService', () => {
         const values = options?.pnlByAddress?.[address] ?? [];
         return Promise.resolve(
           new Map(
-            heights.map((height, index) => [
-              height,
-              pnlResult(values[index] ?? 0),
-            ]),
+            heights.map((height, index) => {
+              const value = values[index] ?? 0;
+              return [
+                height,
+                typeof value === 'number'
+                  ? pnlResult(value)
+                  : pnlResult(value.aum, value.gain ?? 0, value.cost ?? 0),
+              ];
+            }),
           ),
         );
       },
@@ -330,6 +348,113 @@ describe('LeaderboardService', () => {
     expect(result.totalCandidates).toBe(2);
     expect(result.items).toHaveLength(1);
     expect(result.items[0].address).toBe('ak_second');
+  });
+
+  it('uses range-based realized trading PNL when tradingOnly is enabled', async () => {
+    batchTimestampToAeHeightMock.mockImplementation((timestamps: number[]) =>
+      Promise.resolve(
+        new Map(timestamps.map((timestamp, index) => [timestamp, index + 100])),
+      ),
+    );
+    const { service, bclPnlService } = createService({
+      activeRows: [
+        {
+          address: 'ak_transfer_gain',
+          buy_count: '1',
+          sell_count: '1',
+          volume_usd: '100',
+        },
+        {
+          address: 'ak_trader',
+          buy_count: '2',
+          sell_count: '1',
+          volume_usd: '200',
+        },
+      ],
+      pnlByAddress: {
+        ak_transfer_gain: [
+          { aum: 100, gain: 0, cost: 0 },
+          { aum: 500, gain: 0, cost: 0 },
+        ],
+        ak_trader: [
+          { aum: 100, gain: 0, cost: 0 },
+          { aum: 130, gain: 30, cost: 100 },
+        ],
+      },
+    });
+
+    const result = await service.getLeaders({
+      sortBy: 'pnl',
+      tradingOnly: true,
+      startDate: '2026-04-28T10:00:00.000Z',
+      endDate: '2026-04-28T12:00:00.000Z',
+      points: 2,
+    });
+
+    expect(bclPnlService.calculateTokenPnlsBatch).toHaveBeenCalledWith(
+      'ak_transfer_gain',
+      [100, 101],
+      100,
+    );
+    expect(bclPnlService.calculateTokenPnlsBatch).toHaveBeenCalledWith(
+      'ak_trader',
+      [100, 101],
+      100,
+    );
+    expect(result.items[0]).toMatchObject({
+      address: 'ak_trader',
+      aum_usd: 130,
+      pnl_usd: 30,
+      roi_pct: 30,
+    });
+    expect(result.items[1]).toMatchObject({
+      address: 'ak_transfer_gain',
+      aum_usd: 500,
+      pnl_usd: 0,
+      roi_pct: 0,
+    });
+  });
+
+  it('bounds tradingOnly drawdown when realized PNL goes negative', async () => {
+    batchTimestampToAeHeightMock.mockImplementation((timestamps: number[]) =>
+      Promise.resolve(
+        new Map(timestamps.map((timestamp, index) => [timestamp, index + 100])),
+      ),
+    );
+    const { service } = createService({
+      activeRows: [
+        {
+          address: 'ak_loss',
+          buy_count: '1',
+          sell_count: '1',
+          volume_usd: '100',
+        },
+      ],
+      pnlByAddress: {
+        ak_loss: [
+          { aum: 100, gain: 0, cost: 100 },
+          { aum: 110, gain: 10, cost: 100 },
+          { aum: 95, gain: -5, cost: 100 },
+        ],
+      },
+    });
+
+    const result = await service.getLeaders({
+      sortBy: 'pnl',
+      tradingOnly: true,
+      startDate: '2026-04-28T10:00:00.000Z',
+      endDate: '2026-04-28T12:00:00.000Z',
+      points: 3,
+    });
+
+    expect(
+      result.items[0].portfolio_value_usd_sparkline.map(([, v]) => v),
+    ).toEqual([0, 10, -5]);
+    expect(result.items[0]).toMatchObject({
+      pnl_usd: -5,
+      roi_pct: -5,
+      mdd_pct: 100,
+    });
   });
 
   it('accepts a 14-day selected period', async () => {

--- a/src/account/services/leaderboard.service.ts
+++ b/src/account/services/leaderboard.service.ts
@@ -111,6 +111,7 @@ export class LeaderboardService {
           ),
         ),
         points: params.points,
+        tradingOnly: params.tradingOnly ?? false,
       });
 
       return {
@@ -333,6 +334,7 @@ export class LeaderboardService {
     minAumUsd: number;
     maxCandidates: number;
     points?: number;
+    tradingOnly: boolean;
   }): Promise<{ items: LeaderboardItem[]; total: number }> {
     const activeRows = await this.queryActiveAddressRows(
       params.timeFilter,
@@ -364,6 +366,7 @@ export class LeaderboardService {
       accountByAddress,
       sampleTimestamps,
       heights,
+      tradingOnly: params.tradingOnly,
     });
 
     const eligibleItems = eventItems.filter(
@@ -447,6 +450,7 @@ export class LeaderboardService {
     accountByAddress: Map<string, Account>;
     sampleTimestamps: number[];
     heights: number[];
+    tradingOnly: boolean;
   }): Promise<LeaderboardItem[]> {
     const items: LeaderboardItem[] = [];
     const concurrency = 8;
@@ -465,6 +469,7 @@ export class LeaderboardService {
           account: params.accountByAddress.get(address),
           sampleTimestamps: params.sampleTimestamps,
           heights: params.heights,
+          tradingOnly: params.tradingOnly,
         });
         if (item) {
           items.push(item);
@@ -482,16 +487,21 @@ export class LeaderboardService {
     account?: Account;
     sampleTimestamps: number[];
     heights: number[];
+    tradingOnly: boolean;
   }): Promise<LeaderboardItem | undefined> {
+    const startHeight = params.heights[0];
     const pnlByHeight = await this.bclPnlService.calculateTokenPnlsBatch(
       params.address,
       params.heights,
+      params.tradingOnly ? startHeight : undefined,
     );
     const sparkline = params.heights.map((height, index): [number, number] => {
       const pnl = pnlByHeight.get(height);
       return [
         params.sampleTimestamps[index],
-        Math.max(pnl?.totalCurrentValueUsd ?? 0, 0),
+        params.tradingOnly
+          ? (pnl?.totalGainUsd ?? 0)
+          : Math.max(pnl?.totalCurrentValueUsd ?? 0, 0),
       ];
     });
 
@@ -500,9 +510,15 @@ export class LeaderboardService {
     }
 
     const startAumUsd = sparkline[0][1];
-    const endAumUsd = sparkline[sparkline.length - 1][1];
-    const pnlUsd = endAumUsd - startAumUsd;
-    const roiPct = startAumUsd > 0 ? (pnlUsd / startAumUsd) * 100 : 0;
+    const finalPnl = pnlByHeight.get(params.heights[params.heights.length - 1]);
+    const endAumUsd = Math.max(finalPnl?.totalCurrentValueUsd ?? 0, 0);
+    const pnlUsd = params.tradingOnly
+      ? (finalPnl?.totalGainUsd ?? 0)
+      : endAumUsd - startAumUsd;
+    const roiBasisUsd = params.tradingOnly
+      ? (finalPnl?.totalCostBasisUsd ?? 0)
+      : startAumUsd;
+    const roiPct = roiBasisUsd > 0 ? (pnlUsd / roiBasisUsd) * 100 : 0;
     const mddPct = this.calculateMaxDrawdownPct(sparkline);
     const activeRow = params.activeRow;
 
@@ -526,7 +542,8 @@ export class LeaderboardService {
     let peak = Number.NEGATIVE_INFINITY;
     let maxDrawdown = 0;
 
-    for (const [, value] of sparkline) {
+    for (const [, rawValue] of sparkline) {
+      const value = Math.max(rawValue, 0);
       if (value > peak) {
         peak = value;
       }

--- a/src/account/services/leaderboard.types.ts
+++ b/src/account/services/leaderboard.types.ts
@@ -60,5 +60,6 @@ export interface GetLeadersParams {
   minAumUsd?: number;
   startDate?: string;
   endDate?: string;
+  tradingOnly?: boolean;
   maxCandidates?: number; // kept for API compatibility, ignored in snapshot mode
 }

--- a/src/configs/constants.ts
+++ b/src/configs/constants.ts
@@ -232,7 +232,7 @@ export const POPULAR_RANKING_CONFIG = {
     trendingBoost: 0.5, // w_tr (topical relevance)
     contentQuality: 0.3, // w_q (anti-spam)
     reads: 1.5, // w_reads (common passive signal)
-    freshnessBoost: 0.9, // w_fresh (temporary new-post lift)
+    freshnessBoost: 1.5, // w_fresh (temporary new-post lift)
     velocityBoost: 0.6, // w_vel (temporary lift for posts gaining activity quickly)
   },
 

--- a/src/main.validation.spec.ts
+++ b/src/main.validation.spec.ts
@@ -145,6 +145,7 @@ describe('global ValidationPipe request DTO coverage', () => {
         minAumUsd: '1',
         startDate: '2026-04-28T10:00:00.000Z',
         endDate: '2026-04-28T12:00:00.000Z',
+        tradingOnly: 'true',
       },
       assertTransformed(result: GetLeaderboardQueryDto) {
         expect(result.page).toBe(2);
@@ -152,6 +153,7 @@ describe('global ValidationPipe request DTO coverage', () => {
         expect(result.minAumUsd).toBe(1);
         expect(result.startDate).toBe('2026-04-28T10:00:00.000Z');
         expect(result.endDate).toBe('2026-04-28T12:00:00.000Z');
+        expect(result.tradingOnly).toBe(true);
         expect(result.sortDir).toBe('DESC');
       },
     },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes selected-period leaderboard metric calculations (PNL/ROI sparkline + drawdown) and adds a new query flag, which could affect ranking results and edge cases (negative PNL, cost-basis=0). Also tweaks popular-post scoring weight, which may shift feed ordering.
> 
> **Overview**
> Adds a `tradingOnly` query flag to the accounts leaderboard API/DTO and forwards it through to the service.
> 
> When `startDate`/`endDate` mode is used with `tradingOnly=true`, selected-period metrics switch to **realized trading PNL/ROI** (via `BclPnlService.calculateTokenPnlsBatch(..., fromBlockHeight)`), updating sparkline semantics, ROI basis (cost basis), and max-drawdown handling (clamps negatives for drawdown); includes new service tests for transfer-driven AUM changes and negative realized PNL.
> 
> Updates the leaderboard migration runbook example request to include `tradingOnly=true`, and increases `POPULAR_RANKING_CONFIG.WEIGHTS.freshnessBoost` from `0.9` to `1.5`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7db2f7c004b69d12d6397d25b74e2e932f3eb89a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->