### PR TITLE
Release

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,14 @@ REDIS_PORT=6379
 AE_NETWORK_ID=ae_mainnet
 
 APP_PORT=3000
+# Comma-separated list of browser origins allowed to call the API.
+# Leave empty (the default) to allow every origin — this API is public
+# and consumed by third-party explorers/dashboards, and it has no cookie
+# auth to protect. Only set this for private deployments where you want
+# to restrict browser callers; when set, CORS `credentials` is also
+# enabled so cookie-based integrations can work.
+# Example: ALLOWED_ORIGINS=https://superhero.com,https://app.superhero.com
+ALLOWED_ORIGINS=
 # Trending tags API key to be used for authentication from the scraper.
 # Must be a high-entropy random value (>= 32 chars) in production.
 TRENDING_TAGS_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -4,8 +4,9 @@ DB_PORT=5432
 DB_USER=postgres
 DB_PASSWORD=
 DB_DATABASE=bcl_api
-# shouldn't be used in production - otherwise you can lose production data.
-DB_SYNC=true
+# Auto-applies destructive DDL on startup. Forced off in production (see
+# src/configs/database.ts); only takes effect in non-production environments.
+DB_SYNC=false
 
 DISABLE_MDW_SYNC=false
 
@@ -16,8 +17,9 @@ REDIS_PORT=6379
 AE_NETWORK_ID=ae_mainnet
 
 APP_PORT=3000
-# Trending tags API key to be used for authentication from the scraper
-TRENDING_TAGS_API_KEY=your-secret-key-here-xxrf8ca2929
+# Trending tags API key to be used for authentication from the scraper.
+# Must be a high-entropy random value (>= 32 chars) in production.
+TRENDING_TAGS_API_KEY=
 
 # Profile registry integration
 PROFILE_REGISTRY_CONTRACT_ADDRESS=

--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,7 @@ APP_PORT=3000
 # enabled so cookie-based integrations can work.
 # Example: ALLOWED_ORIGINS=https://superhero.com,https://app.superhero.com
 ALLOWED_ORIGINS=
+
 # Trending tags API key to be used for authentication from the scraper.
 # Must be a high-entropy random value (>= 32 chars) in production.
 TRENDING_TAGS_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,10 @@ DISABLE_MDW_SYNC=false
 
 REDIS_HOST=localhost
 REDIS_PORT=6379
+# Optional. Only set this for custom deployments that use an authenticated
+# external Redis; the bundled compose Redis is localhost-only and has no
+# password.
+REDIS_PASSWORD=
 
 # ae_uat, ae_mainnet
 AE_NETWORK_ID=ae_mainnet

--- a/.env.testnet.example
+++ b/.env.testnet.example
@@ -9,7 +9,8 @@ DB_PORT=5437
 DB_USER=testnet
 DB_PASSWORD=testnet
 DB_DATABASE=api_testnet2
-DB_SYNC=true
+# Destructive: auto-applies DDL on startup; forced off in production.
+DB_SYNC=false
 
 REDIS_HOST=127.0.0.1
 REDIS_PORT=6380

--- a/.github/workflows/ssh_deploy.yaml
+++ b/.github/workflows/ssh_deploy.yaml
@@ -176,6 +176,5 @@ jobs:
               -e DB_TYPE=postgres \
               -e DB_HOST=${{ inputs.CONTAINER_NAME }}-db \
               -e DB_PORT=5432 \
-              -e DB_SYNC=true \
               --network ${{ inputs.CONTAINER_NAME }}-db \
               ${{ secrets.DOCKERHUB_REPO }}:${{ inputs.VERSION }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,11 @@ RUN npm ci
 RUN npm run build
 RUN npm prune --omit=dev
 
+# Run as an unprivileged user so a compromise of the Node process does not
+# grant root inside the container (and does not make container-escape
+# trivial). `node` is the default unprivileged user shipped in the
+# official node images.
+RUN chown -R node:node /src
+USER node
+
 CMD ["npm", "run", "start:prod"]

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -8,14 +8,15 @@ services:
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_DB=api
     ports:
-      - "5436:5432"
+      # Bind to loopback so the dev DB cannot be reached from the LAN.
+      - "127.0.0.1:5436:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
 
   redis:
     image: redis:alpine
     ports:
-      - "6379:6379"
+      - "127.0.0.1:6379:6379"
     volumes:
       - redis_data:/data
 

--- a/docker-compose-testnet.yml
+++ b/docker-compose-testnet.yml
@@ -16,7 +16,11 @@ services:
     ports:
       - "${TESTNET_APP_PORT:-3001}:3000"
     environment:
-      - NODE_ENV=production
+      # Testnet is not production: using NODE_ENV=staging here keeps
+      # production-style behaviour in most libs while allowing dev-only
+      # niceties like DB_SYNC=true (which the app refuses to honour when
+      # NODE_ENV=production, see src/configs/database.ts).
+      - NODE_ENV=staging
       - APP_PORT=3000
       - AE_NETWORK_ID=ae_uat
       - DB_TYPE=postgres
@@ -51,7 +55,7 @@ services:
       - POSTGRES_PASSWORD=${TESTNET_DB_PASSWORD:-testnet}
       - POSTGRES_DB=${TESTNET_DB_DATABASE:-api_testnet2}
     ports:
-      - "${TESTNET_DB_PORT:-5437}:5432"
+      - "127.0.0.1:${TESTNET_DB_PORT:-5437}:5432"
     volumes:
       - postgres_testnet2_data:/var/lib/postgresql/data
     healthcheck:
@@ -66,7 +70,7 @@ services:
     image: redis:alpine
     container_name: superhero-api-testnet2-redis
     ports:
-      - "${TESTNET_REDIS_PORT:-6380}:6379"
+      - "127.0.0.1:${TESTNET_REDIS_PORT:-6380}:6379"
     volumes:
       - redis_testnet2_data:/data
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
+      # Only expose the API port publicly; Postgres and Redis stay on the
+      # loopback interface (see below).
       - "${APP_PORT:-3000}:3000"
     environment:
       - DB_HOST=postgres
@@ -31,14 +33,16 @@ services:
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_DB=bcl_api
     ports:
-      - "5432:5432"
+      # Bind to loopback only: the DB port must not be reachable from the
+      # public internet. Use an SSH tunnel to connect from outside the host.
+      - "127.0.0.1:5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
 
   redis:
     image: redis:alpine
     ports:
-      - "6379:6379"
+      - "127.0.0.1:6379:6379"
     volumes:
       - redis_data:/data
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "graphql": "^16.12.0",
         "graphql-type-json": "^0.3.2",
         "hbs": "^4.2.0",
+        "helmet": "^8.1.0",
         "keyv": "^5.5.3",
         "moment": "^2.30.1",
         "nestjs-typeorm-paginate": "^4.1.0",
@@ -8555,6 +8556,15 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/hookified": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "graphql": "^16.12.0",
     "graphql-type-json": "^0.3.2",
     "hbs": "^4.2.0",
+    "helmet": "^8.1.0",
     "keyv": "^5.5.3",
     "moment": "^2.30.1",
     "nestjs-typeorm-paginate": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
     "start:dev": "nest start --watch",
-    "start:debug": "nest start --debug --watch",
+    "start:debug": "nest start --debug 127.0.0.1:9229 --watch",
     "start:prod": "node dist/src/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\"",
     "lint:fix": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",

--- a/src/account/account.module.ts
+++ b/src/account/account.module.ts
@@ -41,7 +41,7 @@ import { AePricingModule } from '@/ae-pricing/ae-pricing.module';
     LeaderboardService,
     LeaderboardSnapshotService,
   ],
-  exports: [TypeOrmModule],
+  exports: [TypeOrmModule, BclPnlService],
   controllers: [LeaderboardController, AccountsController, BclPnlController],
 })
 export class AccountModule {

--- a/src/account/controllers/accounts.controller.spec.ts
+++ b/src/account/controllers/accounts.controller.spec.ts
@@ -113,6 +113,20 @@ describe('AccountsController', () => {
     expect(queryBuilder.andWhere).not.toHaveBeenCalled();
   });
 
+  it('rejects invalid account pagination and ordering inputs before querying', async () => {
+    await expect(
+      controller.listAll(undefined, 0, 100, 'total_volume', 'DESC'),
+    ).rejects.toThrow('Page must be greater than or equal to 1');
+    await expect(
+      controller.listAll(undefined, 1, 101, 'total_volume', 'DESC'),
+    ).rejects.toThrow('Limit must be between 1 and 100');
+    await expect(
+      controller.listAll(undefined, 1, 100, 'unsafe_field', 'DESC'),
+    ).rejects.toThrow('Invalid order_by value: unsafe_field');
+
+    expect(accountRepository.createQueryBuilder).not.toHaveBeenCalled();
+  });
+
   it('throws when account is missing', async () => {
     accountRepository.findOne.mockResolvedValue(null);
 

--- a/src/account/controllers/accounts.controller.ts
+++ b/src/account/controllers/accounts.controller.ts
@@ -1,5 +1,6 @@
 import { CacheInterceptor, CacheTTL } from '@nestjs/cache-manager';
 import {
+  BadRequestException,
   Controller,
   DefaultValuePipe,
   Get,
@@ -33,11 +34,29 @@ import { TradingStatsQueryDto } from '../dto/trading-stats-query.dto';
 import { TradingStatsResponseDto } from '../dto/trading-stats-response.dto';
 import { ProfileReadService } from '@/profile/services/profile-read.service';
 import { ProfileCache } from '@/profile/entities/profile-cache.entity';
-import { buildSparklineSvg, sparklineStroke } from '@/utils/sparkline.util';
+import {
+  buildSparklineSvg,
+  parseSvgDimension,
+  sparklineStroke,
+} from '@/utils/sparkline.util';
 import {
   AeAccountAddressPipe,
   AeAccountReferencePipe,
 } from '@/common/validation/request-validation';
+
+const ALLOWED_ORDER_BY = new Set([
+  'total_volume',
+  'total_tx_count',
+  'total_buy_tx_count',
+  'total_sell_tx_count',
+  'total_created_tokens',
+  'total_invitation_count',
+  'total_claimed_invitation_count',
+  'total_revoked_invitation_count',
+  'created_at',
+]);
+const ALLOWED_ORDER_DIRECTIONS = new Set(['ASC', 'DESC']);
+const MAX_SEARCH_LENGTH = 100;
 
 @UseInterceptors(CacheInterceptor)
 @Controller('accounts')
@@ -90,6 +109,25 @@ export class AccountsController {
     @Query('order_by') orderBy: string = 'total_volume',
     @Query('order_direction') orderDirection: 'ASC' | 'DESC' = 'DESC',
   ) {
+    if (page < 1) {
+      throw new BadRequestException('Page must be greater than or equal to 1');
+    }
+    if (limit < 1 || limit > 100) {
+      throw new BadRequestException('Limit must be between 1 and 100');
+    }
+    if (!ALLOWED_ORDER_BY.has(orderBy)) {
+      throw new BadRequestException(`Invalid order_by value: ${orderBy}`);
+    }
+    if (!ALLOWED_ORDER_DIRECTIONS.has(orderDirection)) {
+      throw new BadRequestException(
+        `Invalid order_direction value: ${orderDirection}`,
+      );
+    }
+    if (search && search.length > MAX_SEARCH_LENGTH) {
+      throw new BadRequestException(
+        `search must be at most ${MAX_SEARCH_LENGTH} characters`,
+      );
+    }
     const query = this.accountRepository.createQueryBuilder('account');
 
     if (search?.trim()) {
@@ -306,8 +344,8 @@ export class AccountsController {
 
     const svg = buildSparklineSvg(
       values,
-      Number(width),
-      Number(height),
+      parseSvgDimension(width, 160),
+      parseSvgDimension(height, 60),
       sparklineStroke(values),
       background,
     );

--- a/src/ae/ae-sdk.service.ts
+++ b/src/ae/ae-sdk.service.ts
@@ -13,7 +13,7 @@ export class AeSdkService {
   sdk: AeSdk;
   constructor() {
     this.sdk = new AeSdk({
-      onCompiler: new CompilerHttp('https://v7.compiler.aepps.com'),
+      onCompiler: new CompilerHttp(ACTIVE_NETWORK.compilerUrl),
       nodes,
       // gasLimit: 5818000,
     });

--- a/src/ae/websocket.service.spec.ts
+++ b/src/ae/websocket.service.spec.ts
@@ -164,4 +164,58 @@ describe('WebSocketService', () => {
 
     expect(service.pings.length).toBe(0);
   });
+
+  it('should ignore messages for unknown subscriptions without crashing', () => {
+    const wsMessage = JSON.stringify({
+      subscription: 'NonExistentChannel',
+      payload: { data: 'test' },
+    });
+
+    expect(() => {
+      (service as any).handleWebsocketMessage(wsMessage);
+    }).not.toThrow();
+  });
+
+  it('should not call subscribers when subscription channel is unknown', () => {
+    const callback = jest.fn();
+    const message = {
+      op: WEB_SOCKET_SUBSCRIBE,
+      payload: WEB_SOCKET_CHANNELS.Transactions,
+    } as IMiddlewareWebSocketSubscriptionMessage;
+    service.subscribeForChannel(message, callback);
+
+    const wsMessage = JSON.stringify({
+      subscription: 'CompletelyDifferentChannel',
+      payload: { hash: 'shouldNotReach' },
+    });
+
+    (service as any).handleWebsocketMessage(wsMessage);
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('should handle PONG with missing payload.id gracefully', () => {
+    service.pings.push({ id: genUuid(), timestamp: Date.now() });
+
+    const pongCallback = mockWsClient.on.mock.calls.find(
+      ([event]) => event === 'pong',
+    )?.[1];
+
+    // pong with no id in payload
+    const pongNoId = JSON.stringify({ payload: {} });
+    expect(() => pongCallback?.(pongNoId)).not.toThrow();
+    expect(service.pings.length).toBe(1);
+  });
+
+  it('should handle malformed PONG JSON without crashing', () => {
+    service.pings.push({ id: genUuid(), timestamp: Date.now() });
+
+    const pongCallback = mockWsClient.on.mock.calls.find(
+      ([event]) => event === 'pong',
+    )?.[1];
+
+    expect(() => pongCallback?.('not valid json {')).not.toThrow();
+    // pings are cleared on parse failure as a safety measure
+    expect(service.pings.length).toBe(0);
+  });
 });

--- a/src/ae/websocket.service.ts
+++ b/src/ae/websocket.service.ts
@@ -37,7 +37,7 @@ export class WebSocketService implements OnModuleDestroy {
   private readonly boundClose = this.handleWebsocketClose.bind(this);
   private readonly boundMessage = this.handleWebsocketMessage.bind(this);
 
-  pings = [];
+  pings: PingI[] = [];
 
   subscribers: Record<
     WebSocketChannelName,
@@ -233,10 +233,19 @@ export class WebSocketService implements OnModuleDestroy {
         return;
       }
 
+      const subscribers =
+        this.subscribers[data.subscription as WebSocketChannelName];
+      if (!subscribers) {
+        this.logger.warn(
+          `Ignoring websocket message for unknown subscription: ${data.subscription}`,
+        );
+        return;
+      }
+
       // Call all subscribers for the channel
-      Object.values(
-        this.subscribers[data.subscription as WebSocketChannelName],
-      ).forEach((subscriberCb) => subscriberCb(data.payload));
+      Object.values(subscribers).forEach((subscriberCb) =>
+        subscriberCb(data.payload),
+      );
     } catch (error) {
       this.logger.error('handleWebsocketMessage->error::', error);
     }
@@ -273,9 +282,18 @@ export class WebSocketService implements OnModuleDestroy {
     this.wsClient.on('close', this.boundClose);
     this.wsClient.on('message', this.boundMessage);
     this.wsClient.on('pong', (data: any) => {
-      const parsedData = JSON.parse(data.toString());
-      const pingData = parsedData.payload;
-      this.pings = this.pings.filter((ping) => ping.id !== pingData.id);
+      try {
+        const parsedData = JSON.parse(data.toString());
+        const pingId = parsedData?.payload?.id;
+        if (!pingId) {
+          this.logger.warn('Ignoring websocket pong without ping id');
+          return;
+        }
+        this.pings = this.pings.filter((ping) => ping.id !== pingId);
+      } catch (error) {
+        this.logger.warn('Failed to parse websocket pong payload', error);
+        this.pings = [];
+      }
     });
     this.pings = [];
   }

--- a/src/affiliation/controllers/affiliation.controller.ts
+++ b/src/affiliation/controllers/affiliation.controller.ts
@@ -2,6 +2,7 @@ import { Controller, Post, Body, Param, Get, Render } from '@nestjs/common';
 import { ApiBody, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import { randomInt } from 'crypto';
 import { CreateAffiliationDto } from '../dto/create-affiliation.dto';
 import { Affiliation } from '../entities/affiliation.entity';
 import { AffiliationCode } from '../entities/affiliation-code.entity';
@@ -80,8 +81,7 @@ export class AffiliationController {
     }
 
     // shuffle availableCodes and pick one
-    const invitationCode =
-      availableCodes[Math.floor(Math.random() * availableCodes.length)];
+    const invitationCode = availableCodes[randomInt(availableCodes.length)];
 
     // update the code with the user info
     await this.affiliationCodeRepository.update(invitationCode.id, {
@@ -133,7 +133,7 @@ export class AffiliationController {
       const chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
       let result = '';
       for (let i = 0; i < 10; i++) {
-        result += chars.charAt(Math.floor(Math.random() * chars.length));
+        result += chars.charAt(randomInt(chars.length));
       }
       return result;
     };

--- a/src/affiliation/controllers/affiliation.controller.ts
+++ b/src/affiliation/controllers/affiliation.controller.ts
@@ -88,14 +88,18 @@ export class AffiliationController {
       claimed_by: `${provider}@${userInfo.id}`,
     });
 
-    // Return the user info along with affiliation details
+    // Return only the minimum data the client needs to redeem the invite.
+    // Previously this leaked the full OAuth profile (including email) and
+    // the full AffiliationCode entity (including claimed_by), which was
+    // unnecessary PII exposure over an unauthenticated endpoint.
     return {
-      user: userInfo,
       affiliation: {
         code: affiliation.code,
         available_codes: availableCodes.length,
       },
-      invitationCode,
+      invitationCode: {
+        private_code: invitationCode.private_code,
+      },
     };
   }
 

--- a/src/affiliation/controllers/invitations.controller.ts
+++ b/src/affiliation/controllers/invitations.controller.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   Controller,
   DefaultValuePipe,
   Get,
@@ -11,6 +12,9 @@ import { paginate } from 'nestjs-typeorm-paginate';
 import { Repository } from 'typeorm';
 import { Invitation } from '../entities/invitation.entity';
 import { Account } from '@/account/entities/account.entity';
+
+const ALLOWED_ORDER_BY = new Set(['amount', 'created_at']);
+const ALLOWED_ORDER_DIRECTIONS = new Set(['ASC', 'DESC']);
 
 @Controller('invitations')
 @ApiTags('Invitations')
@@ -38,6 +42,20 @@ export class InvitationsController {
     @Query('order_by') orderBy: string = 'amount',
     @Query('order_direction') orderDirection: 'ASC' | 'DESC' = 'DESC',
   ) {
+    if (page < 1) {
+      throw new BadRequestException('Page must be greater than or equal to 1');
+    }
+    if (limit < 1 || limit > 100) {
+      throw new BadRequestException('Limit must be between 1 and 100');
+    }
+    if (!ALLOWED_ORDER_BY.has(orderBy)) {
+      throw new BadRequestException(`Invalid order_by value: ${orderBy}`);
+    }
+    if (!ALLOWED_ORDER_DIRECTIONS.has(orderDirection)) {
+      throw new BadRequestException(
+        `Invalid order_direction value: ${orderDirection}`,
+      );
+    }
     const query = this.invitationRepository.createQueryBuilder('invitation');
     if (orderBy) {
       query.orderBy(`invitation.${orderBy}`, orderDirection);

--- a/src/affiliation/dto/create-affiliation.dto.ts
+++ b/src/affiliation/dto/create-affiliation.dto.ts
@@ -1,5 +1,11 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { ArrayNotEmpty, IsArray, IsString } from 'class-validator';
+import {
+  ArrayMaxSize,
+  ArrayNotEmpty,
+  IsArray,
+  IsString,
+  MaxLength,
+} from 'class-validator';
 import { IsAeAccountAddress } from '@/common/validation/request-validation';
 
 export class CreateAffiliationDto {
@@ -11,6 +17,8 @@ export class CreateAffiliationDto {
   @ApiProperty({ example: ['code1', 'code2', 'code3'] })
   @IsArray()
   @ArrayNotEmpty()
+  @ArrayMaxSize(100)
   @IsString({ each: true })
+  @MaxLength(64, { each: true })
   codes: string[];
 }

--- a/src/analytics/analytics.module.ts
+++ b/src/analytics/analytics.module.ts
@@ -6,17 +6,28 @@ import { TokensModule } from '@/tokens/tokens.module';
 import { AeModule } from '@/ae/ae.module';
 import { TransactionsModule } from '@/transactions/transactions.module';
 import { CacheDailyAnalyticsDataService } from './services/cache-daily-analytics-data.service';
+import { ChallengeAnalyticsService } from './services/challenge-analytics.service';
+import { ChallengeAnalyticsController } from './controllers/challenge-analytics.controller';
+import { AccountModule } from '@/account/account.module';
+import { Post } from '@/social/entities/post.entity';
 
 @Module({
   imports: [
     AeModule,
     TokensModule,
     TransactionsModule,
-    TypeOrmModule.forFeature([Analytic]),
+    AccountModule,
+    TypeOrmModule.forFeature([Analytic, Post]),
   ],
-  providers: [CacheDailyAnalyticsDataService],
+  providers: [CacheDailyAnalyticsDataService, ChallengeAnalyticsService],
   exports: [],
-  controllers: [AnalyticController],
+  controllers: [
+    // Register ChallengeAnalyticsController BEFORE AnalyticController so that
+    // /analytics/challenge* routes are matched before any future
+    // /analytics/:something path registered on AnalyticController.
+    ChallengeAnalyticsController,
+    AnalyticController,
+  ],
 })
 export class AnalyticsModule {
   //

--- a/src/analytics/controllers/challenge-analytics.controller.ts
+++ b/src/analytics/controllers/challenge-analytics.controller.ts
@@ -1,0 +1,89 @@
+import {
+  BadRequestException,
+  Controller,
+  Get,
+  Query,
+  Render,
+} from '@nestjs/common';
+import { ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
+import moment from 'moment';
+import { ChallengeAnalyticsService } from '../services/challenge-analytics.service';
+import { isAeAccountAddress } from '@/common/validation/request-validation';
+
+const MAX_ADDRESSES = 10;
+
+@Controller('analytics')
+@ApiTags('Analytics')
+export class ChallengeAnalyticsController {
+  constructor(
+    private readonly challengeAnalyticsService: ChallengeAnalyticsService,
+  ) {}
+
+  @Get('challenge')
+  @ApiQuery({
+    name: 'addresses',
+    type: 'string',
+    required: true,
+    description: `Comma-separated list of account addresses (max ${MAX_ADDRESSES})`,
+  })
+  @ApiQuery({ name: 'start_date', type: 'string', required: false })
+  @ApiQuery({ name: 'end_date', type: 'string', required: false })
+  @ApiOperation({
+    operationId: 'getChallengeAnalytics',
+  })
+  async getChallengeAnalytics(
+    @Query('addresses') addressesRaw: string,
+    @Query('start_date') start_date: string,
+    @Query('end_date') end_date: string,
+  ) {
+    const addresses = (addressesRaw ?? '')
+      .split(',')
+      .map((a) => a.trim())
+      .filter((a) => a.length > 0);
+
+    if (addresses.length === 0) {
+      throw new BadRequestException(
+        'At least one address is required (addresses=ak_a,ak_b,...)',
+      );
+    }
+
+    if (addresses.length > MAX_ADDRESSES) {
+      throw new BadRequestException(
+        `Too many addresses: max ${MAX_ADDRESSES} per request (got ${addresses.length})`,
+      );
+    }
+
+    const invalid = addresses.filter((a) => !isAeAccountAddress(a));
+    if (invalid.length > 0) {
+      throw new BadRequestException(
+        `Invalid account address(es): ${invalid.join(', ')}`,
+      );
+    }
+
+    // Deduplicate while preserving the user-provided order.
+    const uniqueAddresses = Array.from(new Set(addresses));
+
+    const startDate = moment(
+      start_date ?? moment().subtract(14, 'day').format('YYYY-MM-DD'),
+    ).toDate();
+    const endDate = moment(end_date ?? moment().format('YYYY-MM-DD')).toDate();
+
+    if (startDate > endDate) {
+      throw new BadRequestException('Start date must be before end date');
+    }
+
+    const rows = await this.challengeAnalyticsService.getChallengeAnalytics(
+      uniqueAddresses,
+      startDate,
+      endDate,
+    );
+
+    return rows;
+  }
+
+  @Get('challenge/preview')
+  @Render('challenge-analytics')
+  preview() {
+    return {};
+  }
+}

--- a/src/analytics/services/challenge-analytics.service.ts
+++ b/src/analytics/services/challenge-analytics.service.ts
@@ -1,0 +1,274 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import moment from 'moment';
+import { Transaction } from '@/transactions/entities/transaction.entity';
+import { Post } from '@/social/entities/post.entity';
+import {
+  BclPnlService,
+  DailyPnlWindow,
+} from '@/account/services/bcl-pnl.service';
+
+export interface ChallengeAnalyticsRow {
+  address: string;
+  date: string; // YYYY-MM-DD
+  total_posts: number;
+  total_trades: number;
+  total_volume_ae: number;
+  created_tokens: number;
+  pnl_ae: number;
+  pnl_usd: number;
+}
+
+@Injectable()
+export class ChallengeAnalyticsService {
+  private readonly logger = new Logger(ChallengeAnalyticsService.name);
+
+  constructor(
+    @InjectRepository(Transaction)
+    private readonly transactionRepository: Repository<Transaction>,
+    @InjectRepository(Post)
+    private readonly postRepository: Repository<Post>,
+    private readonly bclPnlService: BclPnlService,
+  ) {}
+
+  async getChallengeAnalytics(
+    addresses: string[],
+    startDate: Date,
+    endDate: Date,
+  ): Promise<ChallengeAnalyticsRow[]> {
+    if (addresses.length === 0) {
+      return [];
+    }
+
+    const startOfRange = moment(startDate).startOf('day').toDate();
+    const endOfRange = moment(endDate).endOf('day').toDate();
+
+    // List of day keys (YYYY-MM-DD) covered by the range, used for zero-fill.
+    const dayKeys = this.buildDayKeys(startOfRange, endOfRange);
+
+    // Initialise the (address × day) grid with zero rows so every cell exists.
+    const grid = new Map<string, Map<string, ChallengeAnalyticsRow>>();
+    for (const address of addresses) {
+      const dayMap = new Map<string, ChallengeAnalyticsRow>();
+      for (const dayKey of dayKeys) {
+        dayMap.set(dayKey, {
+          address,
+          date: dayKey,
+          total_posts: 0,
+          total_trades: 0,
+          total_volume_ae: 0,
+          created_tokens: 0,
+          pnl_ae: 0,
+          pnl_usd: 0,
+        });
+      }
+      grid.set(address, dayMap);
+    }
+
+    // Fetch all three data sources in parallel.
+    const [postsRows, txRows, pnlByAddress] = await Promise.all([
+      this.fetchPostsPerDay(addresses, startOfRange, endOfRange),
+      this.fetchTransactionsPerDay(addresses, startOfRange, endOfRange),
+      this.fetchPnlPerDayPerAddress(addresses, startOfRange, endOfRange),
+    ]);
+
+    for (const row of postsRows) {
+      const dayMap = grid.get(row.address);
+      const cell = dayMap?.get(row.date);
+      if (cell) {
+        cell.total_posts = row.total_posts;
+      }
+    }
+
+    for (const row of txRows) {
+      const dayMap = grid.get(row.address);
+      const cell = dayMap?.get(row.date);
+      if (cell) {
+        cell.total_trades = row.total_trades;
+        cell.created_tokens = row.created_tokens;
+        cell.total_volume_ae = row.total_volume_ae;
+      }
+    }
+
+    for (const [address, dayPnl] of pnlByAddress.entries()) {
+      const dayMap = grid.get(address);
+      if (!dayMap) continue;
+      for (const [dayKey, pnl] of dayPnl.entries()) {
+        const cell = dayMap.get(dayKey);
+        if (cell) {
+          cell.pnl_ae = pnl.ae;
+          cell.pnl_usd = pnl.usd;
+        }
+      }
+    }
+
+    // Flatten back into a sorted array (address asc, then date asc).
+    const flat: ChallengeAnalyticsRow[] = [];
+    for (const address of addresses) {
+      const dayMap = grid.get(address)!;
+      for (const dayKey of dayKeys) {
+        flat.push(dayMap.get(dayKey)!);
+      }
+    }
+
+    return flat;
+  }
+
+  private buildDayKeys(startOfRange: Date, endOfRange: Date): string[] {
+    const keys: string[] = [];
+    const cursor = moment(startOfRange).startOf('day');
+    const end = moment(endOfRange).startOf('day');
+    while (cursor.isSameOrBefore(end)) {
+      keys.push(cursor.format('YYYY-MM-DD'));
+      cursor.add(1, 'day');
+    }
+    return keys;
+  }
+
+  private async fetchPostsPerDay(
+    addresses: string[],
+    startOfRange: Date,
+    endOfRange: Date,
+  ): Promise<Array<{ address: string; date: string; total_posts: number }>> {
+    const rows: Array<{
+      day: Date;
+      sender_address: string;
+      total_posts: string | number;
+    }> = await this.postRepository.query(
+      `SELECT
+         date_trunc('day', created_at) AS day,
+         sender_address,
+         COUNT(*) FILTER (WHERE post_id IS NULL)::int AS total_posts
+       FROM posts
+       WHERE created_at BETWEEN $1 AND $2
+         AND is_hidden = false
+         AND sender_address = ANY($3::text[])
+       GROUP BY day, sender_address`,
+      [startOfRange, endOfRange, addresses],
+    );
+
+    return rows.map((row) => ({
+      address: row.sender_address,
+      date: moment(row.day).format('YYYY-MM-DD'),
+      total_posts: Number(row.total_posts ?? 0),
+    }));
+  }
+
+  private async fetchTransactionsPerDay(
+    addresses: string[],
+    startOfRange: Date,
+    endOfRange: Date,
+  ): Promise<
+    Array<{
+      address: string;
+      date: string;
+      total_trades: number;
+      created_tokens: number;
+      total_volume_ae: number;
+    }>
+  > {
+    const rows: Array<{
+      day: Date;
+      address: string;
+      total_trades: string | number;
+      created_tokens: string | number;
+      total_volume_ae: string | number | null;
+    }> = await this.transactionRepository.query(
+      `SELECT
+         date_trunc('day', created_at) AS day,
+         address,
+         COUNT(*) FILTER (WHERE tx_type IN ('buy','sell'))::int        AS total_trades,
+         COUNT(*) FILTER (WHERE tx_type = 'create_community')::int     AS created_tokens,
+         COALESCE(SUM(
+           CASE
+             WHEN tx_type IN ('buy','sell','create_community')
+               THEN CAST(NULLIF(amount->>'ae','NaN') AS DECIMAL)
+             ELSE 0
+           END
+         ), 0) AS total_volume_ae
+       FROM transactions
+       WHERE created_at BETWEEN $1 AND $2
+         AND address = ANY($3::text[])
+       GROUP BY day, address`,
+      [startOfRange, endOfRange, addresses],
+    );
+
+    return rows.map((row) => ({
+      address: row.address,
+      date: moment(row.day).format('YYYY-MM-DD'),
+      total_trades: Number(row.total_trades ?? 0),
+      created_tokens: Number(row.created_tokens ?? 0),
+      total_volume_ae: Number(row.total_volume_ae ?? 0),
+    }));
+  }
+
+  /**
+   * For each address, compute REALIZED PnL per day in the range using
+   * `BclPnlService.calculateDailyPnlBatch` (one batched SQL per address).
+   *
+   * Each day's window is [startOfDay, endOfDay) in epoch ms; PnL for the
+   * window only includes sells closed within that window, valued against the
+   * all-time average cost of the token (so cost basis isn't truncated by the
+   * range start).
+   */
+  private async fetchPnlPerDayPerAddress(
+    addresses: string[],
+    startOfRange: Date,
+    endOfRange: Date,
+  ): Promise<Map<string, Map<string, { ae: number; usd: number }>>> {
+    const dayKeys = this.buildDayKeys(startOfRange, endOfRange);
+    if (dayKeys.length === 0) {
+      return new Map();
+    }
+
+    // Build one set of windows up-front; we reuse it for every address.
+    const windows: DailyPnlWindow[] = dayKeys.map((dayKey) => {
+      const dayStart = moment(dayKey).startOf('day');
+      const dayEnd = moment(dayKey).endOf('day');
+      return {
+        dayStartTs: dayStart.valueOf(),
+        snapshotTs: dayEnd.valueOf(),
+      };
+    });
+
+    const result = new Map<string, Map<string, { ae: number; usd: number }>>();
+
+    await Promise.all(
+      addresses.map(async (address) => {
+        try {
+          const batch = await this.bclPnlService.calculateDailyPnlBatch(
+            address,
+            windows,
+          );
+          // Index windows by their day key so we can look them up cheaply.
+          const winByDay = new Map<string, DailyPnlWindow>();
+          for (const win of windows) {
+            winByDay.set(moment(win.snapshotTs).format('YYYY-MM-DD'), win);
+          }
+          const dayMap = new Map<string, { ae: number; usd: number }>();
+          for (const dayKey of dayKeys) {
+            const win = winByDay.get(dayKey);
+            if (!win) continue;
+            const tokenPnl = batch.get(win.snapshotTs);
+            if (!tokenPnl) continue;
+            dayMap.set(dayKey, {
+              ae: Number(tokenPnl.totalGainAe ?? 0),
+              usd: Number(tokenPnl.totalGainUsd ?? 0),
+            });
+          }
+          result.set(address, dayMap);
+        } catch (error: any) {
+          this.logger.error(
+            `Error computing daily PnL for address ${address}`,
+            error,
+            error?.stack,
+          );
+          result.set(address, new Map());
+        }
+      }),
+    );
+
+    return result;
+  }
+}

--- a/src/api-core/base/base.controller.ts
+++ b/src/api-core/base/base.controller.ts
@@ -292,6 +292,25 @@ export function createBaseController<T>(
       @Query('includes') includes?: string,
       @Query() allQueryParams?: Record<string, any>,
     ) {
+      if (page < 1) {
+        throw new BadRequestException(
+          'Page must be greater than or equal to 1',
+        );
+      }
+      if (limit < 1) {
+        throw new BadRequestException(
+          'Limit must be greater than or equal to 1',
+        );
+      }
+      if (orderBy && !orderByFields.includes(orderBy)) {
+        throw new BadRequestException(`Invalid order_by value: ${orderBy}`);
+      }
+      if (!['ASC', 'DESC'].includes(orderDirection)) {
+        throw new BadRequestException(
+          `Invalid order_direction value: ${orderDirection}`,
+        );
+      }
+
       // Hard limit: maximum 100 items per request
       if (limit > 100) {
         throw new BadRequestException('Maximum limit is 100 items per request');

--- a/src/api-core/base/base.resolver.ts
+++ b/src/api-core/base/base.resolver.ts
@@ -8,14 +8,54 @@ import {
   Parent,
 } from '@nestjs/graphql';
 import { InjectRepository, getRepositoryToken } from '@nestjs/typeorm';
-import { Inject, Optional, Type } from '@nestjs/common';
+import { BadRequestException, Inject, Optional, Type } from '@nestjs/common';
 import { Repository } from 'typeorm';
 import { paginate } from 'nestjs-typeorm-paginate';
 import { PaginatedResponse } from '../types/pagination.type';
 import { EntityConfig } from '../types/entity-config.interface';
+import { getSortableFields } from '../utils/metadata-reader';
+
+const MAX_GRAPHQL_PAGE_SIZE = 100;
+const ALLOWED_ORDER_DIRECTIONS = new Set(['ASC', 'DESC']);
+
+function validateGraphqlPagination(page: number, limit: number): void {
+  if (page < 1) {
+    throw new BadRequestException('Page must be greater than or equal to 1');
+  }
+  if (limit < 1) {
+    throw new BadRequestException('Limit must be greater than or equal to 1');
+  }
+  if (limit > MAX_GRAPHQL_PAGE_SIZE) {
+    throw new BadRequestException('Maximum limit is 100 items per request');
+  }
+}
+
+function validateGraphqlOffset(offset: number): void {
+  if (offset < 0) {
+    throw new BadRequestException('Offset must be greater than or equal to 0');
+  }
+}
+
+function validateOrderDirection(
+  orderDirection?: string,
+  fallback: 'ASC' | 'DESC' = 'DESC',
+): 'ASC' | 'DESC' {
+  if (!orderDirection) {
+    return fallback;
+  }
+  if (!ALLOWED_ORDER_DIRECTIONS.has(orderDirection)) {
+    throw new BadRequestException(
+      `Invalid orderDirection value: ${orderDirection}`,
+    );
+  }
+  return orderDirection as 'ASC' | 'DESC';
+}
 
 export function createBaseResolver<T>(config: EntityConfig<T>) {
   const PaginatedResponseType = PaginatedResponse(config.entity);
+  const orderByFields =
+    config.orderByFields ||
+    getSortableFields(config.entity).map((f) => f.field);
 
   // Collect all unique related entity types for repository injection
   const relatedEntityTypes = config.relations
@@ -59,13 +99,17 @@ export function createBaseResolver<T>(config: EntityConfig<T>) {
       orderDirection?: 'ASC' | 'DESC',
     ) {
       const query = this.repository.createQueryBuilder(config.tableAlias);
-
+      validateGraphqlPagination(page, limit);
+      if (orderBy && !orderByFields.includes(orderBy)) {
+        throw new BadRequestException(`Invalid orderBy value: ${orderBy}`);
+      }
       // Apply ordering
       if (orderBy) {
-        query.orderBy(
-          `${config.tableAlias}.${orderBy}`,
-          orderDirection || config.defaultOrderDirection || 'DESC',
+        const safeOrderDirection = validateOrderDirection(
+          orderDirection,
+          config.defaultOrderDirection || 'DESC',
         );
+        query.orderBy(`${config.tableAlias}.${orderBy}`, safeOrderDirection);
       } else {
         query.orderBy(
           `${config.tableAlias}.${config.defaultOrderBy}`,
@@ -161,6 +205,14 @@ export function createBaseResolver<T>(config: EntityConfig<T>) {
         // Build function body with proper parameter name references
         // Use mapped parameter names for reserved keywords, but keep original field names for DB columns
         // Note: Must use plain JavaScript (no TypeScript syntax like 'as any')
+        const relationOrderByFields = Array.from(
+          new Set(
+            [
+              ...getSortableFields(relation.relatedEntity).map((f) => f.field),
+              relation.defaultOrderBy,
+            ].filter(Boolean),
+          ),
+        );
         const functionBody = `
           const repo = this.relatedRepositories.get(relation.relatedEntity);
           if (!repo) {
@@ -177,6 +229,9 @@ export function createBaseResolver<T>(config: EntityConfig<T>) {
           if (parentValue === undefined || parentValue === null) {
             return [];
           }
+
+          validateGraphqlPagination(1, limit);
+          validateGraphqlOffset(offset);
           
           query.where(
             \`\${tableAlias}.\${relation.joinCondition.localField} = :parentValue\`,
@@ -196,9 +251,15 @@ export function createBaseResolver<T>(config: EntityConfig<T>) {
             .join('')}
 
           if (orderBy) {
+            if (!relationOrderByFields.includes(orderBy)) {
+              throw new BadRequestException(\`Invalid orderBy value: \${orderBy}\`);
+            }
             query.orderBy(
               \`\${tableAlias}.\${orderBy}\`,
-              orderDirection || relation.defaultOrderDirection || 'DESC',
+              validateOrderDirection(
+                orderDirection,
+                relation.defaultOrderDirection || 'DESC',
+              ),
             );
           } else if (relation.defaultOrderBy) {
             query.orderBy(
@@ -214,10 +275,24 @@ export function createBaseResolver<T>(config: EntityConfig<T>) {
         // Create function using Function constructor with closure variables passed as parameters
         const resolverImpl = new Function(
           'relation',
+          'relationOrderByFields',
+          'BadRequestException',
+          'validateGraphqlPagination',
+          'validateGraphqlOffset',
+          'validateOrderDirection',
           'BaseResolver',
           'T',
           `return async function(${paramList}) {${functionBody}}`,
-        )(relation, BaseResolver, config.entity);
+        )(
+          relation,
+          relationOrderByFields,
+          BadRequestException,
+          validateGraphqlPagination,
+          validateGraphqlOffset,
+          validateOrderDirection,
+          BaseResolver,
+          config.entity,
+        );
 
         // Assign implementation to prototype first
         (BaseResolver.prototype as any)[resolveMethodName] = resolverImpl;

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -79,8 +79,10 @@ import { AddressLinksModule } from './plugins/address-links/address-links.module
       autoSchemaFile: join(process.cwd(), 'src/schema.gql'),
       sortSchema: true,
       playground: false,
-      graphiql: true, // enables GraphiQL instead
-      introspection: true,
+      // Keep introspection + GraphiQL off in production so the full schema
+      // is not a reconnaissance aid for unauthenticated callers.
+      graphiql: process.env.NODE_ENV !== 'production',
+      introspection: process.env.NODE_ENV !== 'production',
       hideSchemaDetailsFromClientErrors: true,
     }),
     MdwModule,

--- a/src/bcl/services/fast-pull-tokens.service.ts
+++ b/src/bcl/services/fast-pull-tokens.service.ts
@@ -12,7 +12,7 @@ import {
 import { TokensService } from '@/tokens/tokens.service';
 import { TransactionService } from '@/transactions/services/transaction.service';
 import { SyncState } from '@/mdw-sync/entities/sync-state.entity';
-import { fetchJson } from '@/utils/common';
+import { fetchJson, resolveMiddlewareNextUrlSafely } from '@/utils/common';
 import { InjectQueue } from '@nestjs/bull';
 import { Injectable, Logger } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
@@ -182,9 +182,12 @@ export class FastPullTokensService {
         this.logger.log('loadCreatedCommunityFromMdw->no data::', nextUrl);
       }
 
-      nextUrl = result.next
-        ? `${ACTIVE_NETWORK.middlewareUrl}${result.next}`
-        : null;
+      nextUrl = resolveMiddlewareNextUrlSafely(
+        result.next,
+        ACTIVE_NETWORK.middlewareUrl,
+        this.logger,
+        'FastPullTokensService.loadCreatedCommunityFromMdw',
+      );
     }
   }
 }

--- a/src/bcl/services/fix-holders.service.ts
+++ b/src/bcl/services/fix-holders.service.ts
@@ -3,7 +3,7 @@ import { ACTIVE_NETWORK } from '@/configs/network';
 import { TokenHolder } from '@/tokens/entities/token-holders.entity';
 import { Token } from '@/tokens/entities/token.entity';
 import { SYNC_TOKEN_HOLDERS_QUEUE } from '@/tokens/queues/constants';
-import { fetchJson } from '@/utils/common';
+import { fetchJson, resolveMiddlewareNextUrlSafely } from '@/utils/common';
 import { InjectQueue } from '@nestjs/bull';
 import { Injectable, Logger } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
@@ -122,10 +122,15 @@ export class FixHoldersService {
     }
 
     if (mdwResponse?.next) {
-      await this.pullAndUpdateAccountAex9Balances(
-        `${ACTIVE_NETWORK.middlewareUrl}${mdwResponse.next}`,
-        caller,
+      const nextUrl = resolveMiddlewareNextUrlSafely(
+        mdwResponse.next,
+        ACTIVE_NETWORK.middlewareUrl,
+        this.logger,
+        'FixHoldersService.pullAndUpdateAccountAex9Balances',
       );
+      if (nextUrl) {
+        await this.pullAndUpdateAccountAex9Balances(nextUrl, caller);
+      }
     }
 
     this.logger.log(`Pulled ${mdwResponse.data.length} tokens for ${caller}`);

--- a/src/configs/allowed-origins.ts
+++ b/src/configs/allowed-origins.ts
@@ -1,0 +1,40 @@
+/**
+ * Parse `ALLOWED_ORIGINS` into a value suitable for both the Express CORS
+ * middleware and the socket.io `cors.origin` option.
+ *
+ * This API is intentionally **public**: it is consumed from browsers by
+ * third-party dashboards, explorers, and apps we do not know about in
+ * advance. Locking CORS down to a hard-coded allowlist would break all of
+ * those consumers without providing a real security benefit — the app has
+ * no cookie/session auth, and all admin surfaces require an explicit
+ * `x-admin-api-key` / `Authorization: Bearer` header which browsers do
+ * not attach cross-origin automatically.
+ *
+ * Behaviour:
+ *  - unset / empty → `true` (allow every origin; the default)
+ *  - `"*"`         → `true` (explicit wildcard)
+ *  - comma list    → `string[]` (pin to an allowlist — useful for internal
+ *                    deployments that *do* want strict browser origins)
+ *
+ * The return type (`string[] | boolean`) is the union accepted by both
+ * Express CORS and socket.io.
+ */
+export function parseAllowedOrigins(): string[] | boolean {
+  const raw = process.env.ALLOWED_ORIGINS?.trim();
+  if (!raw || raw === '*') return true;
+  return raw
+    .split(',')
+    .map((o) => o.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Whether the operator has pinned to an explicit origin allowlist.
+ * Used to decide whether it is safe to enable `credentials: true` —
+ * browsers reject `Access-Control-Allow-Credentials: true` when the
+ * response origin is the wildcard `*`.
+ */
+export function hasExplicitAllowlist(): boolean {
+  const raw = process.env.ALLOWED_ORIGINS?.trim();
+  return !!raw && raw !== '*';
+}

--- a/src/configs/constants.ts
+++ b/src/configs/constants.ts
@@ -144,8 +144,26 @@ export const PULL_TRENDING_TAGS_ENABLED = false;
 /**
  * API Keys and Security
  */
-export const TRENDING_TAGS_API_KEY =
-  process.env.TRENDING_TAGS_API_KEY || 'your-secret-key-here-xxrf8ca2929';
+// Intentionally no default value: a missing or empty key must not silently
+// grant access to the guarded POST /trending-tags endpoint. In production a
+// missing key causes the guard to always reject requests.
+export const TRENDING_TAGS_API_KEY: string =
+  process.env.TRENDING_TAGS_API_KEY ?? '';
+
+// The ApiKeyGuard rejects requests when the key is absent or shorter than
+// 16 chars. Use the same threshold here so the warning matches the actual
+// enforcement behaviour and operators know exactly what to fix.
+if (
+  process.env.NODE_ENV === 'production' &&
+  TRENDING_TAGS_API_KEY.length < 16
+) {
+  // eslint-disable-next-line no-console
+  console.error(
+    '[security] TRENDING_TAGS_API_KEY is missing or too short in production' +
+      ' (min 16 chars required). POST /trending-tags will reject all' +
+      ' requests until a sufficiently long key is set.',
+  );
+}
 
 /**
  * Trending Score Configuration

--- a/src/configs/database.ts
+++ b/src/configs/database.ts
@@ -24,6 +24,22 @@ const getValidLogger = (loggerValue: string | undefined): ValidLoggerType => {
     : 'advanced-console';
 };
 
+// `synchronize: true` auto-applies destructive DDL (DROP/ALTER) on startup
+// based on entity definitions and has caused silent data loss in real-world
+// projects. It must never be enabled in production, regardless of env vars.
+// We still allow it in non-production environments because the existing
+// dev/testnet workflows rely on it; migrations are the long-term fix.
+const DB_SYNC_ENABLED =
+  process.env.NODE_ENV !== 'production' && process.env.DB_SYNC === 'true';
+
+if (process.env.NODE_ENV === 'production' && process.env.DB_SYNC === 'true') {
+  // eslint-disable-next-line no-console
+  console.error(
+    '[security] DB_SYNC=true was set in production and is being ignored.' +
+      ' Use migrations to evolve the schema.',
+  );
+}
+
 export const DATABASE_CONFIG: TypeOrmModuleOptions = {
   type: process.env.DB_TYPE as any,
   host: process.env.DB_HOST,
@@ -31,7 +47,7 @@ export const DATABASE_CONFIG: TypeOrmModuleOptions = {
   username: process.env.DB_USER,
   password: process.env.DB_PASSWORD,
   database: process.env.DB_DATABASE,
-  synchronize: process.env.DB_SYNC === 'true',
+  synchronize: DB_SYNC_ENABLED,
   autoLoadEntities: true,
   logging: process.env.DB_LOGGING === 'true',
   logger: getValidLogger(process.env.DB_LOGGER),

--- a/src/configs/database.ts
+++ b/src/configs/database.ts
@@ -43,7 +43,7 @@ if (process.env.NODE_ENV === 'production' && process.env.DB_SYNC === 'true') {
 export const DATABASE_CONFIG: TypeOrmModuleOptions = {
   type: process.env.DB_TYPE as any,
   host: process.env.DB_HOST,
-  port: parseInt(process.env.DB_PORT),
+  port: parseNumber(process.env.DB_PORT, 5432),
   username: process.env.DB_USER,
   password: process.env.DB_PASSWORD,
   database: process.env.DB_DATABASE,

--- a/src/configs/database.ts
+++ b/src/configs/database.ts
@@ -2,13 +2,30 @@ import { TypeOrmModuleOptions } from '@nestjs/typeorm';
 import 'dotenv/config';
 
 type ValidLoggerType = 'debug' | 'advanced-console' | 'simple-console' | 'file';
+type ValidDatabaseType = 'postgres';
 
 const parseNumber = (
   value: string | undefined,
   defaultValue: number,
+  options: { min?: number; max?: number; integer?: boolean } = {},
 ): number => {
+  if (value === undefined || value.trim() === '') {
+    return defaultValue;
+  }
   const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : defaultValue;
+  if (!Number.isFinite(parsed)) {
+    return defaultValue;
+  }
+  if (options.integer && !Number.isInteger(parsed)) {
+    return defaultValue;
+  }
+  if (options.min !== undefined && parsed < options.min) {
+    return defaultValue;
+  }
+  if (options.max !== undefined && parsed > options.max) {
+    return defaultValue;
+  }
+  return parsed;
 };
 
 // Validate logger value
@@ -22,6 +39,21 @@ const getValidLogger = (loggerValue: string | undefined): ValidLoggerType => {
   return validLoggers.includes(loggerValue as ValidLoggerType)
     ? (loggerValue as ValidLoggerType)
     : 'advanced-console';
+};
+
+const getValidDatabaseType = (
+  dbTypeValue: string | undefined,
+): ValidDatabaseType => {
+  const validDatabaseTypes: ValidDatabaseType[] = ['postgres'];
+  if (!dbTypeValue) {
+    return 'postgres';
+  }
+  if (validDatabaseTypes.includes(dbTypeValue as ValidDatabaseType)) {
+    return dbTypeValue as ValidDatabaseType;
+  }
+  throw new Error(
+    `Invalid DB_TYPE "${dbTypeValue}". Supported values: ${validDatabaseTypes.join(', ')}`,
+  );
 };
 
 // `synchronize: true` auto-applies destructive DDL (DROP/ALTER) on startup
@@ -41,9 +73,13 @@ if (process.env.NODE_ENV === 'production' && process.env.DB_SYNC === 'true') {
 }
 
 export const DATABASE_CONFIG: TypeOrmModuleOptions = {
-  type: process.env.DB_TYPE as any,
+  type: getValidDatabaseType(process.env.DB_TYPE),
   host: process.env.DB_HOST,
-  port: parseNumber(process.env.DB_PORT, 5432),
+  port: parseNumber(process.env.DB_PORT, 5432, {
+    integer: true,
+    min: 1,
+    max: 65_535,
+  }),
   username: process.env.DB_USER,
   password: process.env.DB_PASSWORD,
   database: process.env.DB_DATABASE,
@@ -52,12 +88,29 @@ export const DATABASE_CONFIG: TypeOrmModuleOptions = {
   logging: process.env.DB_LOGGING === 'true',
   logger: getValidLogger(process.env.DB_LOGGER),
   extra: {
-    max: parseNumber(process.env.DB_POOL_MAX, 40),
-    min: parseNumber(process.env.DB_POOL_MIN, 5),
-    idleTimeoutMillis: parseNumber(process.env.DB_POOL_IDLE_TIMEOUT_MS, 30_000),
+    max: parseNumber(process.env.DB_POOL_MAX, 40, {
+      integer: true,
+      min: 1,
+    }),
+    min: parseNumber(process.env.DB_POOL_MIN, 5, {
+      integer: true,
+      min: 1,
+    }),
+    idleTimeoutMillis: parseNumber(
+      process.env.DB_POOL_IDLE_TIMEOUT_MS,
+      30_000,
+      {
+        integer: true,
+        min: 1,
+      },
+    ),
     connectionTimeoutMillis: parseNumber(
       process.env.DB_POOL_CONNECTION_TIMEOUT_MS,
       10_000,
+      {
+        integer: true,
+        min: 1,
+      },
     ),
   },
 };

--- a/src/configs/redis.ts
+++ b/src/configs/redis.ts
@@ -1,8 +1,12 @@
 import * as Redis from 'ioredis';
 import 'dotenv/config';
 
+// `REDIS_PASSWORD` is optional and intended for custom deployments that use
+// an authenticated external Redis. The bundled compose Redis is localhost-only
+// and does not enable `requirepass`.
 export const REDIS_CONFIG: Redis.RedisOptions = {
   keyPrefix: process.env.AE_NETWORK_ID || 'ae_mainnet',
   host: process.env.REDIS_HOST || 'localhost',
   port: parseInt(process.env.REDIS_PORT) || 6379,
+  password: process.env.REDIS_PASSWORD || undefined,
 };

--- a/src/dex/controllers/pairs.controller.spec.ts
+++ b/src/dex/controllers/pairs.controller.spec.ts
@@ -31,4 +31,23 @@ describe('PairsController', () => {
       'ct_token',
     );
   });
+
+  it('rejects invalid pair list pagination before calling the service', async () => {
+    await expect(
+      controller.listAll(undefined, undefined, 0, 25, 'created_at', 'ASC'),
+    ).rejects.toThrow('Page must be greater than or equal to 1');
+    await expect(
+      controller.listAll(undefined, undefined, 1, 101, 'created_at', 'ASC'),
+    ).rejects.toThrow('Limit must be between 1 and 100');
+
+    expect(pairService.findAll).not.toHaveBeenCalled();
+  });
+
+  it('rejects out-of-range history intervals before looking up a pair', async () => {
+    await expect(
+      controller.getPaginatedHistory('ct_pair', 30, 'token0', 'ae', 1, 100),
+    ).rejects.toThrow('interval must be between 60 and 86400 seconds');
+
+    expect(pairService.findByAddress).not.toHaveBeenCalled();
+  });
 });

--- a/src/dex/controllers/pairs.controller.ts
+++ b/src/dex/controllers/pairs.controller.ts
@@ -28,6 +28,10 @@ import {
   OptionalAeContractAddressPipe,
 } from '@/common/validation/request-validation';
 
+const MAX_PAGE_LIMIT = 100;
+const MIN_HISTORY_INTERVAL_SECONDS = 60;
+const MAX_HISTORY_INTERVAL_SECONDS = 86_400;
+
 @Controller('dex/pairs')
 @ApiTags('Dex Pair')
 export class PairsController {
@@ -36,6 +40,17 @@ export class PairsController {
     private readonly pairHistoryService: PairHistoryService,
     private readonly pairSummaryService: PairSummaryService,
   ) {}
+
+  private validatePagination(page: number, limit: number): void {
+    if (page < 1) {
+      throw new BadRequestException('Page must be greater than or equal to 1');
+    }
+    if (limit < 1 || limit > MAX_PAGE_LIMIT) {
+      throw new BadRequestException(
+        `Limit must be between 1 and ${MAX_PAGE_LIMIT}`,
+      );
+    }
+  }
 
   @ApiQuery({
     name: 'search',
@@ -74,6 +89,7 @@ export class PairsController {
     @Query('order_by') orderBy: string = 'created_at',
     @Query('order_direction') orderDirection: 'ASC' | 'DESC' = 'DESC',
   ) {
+    this.validatePagination(page, limit);
     return this.pairService.findAll(
       { page, limit },
       orderBy,
@@ -231,13 +247,26 @@ export class PairsController {
   @Get(':address/history')
   async getPaginatedHistory(
     @Param('address', AeContractAddressPipe) address: string,
-    @Query('interval') interval: number = 3600,
+    @Query('interval', new DefaultValuePipe(3600), ParseIntPipe)
+    interval: number = 3600,
     @Query('from_token') fromToken: string = 'token0',
     @Query('convertTo') convertTo: string = 'ae',
     @Query('page', new DefaultValuePipe(1), ParseIntPipe) page = 1,
     @Query('limit', new DefaultValuePipe(100), ParseIntPipe) limit = 100,
   ) {
+    this.validatePagination(page, limit);
+    if (
+      interval < MIN_HISTORY_INTERVAL_SECONDS ||
+      interval > MAX_HISTORY_INTERVAL_SECONDS
+    ) {
+      throw new BadRequestException(
+        `interval must be between ${MIN_HISTORY_INTERVAL_SECONDS} and ${MAX_HISTORY_INTERVAL_SECONDS} seconds`,
+      );
+    }
     const pair = await this.pairService.findByAddress(address);
+    if (!pair) {
+      throw new NotFoundException(`Pair with address ${address} not found`);
+    }
     return this.pairHistoryService.getPaginatedHistoricalData({
       pair,
       interval,

--- a/src/dex/services/dex-sync.service.ts
+++ b/src/dex/services/dex-sync.service.ts
@@ -3,7 +3,7 @@ import camelcaseKeysDeep from 'camelcase-keys-deep';
 import { AeSdkService } from '@/ae/ae-sdk.service';
 import { ACTIVE_NETWORK, TX_FUNCTIONS } from '@/configs';
 import { IMiddlewareRequestConfig } from '@/social/interfaces/post.interfaces';
-import { fetchJson } from '@/utils/common';
+import { fetchJson, resolveMiddlewareNextUrlSafely } from '@/utils/common';
 import { ITransaction } from '@/utils/types';
 import { Contract } from '@aeternity/aepp-sdk';
 import { Injectable, Logger } from '@nestjs/common';
@@ -49,9 +49,7 @@ export class DexSyncService {
   }
 
   async onModuleInit(): Promise<void> {
-    console.log('========================');
-    console.log('==== DexSyncService ====');
-    console.log('========================');
+    this.logger.debug('DexSyncService initialized');
     // await this.dexPairTransactionRepository.clear();
 
     // this.routerContract = await Contract.initialize({
@@ -171,7 +169,7 @@ export class DexSyncService {
     }).toString();
     const url = `${ACTIVE_NETWORK.middlewareUrl}/v3/transactions?${queryString}`;
     await this.pullDexPairsFromMdw(url);
-    console.log('DexTokens synced');
+    this.logger.debug('DexTokens synced');
   }
 
   async pullDexPairsFromMdw(url: string) {
@@ -190,9 +188,12 @@ export class DexSyncService {
         }
         await this.saveTransaction(transaction);
       }
-      nextUrl = result.next
-        ? `${ACTIVE_NETWORK.middlewareUrl}${result.next}`
-        : null;
+      nextUrl = resolveMiddlewareNextUrlSafely(
+        result.next,
+        ACTIVE_NETWORK.middlewareUrl,
+        this.logger,
+        'DexSyncService.pullDexPairsFromMdw',
+      );
     }
   }
 
@@ -242,7 +243,10 @@ export class DexSyncService {
         });
         // console.log('factoryContract.$decodeEvents decodedEvents', decodedEvents);
       } catch (error: any) {
-        console.log('factoryContract.$decodeEvents error', error?.message);
+        this.logger.debug(
+          'factoryContract.$decodeEvents error',
+          error?.message,
+        );
       }
     }
     if (!decodedEvents || decodedEvents.length === 0) {
@@ -286,9 +290,9 @@ export class DexSyncService {
       // if (transaction.tx.function?.includes('liquidity')) {
       //   return null;
       // }
-      console.log('TODO: handle->function:', transaction.tx.function);
-      console.log('decodedEvents:', decodedEvents);
-      console.log('args::', JSON.stringify(args, null, 2));
+      this.logger.debug(`Unhandled DEX function: ${transaction.tx.function}`);
+      this.logger.debug(`Decoded events: ${JSON.stringify(decodedEvents)}`);
+      this.logger.debug(`Args: ${JSON.stringify(args)}`);
     }
     if (!token0Address || !token1Address) {
       return null;

--- a/src/dex/services/pair-history.service.spec.ts
+++ b/src/dex/services/pair-history.service.spec.ts
@@ -1,0 +1,154 @@
+import { PairHistoryService } from './pair-history.service';
+import { Pair } from '../entities/pair.entity';
+
+describe('PairHistoryService', () => {
+  let service: PairHistoryService;
+  let queryRunnerMock: { query: jest.Mock; release: jest.Mock };
+  let dataSourceMock: { createQueryRunner: jest.Mock };
+
+  beforeEach(() => {
+    queryRunnerMock = {
+      query: jest.fn().mockResolvedValue([]),
+      release: jest.fn().mockResolvedValue(undefined),
+    };
+    dataSourceMock = {
+      createQueryRunner: jest.fn().mockReturnValue(queryRunnerMock),
+    };
+
+    service = new PairHistoryService(
+      {} as any,
+      dataSourceMock as any,
+      {} as any,
+    );
+  });
+
+  const makePair = (address = 'ct_testPairAddress'): Pair =>
+    ({
+      address,
+      token0: { symbol: 'TOK0' },
+      token1: { symbol: 'TOK1' },
+    }) as any;
+
+  describe('getPaginatedHistoricalData - SQL parameterization', () => {
+    it('passes offset and limit as positional parameters $3 and $4', async () => {
+      await service.getPaginatedHistoricalData({
+        pair: makePair(),
+        interval: 3600,
+        page: 3,
+        limit: 25,
+        fromToken: 'token0',
+      });
+
+      expect(queryRunnerMock.query).toHaveBeenCalledTimes(1);
+      const [sql, params] = queryRunnerMock.query.mock.calls[0];
+
+      expect(params).toEqual(['ct_testPairAddress', 3600, 50, 25]);
+      expect(sql).toContain('OFFSET $3');
+      expect(sql).toContain('LIMIT $4');
+      expect(sql).not.toMatch(/OFFSET \$\{/);
+      expect(sql).not.toMatch(/LIMIT \$\{/);
+    });
+
+    it('uses make_interval for timeClose instead of string-interpolated interval', async () => {
+      await service.getPaginatedHistoricalData({
+        pair: makePair(),
+        interval: 7200,
+        page: 1,
+        limit: 10,
+        fromToken: 'token1',
+      });
+
+      const [sql] = queryRunnerMock.query.mock.calls[0];
+      expect(sql).toContain('make_interval(secs => $2)');
+      expect(sql).not.toContain("interval '$2 seconds'");
+    });
+
+    it('selects ratio0 columns when fromToken is token0', async () => {
+      await service.getPaginatedHistoricalData({
+        pair: makePair(),
+        interval: 3600,
+        page: 1,
+        limit: 10,
+        fromToken: 'token0',
+      });
+
+      const [sql] = queryRunnerMock.query.mock.calls[0];
+      expect(sql).toContain('ratio0');
+      expect(sql).toContain('volume0');
+    });
+
+    it('selects ratio1 columns when fromToken is token1', async () => {
+      await service.getPaginatedHistoricalData({
+        pair: makePair(),
+        interval: 3600,
+        page: 1,
+        limit: 10,
+        fromToken: 'token1',
+      });
+
+      const [sql] = queryRunnerMock.query.mock.calls[0];
+      expect(sql).toContain('ratio1');
+      expect(sql).toContain('volume1');
+    });
+
+    it('releases the queryRunner even when the query throws', async () => {
+      queryRunnerMock.query.mockRejectedValue(new Error('db down'));
+
+      await expect(
+        service.getPaginatedHistoricalData({
+          pair: makePair(),
+          interval: 3600,
+          page: 1,
+          limit: 10,
+        }),
+      ).rejects.toThrow('db down');
+
+      expect(queryRunnerMock.release).toHaveBeenCalledTimes(1);
+    });
+
+    it('maps raw results to HistoricalDataDto with previous close chaining', async () => {
+      queryRunnerMock.query.mockResolvedValue([
+        {
+          timeOpen: new Date('2025-01-01T00:00:00Z'),
+          timeClose: new Date('2025-01-01T01:00:00Z'),
+          low: '1.0',
+          high: '2.0',
+          open: '1.5',
+          close: '1.8',
+          volume: '100',
+          market_cap: '5000',
+          total_supply: '10000',
+          timeMin: new Date('2025-01-01T00:05:00Z'),
+          timeMax: new Date('2025-01-01T00:55:00Z'),
+        },
+        {
+          timeOpen: new Date('2025-01-01T01:00:00Z'),
+          timeClose: new Date('2025-01-01T02:00:00Z'),
+          low: '1.7',
+          high: '2.5',
+          open: '1.9',
+          close: '2.2',
+          volume: '200',
+          market_cap: '6000',
+          total_supply: '10000',
+          timeMin: new Date('2025-01-01T01:10:00Z'),
+          timeMax: new Date('2025-01-01T01:50:00Z'),
+        },
+      ]);
+
+      const result = await service.getPaginatedHistoricalData({
+        pair: makePair(),
+        interval: 3600,
+        page: 1,
+        limit: 10,
+        fromToken: 'token0',
+      });
+
+      expect(result).toHaveLength(2);
+      expect(result[0].quote.open).toBe('1.5');
+      expect(result[0].quote.close).toBe('1.8');
+      // second interval's open should be the previous close
+      expect(result[1].quote.open).toBe('1.8');
+    });
+  });
+});

--- a/src/dex/services/pair-history.service.ts
+++ b/src/dex/services/pair-history.service.ts
@@ -67,8 +67,10 @@ export class PairHistoryService {
     const queryRunner = this.dataSource.createQueryRunner();
     //"MAX(CAST(transactions.buy_price->>'ae' AS FLOAT)) AS max_buy_price",
     const value = fromToken === 'token0' ? '0' : '1';
-    const rawResults = await queryRunner.query(
-      `
+    let rawResults;
+    try {
+      rawResults = await queryRunner.query(
+        `
         WITH transactions_in_intervals AS (
           SELECT 
             t.created_at,
@@ -87,8 +89,8 @@ export class PairHistoryService {
           SELECT DISTINCT interval_start
           FROM transactions_in_intervals
           ORDER BY interval_start DESC
-          OFFSET ${offset}
-          LIMIT ${limit}
+          OFFSET $3
+          LIMIT $4
         ),
         interval_stats AS (
           SELECT 
@@ -118,7 +120,7 @@ export class PairHistoryService {
         )
         SELECT 
           interval_start as "timeOpen",
-          interval_start + (interval '$2 seconds') as "timeClose",
+          interval_start + make_interval(secs => $2) as "timeClose",
           MIN(low) as low,
           MAX(high) as high,
           MIN(open) as open,
@@ -133,10 +135,11 @@ export class PairHistoryService {
         GROUP BY interval_start
         ORDER BY interval_start ASC
       `,
-      [pair.address, interval],
-    );
-
-    await queryRunner.release();
+        [pair.address, interval, offset, limit],
+      );
+    } finally {
+      await queryRunner.release();
+    }
 
     // Modify the mapping to handle the previous close price correctly
     let lastClose = null;

--- a/src/dex/services/pair-transaction.service.ts
+++ b/src/dex/services/pair-transaction.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { PairTransaction } from '../entities/pair-transaction.entity';
@@ -7,6 +7,9 @@ import {
   paginate,
   Pagination,
 } from 'nestjs-typeorm-paginate';
+
+const ALLOWED_ORDER_BY = new Set(['created_at', 'tx_type']);
+const ALLOWED_ORDER_DIRECTIONS = new Set(['ASC', 'DESC']);
 
 @Injectable()
 export class PairTransactionService {
@@ -24,6 +27,14 @@ export class PairTransactionService {
     account_address?: string,
     tokenAddress?: string,
   ): Promise<Pagination<PairTransaction>> {
+    if (!ALLOWED_ORDER_BY.has(orderBy)) {
+      throw new BadRequestException(`Invalid order_by value: ${orderBy}`);
+    }
+    if (!ALLOWED_ORDER_DIRECTIONS.has(orderDirection)) {
+      throw new BadRequestException(
+        `Invalid order_direction value: ${orderDirection}`,
+      );
+    }
     const query = this.pairTransactionRepository
       .createQueryBuilder('pairTransaction')
       .leftJoinAndSelect('pairTransaction.pair', 'pair')

--- a/src/dex/services/pair.service.ts
+++ b/src/dex/services/pair.service.ts
@@ -1,6 +1,6 @@
 import { AeSdkService } from '@/ae/ae-sdk.service';
 import { Contract, Encoded } from '@aeternity/aepp-sdk';
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import BigNumber from 'bignumber.js';
 import pairInterface from 'dex-contracts-v2/build/AedexV2Pair.aci.json';
@@ -20,6 +20,9 @@ type CachedContract = {
   lastUsedAt: number;
 };
 
+const ALLOWED_ORDER_BY = new Set(['transactions_count', 'created_at']);
+const ALLOWED_ORDER_DIRECTIONS = new Set(['ASC', 'DESC']);
+
 @Injectable()
 export class PairService {
   private static readonly MAX_CACHED_CONTRACTS = 100;
@@ -38,6 +41,14 @@ export class PairService {
     search?: string,
     token_address?: string,
   ): Promise<Pagination<Pair>> {
+    if (!ALLOWED_ORDER_BY.has(orderBy)) {
+      throw new BadRequestException(`Invalid order_by value: ${orderBy}`);
+    }
+    if (!ALLOWED_ORDER_DIRECTIONS.has(orderDirection)) {
+      throw new BadRequestException(
+        `Invalid order_direction value: ${orderDirection}`,
+      );
+    }
     const query = this.pairRepository
       .createQueryBuilder('pair')
       .leftJoinAndSelect('pair.token0', 'token0')

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,11 +2,18 @@ import { NestFactory } from '@nestjs/core';
 import { ValidationPipe } from '@nestjs/common';
 import { NestExpressApplication } from '@nestjs/platform-express';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
+import helmet from 'helmet';
 import { join } from 'path';
 import hbs from 'hbs';
 import { readFileSync } from 'fs';
 import { AppModule } from './app.module';
 import { DEBUG_ENABLED } from './configs';
+import {
+  hasExplicitAllowlist,
+  parseAllowedOrigins,
+} from './configs/allowed-origins';
+
+const IS_PRODUCTION = process.env.NODE_ENV === 'production';
 
 // Global process-level guards to surface and prevent silent killers
 // NOTE: After logging we explicitly exit with code 1 so that the process
@@ -36,7 +43,31 @@ async function bootstrap() {
       : ['error'],
   });
 
-  app.enableCors();
+  // Hardening headers: X-Frame-Options, X-Content-Type-Options,
+  // Referrer-Policy, HSTS, etc. CSP is disabled because this is an API
+  // server, not a browser app, and the admin UIs we host (Swagger,
+  // GraphiQL, Bull Board) all inject inline `<script>` tags that the
+  // default `script-src 'self'` policy blocks — rendering blank pages.
+  app.use(
+    helmet({
+      contentSecurityPolicy: false,
+      crossOriginResourcePolicy: { policy: 'cross-origin' },
+    }),
+  );
+
+  // This is a public API — by default we allow every browser origin so
+  // unknown third-party consumers (explorers, dashboards, embeds) can
+  // call us. Operators can still pin to an allowlist via
+  // `ALLOWED_ORIGINS` for private deployments. Credentials are only
+  // enabled when an explicit allowlist is configured, because browsers
+  // reject `Access-Control-Allow-Credentials: true` alongside a wildcard
+  // origin — and nothing in this codebase relies on cookies anyway
+  // (auth uses explicit `x-api-key` / `Authorization` headers).
+  app.enableCors({
+    origin: parseAllowedOrigins(),
+    methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+    credentials: hasExplicitAllowlist(),
+  });
   app.setGlobalPrefix('api');
   app.useGlobalPipes(
     new ValidationPipe({
@@ -46,14 +77,18 @@ async function bootstrap() {
     }),
   );
 
-  const config = new DocumentBuilder()
-    .setTitle('WORD CRAFT Scan')
-    .setDescription('The WORD CRAFT Scan API')
-    .setVersion('1.0')
-    .build();
+  // Swagger exposes the full endpoint surface and parameter schemas; only
+  // mount it outside production unless an operator explicitly opts in.
+  if (!IS_PRODUCTION || process.env.ENABLE_SWAGGER === 'true') {
+    const config = new DocumentBuilder()
+      .setTitle('WORD CRAFT Scan')
+      .setDescription('The WORD CRAFT Scan API')
+      .setVersion('1.0')
+      .build();
 
-  const document = SwaggerModule.createDocument(app, config);
-  SwaggerModule.setup('api', app, document);
+    const document = SwaggerModule.createDocument(app, config);
+    SwaggerModule.setup('api', app, document);
+  }
 
   app.useStaticAssets(join(__dirname, '..', 'public'));
   app.setBaseViewsDir(join(__dirname, '..', 'views'));

--- a/src/mdw-sync/services/block-sync.service.spec.ts
+++ b/src/mdw-sync/services/block-sync.service.spec.ts
@@ -2,10 +2,14 @@ import { ConfigService } from '@nestjs/config';
 import { BlockSyncService } from './block-sync.service';
 import { fetchJson } from '@/utils/common';
 
-jest.mock('@/utils/common', () => ({
-  fetchJson: jest.fn(),
-  sanitizeJsonForPostgres: jest.fn((value) => value),
-}));
+jest.mock('@/utils/common', () => {
+  const actual = jest.requireActual('@/utils/common');
+  return {
+    ...actual,
+    fetchJson: jest.fn(),
+    sanitizeJsonForPostgres: jest.fn((value) => value),
+  };
+});
 
 describe('BlockSyncService', () => {
   const buildMiddlewareTransaction = () => ({
@@ -157,6 +161,44 @@ describe('BlockSyncService', () => {
         nonce: '7',
         pow: [10, 11, 12],
       }),
+    );
+  });
+
+  it('stops key-block pagination without failing when middleware returns an invalid next URL', async () => {
+    const { service, blockRepository } = setup();
+    const loggerWarn = jest
+      .spyOn((service as any).logger, 'warn')
+      .mockImplementation(() => undefined);
+    (fetchJson as jest.Mock).mockResolvedValueOnce({
+      data: [
+        {
+          hash: 'kh_3',
+          height: 3,
+          prev_hash: 'kh_2',
+          prev_key_hash: 'kh_2',
+          state_hash: 'bs_3',
+          beneficiary: 'ak_ben',
+          miner: 'ak_miner',
+          time: '1700000000200',
+          transactions_count: 0,
+          micro_blocks_count: 0,
+          beneficiary_reward: '0',
+          flags: '{}',
+          info: '{}',
+          target: '1',
+          version: 1,
+        },
+      ],
+      next: 'https://evil.test/v3/key-blocks',
+    });
+
+    await service.syncBlocks(3, 3);
+
+    expect(fetchJson).toHaveBeenCalledTimes(1);
+    expect(blockRepository.upsert).toHaveBeenCalledTimes(1);
+    expect(loggerWarn).toHaveBeenCalledWith(
+      'BlockSyncService.syncBlocks: stopping pagination after invalid next URL',
+      expect.any(Error),
     );
   });
 

--- a/src/mdw-sync/services/block-sync.service.ts
+++ b/src/mdw-sync/services/block-sync.service.ts
@@ -1,4 +1,8 @@
-import { fetchJson, sanitizeJsonForPostgres } from '@/utils/common';
+import {
+  fetchJson,
+  resolveMiddlewareNextUrlSafely,
+  sanitizeJsonForPostgres,
+} from '@/utils/common';
 import {
   isDatabaseConnectionOrPoolError,
   logDatabaseIssue,
@@ -55,7 +59,12 @@ export class BlockSyncService {
       }
 
       // Check if there's a next page
-      url = response.next ? `${middlewareUrl}${response.next}` : null;
+      url = resolveMiddlewareNextUrlSafely(
+        response.next,
+        middlewareUrl,
+        this.logger,
+        'BlockSyncService.syncBlocks',
+      );
     }
 
     // Batch upsert all blocks (split into smaller batches to avoid PostgreSQL parameter limits)
@@ -290,7 +299,12 @@ export class BlockSyncService {
         }
       }
 
-      nextUrl = response.next ? `${middlewareUrl}${response.next}` : null;
+      nextUrl = resolveMiddlewareNextUrlSafely(
+        response.next,
+        middlewareUrl,
+        this.logger,
+        'BlockSyncService.processTransactionPage',
+      );
     }
 
     return txHashesByBlock ?? new Map();

--- a/src/mdw-sync/services/micro-block.service.ts
+++ b/src/mdw-sync/services/micro-block.service.ts
@@ -2,7 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { fetchJson } from '@/utils/common';
+import { fetchJson, resolveMiddlewareNextUrlSafely } from '@/utils/common';
 import { MicroBlock } from '../entities/micro-block.entity';
 
 @Injectable()
@@ -115,9 +115,12 @@ export class MicroBlockService {
       }
 
       // Check if there's a next page
-      microBlocksUrl = response.next
-        ? `${middlewareUrl}${response.next}`
-        : null;
+      microBlocksUrl = resolveMiddlewareNextUrlSafely(
+        response.next,
+        middlewareUrl,
+        this.logger,
+        'MicroBlockService.fetchMicroBlocksForKeyBlock',
+      );
     }
 
     return microBlocksToSave;

--- a/src/plugins/dex/services/dex-transaction-processor.service.ts
+++ b/src/plugins/dex/services/dex-transaction-processor.service.ts
@@ -82,7 +82,9 @@ export class DexTransactionProcessorService {
     try {
       // Check if this is a DEX router transaction
       if (tx.contract_id !== DEX_CONTRACTS.router) {
-        console.log('[dex] not a DEX router transaction', tx);
+        this.logger.debug(
+          `Skipping non-DEX router transaction ${tx.hash ?? ''}`,
+        );
         return null;
       }
 

--- a/src/plugins/governance/governance-plugin-sync.service.spec.ts
+++ b/src/plugins/governance/governance-plugin-sync.service.spec.ts
@@ -5,11 +5,15 @@ import { GovernancePollRegistry } from './services/governance-poll-registry.serv
 import { Tx } from '@/mdw-sync/entities/tx.entity';
 import { GOVERNANCE_CONTRACT } from './config/governance.config';
 
-jest.mock('@/utils/common', () => ({
-  fetchJson: jest.fn(),
-  sanitizeJsonForPostgres: jest.fn((value: any) => value),
-  serializeBigInts: jest.fn((value: any) => value),
-}));
+jest.mock('@/utils/common', () => {
+  const actual = jest.requireActual('@/utils/common');
+  return {
+    ...actual,
+    fetchJson: jest.fn(),
+    sanitizeJsonForPostgres: jest.fn((value: any) => value),
+    serializeBigInts: jest.fn((value: any) => value),
+  };
+});
 
 const POLL_ADDRESS = 'ct_pollAddressUnderTest';
 const CREATE_TX_HASH = 'th_createTxHashUnderTest';

--- a/src/plugins/governance/governance-plugin-sync.service.ts
+++ b/src/plugins/governance/governance-plugin-sync.service.ts
@@ -3,6 +3,8 @@ import { Tx } from '@/mdw-sync/entities/tx.entity';
 import { ACTIVE_NETWORK } from '@/configs/network';
 import {
   fetchJson,
+  resolveMiddlewareNextUrl,
+  resolveMiddlewareNextUrlSafely,
   sanitizeJsonForPostgres,
   serializeBigInts,
 } from '@/utils/common';
@@ -480,8 +482,10 @@ export class GovernancePluginSyncService extends BasePluginSyncService {
     addPollTxHash: string,
   ): Promise<void> {
     const middlewareUrl = this.getMiddlewareUrl();
-    let nextPath: string | null =
-      `/v3/transactions?type=contract_call&contract=${pollAddress}&direction=forward&limit=100`;
+    let nextUrl: string | null = resolveMiddlewareNextUrl(
+      `/v3/transactions?type=contract_call&contract=${pollAddress}&direction=forward&limit=100`,
+      middlewareUrl,
+    );
 
     let savedCount = 0;
     let skippedCount = 0;
@@ -489,11 +493,11 @@ export class GovernancePluginSyncService extends BasePluginSyncService {
 
     try {
       while (
-        nextPath &&
+        nextUrl &&
         safety < GovernancePluginSyncService.VOTE_BACKFILL_PAGE_SAFETY
       ) {
         safety += 1;
-        const response = await fetchJson<any>(`${middlewareUrl}${nextPath}`);
+        const response = await fetchJson<any>(nextUrl);
         const page: any[] = response?.data ?? [];
 
         for (const raw of page) {
@@ -528,12 +532,17 @@ export class GovernancePluginSyncService extends BasePluginSyncService {
 
         const nextLink: string | null =
           typeof response?.next === 'string' ? response.next : null;
-        nextPath = nextLink;
+        nextUrl = resolveMiddlewareNextUrlSafely(
+          nextLink,
+          middlewareUrl,
+          this.logger,
+          'GovernancePluginSyncService.backfillPollVotes',
+        );
       }
 
       if (
         safety >= GovernancePluginSyncService.VOTE_BACKFILL_PAGE_SAFETY &&
-        nextPath
+        nextUrl
       ) {
         this.logger.warn(
           `Vote backfill for poll ${pollAddress} hit the page safety limit (${GovernancePluginSyncService.VOTE_BACKFILL_PAGE_SAFETY}); remaining pages were not scanned.`,

--- a/src/profile/controllers/profile.controller.ts
+++ b/src/profile/controllers/profile.controller.ts
@@ -28,6 +28,8 @@ import {
   isAeAccountAddress,
 } from '@/common/validation/request-validation';
 
+const MAX_PROFILE_ADDRESSES = 100;
+
 @Controller('profile')
 @ApiTags('Profile')
 export class ProfileController {
@@ -143,6 +145,11 @@ export class ProfileController {
       .split(',')
       .map((it) => it.trim())
       .filter(Boolean);
+    if (parsed.length > MAX_PROFILE_ADDRESSES) {
+      throw new BadRequestException(
+        `addresses must contain at most ${MAX_PROFILE_ADDRESSES} entries`,
+      );
+    }
     const invalidAddress = parsed.find(
       (address) => !isAeAccountAddress(address),
     );

--- a/src/profile/dto/request-chain-name.dto.ts
+++ b/src/profile/dto/request-chain-name.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString, Matches, MinLength } from 'class-validator';
+import { IsString, Matches, MaxLength, MinLength } from 'class-validator';
 import { IsAeAccountAddress } from '@/common/validation/request-validation';
 
 export class RequestChainNameDto {
@@ -18,6 +18,7 @@ export class RequestChainNameDto {
   })
   @IsString()
   @MinLength(13)
+  @MaxLength(247)
   @Matches(/^[a-z0-9]+$/, {
     message: 'name must contain only lowercase letters and digits',
   })

--- a/src/profile/services/profile-chain-name.service.spec.ts
+++ b/src/profile/services/profile-chain-name.service.spec.ts
@@ -327,6 +327,7 @@ describe('ProfileChainNameService', () => {
       name: 'myuniquename123.chain',
       status: 'failed',
     });
+    const futureExpiry = Date.now() + 10_000;
     lockedChallengeRepository.createQueryBuilder.mockReturnValue({
       setLock: jest.fn().mockReturnThis(),
       where: jest.fn().mockReturnThis(),
@@ -334,7 +335,7 @@ describe('ProfileChainNameService', () => {
       getOne: jest.fn().mockResolvedValue({
         nonce: 'a'.repeat(24),
         address: validAddress,
-        expires_at: new Date(Date.now() + 10_000),
+        expires_at: new Date(futureExpiry),
         consumed_at: null,
       }),
     });
@@ -348,7 +349,7 @@ describe('ProfileChainNameService', () => {
         address: validAddress,
         name: 'myuniquename123',
         challengeNonce: 'a'.repeat(24),
-        challengeExpiresAt: Date.now() + 10_000,
+        challengeExpiresAt: futureExpiry,
         signatureHex: 'b'.repeat(128),
       }),
     ).rejects.toThrow('This name is already being claimed by another address');

--- a/src/profile/services/profile-indexer.service.ts
+++ b/src/profile/services/profile-indexer.service.ts
@@ -1,5 +1,5 @@
 import { ACTIVE_NETWORK } from '@/configs';
-import { fetchJson } from '@/utils/common';
+import { fetchJson, resolveMiddlewareNextUrlSafely } from '@/utils/common';
 import { Injectable, Logger } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -125,9 +125,12 @@ export class ProfileIndexerService {
           break;
         }
 
-        endpoint = response.next.startsWith('http')
-          ? response.next
-          : `${middlewareUrl}${response.next}`;
+        endpoint = resolveMiddlewareNextUrlSafely(
+          response.next,
+          middlewareUrl,
+          this.logger,
+          'ProfileIndexerService.syncProfiles',
+        );
       }
 
       for (const address of changedAddresses) {

--- a/src/profile/services/profile-read.service.ts
+++ b/src/profile/services/profile-read.service.ts
@@ -2,7 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { In, Repository } from 'typeorm';
 import { ACTIVE_NETWORK } from '@/configs';
-import { fetchJson } from '@/utils/common';
+import { fetchJson, resolveMiddlewareNextUrlSafely } from '@/utils/common';
 import { Account } from '@/account/entities/account.entity';
 import { ProfileCache } from '../entities/profile-cache.entity';
 import { PROFILE_MUTATION_FUNCTIONS } from '../profile.constants';
@@ -508,9 +508,12 @@ export class ProfileReadService {
       if (!response?.next || addresses.length >= targetUnique) {
         break;
       }
-      endpoint = response.next.startsWith('http')
-        ? response.next
-        : `${middlewareUrl}${response.next}`;
+      endpoint = resolveMiddlewareNextUrlSafely(
+        response.next,
+        middlewareUrl,
+        this.logger,
+        'ProfileReadService.getRecentProfileMutationCallers',
+      );
     }
 
     return addresses;

--- a/src/social/controllers/topics.controller.ts
+++ b/src/social/controllers/topics.controller.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   Controller,
   DefaultValuePipe,
   Get,
@@ -20,6 +21,10 @@ import { Repository } from 'typeorm';
 import { Topic } from '../entities/topic.entity';
 import { ApiOkResponsePaginated } from '@/utils/api-type';
 import { TopicParamPipe } from '@/common/validation/request-validation';
+
+const ALLOWED_ORDER_BY = new Set(['name', 'post_count', 'created_at']);
+const ALLOWED_ORDER_DIRECTIONS = new Set(['ASC', 'DESC']);
+const MAX_SEARCH_LENGTH = 100;
 
 @Controller('topics')
 @ApiTags('Topics')
@@ -60,6 +65,25 @@ export class TopicsController {
     @Query('order_direction') orderDirection: 'ASC' | 'DESC' = 'DESC',
     @Query('search') search?: string,
   ) {
+    if (page < 1) {
+      throw new BadRequestException('Page must be greater than or equal to 1');
+    }
+    if (limit < 1 || limit > 100) {
+      throw new BadRequestException('Limit must be between 1 and 100');
+    }
+    if (!ALLOWED_ORDER_BY.has(orderBy)) {
+      throw new BadRequestException(`Invalid order_by value: ${orderBy}`);
+    }
+    if (!ALLOWED_ORDER_DIRECTIONS.has(orderDirection)) {
+      throw new BadRequestException(
+        `Invalid order_direction value: ${orderDirection}`,
+      );
+    }
+    if (search && search.length > MAX_SEARCH_LENGTH) {
+      throw new BadRequestException(
+        `search must be at most ${MAX_SEARCH_LENGTH} characters`,
+      );
+    }
     const query = this.topicRepository.createQueryBuilder('topic');
 
     // Add search functionality
@@ -142,6 +166,9 @@ export class TopicsController {
   async getPopularTopics(
     @Query('limit', new DefaultValuePipe(20), ParseIntPipe) limit = 20,
   ) {
+    if (limit < 1 || limit > 100) {
+      throw new BadRequestException('Limit must be between 1 and 100');
+    }
     return this.topicRepository
       .createQueryBuilder('topic')
       .orderBy('topic.post_count', 'DESC')

--- a/src/social/services/popular-ranking.service.spec.ts
+++ b/src/social/services/popular-ranking.service.spec.ts
@@ -7,6 +7,8 @@ const pipelineMock = {
 };
 
 const redisMock = {
+  on: jest.fn().mockReturnThis(),
+  quit: jest.fn().mockResolvedValue('OK'),
   ping: jest.fn().mockResolvedValue('PONG'),
   del: jest.fn().mockResolvedValue(1),
   zcard: jest.fn().mockResolvedValue(1),

--- a/src/social/services/popular-ranking.service.ts
+++ b/src/social/services/popular-ranking.service.ts
@@ -1,4 +1,10 @@
-import { Injectable, Logger } from '@nestjs/common';
+import {
+  Inject,
+  Injectable,
+  Logger,
+  OnModuleDestroy,
+  Optional,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { In, Repository } from 'typeorm';
 import { Post } from '../entities/post.entity';
@@ -15,7 +21,6 @@ import {
   PopularRankingContributor,
   PopularRankingContentItem,
 } from '@/plugins/popular-ranking.interface';
-import { Inject, Optional } from '@nestjs/common';
 import { POPULAR_RANKING_CONTRIBUTOR } from '@/plugins/plugin.tokens';
 
 export type PopularWindow = '24h' | '7d' | 'all';
@@ -63,7 +68,7 @@ interface PopularScoreInput {
 }
 
 @Injectable()
-export class PopularRankingService {
+export class PopularRankingService implements OnModuleDestroy {
   private readonly logger = new Logger(PopularRankingService.name);
   private readonly redis = new Redis(REDIS_CONFIG);
   private readonly recomputeInFlight = new Map<PopularWindow, Promise<void>>();
@@ -85,7 +90,15 @@ export class PopularRankingService {
     @Optional()
     @Inject(POPULAR_RANKING_CONTRIBUTOR)
     private readonly rankingContributors: PopularRankingContributor[] = [],
-  ) {}
+  ) {
+    this.redis.on('error', (error) => {
+      this.logger.error('Popular ranking Redis connection error', error);
+    });
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await this.redis.quit();
+  }
 
   private getWindowHours(window: PopularWindow): number {
     if (window === '24h') {

--- a/src/social/services/post.service.ts
+++ b/src/social/services/post.service.ts
@@ -8,7 +8,7 @@ import {
   MAX_RETRIES_WHEN_REQUEST_FAILED,
   WAIT_TIME_WHEN_REQUEST_FAILED,
 } from '@/configs';
-import { fetchJson } from '@/utils/common';
+import { fetchJson, resolveMiddlewareNextUrlSafely } from '@/utils/common';
 import moment from 'moment';
 import { ITransaction } from '@/utils/types';
 import camelcaseKeysDeep from 'camelcase-keys-deep';
@@ -319,9 +319,12 @@ export class PostService {
         );
       }
 
-      nextUrl = result.next
-        ? `${ACTIVE_NETWORK.middlewareUrl}${result.next}`
-        : null;
+      nextUrl = resolveMiddlewareNextUrlSafely(
+        result.next,
+        ACTIVE_NETWORK.middlewareUrl,
+        this.logger,
+        'PostService.syncPostsFromMdw',
+      );
     }
 
     return totalCount;
@@ -372,6 +375,15 @@ export class PostService {
      */
     const postTypeInfo = this.detectPostType(transaction);
     // const commentInfo = this.detectComment(transaction);
+    if (!postTypeInfo) {
+      this.logger.warn(
+        'Skipping post transaction with missing post type data',
+        {
+          txHash,
+        },
+      );
+      return null;
+    }
 
     try {
       // Check if post already exists
@@ -623,7 +635,10 @@ export class PostService {
   }
 
   private detectPostType(transaction: ITransaction): IPostTypeInfo | null {
-    if (!transaction?.tx?.arguments?.[1]?.value) {
+    if (
+      !transaction?.tx?.arguments?.[1]?.value ||
+      !Array.isArray(transaction.tx.arguments[1].value)
+    ) {
       return null;
     }
     const argument = transaction.tx.arguments[1];

--- a/src/social/utils/content-parser.util.ts
+++ b/src/social/utils/content-parser.util.ts
@@ -205,8 +205,9 @@ export function isValidMediaUrl(url: string): boolean {
       'youtube.com',
       'vimeo.com',
     ];
-    const isFromMediaHost = commonMediaHosts.some((host) =>
-      parsedUrl.hostname.includes(host),
+    const hostname = parsedUrl.hostname.toLowerCase();
+    const isFromMediaHost = commonMediaHosts.some(
+      (host) => hostname === host || hostname.endsWith(`.${host}`),
     );
 
     return hasValidProtocol && (hasMediaExtension || isFromMediaHost);

--- a/src/social/utils/content-parser.util.ts
+++ b/src/social/utils/content-parser.util.ts
@@ -3,6 +3,9 @@ import {
   IContentParsingOptions,
 } from '../interfaces/post.interfaces';
 import { TOKEN_HASHTAG_REGEX_SOURCE } from './token-mentions-sql.util';
+import { Logger } from '@nestjs/common';
+
+const logger = new Logger('ContentParserUtil');
 
 /**
  * Default options for content parsing
@@ -109,7 +112,7 @@ export function extractMedia(
 
     return media;
   } catch (error) {
-    console.warn('Error extracting media from arguments:', error);
+    logger.warn('Error extracting media from arguments', error);
     return [];
   }
 }

--- a/src/tipping/controllers/tips.controller.ts
+++ b/src/tipping/controllers/tips.controller.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   Controller,
   DefaultValuePipe,
   Get,
@@ -20,6 +21,9 @@ import {
   OpaqueIdPipe,
   OptionalAeAccountAddressPipe,
 } from '@/common/validation/request-validation';
+
+const ALLOWED_ORDER_BY = new Set(['amount', 'type', 'created_at']);
+const ALLOWED_ORDER_DIRECTIONS = new Set(['ASC', 'DESC']);
 
 @Controller('tips')
 @ApiTags('Tips')
@@ -62,6 +66,20 @@ export class TipsController {
     @Query('receiver', OptionalAeAccountAddressPipe) receiver?: string,
     @Query('type') type?: string,
   ) {
+    if (page < 1) {
+      throw new BadRequestException('Page must be greater than or equal to 1');
+    }
+    if (limit < 1 || limit > 100) {
+      throw new BadRequestException('Limit must be between 1 and 100');
+    }
+    if (!ALLOWED_ORDER_BY.has(orderBy)) {
+      throw new BadRequestException(`Invalid order_by value: ${orderBy}`);
+    }
+    if (!ALLOWED_ORDER_DIRECTIONS.has(orderDirection)) {
+      throw new BadRequestException(
+        `Invalid order_direction value: ${orderDirection}`,
+      );
+    }
     const query = this.tipRepository
       .createQueryBuilder('tip')
       .leftJoinAndMapOne(

--- a/src/tokens/account-tokens.controller.ts
+++ b/src/tokens/account-tokens.controller.ts
@@ -1,5 +1,6 @@
 import { CommunityFactoryService } from '@/ae/community-factory.service';
 import {
+  BadRequestException,
   Controller,
   DefaultValuePipe,
   Get,
@@ -21,6 +22,9 @@ import {
   OptionalAeAccountAddressPipe,
   OptionalAeContractAddressPipe,
 } from '@/common/validation/request-validation';
+
+const ALLOWED_ORDER_BY = new Set(['balance']);
+const ALLOWED_ORDER_DIRECTIONS = new Set(['ASC', 'DESC']);
 
 @Controller('accounts')
 @ApiTags('Account Tokens')
@@ -67,8 +71,22 @@ export class AccountTokensController {
     @Query('page', new DefaultValuePipe(1), ParseIntPipe) page = 1,
     @Query('limit', new DefaultValuePipe(100), ParseIntPipe) limit = 100,
     @Query('order_by') orderBy: string = 'balance',
-    @Query('order_direction') orderDirection: 'DESC' | 'DESC' = 'DESC',
+    @Query('order_direction') orderDirection: 'ASC' | 'DESC' = 'DESC',
   ): Promise<Pagination<TokenHolder>> {
+    if (page < 1) {
+      throw new BadRequestException('Page must be greater than or equal to 1');
+    }
+    if (limit < 1 || limit > 100) {
+      throw new BadRequestException('Limit must be between 1 and 100');
+    }
+    if (!ALLOWED_ORDER_BY.has(orderBy)) {
+      throw new BadRequestException(`Invalid order_by value: ${orderBy}`);
+    }
+    if (!ALLOWED_ORDER_DIRECTIONS.has(orderDirection)) {
+      throw new BadRequestException(
+        `Invalid order_direction value: ${orderDirection}`,
+      );
+    }
     // when it's creator_address or owner_address, we should fetch all tokens based no matter if the balance is 0 or not
     if (creator_address || owner_address) {
       const queryBuilder = this.tokenRepository.createQueryBuilder('token');

--- a/src/tokens/queues/remove-old-tokens.queue.ts
+++ b/src/tokens/queues/remove-old-tokens.queue.ts
@@ -26,7 +26,7 @@ export class RemoveOldTokensQueue {
     this.logger.log(`RemoveOldTokensQueue->started`);
     try {
       const factories = job.data.factories;
-      this.tokensRepository
+      await this.tokensRepository
         .createQueryBuilder()
         .where({
           factory_address: Not(In(factories)),

--- a/src/tokens/services/token-holders-lock.service.ts
+++ b/src/tokens/services/token-holders-lock.service.ts
@@ -11,6 +11,12 @@ export class TokenHoldersLockService implements OnModuleDestroy {
     process.env.SYNC_TOKEN_HOLDERS_LOCK_TTL_MS || 240_000,
   );
 
+  constructor() {
+    this.redis.on('error', (error) => {
+      this.logger.error('Token holders lock Redis connection error', error);
+    });
+  }
+
   async acquireLock(saleAddress: string): Promise<string | null> {
     const ownerToken = randomUUID();
     const key = this.getLockKey(saleAddress);

--- a/src/tokens/token-websocket.gateway.ts
+++ b/src/tokens/token-websocket.gateway.ts
@@ -1,16 +1,28 @@
 import { OnModuleInit } from '@nestjs/common';
-import {
-  MessageBody,
-  SubscribeMessage,
-  WebSocketGateway,
-  WebSocketServer,
-} from '@nestjs/websockets';
+import { WebSocketGateway, WebSocketServer } from '@nestjs/websockets';
 
 import { Server } from 'socket.io';
+import {
+  hasExplicitAllowlist,
+  parseAllowedOrigins,
+} from '@/configs/allowed-origins';
 
+/**
+ * Broadcasts token lifecycle events to connected clients.
+ *
+ * There are intentionally no `@SubscribeMessage` handlers here. Previously
+ * the gateway relayed any client-sent message straight back to every
+ * connected client, which let anonymous callers poison the UI with
+ * fabricated prices/events. All emissions must originate from server-side
+ * services that have validated the payload (see `TokensService`,
+ * `TransactionService`, `BclPluginSyncService`,
+ * `plugins/bcl/services/token.service.ts`), which call these methods
+ * directly via dependency injection.
+ */
 @WebSocketGateway({
   cors: {
-    origin: '*',
+    origin: parseAllowedOrigins(),
+    credentials: hasExplicitAllowlist(),
   },
 })
 export class TokenWebsocketGateway implements OnModuleInit {
@@ -21,26 +33,12 @@ export class TokenWebsocketGateway implements OnModuleInit {
     //
   }
 
-  @SubscribeMessage('tokenUpdated')
-  handleTokenUpdated(@MessageBody() payload: any): string {
+  handleTokenUpdated(payload: unknown): string {
     this.server.emit('token-updated', payload);
     return 'Done!';
   }
 
-  @SubscribeMessage('tokenCreated')
-  handleTokenCreated(@MessageBody() payload: any): string {
-    this.server.emit('token-created', payload);
-    return 'Done!';
-  }
-
-  @SubscribeMessage('tokenTransaction')
-  handleTokenTransaction(@MessageBody() payload: any): string {
-    this.server.emit('token-transaction', payload);
-    return 'Done!';
-  }
-
-  @SubscribeMessage('tokenHistory')
-  handleTokenHistory(@MessageBody() payload: any): string {
+  handleTokenHistory(payload: unknown): string {
     this.server.emit('token-history', payload);
     return 'Done!';
   }

--- a/src/tokens/tokens.controller.spec.ts
+++ b/src/tokens/tokens.controller.spec.ts
@@ -226,6 +226,20 @@ describe('TokensController', () => {
     );
   });
 
+  it('rejects invalid token list pagination and search before querying', async () => {
+    await expect(
+      controller.listAll(undefined, undefined, undefined, undefined, 0, 100),
+    ).rejects.toThrow('Page must be greater than or equal to 1');
+    await expect(
+      controller.listAll(undefined, undefined, undefined, undefined, 1, 101),
+    ).rejects.toThrow('Limit must be between 1 and 100');
+    await expect(controller.listAll('x'.repeat(101))).rejects.toThrow(
+      'search must be at most 100 characters',
+    );
+
+    expect(tokensService.queryTokensWithRanks).not.toHaveBeenCalled();
+  });
+
   it('should filter owner holdings with EXISTS instead of a distinct IN subquery', async () => {
     await controller.listAll(undefined, undefined, undefined, 'ak_owner');
 

--- a/src/tokens/tokens.controller.ts
+++ b/src/tokens/tokens.controller.ts
@@ -355,7 +355,13 @@ export class TokensController {
 
     const factory = await this.communityFactoryService.getCurrentFactory();
 
-    // Get tokens with market cap around the target token
+    // All values below are bound as parameters rather than interpolated
+    // into the SQL string. Even though `factory.address` and
+    // `token.sale_address` come from our own DB today, string
+    // interpolation here would mean a single compromised upstream row
+    // becomes SQL injection. `Math.floor(limit / 2)` is numeric and still
+    // bound as a parameter for consistency.
+    const halfLimit = Math.floor(limit / 2);
     const rankedQuery = `
       WITH ranked_tokens AS (
         SELECT 
@@ -367,21 +373,21 @@ export class TokensController {
               t.created_at ASC
           ) AS INTEGER) as rank
         FROM token t
-        WHERE t.factory_address = '${factory.address}'
+        WHERE t.factory_address = $1
       ),
       target_rank AS (
         SELECT rank
         FROM ranked_tokens
-        WHERE sale_address = '${token.sale_address}'
+        WHERE sale_address = $2
       ),
       adjusted_limits AS (
-        SELECT 
-          CASE 
+        SELECT
+          CASE
             WHEN (SELECT rank FROM target_rank) <= 2
-            THEN ${Math.floor(limit / 2)} - (SELECT rank FROM target_rank) + 1
-            ELSE ${Math.floor(limit / 2)} 
+            THEN $3::int - (SELECT rank FROM target_rank) + 1
+            ELSE $3::int
           END as upper_limit,
-          ${Math.floor(limit / 2)} as lower_limit
+          $3::int as lower_limit
       )
       SELECT 
         ranked_tokens.*,
@@ -397,7 +403,11 @@ export class TokensController {
       ORDER BY market_cap DESC
     `;
 
-    const rankedTokens = await this.tokensRepository.query(rankedQuery);
+    const rankedTokens = await this.tokensRepository.query(rankedQuery, [
+      factory.address,
+      token.sale_address,
+      halfLimit,
+    ]);
 
     return {
       items: rankedTokens,

--- a/src/tokens/tokens.controller.ts
+++ b/src/tokens/tokens.controller.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   Controller,
   DefaultValuePipe,
   Get,
@@ -42,6 +43,7 @@ import {
 
 const TOKENS_LIST_CACHE_TTL_MS = 60 * 1000;
 const TRENDING_TOKENS_LIST_CACHE_TTL_MS = 15 * 60 * 1000;
+const MAX_TOKEN_SEARCH_LENGTH = 100;
 
 @Controller('tokens')
 @UseInterceptors(CacheInterceptor)
@@ -150,6 +152,11 @@ export class TokensController {
     const allowedOrderDirections = ['ASC', 'DESC'];
     if (!allowedOrderDirections.includes(orderDirection)) {
       orderDirection = 'DESC';
+    }
+    if (search && search.length > MAX_TOKEN_SEARCH_LENGTH) {
+      throw new BadRequestException(
+        `search must be at most ${MAX_TOKEN_SEARCH_LENGTH} characters`,
+      );
     }
 
     let trendingCacheKey: string | null = null;

--- a/src/tokens/tokens.controller.ts
+++ b/src/tokens/tokens.controller.ts
@@ -44,6 +44,7 @@ import {
 const TOKENS_LIST_CACHE_TTL_MS = 60 * 1000;
 const TRENDING_TOKENS_LIST_CACHE_TTL_MS = 15 * 60 * 1000;
 const MAX_TOKEN_SEARCH_LENGTH = 100;
+const MAX_PAGE_LIMIT = 100;
 
 @Controller('tokens')
 @UseInterceptors(CacheInterceptor)
@@ -64,6 +65,17 @@ export class TokensController {
     @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
   ) {
     //
+  }
+
+  private validatePagination(page: number, limit: number): void {
+    if (page < 1) {
+      throw new BadRequestException('Page must be greater than or equal to 1');
+    }
+    if (limit < 1 || limit > MAX_PAGE_LIMIT) {
+      throw new BadRequestException(
+        `Limit must be between 1 and ${MAX_PAGE_LIMIT}`,
+      );
+    }
   }
 
   private buildTrendingListCacheKey(params: {
@@ -134,6 +146,7 @@ export class TokensController {
     @Query('order_direction') orderDirection: 'ASC' | 'DESC' = 'DESC',
     @Query('collection') collection: 'all' | 'word' | 'number' = 'all',
   ): Promise<Pagination<Token>> {
+    this.validatePagination(page, limit);
     // Now, wrap with RANK()
     // allowed sort fields to avoid SQL Injection
     const allowedSortFields = [
@@ -290,6 +303,7 @@ export class TokensController {
     @Query('page', new DefaultValuePipe(1), ParseIntPipe) page = 1,
     @Query('limit', new DefaultValuePipe(100), ParseIntPipe) limit = 100,
   ): Promise<Pagination<TokenHolder>> {
+    this.validatePagination(page, limit);
     const token = await this.tokensService.findByAddress(address);
     if (!token) {
       throw new NotFoundException('Token not found');
@@ -346,6 +360,7 @@ export class TokensController {
     @Query('page', new DefaultValuePipe(1), ParseIntPipe) page = 1,
     @Query('limit', new DefaultValuePipe(5), ParseIntPipe) limit = 5,
   ): Promise<Pagination<Token>> {
+    this.validatePagination(page, limit);
     const token = await this.tokensService.findByAddress(address);
     if (!token) {
       return {

--- a/src/tokens/tokens.service.spec.ts
+++ b/src/tokens/tokens.service.spec.ts
@@ -7,6 +7,15 @@ import {
   RetryableTokenHoldersSyncError,
   TokensService,
 } from './tokens.service';
+import { fetchJson } from '@/utils/common';
+
+jest.mock('@/utils/common', () => {
+  const actual = jest.requireActual('@/utils/common');
+  return {
+    ...actual,
+    fetchJson: jest.fn(),
+  };
+});
 
 describe('TokensService', () => {
   let service: TokensService;
@@ -18,6 +27,7 @@ describe('TokensService', () => {
   let pullTokenInfoQueue: any;
 
   beforeEach(() => {
+    (fetchJson as jest.Mock).mockReset();
     tokensRepository = {
       createQueryBuilder: jest.fn(),
       update: jest.fn(),
@@ -503,6 +513,34 @@ describe('TokensService', () => {
     expect(service.getTokenContractsBySaleAddress).toHaveBeenCalledTimes(3);
     expect((service as any).sleep).toHaveBeenNthCalledWith(1, 500);
     expect((service as any).sleep).toHaveBeenNthCalledWith(2, 1000);
+  });
+
+  it('marks middleware holder loading as truncated when the response is missing data before any holders are loaded', async () => {
+    jest.spyOn(service, '_loadHoldersFromContract').mockResolvedValue([]);
+    (fetchJson as jest.Mock).mockResolvedValueOnce({ data: null, next: null });
+
+    const result = await service._loadHoldersData(
+      { sale_address: 'ct_sale' } as any,
+      'ct_aex9',
+    );
+
+    expect(result).toEqual({ holders: [], truncated: true });
+  });
+
+  it('marks middleware holder loading as truncated when cursor validation fails', async () => {
+    jest.spyOn(service, '_loadHoldersFromContract').mockResolvedValue([]);
+    (fetchJson as jest.Mock).mockResolvedValueOnce({
+      data: [{ account_id: 'ak_holder', amount: '10' }],
+      next: 'https://evil.test/v3/aex9/ct_aex9/balances',
+    });
+
+    const result = await service._loadHoldersData(
+      { sale_address: 'ct_sale' } as any,
+      'ct_aex9',
+    );
+
+    expect(result.truncated).toBe(true);
+    expect(result.holders).toHaveLength(1);
   });
 
   it('uses upsert and reload when creating a token from a raw transaction', async () => {

--- a/src/tokens/tokens.service.spec.ts
+++ b/src/tokens/tokens.service.spec.ts
@@ -560,4 +560,80 @@ describe('TokensService', () => {
       name: 'BLA',
     });
   });
+
+  describe('SQL parameterization', () => {
+    it('removes duplicated sale addresses in bounded batches', async () => {
+      tokensRepository.query.mockResolvedValueOnce([{ ctid: '(0,1)' }]);
+
+      await service.findAndRemoveDuplicatedTokensBaseSaleAddress();
+
+      expect(tokensRepository.delete).toHaveBeenCalledWith({
+        sale_address: expect.any(Object),
+      });
+      expect(tokensRepository.query).toHaveBeenCalledTimes(1);
+      const [sql, params] = tokensRepository.query.mock.calls[0];
+      expect(params).toEqual([500]);
+      expect(sql).toContain('LIMIT $1');
+      expect(sql).toContain('RETURNING ctid');
+    });
+
+    it('findByAddress passes factory_address and sale_address as $1 and $2', async () => {
+      const qb = {
+        where: jest.fn().mockReturnThis(),
+        orWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue({
+          sale_address: 'ct_sale',
+          factory_address: 'ct_factory',
+        }),
+      };
+      tokensRepository.createQueryBuilder = jest.fn().mockReturnValue(qb);
+      tokensRepository.query.mockResolvedValue([
+        { rank: 5, performance: { score: 42 } },
+      ]);
+
+      await service.findByAddress('ct_sale');
+
+      expect(tokensRepository.query).toHaveBeenCalledTimes(1);
+      const [sql, params] = tokensRepository.query.mock.calls[0];
+      expect(params).toEqual(['ct_factory', 'ct_sale']);
+      expect(sql).toContain('$1');
+      expect(sql).toContain('$2');
+      expect(sql).not.toContain("'ct_factory'");
+      expect(sql).not.toContain("'ct_sale'");
+    });
+
+    it('getTokenRanks uses ANY($2::text[]) for the IN-list', async () => {
+      communityFactoryService.getCurrentFactory.mockResolvedValue({
+        address: 'ct_factory',
+      });
+      tokensRepository.query.mockResolvedValue([
+        { sale_address: 'ct_a', rank: 1 },
+        { sale_address: 'ct_b', rank: 2 },
+      ]);
+
+      const result = await service.getTokenRanks(['ct_a', 'ct_b']);
+
+      expect(tokensRepository.query).toHaveBeenCalledTimes(1);
+      const [sql, params] = tokensRepository.query.mock.calls[0];
+      expect(params).toEqual(['ct_factory', ['ct_a', 'ct_b']]);
+      expect(sql).toContain('ANY($2::text[])');
+      expect(sql).toContain('$1');
+      expect(result.get('ct_a')).toBe(1);
+      expect(result.get('ct_b')).toBe(2);
+    });
+
+    it('getTokenRanksByAex9Address uses ANY($2::text[]) for the IN-list', async () => {
+      communityFactoryService.getCurrentFactory.mockResolvedValue({
+        address: 'ct_factory',
+      });
+      tokensRepository.query.mockResolvedValue([{ address: 'ct_x', rank: 3 }]);
+
+      const result = await service.getTokenRanksByAex9Address(['ct_x']);
+
+      const [sql, params] = tokensRepository.query.mock.calls[0];
+      expect(params).toEqual(['ct_factory', ['ct_x']]);
+      expect(sql).toContain('ANY($2::text[])');
+      expect(result.get('ct_x')).toBe(3);
+    });
+  });
 });

--- a/src/tokens/tokens.service.ts
+++ b/src/tokens/tokens.service.ts
@@ -166,21 +166,34 @@ export class TokensService {
       sale_address: IsNull(),
     });
 
-    const duplicatedTokensQuery = `
-      SELECT sale_address, COUNT(*) as count
-      FROM token
-      WHERE sale_address IS NOT NULL
-      GROUP BY sale_address
-      HAVING COUNT(*) > 1
-    `;
-
-    const duplicatedTokens = await this.tokensRepository.query(
-      duplicatedTokensQuery,
-    );
-    // delete duplicated tokens
-    for (const token of duplicatedTokens) {
-      await this.tokensRepository.delete(token.id);
-    }
+    const duplicateDeleteBatchSize = 500;
+    let deletedRows = 0;
+    do {
+      const result = await this.tokensRepository.query(
+        `
+          WITH duplicate_rows AS (
+            SELECT ctid
+            FROM (
+              SELECT
+                ctid,
+                ROW_NUMBER() OVER (
+                  PARTITION BY sale_address
+                  ORDER BY created_at ASC NULLS LAST, ctid ASC
+                ) AS row_number
+              FROM token
+              WHERE sale_address IS NOT NULL
+            ) duplicated_tokens
+            WHERE duplicated_tokens.row_number > 1
+            LIMIT $1
+          )
+          DELETE FROM token
+          WHERE ctid IN (SELECT ctid FROM duplicate_rows)
+          RETURNING ctid
+        `,
+        [duplicateDeleteBatchSize],
+      );
+      deletedRows = Array.isArray(result) ? result.length : 0;
+    } while (deletedRows === duplicateDeleteBatchSize);
   }
 
   findAll(limit = 1000, offset = 0): Promise<Token[]> {
@@ -235,17 +248,20 @@ export class TokensService {
               created_at ASC
           ) AS INTEGER) as rank
         FROM token
-        WHERE factory_address = '${token.factory_address}'
+        WHERE factory_address = $1
       )
       SELECT
         ranked_tokens.rank,
         row_to_json(token_performance_view.*) as performance
       FROM ranked_tokens
       LEFT JOIN token_performance_view ON ranked_tokens.sale_address = token_performance_view.sale_address
-      WHERE ranked_tokens.sale_address = '${token.sale_address}'
+      WHERE ranked_tokens.sale_address = $2
     `;
 
-    const [rankResult] = await this.tokensRepository.query(rankedQuery);
+    const [rankResult] = await this.tokensRepository.query(rankedQuery, [
+      token.factory_address,
+      token.sale_address,
+    ]);
     return {
       ...token,
       rank: rankResult?.rank,
@@ -856,13 +872,16 @@ export class TokensService {
               t.created_at ASC
           ) AS INTEGER) as rank
         FROM token t
-        WHERE t.factory_address = '${factory.address}'
+        WHERE t.factory_address = $1
         AND t.unlisted = false
       )
-      SELECT * FROM ranked_tokens WHERE sale_address IN (${tokenIds.join(',')})
+      SELECT * FROM ranked_tokens WHERE sale_address = ANY($2::text[])
     `;
 
-    const result = await this.tokensRepository.query(rankedQuery);
+    const result = await this.tokensRepository.query(rankedQuery, [
+      factory.address,
+      tokenIds,
+    ]);
     return new Map(result.map((token) => [token.sale_address, token.rank]));
   }
 
@@ -884,13 +903,16 @@ export class TokensService {
               t.created_at ASC
           ) AS INTEGER) as rank
         FROM token t
-        WHERE t.factory_address = '${factory.address}'
+        WHERE t.factory_address = $1
         AND t.unlisted = false
       )
-      SELECT * FROM ranked_tokens WHERE address IN ('${aex9Addresses.join("','")}')
+      SELECT * FROM ranked_tokens WHERE address = ANY($2::text[])
     `;
 
-    const result = await this.tokensRepository.query(rankedQuery);
+    const result = await this.tokensRepository.query(rankedQuery, [
+      factory.address,
+      aex9Addresses,
+    ]);
     return new Map(result.map((token) => [token.address, token.rank]));
   }
 

--- a/src/tokens/tokens.service.ts
+++ b/src/tokens/tokens.service.ts
@@ -11,7 +11,7 @@ import {
   TOKEN_LIST_ELIGIBILITY_CONFIG,
   TRENDING_SCORE_CONFIG,
 } from '@/configs';
-import { fetchJson } from '@/utils/common';
+import { fetchJson, resolveMiddlewareNextUrl } from '@/utils/common';
 import { runWithDatabaseIssueLogging } from '@/utils/database-issue-logging';
 import { ITransaction } from '@/utils/types';
 import { Encoded } from '@aeternity/aepp-sdk';
@@ -1180,7 +1180,7 @@ export class TokensService {
             `SyncTokenHoldersQueue:failed to load data from url::${nextUrl}`,
           );
           this.logger.error(`SyncTokenHoldersQueue:response::`, response);
-          return { holders: totalHolders, truncated: totalHolders.length > 0 };
+          return { holders: totalHolders, truncated: true };
         }
 
         const holders = response.data.filter((item) => item.amount > 0);
@@ -1198,15 +1198,16 @@ export class TokensService {
           });
         }
 
-        nextUrl = response.next
-          ? `${ACTIVE_NETWORK.middlewareUrl}${response.next}`
-          : null;
+        nextUrl = resolveMiddlewareNextUrl(
+          response.next,
+          ACTIVE_NETWORK.middlewareUrl,
+        );
         page++;
       } catch (error: any) {
         this.logger.error(`SyncTokenHoldersQueue->error`, error, error.stack);
         return {
           holders: totalHolders,
-          truncated: totalHolders.length > 0,
+          truncated: true,
         };
       }
     }

--- a/src/transactions/controllers/historical.controller.ts
+++ b/src/transactions/controllers/historical.controller.ts
@@ -14,7 +14,11 @@ import {
 import { ApiOperation, ApiParam, ApiQuery, ApiTags } from '@nestjs/swagger';
 
 import { TokensService } from '@/tokens/tokens.service';
-import { buildSparklineSvg, sparklineStroke } from '@/utils/sparkline.util';
+import {
+  buildSparklineSvg,
+  parseSvgDimension,
+  sparklineStroke,
+} from '@/utils/sparkline.util';
 import moment from 'moment';
 import {
   ITransactionPreview,
@@ -189,8 +193,8 @@ export class HistoricalController {
 
     const values = preview.result.map((item) => Number(item.last_price));
 
-    const safeWidth = this.parseSvgDimension(width, 160);
-    const safeHeight = this.parseSvgDimension(height, 60);
+    const safeWidth = parseSvgDimension(width, 160);
+    const safeHeight = parseSvgDimension(height, 60);
     const svg = buildSparklineSvg(
       values,
       safeWidth,
@@ -211,13 +215,5 @@ export class HistoricalController {
       return moment.unix(value);
     }
     return moment(value);
-  }
-
-  private parseSvgDimension(value: string, fallback: number): number {
-    const parsed = Number(value);
-    if (!Number.isFinite(parsed)) {
-      return fallback;
-    }
-    return Math.min(Math.max(Math.floor(parsed), 1), 2000);
   }
 }

--- a/src/transactions/controllers/historical.controller.ts
+++ b/src/transactions/controllers/historical.controller.ts
@@ -189,10 +189,12 @@ export class HistoricalController {
 
     const values = preview.result.map((item) => Number(item.last_price));
 
+    const safeWidth = this.parseSvgDimension(width, 160);
+    const safeHeight = this.parseSvgDimension(height, 60);
     const svg = buildSparklineSvg(
       values,
-      Number(width),
-      Number(height),
+      safeWidth,
+      safeHeight,
       sparklineStroke(values),
       background,
     );
@@ -209,5 +211,13 @@ export class HistoricalController {
       return moment.unix(value);
     }
     return moment(value);
+  }
+
+  private parseSvgDimension(value: string, fallback: number): number {
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed)) {
+      return fallback;
+    }
+    return Math.min(Math.max(Math.floor(parsed), 1), 2000);
   }
 }

--- a/src/trending-tags/controllers/trending-tags.controller.ts
+++ b/src/trending-tags/controllers/trending-tags.controller.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   Body,
   Controller,
   DefaultValuePipe,
@@ -26,6 +27,10 @@ import { CreateTrendingTagsDto } from '../dto/create-trending-tags.dto';
 import { TrendingTagsService } from '../services/trending-tags.service';
 import { ApiKeyGuard } from '../guards/api-key.guard';
 import { TopicParamPipe } from '@/common/validation/request-validation';
+
+const ALLOWED_ORDER_BY = new Set(['score', 'source', 'created_at']);
+const ALLOWED_ORDER_DIRECTIONS = new Set(['ASC', 'DESC']);
+const MAX_SEARCH_LENGTH = 100;
 
 @Controller('trending-tags')
 @ApiTags('Trending Tags')
@@ -56,6 +61,25 @@ export class TrendingTagsController {
     @Query('order_direction') orderDirection: 'ASC' | 'DESC' = 'DESC',
     @Query('search') search: string = '',
   ) {
+    if (page < 1) {
+      throw new BadRequestException('Page must be greater than or equal to 1');
+    }
+    if (limit < 1 || limit > 100) {
+      throw new BadRequestException('Limit must be between 1 and 100');
+    }
+    if (!ALLOWED_ORDER_BY.has(orderBy)) {
+      throw new BadRequestException(`Invalid order_by value: ${orderBy}`);
+    }
+    if (!ALLOWED_ORDER_DIRECTIONS.has(orderDirection)) {
+      throw new BadRequestException(
+        `Invalid order_direction value: ${orderDirection}`,
+      );
+    }
+    if (search && search.length > MAX_SEARCH_LENGTH) {
+      throw new BadRequestException(
+        `search must be at most ${MAX_SEARCH_LENGTH} characters`,
+      );
+    }
     const query = this.trendingTagRepository.createQueryBuilder('trending_tag');
     if (orderBy) {
       query.orderBy(`trending_tag.${orderBy}`, orderDirection);

--- a/src/trending-tags/guards/api-key.guard.ts
+++ b/src/trending-tags/guards/api-key.guard.ts
@@ -26,7 +26,9 @@ export class ApiKeyGuard implements CanActivate {
     // Reject outright if the server-side key is unset or too short so that a
     // misconfigured deployment cannot be bypassed by sending an empty key.
     if (!TRENDING_TAGS_API_KEY || TRENDING_TAGS_API_KEY.length < 16) {
-      throw new UnauthorizedException('API key authentication is not configured');
+      throw new UnauthorizedException(
+        'API key authentication is not configured',
+      );
     }
 
     // Constant-time comparison prevents timing side channels.

--- a/src/trending-tags/guards/api-key.guard.ts
+++ b/src/trending-tags/guards/api-key.guard.ts
@@ -5,6 +5,7 @@ import {
   Injectable,
   UnauthorizedException,
 } from '@nestjs/common';
+import { timingSafeEqual } from 'crypto';
 import { Request } from 'express';
 
 @Injectable()
@@ -12,14 +13,29 @@ export class ApiKeyGuard implements CanActivate {
   canActivate(context: ExecutionContext): boolean {
     const request = context.switchToHttp().getRequest<Request>();
     const apiKey =
-      request.headers['x-api-key'] ||
-      request.headers['authorization']?.replace('Bearer ', '');
+      (request.headers['x-api-key'] as string | undefined) ||
+      (request.headers['authorization'] as string | undefined)?.replace(
+        'Bearer ',
+        '',
+      );
 
     if (!apiKey) {
       throw new UnauthorizedException('API key is required');
     }
 
-    if (apiKey !== TRENDING_TAGS_API_KEY) {
+    // Reject outright if the server-side key is unset or too short so that a
+    // misconfigured deployment cannot be bypassed by sending an empty key.
+    if (!TRENDING_TAGS_API_KEY || TRENDING_TAGS_API_KEY.length < 16) {
+      throw new UnauthorizedException('API key authentication is not configured');
+    }
+
+    // Constant-time comparison prevents timing side channels.
+    const provided = Buffer.from(apiKey);
+    const expected = Buffer.from(TRENDING_TAGS_API_KEY);
+    if (
+      provided.length !== expected.length ||
+      !timingSafeEqual(provided, expected)
+    ) {
       throw new UnauthorizedException('Invalid API key');
     }
 

--- a/src/utils/common.spec.ts
+++ b/src/utils/common.spec.ts
@@ -1,0 +1,61 @@
+import {
+  InvalidMiddlewareNextUrlError,
+  resolveMiddlewareNextUrl,
+  resolveMiddlewareNextUrlSafely,
+} from './common';
+
+describe('resolveMiddlewareNextUrl', () => {
+  const middlewareUrl = 'https://mdw.example.test/api';
+
+  it('returns null when the middleware response has no next cursor', () => {
+    expect(resolveMiddlewareNextUrl(null, middlewareUrl)).toBeNull();
+    expect(resolveMiddlewareNextUrl(undefined, middlewareUrl)).toBeNull();
+  });
+
+  it('resolves relative cursors on the middleware origin and path prefix', () => {
+    expect(
+      resolveMiddlewareNextUrl('/v3/transactions?page=2', middlewareUrl),
+    ).toBe('https://mdw.example.test/api/v3/transactions?page=2');
+  });
+
+  it('resolves same-origin absolute cursors', () => {
+    expect(
+      resolveMiddlewareNextUrl(
+        'https://mdw.example.test/api/v3/transactions?page=2',
+        middlewareUrl,
+      ),
+    ).toBe('https://mdw.example.test/api/v3/transactions?page=2');
+  });
+
+  it('throws for off-origin cursors so callers cannot treat partial pagination as complete', () => {
+    expect(() =>
+      resolveMiddlewareNextUrl(
+        'https://evil.example/v3/transactions',
+        middlewareUrl,
+      ),
+    ).toThrow(InvalidMiddlewareNextUrlError);
+  });
+
+  it('throws for malformed cursors', () => {
+    expect(() =>
+      resolveMiddlewareNextUrl('http://[::1', middlewareUrl),
+    ).toThrow(InvalidMiddlewareNextUrlError);
+  });
+
+  it('logs and returns null in safe mode for malformed cursors', () => {
+    const logger = { warn: jest.fn() };
+
+    expect(
+      resolveMiddlewareNextUrlSafely(
+        'http://[::1',
+        middlewareUrl,
+        logger,
+        'test pagination',
+      ),
+    ).toBeNull();
+    expect(logger.warn).toHaveBeenCalledWith(
+      'test pagination: stopping pagination after invalid next URL',
+      expect.any(InvalidMiddlewareNextUrlError),
+    );
+  });
+});

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -23,6 +23,17 @@ class FetchJsonHttpError extends Error {
   }
 }
 
+export class InvalidMiddlewareNextUrlError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidMiddlewareNextUrlError';
+  }
+}
+
+type MiddlewareNextUrlLogger = {
+  warn(message: string, ...optionalParams: unknown[]): void;
+};
+
 function formatResponseDetails(
   url: string,
   response: Response,
@@ -125,6 +136,56 @@ export async function fetchJson<T = any>(
   } finally {
     clearTimeout(timeoutId);
     options?.signal?.removeEventListener('abort', onParentAbort);
+  }
+}
+
+export function resolveMiddlewareNextUrl(
+  next: string | null | undefined,
+  middlewareUrl: string,
+): string | null {
+  if (!next) {
+    return null;
+  }
+
+  let baseUrl: URL;
+  let resolvedUrl: URL;
+
+  try {
+    baseUrl = new URL(middlewareUrl);
+    const basePath = baseUrl.pathname.replace(/\/$/, '');
+    resolvedUrl = next.startsWith('/')
+      ? new URL(`${baseUrl.origin}${basePath}${next}`)
+      : new URL(next, `${middlewareUrl.replace(/\/$/, '')}/`);
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new InvalidMiddlewareNextUrlError(
+      `Invalid middleware next URL "${next}": ${reason}`,
+    );
+  }
+
+  if (resolvedUrl.origin !== baseUrl.origin) {
+    throw new InvalidMiddlewareNextUrlError(
+      `Rejected middleware next URL "${next}" because it resolves outside ${baseUrl.origin}`,
+    );
+  }
+
+  return resolvedUrl.toString();
+}
+
+export function resolveMiddlewareNextUrlSafely(
+  next: string | null | undefined,
+  middlewareUrl: string,
+  logger: MiddlewareNextUrlLogger,
+  context: string,
+): string | null {
+  try {
+    return resolveMiddlewareNextUrl(next, middlewareUrl);
+  } catch (error) {
+    logger.warn(
+      `${context}: stopping pagination after invalid next URL`,
+      error,
+    );
+    return null;
   }
 }
 

--- a/src/utils/getBlochHeight.ts
+++ b/src/utils/getBlochHeight.ts
@@ -1,6 +1,9 @@
 import { ACTIVE_NETWORK } from '@/configs';
 import { fetchJson } from './common';
 import { DataSource } from 'typeorm';
+import { Logger } from '@nestjs/common';
+
+const logger = new Logger('BlockHeight');
 
 // Cache for top block and median interval with TTL
 const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
@@ -68,7 +71,7 @@ async function getKeyBlock(
     const kb = (await response.json()) as { height: number; time: number };
     return { height: kb.height, time: kb.time as number };
   } catch (error) {
-    console.error(`Error fetching key block at height ${height}:`, error);
+    logger.error(`Error fetching key block at height ${height}`, error);
     throw error;
   }
 }
@@ -195,7 +198,7 @@ async function getApproximateBlockHeightFromDB(
 
     return null;
   } catch (error) {
-    console.warn(
+    logger.warn(
       `[getApproximateBlockHeightFromDB] Error querying database:`,
       error,
     );
@@ -337,7 +340,7 @@ export async function timestampToAeHeight(
       lowTime = (await getKeyBlock(low)).time;
     }
   } catch (error) {
-    console.warn(
+    logger.warn(
       `[timestampToAeHeight] Error in sanity check for timestamp ${targetMs}, using low=${low}:`,
       error,
     );
@@ -395,7 +398,7 @@ export async function batchTimestampToAeHeight(
       [targetTimestamps],
     );
   } catch (error) {
-    console.warn(
+    logger.warn(
       '[batchTimestampToAeHeight] key_blocks query failed, will try transactions fallback:',
       error,
     );
@@ -439,7 +442,7 @@ export async function batchTimestampToAeHeight(
         [fallbackTimestamps],
       );
     } catch (error) {
-      console.warn(
+      logger.warn(
         '[batchTimestampToAeHeight] transactions fallback query failed:',
         error,
       );

--- a/src/utils/sparkline.util.spec.ts
+++ b/src/utils/sparkline.util.spec.ts
@@ -1,0 +1,44 @@
+import { parseSvgDimension } from './sparkline.util';
+
+describe('parseSvgDimension', () => {
+  it('parses a valid integer string', () => {
+    expect(parseSvgDimension('200', 100)).toBe(200);
+  });
+
+  it('floors fractional values', () => {
+    expect(parseSvgDimension('150.9', 100)).toBe(150);
+  });
+
+  it('returns fallback for NaN', () => {
+    expect(parseSvgDimension('abc', 100)).toBe(100);
+  });
+
+  it('treats empty string as 0, clamped to 1', () => {
+    // Number('') is 0, which is finite, so it gets clamped to min=1
+    expect(parseSvgDimension('', 100)).toBe(1);
+  });
+
+  it('returns fallback for Infinity', () => {
+    expect(parseSvgDimension('Infinity', 100)).toBe(100);
+  });
+
+  it('clamps negative values to 1', () => {
+    expect(parseSvgDimension('-50', 100)).toBe(1);
+  });
+
+  it('clamps zero to 1', () => {
+    expect(parseSvgDimension('0', 100)).toBe(1);
+  });
+
+  it('clamps values above 2000 to 2000', () => {
+    expect(parseSvgDimension('5000', 100)).toBe(2000);
+  });
+
+  it('allows the boundary value 2000', () => {
+    expect(parseSvgDimension('2000', 100)).toBe(2000);
+  });
+
+  it('allows the boundary value 1', () => {
+    expect(parseSvgDimension('1', 100)).toBe(1);
+  });
+});

--- a/src/utils/sparkline.util.ts
+++ b/src/utils/sparkline.util.ts
@@ -30,6 +30,14 @@ export function sparklineStroke(values: number[]): string {
     : COLOR_DOWN;
 }
 
+export function parseSvgDimension(value: string, fallback: number): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    return fallback;
+  }
+  return Math.min(Math.max(Math.floor(parsed), 1), 2000);
+}
+
 /**
  * Build a minimal SVG sparkline path from a numeric series.
  */

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,8 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "inlineSourceMap": false,
+    "sourceMap": false
+  },
   "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
 }

--- a/views/challenge-analytics.hbs
+++ b/views/challenge-analytics.hbs
@@ -1,0 +1,1082 @@
+{{#> main-layout title="Challenge Analytics" active="bcl-challenge"}}
+<style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+        font-family: "Inter", sans-serif;
+      }
+
+      body {
+        background-color: #f8fafc;
+        color: #1e293b;
+        padding: 0;
+        min-height: 100vh;
+      }
+
+      .container {
+        max-width: 1400px;
+        margin: 0 auto;
+      }
+
+      .toolbar {
+        background: white;
+        padding: 1rem;
+        border-radius: 0.5rem;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+        margin-bottom: 1rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+      }
+
+      .toolbar-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        align-items: flex-end;
+      }
+
+      .toolbar-row > .field {
+        display: flex;
+        flex-direction: column;
+        gap: 0.4rem;
+        min-width: 160px;
+      }
+
+      .toolbar-row > .field.address-field {
+        flex: 1;
+        min-width: 280px;
+      }
+
+      .toolbar label {
+        font-size: 0.8rem;
+        color: #475569;
+      }
+
+      .toolbar input,
+      .toolbar select {
+        padding: 0.5rem;
+        border: 1px solid #e2e8f0;
+        border-radius: 0.25rem;
+        font-size: 0.875rem;
+        color: #1e293b;
+        width: 100%;
+      }
+
+      .toolbar button {
+        padding: 0.5rem 1rem;
+        background-color: #3b82f6;
+        color: white;
+        border: none;
+        border-radius: 0.25rem;
+        font-size: 0.875rem;
+        cursor: pointer;
+        white-space: nowrap;
+      }
+
+      .toolbar button:hover {
+        background-color: #2563eb;
+      }
+
+      .toolbar button.secondary {
+        background-color: #e2e8f0;
+        color: #1e293b;
+      }
+
+      .toolbar button.secondary:hover {
+        background-color: #cbd5e1;
+      }
+
+      .segmented {
+        display: inline-flex;
+        border: 1px solid #e2e8f0;
+        border-radius: 0.25rem;
+        overflow: hidden;
+      }
+
+      .segmented button {
+        padding: 0.5rem 0.85rem;
+        background: white;
+        color: #475569;
+        border: none;
+        border-radius: 0;
+        font-size: 0.85rem;
+        cursor: pointer;
+        white-space: nowrap;
+      }
+
+      .segmented button + button {
+        border-left: 1px solid #e2e8f0;
+      }
+
+      .segmented button:hover {
+        background: #f1f5f9;
+      }
+
+      .segmented button.active {
+        background: #3b82f6;
+        color: white;
+      }
+
+      .segmented button.active:hover {
+        background: #2563eb;
+      }
+
+      .chips {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.4rem;
+        min-height: 1.5rem;
+      }
+
+      .chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        padding: 0.3rem 0.6rem;
+        border-radius: 999px;
+        font-size: 0.8rem;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+          "Liberation Mono", "Courier New", monospace;
+        color: #0f172a;
+        background: #eff6ff;
+        border: 1px solid #bfdbfe;
+      }
+
+      .chip .swatch {
+        width: 10px;
+        height: 10px;
+        border-radius: 50%;
+        flex-shrink: 0;
+      }
+
+      .chip .remove {
+        cursor: pointer;
+        color: #475569;
+        font-weight: 700;
+        margin-left: 0.2rem;
+      }
+
+      .chip .remove:hover {
+        color: #b91c1c;
+      }
+
+      .empty-chips {
+        font-size: 0.85rem;
+        color: #94a3b8;
+        font-style: italic;
+      }
+
+      .table-card {
+        background: white;
+        border-radius: 0.5rem;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+        margin-bottom: 1rem;
+        overflow: hidden;
+      }
+
+      .table-card .head {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 0.75rem 1rem;
+        border-bottom: 1px solid #e2e8f0;
+      }
+
+      .table-card .head h2 {
+        font-size: 1rem;
+        color: #475569;
+      }
+
+      .table-card .head .meta {
+        font-size: 0.8rem;
+        color: #64748b;
+      }
+
+      .table-wrapper {
+        overflow-x: auto;
+        max-height: 540px;
+      }
+
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 0.85rem;
+      }
+
+      thead th {
+        background: #f8fafc;
+        position: sticky;
+        top: 0;
+        text-align: left;
+        padding: 0.6rem 0.8rem;
+        color: #475569;
+        font-weight: 600;
+        border-bottom: 1px solid #e2e8f0;
+        white-space: nowrap;
+      }
+
+      tbody td {
+        padding: 0.5rem 0.8rem;
+        border-bottom: 1px solid #f1f5f9;
+        white-space: nowrap;
+      }
+
+      tbody tr:hover td {
+        background: #f8fafc;
+      }
+
+      td.num,
+      th.num {
+        text-align: right;
+        font-variant-numeric: tabular-nums;
+      }
+
+      th.sortable {
+        cursor: pointer;
+        user-select: none;
+      }
+
+      th.sortable:hover {
+        background: #eef2f7;
+      }
+
+      th .sort-ind {
+        font-size: 0.7rem;
+        color: #94a3b8;
+        margin-left: 0.25rem;
+        font-weight: 700;
+      }
+
+      th.sortable.active .sort-ind {
+        color: #3b82f6;
+      }
+
+      td.address {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+      }
+
+      td.address .swatch {
+        width: 10px;
+        height: 10px;
+        border-radius: 50%;
+        flex-shrink: 0;
+      }
+
+      td.address .mono {
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+          "Liberation Mono", "Courier New", monospace;
+        cursor: pointer;
+      }
+
+      td.address .mono:hover {
+        text-decoration: underline;
+      }
+
+      .pnl-positive { color: #15803d; font-weight: 600; }
+      .pnl-negative { color: #b91c1c; font-weight: 600; }
+      .pnl-zero    { color: #94a3b8; }
+
+      .pnl-sub {
+        display: block;
+        font-size: 0.7rem;
+        color: #94a3b8;
+        font-weight: 400;
+        margin-top: 1px;
+      }
+
+      .charts-grid {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        gap: 1rem;
+      }
+
+      .chart-container {
+        background: white;
+        padding: 1rem;
+        border-radius: 0.5rem;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+        height: 320px;
+      }
+
+      .chart-container h2 {
+        font-size: 1rem;
+        margin-bottom: 0.5rem;
+        color: #475569;
+      }
+
+      .chart-wrapper {
+        height: calc(100% - 2rem);
+        position: relative;
+      }
+
+      .empty-state {
+        text-align: center;
+        padding: 3rem 1rem;
+        color: #94a3b8;
+      }
+
+      .error-banner {
+        background: #fef2f2;
+        color: #b91c1c;
+        border: 1px solid #fecaca;
+        padding: 0.6rem 0.9rem;
+        border-radius: 0.5rem;
+        margin-bottom: 1rem;
+        font-size: 0.85rem;
+      }
+
+      .loading-indicator {
+        font-size: 0.8rem;
+        color: #64748b;
+      }
+
+      @media (max-width: 1024px) {
+        .charts-grid { grid-template-columns: 1fr; }
+      }
+    </style>
+
+    <div class="container">
+
+      <div class="toolbar">
+        <div class="toolbar-row">
+          <div class="field address-field">
+            <label for="addressInput">Add address (paste one or many, comma-separated)</label>
+            <input
+              type="text"
+              id="addressInput"
+              placeholder="ak_..."
+              autocomplete="off"
+            />
+          </div>
+          <button onclick="addAddressesFromInput()">Add</button>
+          <button class="secondary" onclick="clearAllAddresses()">Clear all</button>
+        </div>
+
+        <div class="chips" id="chips">
+          <div class="empty-chips" id="emptyChips">No addresses yet. Add at least one to start.</div>
+        </div>
+
+        <div class="toolbar-row">
+          <div class="field">
+            <label for="startDate">Start Date</label>
+            <input type="date" id="startDate" />
+          </div>
+          <div class="field">
+            <label for="endDate">End Date</label>
+            <input type="date" id="endDate" />
+          </div>
+          <div class="field" style="min-width: 0;">
+            <label>View</label>
+            <div class="segmented" id="viewToggle">
+              <button type="button" data-mode="per_day" class="active" onclick="setViewMode('per_day')">Per-day</button>
+              <button type="button" data-mode="range" onclick="setViewMode('range')">Range</button>
+            </div>
+          </div>
+          <button onclick="runComparison()">Run comparison</button>
+          <button class="secondary" onclick="exportCsv()">Export CSV</button>
+          <span class="loading-indicator" id="loadingIndicator"></span>
+        </div>
+      </div>
+
+      <div id="errorBanner" class="error-banner" style="display: none;"></div>
+
+      <div class="table-card">
+        <div class="head">
+          <h2 id="tableTitle">Per-day breakdown</h2>
+          <span class="meta" id="tableMeta"></span>
+        </div>
+        <div class="table-wrapper">
+          <table id="resultsTable">
+            <thead>
+              <tr>
+                <th class="sortable" data-sort-key="address" onclick="clickSortHeader('address')">
+                  Address <span class="sort-ind"></span>
+                </th>
+                <th>Date</th>
+                <th class="num sortable" data-sort-key="total_posts" onclick="clickSortHeader('total_posts')">
+                  Total Posts <span class="sort-ind"></span>
+                </th>
+                <th class="num sortable" data-sort-key="total_trades" onclick="clickSortHeader('total_trades')">
+                  Total Trades <span class="sort-ind"></span>
+                </th>
+                <th class="num sortable" data-sort-key="pnl_ae" onclick="clickSortHeader('pnl_ae')">
+                  PNL (excluding deposit) <span class="sort-ind"></span>
+                </th>
+                <th class="num sortable" data-sort-key="total_volume_ae" onclick="clickSortHeader('total_volume_ae')">
+                  Total Volume (AE) <span class="sort-ind"></span>
+                </th>
+                <th class="num sortable" data-sort-key="created_tokens" onclick="clickSortHeader('created_tokens')">
+                  Created Tokens <span class="sort-ind"></span>
+                </th>
+              </tr>
+            </thead>
+            <tbody id="resultsBody">
+              <tr><td colspan="7" class="empty-state">Add addresses and run a comparison to see results.</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="charts-grid">
+        <div class="chart-container">
+          <h2>PNL (AE)</h2>
+          <div class="chart-wrapper"><canvas id="pnlChart"></canvas></div>
+        </div>
+        <div class="chart-container">
+          <h2>Total Posts</h2>
+          <div class="chart-wrapper"><canvas id="postsChart"></canvas></div>
+        </div>
+        <div class="chart-container">
+          <h2>Total Trades</h2>
+          <div class="chart-wrapper"><canvas id="tradesChart"></canvas></div>
+        </div>
+        <div class="chart-container">
+          <h2>Total Volume (AE)</h2>
+          <div class="chart-wrapper"><canvas id="volumeChart"></canvas></div>
+        </div>
+        <div class="chart-container">
+          <h2>Created Tokens</h2>
+          <div class="chart-wrapper"><canvas id="createdTokensChart"></canvas></div>
+        </div>
+      </div>
+    </div>
+
+    <script>
+      // ---------- Constants ----------
+      const STORAGE_KEY = 'challenge.addresses';
+      const VIEW_MODE_KEY = 'challenge.viewMode';
+      const SORT_STATE_KEY = 'challenge.sortState';
+      const MAX_ADDRESSES = 10;
+      // Numeric sort keys that map to row fields (used by applySort).
+      const NUMERIC_SORT_KEYS = new Set([
+        'total_posts',
+        'total_trades',
+        'pnl_ae',
+        'total_volume_ae',
+        'created_tokens',
+      ]);
+      // Colors used for chart lines + chips. Indexed by address position.
+      const PALETTE = [
+        '#3b82f6', // blue
+        '#ef4444', // red
+        '#10b981', // green
+        '#f59e0b', // amber
+        '#8b5cf6', // violet
+        '#ec4899', // pink
+        '#0ea5e9', // sky
+        '#f97316', // orange
+        '#14b8a6', // teal
+        '#a855f7', // purple
+      ];
+
+      // ---------- State ----------
+      let addresses = loadAddresses();
+      let lastRows = []; // raw per-day rows from the last successful fetch
+      let viewMode = loadViewMode(); // 'per_day' | 'range'
+      let sortState = loadSortState(); // { key: string|null, dir: 'asc'|'desc' }
+      const charts = {};
+      let runRequestId = 0; // monotonically increasing id to discard stale fetches
+
+      // ---------- Helpers ----------
+      function loadAddresses() {
+        try {
+          const raw = localStorage.getItem(STORAGE_KEY);
+          if (!raw) return [];
+          const parsed = JSON.parse(raw);
+          if (!Array.isArray(parsed)) return [];
+          return parsed.filter((a) => typeof a === 'string').slice(0, MAX_ADDRESSES);
+        } catch (e) {
+          return [];
+        }
+      }
+
+      function saveAddresses() {
+        try {
+          localStorage.setItem(STORAGE_KEY, JSON.stringify(addresses));
+        } catch (e) {
+          // Storage quota / privacy mode - fail silently.
+        }
+      }
+
+      function loadViewMode() {
+        try {
+          const raw = localStorage.getItem(VIEW_MODE_KEY);
+          return raw === 'range' ? 'range' : 'per_day';
+        } catch (e) {
+          return 'per_day';
+        }
+      }
+
+      function saveViewMode() {
+        try {
+          localStorage.setItem(VIEW_MODE_KEY, viewMode);
+        } catch (e) {
+          // ignore
+        }
+      }
+
+      function loadSortState() {
+        try {
+          const raw = localStorage.getItem(SORT_STATE_KEY);
+          if (!raw) return { key: null, dir: 'desc' };
+          const parsed = JSON.parse(raw);
+          const dir = parsed.dir === 'asc' ? 'asc' : 'desc';
+          const key =
+            parsed.key === 'address' || NUMERIC_SORT_KEYS.has(parsed.key)
+              ? parsed.key
+              : null;
+          return { key, dir };
+        } catch (e) {
+          return { key: null, dir: 'desc' };
+        }
+      }
+
+      function saveSortState() {
+        try {
+          localStorage.setItem(SORT_STATE_KEY, JSON.stringify(sortState));
+        } catch (e) {
+          // ignore
+        }
+      }
+
+      function isValidAddress(addr) {
+        // Light client-side check; the backend re-validates.
+        return /^ak_[1-9A-HJ-NP-Za-km-z]{40,60}$/.test(addr);
+      }
+
+      function colorFor(addr) {
+        const idx = addresses.indexOf(addr);
+        if (idx === -1) return '#64748b';
+        return PALETTE[idx % PALETTE.length];
+      }
+
+      function shortenAddress(addr) {
+        if (!addr || addr.length < 14) return addr || '';
+        return addr.slice(0, 8) + '...' + addr.slice(-6);
+      }
+
+      function formatNumber(n, opts = {}) {
+        if (n === null || n === undefined || Number.isNaN(n)) return '0';
+        const decimals = opts.decimals ?? 0;
+        return Number(n).toLocaleString(undefined, {
+          minimumFractionDigits: decimals,
+          maximumFractionDigits: decimals,
+        });
+      }
+
+      function formatAe(n) {
+        const v = Number(n ?? 0);
+        if (Math.abs(v) >= 1000) return formatNumber(v, { decimals: 2 });
+        if (Math.abs(v) >= 1) return formatNumber(v, { decimals: 4 });
+        return formatNumber(v, { decimals: 6 });
+      }
+
+      function formatUsd(n) {
+        const v = Number(n ?? 0);
+        if (v === 0) return '$0';
+        if (Math.abs(v) >= 1) return '$' + formatNumber(v, { decimals: 2 });
+        return '$' + formatNumber(v, { decimals: 4 });
+      }
+
+      function pnlClass(v) {
+        if (v > 0) return 'pnl-positive';
+        if (v < 0) return 'pnl-negative';
+        return 'pnl-zero';
+      }
+
+      function showError(msg) {
+        const banner = document.getElementById('errorBanner');
+        if (msg) {
+          banner.textContent = msg;
+          banner.style.display = 'block';
+        } else {
+          banner.textContent = '';
+          banner.style.display = 'none';
+        }
+      }
+
+      function setLoading(isLoading) {
+        document.getElementById('loadingIndicator').textContent = isLoading
+          ? 'Loading...'
+          : '';
+      }
+
+      // ---------- Chips ----------
+      function renderChips() {
+        const container = document.getElementById('chips');
+        const empty = document.getElementById('emptyChips');
+        // Remove all existing chips (but keep the empty-state placeholder).
+        container.querySelectorAll('.chip').forEach((el) => el.remove());
+
+        if (addresses.length === 0) {
+          empty.style.display = '';
+          return;
+        }
+        empty.style.display = 'none';
+
+        for (const addr of addresses) {
+          const chip = document.createElement('span');
+          chip.className = 'chip';
+          chip.style.borderColor = colorFor(addr);
+          chip.innerHTML =
+            '<span class="swatch" style="background:' + colorFor(addr) + '"></span>' +
+            '<span title="' + addr + '">' + shortenAddress(addr) + '</span>' +
+            '<span class="remove" title="Remove">&times;</span>';
+          chip.querySelector('.remove').addEventListener('click', () => {
+            removeAddress(addr);
+          });
+          container.appendChild(chip);
+        }
+      }
+
+      function addAddressesFromInput() {
+        const input = document.getElementById('addressInput');
+        const raw = (input.value || '').trim();
+        if (!raw) return;
+        const candidates = raw
+          .split(/[\s,]+/)
+          .map((s) => s.trim())
+          .filter((s) => s.length > 0);
+
+        const accepted = [];
+        const rejected = [];
+        for (const c of candidates) {
+          if (!isValidAddress(c)) {
+            rejected.push(c);
+            continue;
+          }
+          if (addresses.includes(c)) continue;
+          if (addresses.length + accepted.length >= MAX_ADDRESSES) {
+            rejected.push(c + ' (max ' + MAX_ADDRESSES + ' addresses)');
+            continue;
+          }
+          accepted.push(c);
+        }
+
+        if (accepted.length > 0) {
+          addresses = addresses.concat(accepted);
+          saveAddresses();
+          renderChips();
+          input.value = '';
+          showError(rejected.length > 0 ? 'Skipped: ' + rejected.join(', ') : '');
+          runComparison();
+        } else if (rejected.length > 0) {
+          showError('Skipped: ' + rejected.join(', '));
+        }
+      }
+
+      function removeAddress(addr) {
+        addresses = addresses.filter((a) => a !== addr);
+        saveAddresses();
+        renderChips();
+        if (addresses.length === 0) {
+          resetResults();
+        } else {
+          runComparison();
+        }
+      }
+
+      function clearAllAddresses() {
+        addresses = [];
+        saveAddresses();
+        renderChips();
+        resetResults();
+      }
+
+      // ---------- Date range ----------
+      function initDateRange() {
+        const start = document.getElementById('startDate');
+        const end = document.getElementById('endDate');
+        const today = moment().format('YYYY-MM-DD');
+        const startDefault = moment().subtract(13, 'day').format('YYYY-MM-DD');
+        if (!start.value) start.value = startDefault;
+        if (!end.value) end.value = today;
+        start.addEventListener('change', runComparison);
+        end.addEventListener('change', runComparison);
+      }
+
+      // ---------- Fetch + render ----------
+      async function runComparison() {
+        if (addresses.length === 0) {
+          resetResults();
+          return;
+        }
+        const start = document.getElementById('startDate').value;
+        const end = document.getElementById('endDate').value;
+        if (!start || !end) return;
+        if (moment(start).isAfter(moment(end))) {
+          showError('Start date must be before end date');
+          return;
+        }
+        showError('');
+
+        const myId = ++runRequestId;
+        setLoading(true);
+
+        const params = new URLSearchParams({
+          addresses: addresses.join(','),
+          start_date: start,
+          end_date: end,
+        });
+
+        try {
+          const res = await fetch('/api/analytics/challenge?' + params.toString());
+          if (!res.ok) {
+            const text = await res.text();
+            throw new Error('API ' + res.status + ': ' + text);
+          }
+          const rows = await res.json();
+          if (myId !== runRequestId) return; // stale response
+          if (!Array.isArray(rows)) {
+            throw new Error('Unexpected response shape');
+          }
+          lastRows = rows;
+          renderResults();
+        } catch (err) {
+          if (myId !== runRequestId) return;
+          showError('Failed to load data: ' + (err && err.message ? err.message : err));
+          resetResults({ keepError: true });
+        } finally {
+          if (myId === runRequestId) setLoading(false);
+        }
+      }
+
+      // Single source of truth for table+chart rendering: derive view rows,
+      // sort them, then push to the table. Charts always show raw per-day data.
+      function renderResults() {
+        const baseRows =
+          viewMode === 'range' ? aggregateToRange(lastRows) : lastRows;
+        const sorted = applySort(baseRows);
+        renderTable(sorted);
+        renderCharts(lastRows);
+        updateSortIndicators();
+      }
+
+      function resetResults(opts = {}) {
+        if (!opts.keepError) showError('');
+        lastRows = [];
+        document.getElementById('tableMeta').textContent = '';
+        document.getElementById('resultsBody').innerHTML =
+          '<tr><td colspan="7" class="empty-state">' +
+          (addresses.length === 0
+            ? 'Add addresses and run a comparison to see results.'
+            : 'No data for the selected range.') +
+          '</td></tr>';
+        // Wipe charts.
+        Object.keys(charts).forEach((k) => {
+          charts[k].destroy();
+          delete charts[k];
+        });
+        updateSortIndicators();
+      }
+
+      function renderTable(rows) {
+        const body = document.getElementById('resultsBody');
+        if (rows.length === 0) {
+          body.innerHTML =
+            '<tr><td colspan="7" class="empty-state">No data for the selected range.</td></tr>';
+          document.getElementById('tableMeta').textContent = '';
+          return;
+        }
+
+        const html = rows
+          .map((r) => {
+            const c = colorFor(r.address);
+            const pnl = Number(r.pnl_ae ?? 0);
+            const pnlUsd = Number(r.pnl_usd ?? 0);
+            const pnlClsName = pnlClass(pnl);
+            return (
+              '<tr>' +
+              '<td class="address">' +
+                '<span class="swatch" style="background:' + c + '"></span>' +
+                '<span class="mono" title="' + r.address + '" onclick="copyToClipboard(\'' + r.address + '\')">' +
+                  shortenAddress(r.address) +
+                '</span>' +
+              '</td>' +
+              '<td>' + r.date + '</td>' +
+              '<td class="num">' + formatNumber(r.total_posts) + '</td>' +
+              '<td class="num">' + formatNumber(r.total_trades) + '</td>' +
+              '<td class="num ' + pnlClsName + '">' +
+                (pnl >= 0 ? '+' : '') + formatAe(pnl) +
+                '<span class="pnl-sub">' + (pnlUsd >= 0 ? '+' : '') + formatUsd(pnlUsd) + '</span>' +
+              '</td>' +
+              '<td class="num">' + formatAe(r.total_volume_ae) + '</td>' +
+              '<td class="num">' + formatNumber(r.created_tokens) + '</td>' +
+              '</tr>'
+            );
+          })
+          .join('');
+        body.innerHTML = html;
+        document.getElementById('tableMeta').textContent =
+          rows.length + ' row(s) • ' + addresses.length + ' address(es)';
+      }
+
+      function copyToClipboard(text) {
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          navigator.clipboard.writeText(text).catch(() => {});
+        }
+      }
+
+      // ---------- View mode (per-day vs range) ----------
+      function aggregateToRange(rows) {
+        const byAddr = new Map();
+        for (const r of rows) {
+          const cur = byAddr.get(r.address) || {
+            address: r.address,
+            total_posts: 0,
+            total_trades: 0,
+            total_volume_ae: 0,
+            created_tokens: 0,
+            pnl_ae: 0,
+            pnl_usd: 0,
+          };
+          cur.total_posts += Number(r.total_posts || 0);
+          cur.total_trades += Number(r.total_trades || 0);
+          cur.total_volume_ae += Number(r.total_volume_ae || 0);
+          cur.created_tokens += Number(r.created_tokens || 0);
+          cur.pnl_ae += Number(r.pnl_ae || 0);
+          cur.pnl_usd += Number(r.pnl_usd || 0);
+          byAddr.set(r.address, cur);
+        }
+        const start = document.getElementById('startDate').value;
+        const end = document.getElementById('endDate').value;
+        const dateLabel = start && end ? start + ' \u2192 ' + end : '';
+        // Preserve the user's original address order by iterating `addresses`.
+        return addresses
+          .map((a) => byAddr.get(a))
+          .filter(Boolean)
+          .map((row) => Object.assign({}, row, { date: dateLabel }));
+      }
+
+      function setViewMode(mode) {
+        if (mode !== 'per_day' && mode !== 'range') return;
+        if (viewMode === mode) return;
+        viewMode = mode;
+        saveViewMode();
+        document.querySelectorAll('#viewToggle button').forEach((btn) => {
+          btn.classList.toggle('active', btn.dataset.mode === mode);
+        });
+        document.getElementById('tableTitle').textContent =
+          mode === 'range' ? 'Per-address summary' : 'Per-day breakdown';
+        renderResults();
+      }
+
+      // ---------- Sorting ----------
+      function clickSortHeader(key) {
+        if (sortState.key !== key) {
+          // First click on a new column starts at desc (top performer first).
+          sortState = { key, dir: 'desc' };
+        } else if (sortState.dir === 'desc') {
+          sortState = { key, dir: 'asc' };
+        } else {
+          // Third click clears the sort (back to default order).
+          sortState = { key: null, dir: 'desc' };
+        }
+        saveSortState();
+        renderResults();
+      }
+
+      function applySort(rows) {
+        if (!sortState.key) return rows;
+        const key = sortState.key;
+        const dir = sortState.dir === 'asc' ? 1 : -1;
+
+        if (viewMode === 'range') {
+          return rows.slice().sort((a, b) => {
+            if (key === 'address') {
+              return String(a.address).localeCompare(String(b.address)) * dir;
+            }
+            return (Number(a[key] || 0) - Number(b[key] || 0)) * dir;
+          });
+        }
+
+        // per_day mode: rank ADDRESS GROUPS by sum-across-days, then re-emit
+        // rows grouped by ranked address (rows within an address stay in the
+        // original date-asc order).
+        const totals = new Map();
+        const seen = [];
+        for (const r of rows) {
+          if (!totals.has(r.address)) {
+            totals.set(r.address, 0);
+            seen.push(r.address);
+          }
+          if (key !== 'address') {
+            totals.set(r.address, totals.get(r.address) + Number(r[key] || 0));
+          }
+        }
+        const ranked = seen.slice().sort((a, b) => {
+          if (key === 'address') {
+            return String(a).localeCompare(String(b)) * dir;
+          }
+          return (Number(totals.get(a) || 0) - Number(totals.get(b) || 0)) * dir;
+        });
+        const byAddr = new Map(ranked.map((a) => [a, []]));
+        for (const r of rows) {
+          if (byAddr.has(r.address)) byAddr.get(r.address).push(r);
+        }
+        const out = [];
+        for (const a of ranked) {
+          const group = byAddr.get(a) || [];
+          for (const r of group) out.push(r);
+        }
+        return out;
+      }
+
+      function updateSortIndicators() {
+        document.querySelectorAll('th.sortable').forEach((th) => {
+          const key = th.dataset.sortKey;
+          const ind = th.querySelector('.sort-ind');
+          if (sortState.key === key) {
+            th.classList.add('active');
+            if (ind) ind.textContent = sortState.dir === 'asc' ? '\u2191' : '\u2193';
+          } else {
+            th.classList.remove('active');
+            if (ind) ind.textContent = '';
+          }
+        });
+      }
+
+      // ---------- CSV export ----------
+      function exportCsv() {
+        const baseRows =
+          viewMode === 'range' ? aggregateToRange(lastRows) : lastRows;
+        const rows = applySort(baseRows);
+        if (!rows || rows.length === 0) {
+          showError('Nothing to export');
+          return;
+        }
+        showError('');
+        const headers = [
+          'Address',
+          'Date',
+          'Total Posts',
+          'Total Trades',
+          'PNL (AE)',
+          'PNL (USD)',
+          'Total Volume (AE)',
+          'Created Tokens',
+        ];
+        const escape = (v) => {
+          const s = v === null || v === undefined ? '' : String(v);
+          return /[",\n]/.test(s) ? '"' + s.replace(/"/g, '""') + '"' : s;
+        };
+        const lines = [headers.join(',')];
+        for (const r of rows) {
+          lines.push(
+            [
+              r.address,
+              r.date,
+              Number(r.total_posts || 0),
+              Number(r.total_trades || 0),
+              Number(r.pnl_ae || 0),
+              Number(r.pnl_usd || 0),
+              Number(r.total_volume_ae || 0),
+              Number(r.created_tokens || 0),
+            ]
+              .map(escape)
+              .join(','),
+          );
+        }
+        const csv = lines.join('\n');
+        const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        const start = document.getElementById('startDate').value;
+        const end = document.getElementById('endDate').value;
+        a.href = url;
+        a.download = 'challenge_' + viewMode + '_' + start + '_' + end + '.csv';
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+      }
+
+      // ---------- Charts ----------
+      function buildSeries(rows, metric) {
+        // Group by date in input order; one dataset per address.
+        const dateSet = new Set();
+        const byAddr = new Map();
+        for (const r of rows) {
+          dateSet.add(r.date);
+          if (!byAddr.has(r.address)) byAddr.set(r.address, new Map());
+          byAddr.get(r.address).set(r.date, Number(r[metric] ?? 0));
+        }
+        const dates = Array.from(dateSet).sort();
+        const datasets = addresses.map((addr) => {
+          const dayMap = byAddr.get(addr) || new Map();
+          return {
+            label: shortenAddress(addr),
+            data: dates.map((d) => dayMap.get(d) ?? 0),
+            borderColor: colorFor(addr),
+            backgroundColor: colorFor(addr) + '33',
+            tension: 0.25,
+            spanGaps: true,
+            pointRadius: 2,
+            borderWidth: 2,
+          };
+        });
+        return { dates, datasets };
+      }
+
+      function renderChart(canvasId, rows, metric, yLabel) {
+        const ctx = document.getElementById(canvasId);
+        if (!ctx) return;
+        const { dates, datasets } = buildSeries(rows, metric);
+        if (charts[canvasId]) {
+          charts[canvasId].destroy();
+        }
+        charts[canvasId] = new Chart(ctx, {
+          type: 'line',
+          data: { labels: dates, datasets },
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            interaction: { mode: 'index', intersect: false },
+            plugins: {
+              legend: { position: 'bottom', labels: { boxWidth: 12, font: { size: 11 } } },
+              tooltip: {
+                callbacks: {
+                  title: (items) => items[0].label,
+                  label: (item) => item.dataset.label + ': ' + formatNumber(item.parsed.y, { decimals: yLabel === 'AE' ? 4 : 0 }),
+                },
+              },
+            },
+            scales: {
+              x: { ticks: { autoSkip: true, maxTicksLimit: 10 } },
+              y: { beginAtZero: false, ticks: { font: { size: 10 } } },
+            },
+          },
+        });
+      }
+
+      function renderCharts(rows) {
+        renderChart('pnlChart', rows, 'pnl_ae', 'AE');
+        renderChart('postsChart', rows, 'total_posts');
+        renderChart('tradesChart', rows, 'total_trades');
+        renderChart('volumeChart', rows, 'total_volume_ae', 'AE');
+        renderChart('createdTokensChart', rows, 'created_tokens');
+      }
+
+      // ---------- Init ----------
+      document.getElementById('addressInput').addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') {
+          e.preventDefault();
+          addAddressesFromInput();
+        }
+      });
+      initDateRange();
+      renderChips();
+      // Reflect persisted view mode on the toggle and table title.
+      document.querySelectorAll('#viewToggle button').forEach((btn) => {
+        btn.classList.toggle('active', btn.dataset.mode === viewMode);
+      });
+      document.getElementById('tableTitle').textContent =
+        viewMode === 'range' ? 'Per-address summary' : 'Per-day breakdown';
+      updateSortIndicators();
+      if (addresses.length > 0) runComparison();
+    </script>
+{{/main-layout}}

--- a/views/main-layout.hbs
+++ b/views/main-layout.hbs
@@ -231,6 +231,12 @@
               >
                 Core
               </a>
+              <a
+                href="/api/analytics/challenge/preview"
+                class="{{#if (eq active 'bcl-challenge')}}active{{/if}}"
+              >
+                Challenge
+              </a>
             </div>
           </div>
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches multiple security-sensitive surfaces (CORS/headers, API key auth, DB sync safeguards, WebSocket behavior) and adds new analytics queries, so misconfiguration or validation mistakes could impact availability or exposure despite mostly additive/defensive changes.
> 
> **Overview**
> **Hardens production deployments and public API surfaces.** Adds `helmet` headers, configurable CORS via `ALLOWED_ORIGINS`, disables GraphQL introspection/GraphiQL and Swagger by default in production, runs Docker as non-root, binds Postgres/Redis ports to loopback in compose files, supports optional `REDIS_PASSWORD`, and forces `DB_SYNC` off in production with stricter DB config parsing.
> 
> **Reduces injection/PII risks and tightens input validation.** Adds allowlists and bounds checks for pagination/order/search across many REST + GraphQL endpoints, switches several raw SQL paths to parameterized queries (notably token rankings, pair history, token de-dup cleanup), introduces safe middleware pagination URL resolution to prevent off-origin `next` cursors, clamps sparkline SVG dimensions, and strengthens `TRENDING_TAGS_API_KEY` handling (no default, min length, constant-time compare). Also removes unauthenticated WebSocket message relaying and limits unauthenticated affiliation invite responses to minimal fields.
> 
> **Adds new BCL “challenge analytics” capability.** Introduces `GET /analytics/challenge` (and a preview page) returning per-address/per-day totals for posts, trades/volume, created tokens, and realized PnL, wired via a new service and UI view.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2c6d277a506a5b79dc4eb986a4f3e5bed75e818. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->