### PR TITLE
Release

### DIFF
--- a/src/social/services/popular-ranking.service.spec.ts
+++ b/src/social/services/popular-ranking.service.spec.ts
@@ -24,6 +24,19 @@ jest.mock('ioredis', () => {
 
 import { PopularRankingService } from './popular-ranking.service';
 
+function createCandidateQueryBuilder(posts: Array<{ id: string }>) {
+  return {
+    select: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    getRawMany: jest
+      .fn()
+      .mockResolvedValue(posts.map((post) => ({ id: post.id }))),
+  };
+}
+
 describe('PopularRankingService', () => {
   let service: PopularRankingService;
   let postRepository: any;
@@ -32,23 +45,15 @@ describe('PopularRankingService', () => {
   let postReadsRepository: any;
 
   beforeEach(() => {
-    const candidateQueryBuilder = {
-      leftJoinAndSelect: jest.fn().mockReturnThis(),
-      where: jest.fn().mockReturnThis(),
-      andWhere: jest.fn().mockReturnThis(),
-      orderBy: jest.fn().mockReturnThis(),
-      limit: jest.fn().mockReturnThis(),
-      getMany: jest.fn().mockResolvedValue([
-        {
-          id: 'post-1',
-          sender_address: 'ak_author',
-          created_at: new Date().toISOString(),
-          total_comments: 0,
-          content: '',
-          topics: [],
-        },
-      ]),
+    const defaultPost = {
+      id: 'post-1',
+      sender_address: 'ak_author',
+      created_at: new Date().toISOString(),
+      total_comments: 0,
+      content: '',
+      topics: [],
     };
+    const candidateQueryBuilder = createCandidateQueryBuilder([defaultPost]);
     const tipQueryBuilder = {
       select: jest.fn().mockReturnThis(),
       innerJoin: jest.fn().mockReturnThis(),
@@ -81,7 +86,8 @@ describe('PopularRankingService', () => {
         .fn()
         .mockReturnValueOnce(candidateQueryBuilder)
         .mockReturnValueOnce(commentQueryBuilder),
-      findBy: jest.fn().mockResolvedValue([]),
+      find: jest.fn().mockResolvedValue([defaultPost]),
+      findBy: jest.fn().mockResolvedValue([defaultPost]),
     };
     tipRepository = {
       createQueryBuilder: jest.fn().mockReturnValue(tipQueryBuilder),
@@ -137,8 +143,8 @@ describe('PopularRankingService', () => {
   it('falls back to window-filtered recent posts when Redis cache is empty', async () => {
     jest.spyOn(service, 'recompute').mockResolvedValue(undefined);
     redisMock.zcard
-      .mockResolvedValueOnce(0) // getVerifiedPopularIds — cache empty
-      .mockResolvedValueOnce(0); // after awaited recompute — still empty
+      .mockResolvedValueOnce(0) // getVerifiedPopularIds РІР‚вЂќ cache empty
+      .mockResolvedValueOnce(0); // after awaited recompute РІР‚вЂќ still empty
 
     const fallbackPost = {
       id: 'fallback-1',
@@ -188,14 +194,10 @@ describe('PopularRankingService', () => {
       content: 'old',
       topics: [],
     };
-    const candidateQueryBuilder = {
-      leftJoinAndSelect: jest.fn().mockReturnThis(),
-      where: jest.fn().mockReturnThis(),
-      andWhere: jest.fn().mockReturnThis(),
-      orderBy: jest.fn().mockReturnThis(),
-      limit: jest.fn().mockReturnThis(),
-      getMany: jest.fn().mockResolvedValue([oldPost, fastPost]),
-    };
+    const candidateQueryBuilder = createCandidateQueryBuilder([
+      oldPost,
+      fastPost,
+    ]);
     const tipQueryBuilder = {
       select: jest.fn().mockReturnThis(),
       innerJoin: jest.fn().mockReturnThis(),
@@ -247,6 +249,7 @@ describe('PopularRankingService', () => {
         .fn()
         .mockReturnValueOnce(candidateQueryBuilder)
         .mockReturnValueOnce(commentQueryBuilder),
+      find: jest.fn().mockResolvedValue([oldPost, fastPost]),
       findBy: jest.fn().mockResolvedValue([oldPost, fastPost]),
     };
     tipRepository = {
@@ -381,14 +384,7 @@ describe('PopularRankingService', () => {
         content: 'weight test content that is long enough',
         topics: [],
       };
-      const candidateQB = {
-        leftJoinAndSelect: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        andWhere: jest.fn().mockReturnThis(),
-        orderBy: jest.fn().mockReturnThis(),
-        limit: jest.fn().mockReturnThis(),
-        getMany: jest.fn().mockResolvedValue([post]),
-      };
+      const candidateQB = createCandidateQueryBuilder([post]);
       const commentQB = {
         innerJoin: jest.fn().mockReturnThis(),
         select: jest.fn().mockReturnThis(),
@@ -432,6 +428,7 @@ describe('PopularRankingService', () => {
           .fn()
           .mockReturnValueOnce(candidateQB)
           .mockReturnValueOnce(commentQB),
+        find: jest.fn().mockResolvedValue([post]),
         findBy: jest.fn().mockResolvedValue([post]),
       };
       const tipRepo = { createQueryBuilder: jest.fn().mockReturnValue(tipQB) };
@@ -482,14 +479,7 @@ describe('PopularRankingService', () => {
 
   describe('computeInteractionsPerHour edge cases', () => {
     function buildServiceWith(post: any) {
-      const candidateQB = {
-        leftJoinAndSelect: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        andWhere: jest.fn().mockReturnThis(),
-        orderBy: jest.fn().mockReturnThis(),
-        limit: jest.fn().mockReturnThis(),
-        getMany: jest.fn().mockResolvedValue([post]),
-      };
+      const candidateQB = createCandidateQueryBuilder([post]);
       const commentQB = {
         innerJoin: jest.fn().mockReturnThis(),
         select: jest.fn().mockReturnThis(),
@@ -532,6 +522,7 @@ describe('PopularRankingService', () => {
             .fn()
             .mockReturnValueOnce(candidateQB)
             .mockReturnValueOnce(commentQB),
+          find: jest.fn().mockResolvedValue([post]),
           findBy: jest.fn().mockResolvedValue([post]),
         } as any,
         { createQueryBuilder: jest.fn().mockReturnValue(tipQB) } as any,
@@ -592,14 +583,10 @@ describe('PopularRankingService', () => {
         topics: [],
       };
 
-      const candidateQB = {
-        leftJoinAndSelect: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        andWhere: jest.fn().mockReturnThis(),
-        orderBy: jest.fn().mockReturnThis(),
-        limit: jest.fn().mockReturnThis(),
-        getMany: jest.fn().mockResolvedValue([very_old_post, recent_post]),
-      };
+      const candidateQB = createCandidateQueryBuilder([
+        very_old_post,
+        recent_post,
+      ]);
       const commentQB = {
         innerJoin: jest.fn().mockReturnThis(),
         select: jest.fn().mockReturnThis(),
@@ -652,6 +639,7 @@ describe('PopularRankingService', () => {
             .fn()
             .mockReturnValueOnce(candidateQB)
             .mockReturnValueOnce(commentQB),
+          find: jest.fn().mockResolvedValue([very_old_post, recent_post]),
           findBy: jest.fn().mockResolvedValue([very_old_post, recent_post]),
         } as any,
         { createQueryBuilder: jest.fn().mockReturnValue(tipQB) } as any,
@@ -695,14 +683,7 @@ describe('PopularRankingService', () => {
       posts: any[],
       comments: Record<string, string>,
     ) {
-      const candidateQB = {
-        leftJoinAndSelect: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        andWhere: jest.fn().mockReturnThis(),
-        orderBy: jest.fn().mockReturnThis(),
-        limit: jest.fn().mockReturnThis(),
-        getMany: jest.fn().mockResolvedValue(posts),
-      };
+      const candidateQB = createCandidateQueryBuilder(posts);
       const commentQB = {
         innerJoin: jest.fn().mockReturnThis(),
         select: jest.fn().mockReturnThis(),
@@ -741,6 +722,7 @@ describe('PopularRankingService', () => {
             .fn()
             .mockReturnValueOnce(candidateQB)
             .mockReturnValueOnce(commentQB),
+          find: jest.fn().mockResolvedValue(posts),
           findBy: jest.fn().mockResolvedValue(posts),
         } as any,
         { createQueryBuilder: jest.fn().mockReturnValue(tipQB) } as any,
@@ -749,6 +731,93 @@ describe('PopularRankingService', () => {
         [],
       );
     }
+
+    it('limits distinct candidate posts before hydrating topics', async () => {
+      const now = Date.now();
+      const topicHeavyPost = {
+        id: 'topic-heavy',
+        sender_address: 'ak_topic_heavy',
+        created_at: new Date(now - 60 * 60 * 1000).toISOString(),
+        content: 'topic heavy post',
+        topics: [{ name: 'ae' }, { name: 'superhero' }],
+      };
+      const targetPost = {
+        id: 'target-post',
+        sender_address: 'ak_target',
+        created_at: new Date(now - 2 * 60 * 60 * 1000).toISOString(),
+        content: 'older target post with strong engagement',
+        topics: [],
+      };
+      const candidateQB = {
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        getRawMany: jest
+          .fn()
+          .mockResolvedValue([{ id: 'topic-heavy' }, { id: 'target-post' }]),
+      };
+      const commentQB = {
+        innerJoin: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: jest
+          .fn()
+          .mockResolvedValue([{ parent_id: 'target-post', count: '4' }]),
+      };
+      const tipQB = {
+        select: jest.fn().mockReturnThis(),
+        innerJoin: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([]),
+      };
+      const readsQB = {
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([]),
+      };
+      const repo = {
+        createQueryBuilder: jest
+          .fn()
+          .mockReturnValueOnce(candidateQB)
+          .mockReturnValueOnce(commentQB),
+        find: jest.fn().mockResolvedValue([targetPost, topicHeavyPost]),
+        findBy: jest.fn().mockResolvedValue([targetPost, topicHeavyPost]),
+      };
+      const svc = new PopularRankingService(
+        repo as any,
+        { createQueryBuilder: jest.fn().mockReturnValue(tipQB) } as any,
+        { find: jest.fn().mockResolvedValue([]) } as any,
+        { createQueryBuilder: jest.fn().mockReturnValue(readsQB) } as any,
+        [],
+      );
+
+      const result = await svc.getPopularPostsPage('all', 10, 0, undefined, {
+        comments: 'med',
+      });
+
+      expect(candidateQB.leftJoinAndSelect).not.toHaveBeenCalled();
+      expect(candidateQB.select).toHaveBeenCalledWith('post.id', 'id');
+      expect(repo.find).toHaveBeenCalledWith({
+        where: { id: expect.anything() },
+        relations: ['topics'],
+      });
+      expect(result.scoredItems!.map((item) => item.postId)).toEqual([
+        'target-post',
+        'topic-heavy',
+      ]);
+    });
 
     it('boosts fresh posts and removes that boost after 24 hours', async () => {
       const now = Date.now();
@@ -987,14 +1056,7 @@ describe('PopularRankingService', () => {
         content: 'personalized',
         topics: [],
       };
-      const candidateQB = {
-        leftJoinAndSelect: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        andWhere: jest.fn().mockReturnThis(),
-        orderBy: jest.fn().mockReturnThis(),
-        limit: jest.fn().mockReturnThis(),
-        getMany: jest.fn().mockResolvedValue([post]),
-      };
+      const candidateQB = createCandidateQueryBuilder([post]);
       const commentQB = {
         innerJoin: jest.fn().mockReturnThis(),
         select: jest.fn().mockReturnThis(),
@@ -1028,6 +1090,7 @@ describe('PopularRankingService', () => {
             .fn()
             .mockReturnValueOnce(candidateQB)
             .mockReturnValueOnce(commentQB),
+          find: jest.fn().mockResolvedValue([post]),
           findBy: jest.fn().mockResolvedValue([post]),
         } as any,
         { createQueryBuilder: jest.fn().mockReturnValue(tipQB) } as any,

--- a/src/social/services/popular-ranking.service.ts
+++ b/src/social/services/popular-ranking.service.ts
@@ -593,9 +593,9 @@ export class PopularRankingService implements OnModuleDestroy {
     const hours = this.getWindowHours(window);
     const since = new Date(Date.now() - hours * 60 * 60 * 1000);
 
-    const candidates = await this.postRepository
+    const candidateRows = await this.postRepository
       .createQueryBuilder('post')
-      .leftJoinAndSelect('post.topics', 'topic')
+      .select('post.id', 'id')
       .where('post.is_hidden = false')
       .andWhere('post.post_id IS NULL')
       .andWhere(window === 'all' ? '1=1' : 'post.created_at >= :since', {
@@ -603,7 +603,20 @@ export class PopularRankingService implements OnModuleDestroy {
       })
       .orderBy('post.created_at', 'DESC')
       .limit(maxCandidates)
-      .getMany();
+      .getRawMany<{ id: string }>();
+    const candidateIds: string[] = candidateRows.map((row) => row.id);
+    const candidateOrder = new Map<string, number>(
+      candidateIds.map((id, index) => [id, index] as const),
+    );
+    const hydratedCandidates = candidateIds.length
+      ? await this.postRepository.find({
+          where: { id: In(candidateIds) },
+          relations: ['topics'],
+        })
+      : [];
+    const candidates = hydratedCandidates.sort(
+      (a, b) => candidateOrder.get(a.id)! - candidateOrder.get(b.id)!,
+    );
 
     this.logger.log(
       `Found ${candidates.length} candidate posts for window ${window}`,

--- a/views/challenge-analytics.hbs
+++ b/views/challenge-analytics.hbs
@@ -451,6 +451,14 @@
       const VIEW_MODE_KEY = 'challenge.viewMode';
       const SORT_STATE_KEY = 'challenge.sortState';
       const MAX_ADDRESSES = 10;
+      const URL_SYNC_KEYS = {
+        addresses: 'addresses',
+        startDate: 'start_date',
+        endDate: 'end_date',
+        view: 'view',
+        sortKey: 'sort_key',
+        sortDir: 'sort_dir',
+      };
       // Numeric sort keys that map to row fields (used by applySort).
       const NUMERIC_SORT_KEYS = new Set([
         'total_posts',
@@ -540,6 +548,96 @@
           localStorage.setItem(SORT_STATE_KEY, JSON.stringify(sortState));
         } catch (e) {
           // ignore
+        }
+      }
+
+      // ---------- URL sync ----------
+      function sanitizeAddressList(raw) {
+        if (!raw) return [];
+        const candidates = String(raw)
+          .split(/[\s,]+/)
+          .map((s) => s.trim())
+          .filter(Boolean);
+        const out = [];
+        for (const c of candidates) {
+          if (!isValidAddress(c)) continue;
+          if (out.includes(c)) continue;
+          out.push(c);
+          if (out.length >= MAX_ADDRESSES) break;
+        }
+        return out;
+      }
+
+      function updateUrlFromState() {
+        const params = new URLSearchParams(window.location.search);
+
+        const start = document.getElementById('startDate')?.value || '';
+        const end = document.getElementById('endDate')?.value || '';
+
+        if (addresses.length > 0) {
+          params.set(URL_SYNC_KEYS.addresses, addresses.join(','));
+        } else {
+          params.delete(URL_SYNC_KEYS.addresses);
+        }
+
+        if (start) params.set(URL_SYNC_KEYS.startDate, start);
+        else params.delete(URL_SYNC_KEYS.startDate);
+
+        if (end) params.set(URL_SYNC_KEYS.endDate, end);
+        else params.delete(URL_SYNC_KEYS.endDate);
+
+        params.set(URL_SYNC_KEYS.view, viewMode);
+
+        if (sortState && sortState.key) {
+          params.set(URL_SYNC_KEYS.sortKey, sortState.key);
+          params.set(URL_SYNC_KEYS.sortDir, sortState.dir === 'asc' ? 'asc' : 'desc');
+        } else {
+          params.delete(URL_SYNC_KEYS.sortKey);
+          params.delete(URL_SYNC_KEYS.sortDir);
+        }
+
+        const next = window.location.pathname + (params.toString() ? '?' + params.toString() : '');
+        if (next !== window.location.pathname + window.location.search) {
+          window.history.replaceState(null, '', next);
+        }
+      }
+
+      function initStateFromUrl() {
+        const params = new URLSearchParams(window.location.search);
+
+        // Addresses
+        if (params.has(URL_SYNC_KEYS.addresses)) {
+          const urlAddresses = sanitizeAddressList(params.get(URL_SYNC_KEYS.addresses));
+          addresses = urlAddresses;
+          saveAddresses();
+        }
+
+        // Dates
+        const start = params.get(URL_SYNC_KEYS.startDate);
+        const end = params.get(URL_SYNC_KEYS.endDate);
+        if (start) {
+          const el = document.getElementById('startDate');
+          if (el) el.value = start;
+        }
+        if (end) {
+          const el = document.getElementById('endDate');
+          if (el) el.value = end;
+        }
+
+        // View mode
+        const view = params.get(URL_SYNC_KEYS.view);
+        if (view === 'per_day' || view === 'range') {
+          viewMode = view;
+          saveViewMode();
+        }
+
+        // Sort state
+        const sortKey = params.get(URL_SYNC_KEYS.sortKey);
+        const sortDir = params.get(URL_SYNC_KEYS.sortDir);
+        const keyOk = sortKey === 'address' || NUMERIC_SORT_KEYS.has(sortKey);
+        if (keyOk) {
+          sortState = { key: sortKey, dir: sortDir === 'asc' ? 'asc' : 'desc' };
+          saveSortState();
         }
       }
 
@@ -662,6 +760,7 @@
           saveAddresses();
           renderChips();
           input.value = '';
+          updateUrlFromState();
           showError(rejected.length > 0 ? 'Skipped: ' + rejected.join(', ') : '');
           runComparison();
         } else if (rejected.length > 0) {
@@ -673,6 +772,7 @@
         addresses = addresses.filter((a) => a !== addr);
         saveAddresses();
         renderChips();
+        updateUrlFromState();
         if (addresses.length === 0) {
           resetResults();
         } else {
@@ -684,6 +784,7 @@
         addresses = [];
         saveAddresses();
         renderChips();
+        updateUrlFromState();
         resetResults();
       }
 
@@ -695,6 +796,7 @@
         const startDefault = moment().subtract(13, 'day').format('YYYY-MM-DD');
         if (!start.value) start.value = startDefault;
         if (!end.value) end.value = today;
+        updateUrlFromState();
         start.addEventListener('change', runComparison);
         end.addEventListener('change', runComparison);
       }
@@ -702,6 +804,7 @@
       // ---------- Fetch + render ----------
       async function runComparison() {
         if (addresses.length === 0) {
+          updateUrlFromState();
           resetResults();
           return;
         }
@@ -713,6 +816,7 @@
           return;
         }
         showError('');
+        updateUrlFromState();
 
         const myId = ++runRequestId;
         setLoading(true);
@@ -857,6 +961,7 @@
         if (viewMode === mode) return;
         viewMode = mode;
         saveViewMode();
+        updateUrlFromState();
         document.querySelectorAll('#viewToggle button').forEach((btn) => {
           btn.classList.toggle('active', btn.dataset.mode === mode);
         });
@@ -877,6 +982,7 @@
           sortState = { key: null, dir: 'desc' };
         }
         saveSortState();
+        updateUrlFromState();
         renderResults();
       }
 
@@ -1068,6 +1174,8 @@
           addAddressesFromInput();
         }
       });
+      // Prefer URL params (shareable links) over localStorage defaults.
+      initStateFromUrl();
       initDateRange();
       renderChips();
       // Reflect persisted view mode on the toggle and table title.
@@ -1077,6 +1185,8 @@
       document.getElementById('tableTitle').textContent =
         viewMode === 'range' ? 'Per-address summary' : 'Per-day breakdown';
       updateSortIndicators();
+      // Ensure the current state is reflected in the URL.
+      updateUrlFromState();
       if (addresses.length > 0) runComparison();
     </script>
 {{/main-layout}}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the popular ranking candidate fetch path to a new two-step query/hydration flow, which could affect ranking results or DB load if ordering/filtering differs. Adds client-side URL state syncing in the analytics view, which is low risk but touches navigation/state behavior.
> 
> **Overview**
> **Popular ranking scoring now fetches candidate post IDs first, then hydrates posts with topics in a second query.** `buildScoredItems` switches from `leftJoinAndSelect`/`getMany()` to `select(post.id)`/`getRawMany()`, followed by `postRepository.find({ relations: ['topics'] })` and an explicit re-sort to preserve the original candidate order, reducing topic join work before limiting candidates.
> 
> **Tests were updated and expanded to match the new repository/query behavior.** The spec introduces a shared `createCandidateQueryBuilder` returning `getRawMany()` results, adds missing `postRepository.find` mocks, and includes a new test asserting candidates are limited/distinct before topics are hydrated.
> 
> **Challenge analytics UI now syncs filters to the URL for shareable links.** Adds URL param parsing on load (addresses, date range, view mode, sort state) and updates the URL via `history.replaceState` whenever addresses/dates/view/sort change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80adf26a18e858e0a1daf242741e0e8afe4468ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->