### PR TITLE
fix: add account info on new trades, if no account exists

### DIFF
--- a/src/account/account.module.ts
+++ b/src/account/account.module.ts
@@ -41,7 +41,7 @@ import { AePricingModule } from '@/ae-pricing/ae-pricing.module';
     LeaderboardService,
     LeaderboardSnapshotService,
   ],
-  exports: [TypeOrmModule, BclPnlService],
+  exports: [TypeOrmModule, AccountService, BclPnlService],
   controllers: [LeaderboardController, AccountsController, BclPnlController],
 })
 export class AccountModule {

--- a/src/account/controllers/accounts.controller.spec.ts
+++ b/src/account/controllers/accounts.controller.spec.ts
@@ -1,7 +1,7 @@
 import { AccountsController } from './accounts.controller';
 import { StreamableFile } from '@nestjs/common';
 import { paginate } from 'nestjs-typeorm-paginate';
-import { NotFoundException } from '@nestjs/common';
+import { Logger, NotFoundException } from '@nestjs/common';
 
 jest.mock('nestjs-typeorm-paginate', () => ({
   paginate: jest.fn().mockResolvedValue({ items: [], meta: {} }),
@@ -23,6 +23,7 @@ describe('AccountsController', () => {
   let queryBuilder: ReturnType<typeof createQueryBuilder>;
   let accountService: {
     getChainNameForAccount: jest.Mock;
+    ensureAccountFromTransactions: jest.Mock;
   };
   let profileReadService: {
     getProfile: jest.Mock;
@@ -45,6 +46,7 @@ describe('AccountsController', () => {
     };
     accountService = {
       getChainNameForAccount: jest.fn(),
+      ensureAccountFromTransactions: jest.fn().mockResolvedValue(null),
     };
     profileReadService = {
       getProfile: jest.fn(),
@@ -91,9 +93,37 @@ describe('AccountsController', () => {
     expect(result).toEqual({ items: [], meta: {} });
   });
 
+  it('hydrates account from transactions when searching by account address', async () => {
+    const address = 'ak_3yT4BoLMWVWtCEpbb3Sv3ArtetmR5kVMDANpFsezXpqHBiFGQ';
+
+    await controller.listAll(address, 1, 10, 'total_volume', 'DESC');
+
+    expect(accountService.ensureAccountFromTransactions).toHaveBeenCalledWith(
+      address,
+    );
+  });
+
+  it('continues search when account hydration fails', async () => {
+    const address = 'ak_3yT4BoLMWVWtCEpbb3Sv3ArtetmR5kVMDANpFsezXpqHBiFGQ';
+    const loggerError = jest
+      .spyOn(Logger.prototype, 'error')
+      .mockImplementation(() => undefined);
+    accountService.ensureAccountFromTransactions.mockRejectedValue(
+      new Error('aggregation timeout'),
+    );
+
+    await expect(
+      controller.listAll(address, 1, 10, 'total_volume', 'DESC'),
+    ).resolves.toEqual({ items: [], meta: {} });
+
+    expect(loggerError).toHaveBeenCalled();
+    loggerError.mockRestore();
+  });
+
   it('applies search across account addresses and names', async () => {
     await controller.listAll('alice', 1, 100, 'total_volume', 'DESC');
 
+    expect(accountService.ensureAccountFromTransactions).not.toHaveBeenCalled();
     expect(queryBuilder.leftJoin).toHaveBeenCalledWith(
       expect.any(Function),
       'profile_cache',
@@ -133,6 +163,55 @@ describe('AccountsController', () => {
     await expect(controller.getAccount('missing')).rejects.toBeInstanceOf(
       NotFoundException,
     );
+  });
+
+  it('falls back to stored account when hydration fails', async () => {
+    const account = {
+      address: 'ak_3yT4BoLMWVWtCEpbb3Sv3ArtetmR5kVMDANpFsezXpqHBiFGQ',
+      chain_name: null,
+      chain_name_updated_at: new Date(),
+    };
+    const loggerError = jest
+      .spyOn(Logger.prototype, 'error')
+      .mockImplementation(() => undefined);
+    accountService.ensureAccountFromTransactions.mockRejectedValue(
+      new Error('upsert failed'),
+    );
+    accountRepository.findOne.mockResolvedValue(account);
+    profileReadService.getProfile.mockResolvedValue({
+      profile: null,
+      public_name: null,
+    });
+
+    const result = await controller.getAccount(account.address);
+
+    expect(accountRepository.findOne).toHaveBeenCalledWith({
+      where: { address: account.address },
+    });
+    expect(result).toMatchObject({ address: account.address });
+    expect(loggerError).toHaveBeenCalled();
+    loggerError.mockRestore();
+  });
+
+  it('hydrates account details from transactions before returning 404', async () => {
+    const account = {
+      address: 'ak_3yT4BoLMWVWtCEpbb3Sv3ArtetmR5kVMDANpFsezXpqHBiFGQ',
+      chain_name: null,
+      chain_name_updated_at: new Date(),
+    };
+    accountService.ensureAccountFromTransactions.mockResolvedValue(account);
+    profileReadService.getProfile.mockResolvedValue({
+      profile: null,
+      public_name: null,
+    });
+
+    const result = await controller.getAccount(account.address);
+
+    expect(accountService.ensureAccountFromTransactions).toHaveBeenCalledWith(
+      account.address,
+    );
+    expect(accountRepository.findOne).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ address: account.address });
   });
 
   describe('getPortfolioPnlChart', () => {

--- a/src/account/controllers/accounts.controller.ts
+++ b/src/account/controllers/accounts.controller.ts
@@ -42,6 +42,7 @@ import {
 import {
   AeAccountAddressPipe,
   AeAccountReferencePipe,
+  isAeAccountAddress,
 } from '@/common/validation/request-validation';
 
 const ALLOWED_ORDER_BY = new Set([
@@ -128,6 +129,12 @@ export class AccountsController {
         `search must be at most ${MAX_SEARCH_LENGTH} characters`,
       );
     }
+
+    const trimmedSearch = search?.trim();
+    if (trimmedSearch && isAeAccountAddress(trimmedSearch)) {
+      await this.tryHydrateAccountFromTransactions(trimmedSearch);
+    }
+
     const query = this.accountRepository.createQueryBuilder('account');
 
     if (search?.trim()) {
@@ -396,9 +403,11 @@ export class AccountsController {
   @CacheTTL(10 * 60_000)
   @Get(':address')
   async getAccount(@Param('address', AeAccountAddressPipe) address: string) {
-    const account = await this.accountRepository.findOne({
-      where: { address },
-    });
+    const account =
+      (await this.tryHydrateAccountFromTransactions(address)) ??
+      (await this.accountRepository.findOne({
+        where: { address },
+      }));
 
     if (!account) {
       throw new NotFoundException('Account not found');
@@ -441,5 +450,19 @@ export class AccountsController {
       profile: profile.profile,
       public_name: profile.public_name,
     };
+  }
+
+  private async tryHydrateAccountFromTransactions(
+    address: string,
+  ): Promise<Account | null> {
+    try {
+      return await this.accountService.ensureAccountFromTransactions(address);
+    } catch (error) {
+      this.logger.error(
+        `Failed to hydrate account from transactions for ${address}`,
+        error instanceof Error ? error.stack : String(error),
+      );
+      return null;
+    }
   }
 }

--- a/src/account/services/account.service.ts
+++ b/src/account/services/account.service.ts
@@ -5,9 +5,18 @@ import { Injectable, Logger } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { InjectRepository } from '@nestjs/typeorm';
 import BigNumber from 'bignumber.js';
-import { IsNull, LessThan, Not, Repository } from 'typeorm';
+import { EntityManager, IsNull, LessThan, Not, Repository } from 'typeorm';
 import { Account } from '../entities/account.entity';
 import { fetchJson } from '@/utils/common';
+
+type AggregatedAccountRow = {
+  address: string;
+  total_tx_count: number;
+  total_buy_tx_count: number;
+  total_sell_tx_count: number;
+  total_created_tokens: number;
+  total_volume: string;
+};
 
 @Injectable()
 export class AccountService {
@@ -29,6 +38,101 @@ export class AccountService {
     }
   }
 
+  /**
+   * Ensures a minimal account row exists (used when indexing activity).
+   */
+  async ensureAccountExists(
+    address: string,
+    manager?: EntityManager,
+  ): Promise<Account | null> {
+    const accountRepository = manager
+      ? manager.getRepository(Account)
+      : this.accountRepository;
+
+    await accountRepository.upsert(
+      { address },
+      {
+        conflictPaths: ['address'],
+        skipUpdateIfNoValuesChanged: true,
+      },
+    );
+
+    return accountRepository.findOne({ where: { address } });
+  }
+
+  /**
+   * Creates or refreshes an account row from indexed BCL transactions.
+   * The accounts list/search only queries this table; without a row, active
+   * traders are invisible even when transactions exist.
+   */
+  async ensureAccountFromTransactions(
+    address: string,
+    manager?: EntityManager,
+  ): Promise<Account | null> {
+    const accountRepository = manager
+      ? manager.getRepository(Account)
+      : this.accountRepository;
+    const transactionRepository = manager
+      ? manager.getRepository(Transaction)
+      : this.transactionRepository;
+
+    const existing = await accountRepository.findOne({
+      where: { address },
+    });
+
+    const aggregated = await this.aggregateAccountRow(
+      address,
+      transactionRepository,
+    );
+    if (!aggregated) {
+      return existing;
+    }
+
+    await accountRepository.upsert(aggregated, {
+      conflictPaths: ['address'],
+    });
+
+    return accountRepository.findOne({ where: { address } });
+  }
+
+  private async aggregateAccountRow(
+    address: string,
+    transactionRepository: Repository<Transaction>,
+  ): Promise<Account | null> {
+    const rows: AggregatedAccountRow[] = await transactionRepository.query(
+      `SELECT
+          address,
+          COUNT(*)::int                                    AS total_tx_count,
+          COUNT(*) FILTER (WHERE tx_type = $2)::int        AS total_buy_tx_count,
+          COUNT(*) FILTER (WHERE tx_type = $3)::int        AS total_sell_tx_count,
+          COUNT(*) FILTER (WHERE tx_type = $4)::int        AS total_created_tokens,
+          COALESCE(SUM(CAST(NULLIF(amount->>'ae','NaN') AS DECIMAL)), 0) AS total_volume
+        FROM transactions
+        WHERE address = $1
+        GROUP BY address`,
+      [
+        address,
+        TX_FUNCTIONS.buy,
+        TX_FUNCTIONS.sell,
+        TX_FUNCTIONS.create_community,
+      ],
+    );
+
+    if (!rows.length) {
+      return null;
+    }
+
+    const row = rows[0];
+    return {
+      address: row.address,
+      total_tx_count: row.total_tx_count,
+      total_buy_tx_count: row.total_buy_tx_count,
+      total_sell_tx_count: row.total_sell_tx_count,
+      total_created_tokens: row.total_created_tokens,
+      total_volume: new BigNumber(row.total_volume),
+    } as Account;
+  }
+
   private static readonly ACCOUNT_BATCH_SIZE = 500;
 
   isPullingAccounts = false;
@@ -38,15 +142,9 @@ export class AccountService {
     }
     this.isPullingAccounts = true;
     try {
-      const aggregated: Array<{
-        address: string;
-        total_tx_count: number;
-        total_buy_tx_count: number;
-        total_sell_tx_count: number;
-        total_created_tokens: number;
-        total_volume: string;
-      }> = await this.transactionRepository.query(
-        `SELECT
+      const aggregated: AggregatedAccountRow[] =
+        await this.transactionRepository.query(
+          `SELECT
           address,
           COUNT(*)::int                                    AS total_tx_count,
           COUNT(*) FILTER (WHERE tx_type = $1)::int        AS total_buy_tx_count,
@@ -55,8 +153,8 @@ export class AccountService {
           COALESCE(SUM(CAST(NULLIF(amount->>'ae','NaN') AS DECIMAL)), 0) AS total_volume
         FROM transactions
         GROUP BY address`,
-        [TX_FUNCTIONS.buy, TX_FUNCTIONS.sell, TX_FUNCTIONS.create_community],
-      );
+          [TX_FUNCTIONS.buy, TX_FUNCTIONS.sell, TX_FUNCTIONS.create_community],
+        );
 
       for (
         let i = 0;
@@ -74,13 +172,10 @@ export class AccountService {
             total_volume: new BigNumber(row.total_volume),
           }));
 
-        await this.accountRepository
-          .createQueryBuilder()
-          .insert()
-          .into(Account)
-          .values(batch)
-          .orIgnore()
-          .execute();
+        await this.accountRepository.upsert(batch, {
+          conflictPaths: ['address'],
+          skipUpdateIfNoValuesChanged: true,
+        });
       }
     } catch (error) {
       this.logger.error('Error pulling and saving accounts', error);

--- a/src/plugins/bcl/bcl-plugin.module.ts
+++ b/src/plugins/bcl/bcl-plugin.module.ts
@@ -10,6 +10,7 @@ import { BullModule } from '@nestjs/bull';
 import { Transaction } from '@/transactions/entities/transaction.entity';
 import { TokenHolder } from '@/tokens/entities/token-holders.entity';
 import { Token } from '@/tokens/entities/token.entity';
+import { AccountModule } from '@/account/account.module';
 import { PULL_TOKEN_INFO_QUEUE } from '@/tokens/queues/constants';
 import { BclPlugin } from './bcl.plugin';
 import { BclPluginSyncService } from './bcl-plugin-sync.service';
@@ -32,6 +33,7 @@ import { TokenHolderService } from './services/token-holder.service';
     ]),
     TransactionsModule,
     TokensModule,
+    AccountModule,
     AePricingModule,
     AeModule,
     BullModule.registerQueue({

--- a/src/plugins/bcl/services/transaction-persistence.service.spec.ts
+++ b/src/plugins/bcl/services/transaction-persistence.service.spec.ts
@@ -5,9 +5,13 @@ import { Logger } from '@nestjs/common';
 
 describe('TransactionPersistenceService', () => {
   let service: TransactionPersistenceService;
+  let accountService: any;
 
   beforeEach(() => {
-    service = new TransactionPersistenceService();
+    accountService = {
+      ensureAccountFromTransactions: jest.fn().mockResolvedValue(null),
+    };
+    service = new TransactionPersistenceService(accountService as any);
   });
 
   it('updates token transaction counters after saving a transaction', async () => {
@@ -33,6 +37,7 @@ describe('TransactionPersistenceService', () => {
       {
         tx_hash: 'th_1',
         sale_address: 'ct_sale',
+        address: 'ak_trader',
       } as any,
       manager as any,
     );
@@ -45,7 +50,45 @@ describe('TransactionPersistenceService', () => {
       tx_count: 7,
       last_sync_tx_count: 7,
     });
+    expect(accountService.ensureAccountFromTransactions).toHaveBeenCalledWith(
+      'ak_trader',
+      manager,
+    );
     expect(transaction).toEqual({ tx_hash: 'th_1' });
+  });
+
+  it('returns cleaned up account addresses so callers can refresh stale totals', async () => {
+    const query = jest
+      .fn()
+      .mockResolvedValue([{ address: 'ak_old' }, { address: null }]);
+    const execute = jest.fn().mockResolvedValue(undefined);
+    const andWhere = jest.fn().mockReturnThis();
+    const where = jest.fn().mockReturnThis();
+    const from = jest.fn().mockReturnThis();
+    const deleteQuery = jest.fn().mockReturnThis();
+    const manager = {
+      query,
+      createQueryBuilder: jest.fn(() => ({
+        delete: deleteQuery,
+        from,
+        where,
+        andWhere,
+        execute,
+      })),
+    };
+
+    const addresses = await service.cleanupOldTransactions(
+      'ct_sale',
+      'th_current',
+      manager as any,
+    );
+
+    expect(addresses).toEqual(['ak_old']);
+    expect(query).toHaveBeenCalledWith(
+      expect.stringContaining('SELECT DISTINCT address'),
+      ['ct_sale', 'create_community', 'th_current'],
+    );
+    expect(execute).toHaveBeenCalled();
   });
 
   it('does not fail transaction persistence when counter refresh fails', async () => {
@@ -83,6 +126,46 @@ describe('TransactionPersistenceService', () => {
       tx_count: 8,
       last_sync_tx_count: 8,
     });
+    expect(loggerError).toHaveBeenCalled();
+  });
+
+  it('does not fail transaction persistence when account totals refresh fails', async () => {
+    const upsert = jest.fn().mockResolvedValue(undefined);
+    const findOne = jest.fn().mockResolvedValue({ tx_hash: 'th_3' });
+    const query = jest.fn().mockRejectedValue(new Error('insert failed'));
+    const loggerError = jest
+      .spyOn(Logger.prototype, 'error')
+      .mockImplementation(() => undefined);
+    const manager = {
+      query,
+      getRepository: jest.fn((entity) => {
+        if (entity === Transaction) {
+          return { upsert, findOne };
+        }
+        if (entity === Token) {
+          return { update: jest.fn() };
+        }
+        throw new Error('Unexpected repository request');
+      }),
+    };
+
+    accountService.ensureAccountFromTransactions.mockRejectedValue(
+      new Error('insert failed'),
+    );
+
+    const transaction = await service.saveTransaction(
+      {
+        tx_hash: 'th_3',
+        address: 'ak_trader',
+      } as any,
+      manager as any,
+    );
+
+    expect(transaction).toEqual({ tx_hash: 'th_3' });
+    expect(accountService.ensureAccountFromTransactions).toHaveBeenCalledWith(
+      'ak_trader',
+      manager,
+    );
     expect(loggerError).toHaveBeenCalled();
   });
 });

--- a/src/plugins/bcl/services/transaction-persistence.service.ts
+++ b/src/plugins/bcl/services/transaction-persistence.service.ts
@@ -1,3 +1,4 @@
+import { AccountService } from '@/account/services/account.service';
 import { Injectable, Logger } from '@nestjs/common';
 import { EntityManager } from 'typeorm';
 import { Transaction } from '@/transactions/entities/transaction.entity';
@@ -9,6 +10,8 @@ import { TransactionData } from './transaction-data.service';
 export class TransactionPersistenceService {
   private readonly logger = new Logger(TransactionPersistenceService.name);
 
+  constructor(private readonly accountService: AccountService) {}
+
   /**
    * Cleanup old create_community transactions for the same sale address
    * @param saleAddress - Sale address
@@ -19,7 +22,16 @@ export class TransactionPersistenceService {
     saleAddress: string,
     txHash: string,
     manager: EntityManager,
-  ): Promise<void> {
+  ): Promise<string[]> {
+    const oldTransactions: Array<{ address: string }> = await manager.query(
+      `SELECT DISTINCT address
+       FROM transactions
+       WHERE sale_address = $1
+         AND tx_type = $2
+         AND tx_hash != $3`,
+      [saleAddress, BCL_FUNCTIONS.create_community, txHash],
+    );
+
     await manager
       .createQueryBuilder()
       .delete()
@@ -34,6 +46,8 @@ export class TransactionPersistenceService {
         tx_hash: txHash,
       })
       .execute();
+
+    return oldTransactions.map((tx) => tx.address).filter(Boolean);
   }
 
   /**
@@ -54,6 +68,18 @@ export class TransactionPersistenceService {
     await transactionRepository.upsert(txData, {
       conflictPaths: ['tx_hash'],
     });
+
+    if (txData.address) {
+      try {
+        await this.refreshAccountFromTransactions(txData.address, manager);
+      } catch (error) {
+        this.logger.error(
+          `Failed to refresh account totals for ${txData.address}`,
+          error instanceof Error ? error.stack : String(error),
+        );
+      }
+    }
+
     // Fetch and return the transaction entity
     const transaction = await transactionRepository.findOne({
       where: { tx_hash: txData.tx_hash },
@@ -83,5 +109,12 @@ export class TransactionPersistenceService {
     }
 
     return transaction;
+  }
+
+  async refreshAccountFromTransactions(
+    address: string,
+    manager: EntityManager,
+  ): Promise<void> {
+    await this.accountService.ensureAccountFromTransactions(address, manager);
   }
 }

--- a/src/plugins/bcl/services/transaction-processor.service.spec.ts
+++ b/src/plugins/bcl/services/transaction-processor.service.spec.ts
@@ -1,5 +1,6 @@
 import BigNumber from 'bignumber.js';
 import { BCL_FUNCTIONS } from '@/configs';
+import { Logger } from '@nestjs/common';
 import { SyncDirectionEnum } from '../../plugin.interface';
 import { TransactionProcessorService } from './transaction-processor.service';
 
@@ -13,6 +14,7 @@ describe('TransactionProcessorService', () => {
   let persistenceService: {
     cleanupOldTransactions: jest.Mock;
     saveTransaction: jest.Mock;
+    refreshAccountFromTransactions: jest.Mock;
   };
   let transactionsService: {
     decodeTxEvents: jest.Mock;
@@ -39,8 +41,9 @@ describe('TransactionProcessorService', () => {
       prepareTransactionData: jest.fn(),
     };
     persistenceService = {
-      cleanupOldTransactions: jest.fn(),
+      cleanupOldTransactions: jest.fn().mockResolvedValue([]),
       saveTransaction: jest.fn(),
+      refreshAccountFromTransactions: jest.fn(),
     };
     transactionsService = {
       decodeTxEvents: jest.fn(),
@@ -180,5 +183,64 @@ describe('TransactionProcessorService', () => {
     );
 
     expect(tokenService.updateTokenTrendingScore).toHaveBeenCalledWith(token);
+  });
+
+  it('continues processing when cleanup account refresh fails', async () => {
+    const rawTransaction = {
+      hash: 'th_cleanup_fail',
+      function: BCL_FUNCTIONS.create_community,
+      block_height: 123,
+      caller_id: 'ak_test',
+      raw: { log: [] },
+    };
+    const token = {
+      sale_address: 'ct_sale',
+      factory_address: 'ct_factory',
+    };
+
+    validationService.validateTransaction.mockResolvedValue({
+      isValid: true,
+      saleAddress: 'ct_sale',
+    });
+    tokenService.getToken.mockResolvedValue(token);
+    transactionsService.decodeTxEvents.mockResolvedValue(rawTransaction);
+    transactionsService.parseTransactionData.mockResolvedValue({
+      amount: new BigNumber(10),
+      volume: new BigNumber(2),
+      total_supply: new BigNumber(100),
+      protocol_reward: new BigNumber(1),
+    });
+    dataService.calculatePrices.mockReturnValue({
+      unitPriceData: { ae: 1 },
+      marketCapData: { ae: 10 },
+      buyPriceData: { ae: 1 },
+      previousBuyPriceData: { ae: 1 },
+    });
+    dataService.prepareTransactionData.mockResolvedValue({
+      tx_hash: rawTransaction.hash,
+      address: 'ak_trader',
+    });
+    persistenceService.saveTransaction.mockResolvedValue({ id: 1 });
+    persistenceService.cleanupOldTransactions.mockResolvedValue(['ak_old']);
+    persistenceService.refreshAccountFromTransactions.mockRejectedValue(
+      new Error('insert failed'),
+    );
+    tokenService.update.mockResolvedValue(token);
+    transactionsService.isTokenSupportedCollection.mockResolvedValue(true);
+    tokenService.syncTokenPrice.mockResolvedValue(undefined);
+    tokenHolderService.updateTokenHolder.mockResolvedValue(undefined);
+    tokenService.updateTokenTrendingScore.mockResolvedValue(undefined);
+    const loggerError = jest
+      .spyOn(Logger.prototype, 'error')
+      .mockImplementation(() => undefined);
+
+    await expect(
+      service.processTransaction(rawTransaction as any, SyncDirectionEnum.Live),
+    ).resolves.not.toThrow();
+
+    expect(
+      persistenceService.refreshAccountFromTransactions,
+    ).toHaveBeenCalledWith('ak_old', expect.anything());
+    expect(loggerError).toHaveBeenCalled();
   });
 });

--- a/src/plugins/bcl/services/transaction-processor.service.ts
+++ b/src/plugins/bcl/services/transaction-processor.service.ts
@@ -63,15 +63,7 @@ export class TransactionProcessorService {
     const result = await this.transactionRepository.manager.transaction(
       async (manager) => {
         let transactionToken: Token | undefined;
-
-        // Delete old transactions (if create_community)
-        if (rawTransaction.function === BCL_FUNCTIONS.create_community) {
-          await this.persistenceService.cleanupOldTransactions(
-            saleAddress,
-            rawTransaction.hash,
-            manager,
-          );
-        }
+        let cleanupAffectedAddresses: string[] = [];
 
         // Resolve token first. For buy/sell this may lazily create token by sale
         // address via TokensService.getToken().
@@ -160,11 +152,37 @@ export class TransactionProcessorService {
           priceCalculations,
         );
 
+        // Delete stale create_community rows only once the replacement row is ready.
+        if (rawTransaction.function === BCL_FUNCTIONS.create_community) {
+          cleanupAffectedAddresses =
+            await this.persistenceService.cleanupOldTransactions(
+              saleAddress,
+              rawTransaction.hash,
+              manager,
+            );
+        }
+
         // Save transaction
         const savedTransaction = await this.persistenceService.saveTransaction(
           txData,
           manager,
         );
+
+        for (const address of new Set(cleanupAffectedAddresses)) {
+          if (address && address !== txData.address) {
+            try {
+              await this.persistenceService.refreshAccountFromTransactions(
+                address,
+                manager,
+              );
+            } catch (error) {
+              this.logger.error(
+                `Failed to refresh account totals for ${address}`,
+                error instanceof Error ? error.stack : String(error),
+              );
+            }
+          }
+        }
 
         // Update token's last_tx_hash and last_sync_block_height for live transactions only
         if (syncDirection === SyncDirectionEnum.Live) {

--- a/src/plugins/social-tipping/services/social-tipping-transaction-processor.service.spec.ts
+++ b/src/plugins/social-tipping/services/social-tipping-transaction-processor.service.spec.ts
@@ -4,6 +4,7 @@ describe('SocialTippingTransactionProcessorService', () => {
   let service: SocialTippingTransactionProcessorService;
   let tipRepository: any;
   let postRepository: any;
+  let accountService: any;
   let tokensService: any;
 
   beforeEach(() => {
@@ -15,13 +16,16 @@ describe('SocialTippingTransactionProcessorService', () => {
     postRepository = {
       findOne: jest.fn(),
     };
+    accountService = {
+      ensureAccountExists: jest.fn(),
+    };
     tokensService = {
       updateTrendingScoresForSymbols: jest.fn().mockResolvedValue(undefined),
     };
 
     service = new SocialTippingTransactionProcessorService(
       tipRepository as any,
-      {} as any,
+      accountService as any,
       postRepository as any,
       tokensService as any,
     );
@@ -159,7 +163,7 @@ describe('SocialTippingTransactionProcessorService', () => {
     };
 
     const ensureAccountExists = jest.spyOn(
-      service as any,
+      accountService,
       'ensureAccountExists',
     );
 
@@ -208,7 +212,7 @@ describe('SocialTippingTransactionProcessorService', () => {
     };
 
     const ensureAccountExists = jest.spyOn(
-      service as any,
+      accountService,
       'ensureAccountExists',
     );
 

--- a/src/plugins/social-tipping/services/social-tipping-transaction-processor.service.ts
+++ b/src/plugins/social-tipping/services/social-tipping-transaction-processor.service.ts
@@ -1,3 +1,4 @@
+import { AccountService } from '@/account/services/account.service';
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, EntityManager } from 'typeorm';
@@ -5,7 +6,6 @@ import { Tx } from '@/mdw-sync/entities/tx.entity';
 import { SyncDirection } from '../../plugin.interface';
 import { decode, toAe } from '@aeternity/aepp-sdk';
 import { Tip } from '@/tipping/entities/tip.entity';
-import { Account } from '@/account/entities/account.entity';
 import { Post } from '@/social/entities/post.entity';
 import { TokensService } from '@/tokens/tokens.service';
 import { refreshTrendingScoresForPostSafely } from '@/social/utils/token-mentions.util';
@@ -20,8 +20,7 @@ export class SocialTippingTransactionProcessorService {
   constructor(
     @InjectRepository(Tip)
     private readonly tipRepository: Repository<Tip>,
-    @InjectRepository(Account)
-    private readonly accountRepository: Repository<Account>,
+    private readonly accountService: AccountService,
     @InjectRepository(Post)
     private readonly postRepository: Repository<Post>,
     private readonly tokensService: TokensService,
@@ -143,8 +142,8 @@ export class SocialTippingTransactionProcessorService {
 
     // Ensure sender and receiver accounts exist
     const [senderAccount, receiverAccount] = await Promise.all([
-      this.ensureAccountExists(tx.sender_id, manager),
-      this.ensureAccountExists(tx.recipient_id, manager),
+      this.accountService.ensureAccountExists(tx.sender_id, manager),
+      this.accountService.ensureAccountExists(tx.recipient_id, manager),
     ]);
 
     if (!senderAccount || !receiverAccount) {
@@ -174,34 +173,5 @@ export class SocialTippingTransactionProcessorService {
       }),
       post,
     };
-  }
-
-  /**
-   * Ensures an account exists, creates it if it doesn't
-   */
-  private async ensureAccountExists(
-    address: string,
-    manager: EntityManager,
-  ): Promise<Account | null> {
-    try {
-      const accountRepository = manager.getRepository(Account);
-
-      // Use upsert to handle duplicate key violations gracefully during parallel processing
-      await accountRepository.upsert(
-        { address },
-        {
-          conflictPaths: ['address'],
-          skipUpdateIfNoValuesChanged: true,
-        },
-      );
-
-      // Fetch and return the account
-      return await accountRepository.findOne({
-        where: { address },
-      });
-    } catch (error) {
-      this.logger.error(`Failed to ensure account exists: ${address}`, error);
-      return null;
-    }
   }
 }

--- a/src/tipping/services/tips.service.spec.ts
+++ b/src/tipping/services/tips.service.spec.ts
@@ -4,7 +4,7 @@ describe('TipService', () => {
   let service: TipService;
   let tipRepository: any;
   let postRepository: any;
-  let accountRepository: any;
+  let accountService: any;
   let tokensService: any;
 
   beforeEach(() => {
@@ -15,7 +15,9 @@ describe('TipService', () => {
     postRepository = {
       findOne: jest.fn(),
     };
-    accountRepository = {};
+    accountService = {
+      ensureAccountExists: jest.fn(),
+    };
     tokensService = {
       updateTrendingScoresForSymbols: jest.fn(),
     };
@@ -23,7 +25,7 @@ describe('TipService', () => {
     service = new TipService(
       tipRepository as any,
       postRepository as any,
-      accountRepository as any,
+      accountService as any,
       tokensService as any,
     );
   });
@@ -38,7 +40,7 @@ describe('TipService', () => {
       token_mentions: ['ALPHA'],
     });
     jest
-      .spyOn(service as any, 'ensureAccountExists')
+      .spyOn(accountService, 'ensureAccountExists')
       .mockResolvedValueOnce({ address: 'ak_sender' })
       .mockResolvedValueOnce({ address: 'ak_receiver' });
     tokensService.updateTrendingScoresForSymbols.mockRejectedValue(
@@ -71,7 +73,7 @@ describe('TipService', () => {
       token_mentions: ['ALPHA'],
     });
     const ensureAccountExists = jest.spyOn(
-      service as any,
+      accountService,
       'ensureAccountExists',
     );
 
@@ -96,7 +98,7 @@ describe('TipService', () => {
   it('does not persist self-tips on a profile', async () => {
     tipRepository.findOne.mockResolvedValue(null);
     const ensureAccountExists = jest.spyOn(
-      service as any,
+      accountService,
       'ensureAccountExists',
     );
 

--- a/src/tipping/services/tips.service.ts
+++ b/src/tipping/services/tips.service.ts
@@ -1,4 +1,4 @@
-import { Account } from '@/account/entities/account.entity';
+import { AccountService } from '@/account/services/account.service';
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -22,8 +22,7 @@ export class TipService {
     @InjectRepository(Post)
     private readonly postRepository: Repository<Post>,
 
-    @InjectRepository(Account)
-    private readonly accountRepository: Repository<Account>,
+    private readonly accountService: AccountService,
 
     private readonly tokensService: TokensService,
   ) {
@@ -119,8 +118,8 @@ export class TipService {
 
     // Ensure sender and receiver accounts exist
     const [senderAccount, receiverAccount] = await Promise.all([
-      this.ensureAccountExists(senderAddress),
-      this.ensureAccountExists(receiverAddress),
+      this.accountService.ensureAccountExists(senderAddress),
+      this.accountService.ensureAccountExists(receiverAddress),
     ]);
 
     const savedTip = await this.tipRepository.save({
@@ -145,29 +144,6 @@ export class TipService {
     });
 
     return savedTip;
-  }
-
-  /**
-   * Ensures an account exists, creates it if it doesn't
-   */
-  private async ensureAccountExists(address: string): Promise<Account> {
-    try {
-      let existingAccount = await this.accountRepository.findOne({
-        where: { address },
-      });
-
-      if (!existingAccount) {
-        existingAccount = await this.accountRepository.save({
-          address,
-        });
-        this.logger.log(`Created new account: ${address}`);
-      }
-      return existingAccount;
-    } catch (error) {
-      this.logger.error(`Failed to ensure account exists: ${address}`, error);
-      // Don't throw - account creation failure shouldn't break tip processing
-    }
-    return null;
   }
 
   /**


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core indexing and account aggregation SQL on the hot path for every BCL trade; failures are isolated but incorrect aggregation could skew leaderboard/search totals.
> 
> **Overview**
> Account rows are now **created or updated from indexed BCL transactions** so traders with on-chain activity but no `accounts` row show up in list/search and detail APIs.
> 
> **`AccountService`** adds `ensureAccountExists` (minimal upsert) and `ensureAccountFromTransactions` (SQL aggregation of tx counts/volume, then upsert). The bulk account pull job switches from insert-or-ignore to **upsert** so totals can refresh.
> 
> **Accounts API**: `listAll` hydrates when `search` is a full `ak_…` address; `getAccount` tries hydration before DB lookup, with errors logged and requests still succeeding via fallback.
> 
> **BCL sync**: after each saved trade, account totals refresh inside the DB transaction (failures logged only). `create_community` cleanup runs **after** the replacement tx is prepared, returns affected addresses, and refreshes their totals; tip flows reuse shared `AccountService` instead of local account upserts.
> 
> **`AccountService` is exported** from `AccountModule` and wired into `BclPluginModule`, persistence, and tipping processors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd978efe3d72e8bc03dcb82d547f252832b6ed62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->