### PR TITLE
Add depricated dex backend endpoints

### DIFF
--- a/src/dex/controllers/dex-tokens.controller.spec.ts
+++ b/src/dex/controllers/dex-tokens.controller.spec.ts
@@ -1,3 +1,4 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { DexTokensController } from './dex-tokens.controller';
 
 describe('DexTokensController', () => {
@@ -7,6 +8,11 @@ describe('DexTokensController', () => {
     findByAddress: jest.Mock;
     getTokenPrice: jest.Mock;
     getTokenPriceWithLiquidityAnalysis: jest.Mock;
+    findBestPairForToken: jest.Mock;
+    setListed: jest.Mock;
+  };
+  let pairHistoryService: {
+    getPaginatedHistoricalData: jest.Mock;
   };
 
   beforeEach(() => {
@@ -15,23 +21,174 @@ describe('DexTokensController', () => {
       findByAddress: jest.fn(),
       getTokenPrice: jest.fn(),
       getTokenPriceWithLiquidityAnalysis: jest.fn(),
+      findBestPairForToken: jest.fn(),
+      setListed: jest.fn(),
+    };
+    pairHistoryService = {
+      getPaginatedHistoricalData: jest.fn().mockResolvedValue([]),
     };
 
     controller = new DexTokensController(
       dexTokenService as any,
       {} as any,
       {} as any,
+      pairHistoryService as any,
     );
   });
 
-  it('forwards search params to dexTokenService.findAll', async () => {
-    await controller.listAll(3, 20, 'wae', 'price', 'ASC');
+  describe('listAll', () => {
+    it('forwards search params to dexTokenService.findAll', async () => {
+      await controller.listAll(3, 20, 'wae', 'price', 'ASC');
 
-    expect(dexTokenService.findAll).toHaveBeenCalledWith(
-      { page: 3, limit: 20 },
-      'wae',
-      'price',
-      'ASC',
-    );
+      expect(dexTokenService.findAll).toHaveBeenCalledWith(
+        { page: 3, limit: 20 },
+        'wae',
+        'price',
+        'ASC',
+        undefined,
+      );
+    });
+
+    it('parses listed=true into a boolean filter', async () => {
+      await controller.listAll(1, 100, '', 'created_at', 'DESC', 'true');
+
+      expect(dexTokenService.findAll).toHaveBeenCalledWith(
+        { page: 1, limit: 100 },
+        '',
+        'created_at',
+        'DESC',
+        true,
+      );
+    });
+
+    it('parses listed=false into a boolean filter', async () => {
+      await controller.listAll(1, 100, '', 'created_at', 'DESC', 'false');
+
+      expect(dexTokenService.findAll).toHaveBeenCalledWith(
+        { page: 1, limit: 100 },
+        '',
+        'created_at',
+        'DESC',
+        false,
+      );
+    });
+
+    it('accepts listed=1 / listed=0 and is case-insensitive', async () => {
+      await controller.listAll(1, 100, '', 'created_at', 'DESC', '1');
+      expect(dexTokenService.findAll).toHaveBeenLastCalledWith(
+        { page: 1, limit: 100 },
+        '',
+        'created_at',
+        'DESC',
+        true,
+      );
+
+      await controller.listAll(1, 100, '', 'created_at', 'DESC', '0');
+      expect(dexTokenService.findAll).toHaveBeenLastCalledWith(
+        { page: 1, limit: 100 },
+        '',
+        'created_at',
+        'DESC',
+        false,
+      );
+
+      await controller.listAll(1, 100, '', 'created_at', 'DESC', 'TRUE');
+      expect(dexTokenService.findAll).toHaveBeenLastCalledWith(
+        { page: 1, limit: 100 },
+        '',
+        'created_at',
+        'DESC',
+        true,
+      );
+    });
+
+    it('treats an empty listed param as no filter', async () => {
+      await controller.listAll(1, 100, '', 'created_at', 'DESC', '');
+
+      expect(dexTokenService.findAll).toHaveBeenCalledWith(
+        { page: 1, limit: 100 },
+        '',
+        'created_at',
+        'DESC',
+        undefined,
+      );
+    });
+
+    it('rejects an invalid listed value with 400 instead of coercing it', async () => {
+      await expect(
+        controller.listAll(1, 100, '', 'created_at', 'DESC', 'yes'),
+      ).rejects.toBeInstanceOf(BadRequestException);
+
+      expect(dexTokenService.findAll).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getTokenHistory', () => {
+    it('rejects out-of-range intervals before any lookup', async () => {
+      await expect(
+        controller.getTokenHistory('ct_token', 30, 'ae', 1, 100),
+      ).rejects.toThrow('interval must be between 60 and 86400 seconds');
+
+      expect(dexTokenService.findByAddress).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFound when the token does not exist', async () => {
+      dexTokenService.findByAddress.mockResolvedValue(null);
+
+      await expect(
+        controller.getTokenHistory('ct_token', 3600, 'ae', 1, 100),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('throws NotFound when no pool can chart the token', async () => {
+      dexTokenService.findByAddress.mockResolvedValue({ address: 'ct_token' });
+      dexTokenService.findBestPairForToken.mockResolvedValue(null);
+
+      await expect(
+        controller.getTokenHistory('ct_token', 3600, 'ae', 1, 100),
+      ).rejects.toThrow(/No liquidity pool/);
+    });
+
+    it('delegates to the pair history service using the base token position', async () => {
+      const pair = { address: 'ct_pair' };
+      dexTokenService.findByAddress.mockResolvedValue({ address: 'ct_token' });
+      dexTokenService.findBestPairForToken.mockResolvedValue({
+        pair,
+        basePosition: 'token1',
+      });
+
+      await controller.getTokenHistory('ct_token', 3600, 'usd', 2, 50);
+
+      expect(
+        pairHistoryService.getPaginatedHistoricalData,
+      ).toHaveBeenCalledWith({
+        pair,
+        interval: 3600,
+        fromToken: 'token1',
+        convertTo: 'usd',
+        page: 2,
+        limit: 50,
+      });
+    });
+  });
+
+  describe('setListed', () => {
+    it('returns the updated token', async () => {
+      const token = { address: 'ct_token', listed: true };
+      dexTokenService.setListed.mockResolvedValue(token);
+
+      const result = await controller.setListed('ct_token', { listed: true });
+
+      expect(dexTokenService.setListed).toHaveBeenCalledWith('ct_token', true);
+      expect(result).toBe(token);
+    });
+
+    it('throws NotFound when the token does not exist', async () => {
+      dexTokenService.setListed.mockResolvedValue(null);
+
+      await expect(
+        controller.setListed('ct_token', { listed: true }),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
   });
 });

--- a/src/dex/controllers/dex-tokens.controller.ts
+++ b/src/dex/controllers/dex-tokens.controller.ts
@@ -1,30 +1,63 @@
 import { ApiOkResponsePaginated } from '@/utils/api-type';
 import {
+  BadRequestException,
+  Body,
   Controller,
   DefaultValuePipe,
   Get,
   NotFoundException,
   Param,
   ParseIntPipe,
+  Patch,
   Query,
+  UseGuards,
 } from '@nestjs/common';
 import {
   ApiOkResponse,
   ApiOperation,
   ApiParam,
   ApiQuery,
+  ApiSecurity,
   ApiTags,
 } from '@nestjs/swagger';
+import { ApiKeyGuard } from '@/trending-tags/guards/api-key.guard';
+import { SetListedDto } from '../dto/set-listed.dto';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { DexTokenDto, DexTokenSummaryDto } from '../dto';
 import { Pair } from '../entities/pair.entity';
 import { DexTokenSummaryService } from '../services/dex-token-summary.service';
 import { DexTokenService } from '../services/dex-token.service';
+import { PairHistoryService } from '../services/pair-history.service';
 import {
   AeContractAddressPipe,
   OptionalAeContractAddressPipe,
 } from '@/common/validation/request-validation';
+
+const MIN_HISTORY_INTERVAL_SECONDS = 60;
+const MAX_HISTORY_INTERVAL_SECONDS = 86_400;
+
+/**
+ * Parse the optional ?listed query param into a boolean filter.
+ * Accepts 'true'/'1' (→ true) and 'false'/'0' (→ false), case-insensitively,
+ * and returns undefined when the param is omitted. Any other value throws a
+ * 400 instead of being silently coerced to a (wrong) filter.
+ */
+function parseListedFilter(value?: string): boolean | undefined {
+  if (value === undefined || value === '') {
+    return undefined;
+  }
+  const normalized = value.trim().toLowerCase();
+  if (normalized === 'true' || normalized === '1') {
+    return true;
+  }
+  if (normalized === 'false' || normalized === '0') {
+    return false;
+  }
+  throw new BadRequestException(
+    `Invalid listed value: ${value}. Expected 'true' or 'false'.`,
+  );
+}
 
 @Controller('dex/tokens')
 @ApiTags('DEX')
@@ -34,6 +67,7 @@ export class DexTokensController {
     @InjectRepository(Pair)
     private readonly pairRepository: Repository<Pair>,
     private readonly dexTokenSummaryService: DexTokenSummaryService,
+    private readonly pairHistoryService: PairHistoryService,
   ) {
     //
   }
@@ -60,6 +94,13 @@ export class DexTokensController {
     required: false,
   })
   @ApiQuery({ name: 'order_direction', enum: ['ASC', 'DESC'], required: false })
+  @ApiQuery({
+    name: 'listed',
+    type: 'boolean',
+    required: false,
+    description:
+      'Filter to only listed (true) or only unlisted (false) tokens. Omit to return all tokens.',
+  })
   @ApiOperation({
     operationId: 'listAllDexTokens',
     summary: 'Get all DEX tokens',
@@ -74,12 +115,14 @@ export class DexTokensController {
     @Query('search') search = '',
     @Query('order_by') orderBy: string = 'created_at',
     @Query('order_direction') orderDirection: 'ASC' | 'DESC' = 'DESC',
+    @Query('listed') listed?: string,
   ) {
     return this.dexTokenService.findAll(
       { page, limit },
       search,
       orderBy,
       orderDirection,
+      parseListedFilter(listed),
     );
   }
 
@@ -236,5 +279,100 @@ export class DexTokensController {
     const summary =
       await this.dexTokenSummaryService.createOrUpdateSummary(address);
     return { ...summary, address };
+  }
+
+  @ApiParam({
+    name: 'address',
+    type: 'string',
+    description: 'Token contract address',
+  })
+  @ApiQuery({
+    name: 'interval',
+    type: 'number',
+    required: false,
+    description: `Candle interval in seconds (default 3600, min ${MIN_HISTORY_INTERVAL_SECONDS}, max ${MAX_HISTORY_INTERVAL_SECONDS})`,
+  })
+  @ApiQuery({
+    name: 'convertTo',
+    type: 'string',
+    required: false,
+    description: 'Currency label for the returned quote (default: ae)',
+  })
+  @ApiQuery({ name: 'page', type: 'number', required: false })
+  @ApiQuery({ name: 'limit', type: 'number', required: false })
+  @ApiOperation({
+    operationId: 'getDexTokenHistory',
+    summary: 'Get DEX token price history',
+    description:
+      'Get OHLCV price history for a single token. The series is derived from the deepest pool that pairs the token against WAE (so the price is expressed in AE); if no WAE pool exists, the deepest available pool is used.',
+  })
+  @Get(':address/history')
+  async getTokenHistory(
+    @Param('address', AeContractAddressPipe) address: string,
+    @Query('interval', new DefaultValuePipe(3600), ParseIntPipe)
+    interval: number = 3600,
+    @Query('convertTo') convertTo: string = 'ae',
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page = 1,
+    @Query('limit', new DefaultValuePipe(100), ParseIntPipe) limit = 100,
+  ) {
+    if (
+      interval < MIN_HISTORY_INTERVAL_SECONDS ||
+      interval > MAX_HISTORY_INTERVAL_SECONDS
+    ) {
+      throw new BadRequestException(
+        `interval must be between ${MIN_HISTORY_INTERVAL_SECONDS} and ${MAX_HISTORY_INTERVAL_SECONDS} seconds`,
+      );
+    }
+
+    const token = await this.dexTokenService.findByAddress(address);
+    if (!token) {
+      throw new NotFoundException(
+        `DEX token with address ${address} not found`,
+      );
+    }
+
+    const best = await this.dexTokenService.findBestPairForToken(address);
+    if (!best) {
+      throw new NotFoundException(
+        `No liquidity pool found to chart token ${address}`,
+      );
+    }
+
+    return this.pairHistoryService.getPaginatedHistoricalData({
+      pair: best.pair,
+      interval,
+      fromToken: best.basePosition,
+      convertTo,
+      page,
+      limit,
+    });
+  }
+
+  @ApiParam({
+    name: 'address',
+    type: 'string',
+    description: 'Token contract address',
+  })
+  @ApiSecurity('api-key')
+  @ApiOperation({
+    operationId: 'setDexTokenListed',
+    summary: 'Set the listed flag for a DEX token (admin)',
+    description:
+      'Mark a token as listed/unlisted. Requires an API key (x-api-key header or Bearer token).',
+  })
+  @ApiOkResponse({ type: DexTokenDto })
+  @UseGuards(ApiKeyGuard)
+  @Patch(':address/listed')
+  async setListed(
+    @Param('address', AeContractAddressPipe) address: string,
+    @Body() body: SetListedDto,
+  ) {
+    const token = await this.dexTokenService.setListed(address, body.listed);
+    if (!token) {
+      throw new NotFoundException(
+        `DEX token with address ${address} not found`,
+      );
+    }
+    return token;
   }
 }

--- a/src/dex/controllers/dex-tokens.controller.ts
+++ b/src/dex/controllers/dex-tokens.controller.ts
@@ -294,9 +294,13 @@ export class DexTokensController {
   })
   @ApiQuery({
     name: 'convertTo',
-    type: 'string',
+    enum: ['ae', 'usd', 'eur', 'aud', 'brl', 'cad', 'chf', 'gbp', 'xau'],
     required: false,
-    description: 'Currency label for the returned quote (default: ae)',
+    description:
+      'Currency the OHLC/market-cap/volume values are converted into (default: ae). ' +
+      'Fiat conversion uses the AE→currency rate as of each candle’s time (historical ' +
+      'coin_prices snapshots) and requires the token to have a WAE-quoted pool; requesting ' +
+      'a fiat currency for a token without one returns 400.',
   })
   @ApiQuery({ name: 'page', type: 'number', required: false })
   @ApiQuery({ name: 'limit', type: 'number', required: false })
@@ -304,7 +308,7 @@ export class DexTokensController {
     operationId: 'getDexTokenHistory',
     summary: 'Get DEX token price history',
     description:
-      'Get OHLCV price history for a single token. The series is derived from the deepest pool that pairs the token against WAE (so the price is expressed in AE); if no WAE pool exists, the deepest available pool is used.',
+      'Get OHLCV price history for a single token. The series is derived from the deepest pool that pairs the token against WAE (so the price is expressed in AE); if no WAE pool exists, the deepest available pool is used. Pass convertTo to express the values in a fiat currency.',
   })
   @Get(':address/history')
   async getTokenHistory(

--- a/src/dex/controllers/pair-transactions.controller.spec.ts
+++ b/src/dex/controllers/pair-transactions.controller.spec.ts
@@ -1,0 +1,63 @@
+import { PairTransactionsController } from './pair-transactions.controller';
+
+describe('PairTransactionsController', () => {
+  let controller: PairTransactionsController;
+  let service: {
+    findAll: jest.Mock;
+    findByTxHash: jest.Mock;
+    findByPairAddress: jest.Mock;
+  };
+
+  beforeEach(() => {
+    service = {
+      findAll: jest.fn().mockResolvedValue({ items: [], meta: {} }),
+      findByTxHash: jest.fn(),
+      findByPairAddress: jest.fn(),
+    };
+
+    controller = new PairTransactionsController(service as any);
+  });
+
+  it('forwards all filters including the date range to the service', async () => {
+    await controller.listAll(
+      2,
+      50,
+      'created_at',
+      'ASC',
+      'ct_pair',
+      'ct_token',
+      'swap_exact_tokens_for_tokens',
+      'ak_account',
+      '2024-01-01T00:00:00.000Z',
+      '2024-02-01T00:00:00.000Z',
+    );
+
+    expect(service.findAll).toHaveBeenCalledWith(
+      { page: 2, limit: 50 },
+      'created_at',
+      'ASC',
+      'ct_pair',
+      'swap_exact_tokens_for_tokens',
+      'ak_account',
+      'ct_token',
+      '2024-01-01T00:00:00.000Z',
+      '2024-02-01T00:00:00.000Z',
+    );
+  });
+
+  it('forwards undefined dates when the range is not supplied', async () => {
+    await controller.listAll(1, 100, 'created_at', 'DESC');
+
+    expect(service.findAll).toHaveBeenCalledWith(
+      { page: 1, limit: 100 },
+      'created_at',
+      'DESC',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    );
+  });
+});

--- a/src/dex/controllers/pair-transactions.controller.ts
+++ b/src/dex/controllers/pair-transactions.controller.ts
@@ -63,6 +63,20 @@ export class PairTransactionsController {
     required: false,
     description: 'Filter by transaction type',
   })
+  @ApiQuery({
+    name: 'from_date',
+    type: 'string',
+    required: false,
+    description:
+      'Only include transactions at or after this ISO-8601 date/time (created_at >= from_date)',
+  })
+  @ApiQuery({
+    name: 'to_date',
+    type: 'string',
+    required: false,
+    description:
+      'Only include transactions at or before this ISO-8601 date/time (created_at <= to_date)',
+  })
   @ApiOperation({
     operationId: 'listAllPairTransactions',
     summary: 'Get all pair transactions',
@@ -82,6 +96,8 @@ export class PairTransactionsController {
     @Query('tx_type') txType?: string,
     @Query('account_address', OptionalAeAccountAddressPipe)
     account_address?: string,
+    @Query('from_date') fromDate?: string,
+    @Query('to_date') toDate?: string,
   ) {
     return this.pairTransactionService.findAll(
       { page, limit },
@@ -91,6 +107,8 @@ export class PairTransactionsController {
       txType,
       account_address,
       tokenAddress,
+      fromDate,
+      toDate,
     );
   }
 

--- a/src/dex/controllers/swap-routes.controller.spec.ts
+++ b/src/dex/controllers/swap-routes.controller.spec.ts
@@ -6,6 +6,23 @@ describe('SwapRoutesController', () => {
     findSwapPaths: jest.Mock;
   };
 
+  const makePair = (
+    address: string,
+    token0: string,
+    token1: string,
+    reserve0: string = '100',
+    reserve1: string = '200',
+    total_supply: string = '300',
+  ) =>
+    ({
+      address,
+      token0: { address: token0 },
+      token1: { address: token1 },
+      reserve0,
+      reserve1,
+      total_supply,
+    }) as any;
+
   beforeEach(() => {
     pairService = {
       findSwapPaths: jest.fn(),
@@ -21,48 +38,65 @@ describe('SwapRoutesController', () => {
     expect(pairService.findSwapPaths).toHaveBeenCalledWith('ct_from', 'ct_to');
   });
 
-  it('summarises a direct route with hasDirectPath and totalPaths', async () => {
-    const directPair = { address: 'ct_pair' };
+  it('maps each pair to the legacy route shape (synchronized + liquidityInfo + address tokens)', async () => {
     pairService.findSwapPaths.mockResolvedValue({
-      paths: [[directPair]],
-      directPairs: [directPair],
-    });
-
-    const result = await controller.getSwapRoutes('ct_from', 'ct_to');
-
-    expect(result).toEqual({
-      paths: [[directPair]],
-      directPairs: [directPair],
-      hasDirectPath: true,
-      totalPaths: 1,
-    });
-  });
-
-  it('counts multi-hop paths and reports no direct path', async () => {
-    const hopA = { address: 'ct_a' };
-    const hopB = { address: 'ct_b' };
-    pairService.findSwapPaths.mockResolvedValue({
-      paths: [[hopA, hopB]],
+      paths: [[makePair('ct_pair', 'ct_from', 'ct_to', '100', '200', '300')]],
       directPairs: [],
     });
 
     const result = await controller.getSwapRoutes('ct_from', 'ct_to');
 
-    expect(result.hasDirectPath).toBe(false);
-    expect(result.totalPaths).toBe(1);
-    expect(result.paths).toEqual([[hopA, hopB]]);
+    expect(result).toEqual([
+      [
+        {
+          address: 'ct_pair',
+          synchronized: true,
+          token0: 'ct_from',
+          token1: 'ct_to',
+          liquidityInfo: {
+            totalSupply: '300',
+            reserve0: '100',
+            reserve1: '200',
+          },
+        },
+      ],
+    ]);
   });
 
-  it('returns an empty result instead of throwing when no route exists', async () => {
+  it('marks a pair as not synchronized when either reserve is zero', async () => {
+    pairService.findSwapPaths.mockResolvedValue({
+      paths: [[makePair('ct_empty', 'ct_from', 'ct_to', '0', '200')]],
+      directPairs: [],
+    });
+
+    const [[routePair]] = await controller.getSwapRoutes('ct_from', 'ct_to');
+
+    // The swap UI filters routes by `pairs.every(p => p.synchronized)`, so this
+    // empty pool must report synchronized=false rather than undefined.
+    expect(routePair.synchronized).toBe(false);
+  });
+
+  it('preserves multi-hop route ordering', async () => {
+    pairService.findSwapPaths.mockResolvedValue({
+      paths: [
+        [
+          makePair('ct_a', 'ct_from', 'ct_mid'),
+          makePair('ct_b', 'ct_mid', 'ct_to'),
+        ],
+      ],
+      directPairs: [],
+    });
+
+    const result = await controller.getSwapRoutes('ct_from', 'ct_to');
+
+    expect(result[0].map((p) => p.address)).toEqual(['ct_a', 'ct_b']);
+  });
+
+  it('returns an empty array instead of throwing when no route exists', async () => {
     pairService.findSwapPaths.mockResolvedValue({ paths: [], directPairs: [] });
 
     const result = await controller.getSwapRoutes('ct_from', 'ct_to');
 
-    expect(result).toEqual({
-      paths: [],
-      directPairs: [],
-      hasDirectPath: false,
-      totalPaths: 0,
-    });
+    expect(result).toEqual([]);
   });
 });

--- a/src/dex/controllers/swap-routes.controller.spec.ts
+++ b/src/dex/controllers/swap-routes.controller.spec.ts
@@ -1,0 +1,68 @@
+import { SwapRoutesController } from './swap-routes.controller';
+
+describe('SwapRoutesController', () => {
+  let controller: SwapRoutesController;
+  let pairService: {
+    findSwapPaths: jest.Mock;
+  };
+
+  beforeEach(() => {
+    pairService = {
+      findSwapPaths: jest.fn(),
+    };
+    controller = new SwapRoutesController(pairService as any);
+  });
+
+  it('forwards the token addresses to pairService.findSwapPaths', async () => {
+    pairService.findSwapPaths.mockResolvedValue({ paths: [], directPairs: [] });
+
+    await controller.getSwapRoutes('ct_from', 'ct_to');
+
+    expect(pairService.findSwapPaths).toHaveBeenCalledWith('ct_from', 'ct_to');
+  });
+
+  it('summarises a direct route with hasDirectPath and totalPaths', async () => {
+    const directPair = { address: 'ct_pair' };
+    pairService.findSwapPaths.mockResolvedValue({
+      paths: [[directPair]],
+      directPairs: [directPair],
+    });
+
+    const result = await controller.getSwapRoutes('ct_from', 'ct_to');
+
+    expect(result).toEqual({
+      paths: [[directPair]],
+      directPairs: [directPair],
+      hasDirectPath: true,
+      totalPaths: 1,
+    });
+  });
+
+  it('counts multi-hop paths and reports no direct path', async () => {
+    const hopA = { address: 'ct_a' };
+    const hopB = { address: 'ct_b' };
+    pairService.findSwapPaths.mockResolvedValue({
+      paths: [[hopA, hopB]],
+      directPairs: [],
+    });
+
+    const result = await controller.getSwapRoutes('ct_from', 'ct_to');
+
+    expect(result.hasDirectPath).toBe(false);
+    expect(result.totalPaths).toBe(1);
+    expect(result.paths).toEqual([[hopA, hopB]]);
+  });
+
+  it('returns an empty result instead of throwing when no route exists', async () => {
+    pairService.findSwapPaths.mockResolvedValue({ paths: [], directPairs: [] });
+
+    const result = await controller.getSwapRoutes('ct_from', 'ct_to');
+
+    expect(result).toEqual({
+      paths: [],
+      directPairs: [],
+      hasDirectPath: false,
+      totalPaths: 0,
+    });
+  });
+});

--- a/src/dex/controllers/swap-routes.controller.ts
+++ b/src/dex/controllers/swap-routes.controller.ts
@@ -1,0 +1,88 @@
+import { Controller, Get, Param } from '@nestjs/common';
+import {
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+  ApiTags,
+} from '@nestjs/swagger';
+import { AeContractAddressPipe } from '@/common/validation/request-validation';
+import { PairService } from '../services/pair.service';
+
+/**
+ * Replicates the legacy DEX backend's `/swap-routes/:from/:to` endpoint that
+ * the swap UI uses to quote a trade. It returns every routing path (direct and
+ * single-hop) between two tokens, reusing the proven path-finding in
+ * PairService.findSwapPaths.
+ *
+ * Unlike the sibling `dex/pairs/.../providers` endpoint, this does NOT 404 when
+ * no route exists: "no route" is a normal answer for a quote, so callers get an
+ * empty `paths` array (totalPaths: 0) to handle gracefully.
+ */
+@Controller('dex/swap-routes')
+@ApiTags('DEX')
+export class SwapRoutesController {
+  constructor(private readonly pairService: PairService) {}
+
+  @ApiParam({
+    name: 'from_token',
+    type: 'string',
+    description: 'Source token contract address',
+  })
+  @ApiParam({
+    name: 'to_token',
+    type: 'string',
+    description: 'Destination token contract address',
+  })
+  @ApiOperation({
+    operationId: 'getSwapRoutes',
+    summary: 'Get swap routes between two tokens',
+    description:
+      'Returns all swap routes (direct pairs and multi-hop paths) from one ' +
+      'token to another, used by the swap UI to quote a trade. Returns an ' +
+      'empty paths array when no route exists.',
+  })
+  @ApiOkResponse({
+    description:
+      'All swap routes between the tokens, with direct pairs and path count',
+    schema: {
+      type: 'object',
+      properties: {
+        paths: {
+          type: 'array',
+          items: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/PairDto' },
+          },
+          description:
+            'All possible swap paths, where each path is an ordered array of pairs',
+        },
+        directPairs: {
+          type: 'array',
+          items: { $ref: '#/components/schemas/PairDto' },
+          description: 'Direct pairs between the tokens (if any)',
+        },
+        hasDirectPath: {
+          type: 'boolean',
+          description: 'Whether there is a direct pair between the tokens',
+        },
+        totalPaths: {
+          type: 'number',
+          description: 'Total number of possible paths',
+        },
+      },
+    },
+  })
+  @Get(':from_token/:to_token')
+  async getSwapRoutes(
+    @Param('from_token', AeContractAddressPipe) fromToken: string,
+    @Param('to_token', AeContractAddressPipe) toToken: string,
+  ) {
+    const result = await this.pairService.findSwapPaths(fromToken, toToken);
+
+    return {
+      ...result,
+      hasDirectPath: result.directPairs.length > 0,
+      totalPaths: result.paths.length,
+    };
+  }
+}

--- a/src/dex/controllers/swap-routes.controller.ts
+++ b/src/dex/controllers/swap-routes.controller.ts
@@ -1,22 +1,50 @@
 import { Controller, Get, Param } from '@nestjs/common';
 import {
+  ApiExtraModels,
   ApiOkResponse,
   ApiOperation,
   ApiParam,
   ApiTags,
+  getSchemaPath,
 } from '@nestjs/swagger';
 import { AeContractAddressPipe } from '@/common/validation/request-validation';
+import { SwapRoutePairDto } from '../dto/swap-route.dto';
+import { Pair } from '../entities/pair.entity';
 import { PairService } from '../services/pair.service';
 
 /**
+ * Map an internal Pair entity to the lean route shape the swap UI expects:
+ * address-form tokens, reserves under `liquidityInfo`, and a `synchronized`
+ * flag derived from whether the pool actually has liquidity on both sides.
+ */
+function toRoutePair(pair: Pair): SwapRoutePairDto {
+  const reserve0 = pair.reserve0?.toString() ?? '0';
+  const reserve1 = pair.reserve1?.toString() ?? '0';
+  return {
+    address: pair.address,
+    synchronized: Number(reserve0) > 0 && Number(reserve1) > 0,
+    token0: pair.token0?.address,
+    token1: pair.token1?.address,
+    liquidityInfo: {
+      totalSupply: pair.total_supply?.toString() ?? '0',
+      reserve0,
+      reserve1,
+    },
+  };
+}
+
+/**
  * Replicates the legacy DEX backend's `/swap-routes/:from/:to` endpoint that
- * the swap UI uses to quote a trade. It returns every routing path (direct and
+ * the swap UI uses to quote a trade. It returns every routing route (direct and
  * single-hop) between two tokens, reusing the proven path-finding in
  * PairService.findSwapPaths.
  *
- * Unlike the sibling `dex/pairs/.../providers` endpoint, this does NOT 404 when
- * no route exists: "no route" is a normal answer for a quote, so callers get an
- * empty `paths` array (totalPaths: 0) to handle gracefully.
+ * The response is a bare array of routes (each route an ordered array of
+ * pairs), matching the legacy contract. This is leaner than wrapping it in an
+ * object: a direct route is simply a route of length 1, and the route count is
+ * the array length — so no redundant `directPairs`/`totalPaths` fields are
+ * sent. An empty array means no route exists (not a 404), which is a normal
+ * answer for a quote.
  */
 @Controller('dex/swap-routes')
 @ApiTags('DEX')
@@ -37,38 +65,19 @@ export class SwapRoutesController {
     operationId: 'getSwapRoutes',
     summary: 'Get swap routes between two tokens',
     description:
-      'Returns all swap routes (direct pairs and multi-hop paths) from one ' +
-      'token to another, used by the swap UI to quote a trade. Returns an ' +
-      'empty paths array when no route exists.',
+      'Returns all swap routes (direct and single-hop) from one token to ' +
+      'another, used by the swap UI to quote a trade. Each route is an ordered ' +
+      'array of pairs. Returns an empty array when no route exists.',
   })
+  @ApiExtraModels(SwapRoutePairDto)
   @ApiOkResponse({
     description:
-      'All swap routes between the tokens, with direct pairs and path count',
+      'All swap routes between the tokens; each route is an ordered array of pairs',
     schema: {
-      type: 'object',
-      properties: {
-        paths: {
-          type: 'array',
-          items: {
-            type: 'array',
-            items: { $ref: '#/components/schemas/PairDto' },
-          },
-          description:
-            'All possible swap paths, where each path is an ordered array of pairs',
-        },
-        directPairs: {
-          type: 'array',
-          items: { $ref: '#/components/schemas/PairDto' },
-          description: 'Direct pairs between the tokens (if any)',
-        },
-        hasDirectPath: {
-          type: 'boolean',
-          description: 'Whether there is a direct pair between the tokens',
-        },
-        totalPaths: {
-          type: 'number',
-          description: 'Total number of possible paths',
-        },
+      type: 'array',
+      items: {
+        type: 'array',
+        items: { $ref: getSchemaPath(SwapRoutePairDto) },
       },
     },
   })
@@ -76,13 +85,8 @@ export class SwapRoutesController {
   async getSwapRoutes(
     @Param('from_token', AeContractAddressPipe) fromToken: string,
     @Param('to_token', AeContractAddressPipe) toToken: string,
-  ) {
-    const result = await this.pairService.findSwapPaths(fromToken, toToken);
-
-    return {
-      ...result,
-      hasDirectPath: result.directPairs.length > 0,
-      totalPaths: result.paths.length,
-    };
+  ): Promise<SwapRoutePairDto[][]> {
+    const { paths } = await this.pairService.findSwapPaths(fromToken, toToken);
+    return paths.map((route) => route.map(toRoutePair));
   }
 }

--- a/src/dex/dex.module.ts
+++ b/src/dex/dex.module.ts
@@ -6,6 +6,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { DexTokensController } from './controllers/dex-tokens.controller';
 import { PairsController } from './controllers/pairs.controller';
 import { PairTransactionsController } from './controllers/pair-transactions.controller';
+import { SwapRoutesController } from './controllers/swap-routes.controller';
 import { DexToken } from './entities/dex-token.entity';
 import { Pair } from './entities/pair.entity';
 import { PairTransaction } from './entities/pair-transaction.entity';
@@ -18,6 +19,7 @@ import { PairHistoryService } from './services/pair-history.service';
 import { PairSummaryService } from './services/pair-summary.service';
 import { DexTokenSummary } from './entities/dex-token-summary.entity';
 import { DexTokenSummaryService } from './services/dex-token-summary.service';
+import { DexSchemaBootstrapService } from './services/dex-schema-bootstrap.service';
 
 @Module({
   imports: [
@@ -40,6 +42,7 @@ import { DexTokenSummaryService } from './services/dex-token-summary.service';
     PairHistoryService,
     PairSummaryService,
     DexTokenSummaryService,
+    DexSchemaBootstrapService,
   ],
   exports: [
     PairService,
@@ -53,6 +56,7 @@ import { DexTokenSummaryService } from './services/dex-token-summary.service';
     PairsController,
     DexTokensController,
     PairTransactionsController,
+    SwapRoutesController,
   ],
 })
 export class DexModule {

--- a/src/dex/dto/dex-token.dto.ts
+++ b/src/dex/dto/dex-token.dto.ts
@@ -46,6 +46,12 @@ export class DexTokenDto {
   is_ae: boolean;
 
   @ApiProperty({
+    description: 'Whether the token is officially listed/featured by the DEX',
+    example: false,
+  })
+  listed: boolean;
+
+  @ApiProperty({
     description: 'Price Data',
   })
   price: PriceDto;

--- a/src/dex/dto/pair-transaction.dto.ts
+++ b/src/dex/dto/pair-transaction.dto.ts
@@ -1,12 +1,56 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { PairDto } from './pair.dto';
 
+export class SwapInfoDto {
+  @ApiProperty({ description: 'Amount of token0 sent into the pair' })
+  amount0In: string;
+
+  @ApiProperty({ description: 'Amount of token1 sent into the pair' })
+  amount1In: string;
+
+  @ApiProperty({ description: 'Amount of token0 sent out of the pair' })
+  amount0Out: string;
+
+  @ApiProperty({ description: 'Amount of token1 sent out of the pair' })
+  amount1Out: string;
+
+  @ApiProperty({ description: 'Recipient account address', nullable: true })
+  to: string;
+}
+
+export class LiquidityInfoDto {
+  @ApiProperty({
+    description: 'Liquidity operation type',
+    enum: ['PairMint', 'PairBurn'],
+  })
+  type: string;
+
+  @ApiProperty({ description: 'Amount of token0 added/removed' })
+  amount0: string;
+
+  @ApiProperty({ description: 'Amount of token1 added/removed' })
+  amount1: string;
+}
+
 export class PairTransactionDto {
   @ApiProperty({
     description: 'Transaction hash',
     example: 'th_2AfnEfCSPx4A6VjMBfDfqHNYcqDJjuJjGV1qhqP5qNKNBvYfE2',
   })
   tx_hash: string;
+
+  @ApiProperty({
+    description: 'Account that submitted the transaction',
+    example: 'ak_2AfnEfCSPx4A6VjMBfDfqHNYcqDJjuJjGV1qhqP5qNKNBvYfE2',
+    nullable: true,
+  })
+  account_address: string;
+
+  @ApiProperty({
+    description: 'Block height at which the transaction was included',
+    example: 1234567,
+  })
+  block_height: number;
 
   @ApiProperty({
     description: 'Associated pair',
@@ -20,6 +64,74 @@ export class PairTransactionDto {
     example: 'swap_exact_tokens_for_tokens',
   })
   tx_type: string;
+
+  @ApiProperty({
+    description: 'Reserve of token0 after the transaction',
+    example: '1000000000000000000000000',
+  })
+  reserve0: string;
+
+  @ApiProperty({
+    description: 'Reserve of token1 after the transaction',
+    example: '1000000000000000000000000',
+  })
+  reserve1: string;
+
+  @ApiProperty({
+    description: 'Price of token0 quoted in token1 (reserve0 / reserve1)',
+    example: '0.5',
+  })
+  ratio0: string;
+
+  @ApiProperty({
+    description: 'Price of token1 quoted in token0 (reserve1 / reserve0)',
+    example: '2',
+  })
+  ratio1: string;
+
+  @ApiProperty({
+    description: 'Total supply of the pair LP token after the transaction',
+    example: '1000000000000000000000000',
+  })
+  total_supply: string;
+
+  @ApiProperty({
+    description:
+      'Traded volume of token0 (sum of in/out amounts) for swaps; 0 for liquidity operations',
+    example: '1000000000000000000',
+  })
+  volume0: string;
+
+  @ApiProperty({
+    description:
+      'Traded volume of token1 (sum of in/out amounts) for swaps; 0 for liquidity operations',
+    example: '1000000000000000000',
+  })
+  volume1: string;
+
+  @ApiProperty({ description: 'Market cap denominated in token0' })
+  market_cap0: string;
+
+  @ApiProperty({ description: 'Market cap denominated in token1' })
+  market_cap1: string;
+
+  @ApiProperty({ description: 'Pool market cap' })
+  market_cap: string;
+
+  @ApiProperty({
+    description: 'Swap event details (present for swap transactions)',
+    type: () => SwapInfoDto,
+    nullable: true,
+  })
+  swap_info: SwapInfoDto | null;
+
+  @ApiProperty({
+    description:
+      'Liquidity event details (present for add/remove liquidity transactions)',
+    type: () => LiquidityInfoDto,
+    nullable: true,
+  })
+  pair_mint_info: LiquidityInfoDto | null;
 
   @ApiProperty({
     description: 'Transaction creation timestamp',

--- a/src/dex/dto/set-listed.dto.ts
+++ b/src/dex/dto/set-listed.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean } from 'class-validator';
+
+export class SetListedDto {
+  @ApiProperty({
+    description: 'Whether the token should be marked as listed',
+    example: true,
+  })
+  @IsBoolean()
+  listed: boolean;
+}

--- a/src/dex/dto/swap-route.dto.ts
+++ b/src/dex/dto/swap-route.dto.ts
@@ -1,0 +1,42 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class RouteLiquidityInfoDto {
+  @ApiProperty({ description: 'Total supply of the pair LP token' })
+  totalSupply: string;
+
+  @ApiProperty({ description: 'Reserve of token0' })
+  reserve0: string;
+
+  @ApiProperty({ description: 'Reserve of token1' })
+  reserve1: string;
+}
+
+/**
+ * Lean pair shape used inside swap routes, matching the legacy dex-backend
+ * `PairWithLiquidityAndTokenAddresses` contract the swap UI consumes:
+ * token0/token1 are plain addresses (not nested objects) and reserves live
+ * under `liquidityInfo`. `synchronized` tells the UI the pool has usable
+ * liquidity — the swap UI filters out routes where any pair is not synchronized,
+ * so this field must be present (an absent/undefined value silently drops the
+ * route).
+ */
+export class SwapRoutePairDto {
+  @ApiProperty({ description: 'Pair contract address' })
+  address: string;
+
+  @ApiProperty({
+    description:
+      'Whether the pair has usable (non-zero) reserves on both sides. Routes containing an unsynchronized pair are not quotable.',
+    example: true,
+  })
+  synchronized: boolean;
+
+  @ApiProperty({ description: 'token0 contract address' })
+  token0: string;
+
+  @ApiProperty({ description: 'token1 contract address' })
+  token1: string;
+
+  @ApiProperty({ type: () => RouteLiquidityInfoDto })
+  liquidityInfo: RouteLiquidityInfoDto;
+}

--- a/src/dex/entities/dex-token.entity.ts
+++ b/src/dex/entities/dex-token.entity.ts
@@ -42,6 +42,13 @@ export class DexToken {
   })
   is_ae: boolean;
 
+  // Curated "listed" flag: a token is officially listed/featured by the DEX.
+  // Defaults to false and is toggled via the guarded admin endpoint.
+  @Column({
+    default: false,
+  })
+  listed: boolean;
+
   @CreateDateColumn({
     type: 'timestamp',
     default: () => 'CURRENT_TIMESTAMP(6)',

--- a/src/dex/entities/pair-transaction.entity.ts
+++ b/src/dex/entities/pair-transaction.entity.ts
@@ -2,6 +2,7 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  Index,
   JoinColumn,
   ManyToOne,
   PrimaryColumn,
@@ -11,6 +12,11 @@ import { Pair } from './pair.entity';
 @Entity({
   name: 'pair_transactions',
 })
+// Backs the per-pair, time-ordered history query (PairHistoryService) and the
+// from_date/to_date range filter. Index name is shared with the idempotent
+// bootstrap so synchronize-based and production environments converge on one
+// index. Keep both in sync if you rename it.
+@Index('IDX_pair_transactions_pair_created_at', ['pair', 'created_at'])
 export class PairTransaction {
   @PrimaryColumn()
   tx_hash: string;

--- a/src/dex/services/dex-schema-bootstrap.service.spec.ts
+++ b/src/dex/services/dex-schema-bootstrap.service.spec.ts
@@ -3,8 +3,18 @@ import { DexSchemaBootstrapService } from './dex-schema-bootstrap.service';
 
 describe('DexSchemaBootstrapService', () => {
   const makeService = (query: jest.Mock) => {
-    const dataSource = { query };
-    return new DexSchemaBootstrapService(dataSource as any);
+    const queryRunner = {
+      connect: jest.fn().mockResolvedValue(undefined),
+      query,
+      release: jest.fn().mockResolvedValue(undefined),
+    };
+    const dataSource = {
+      createQueryRunner: jest.fn().mockReturnValue(queryRunner),
+    };
+    return {
+      service: new DexSchemaBootstrapService(dataSource as any),
+      queryRunner,
+    };
   };
 
   beforeEach(() => {
@@ -15,23 +25,21 @@ describe('DexSchemaBootstrapService', () => {
     jest.restoreAllMocks();
   });
 
-  it('runs every bootstrap statement once on init', async () => {
+  it('runs every required and index statement on init', async () => {
     const query = jest.fn().mockResolvedValue(undefined);
-    const service = makeService(query);
+    const { service } = makeService(query);
 
     await service.onModuleInit();
 
-    expect(query).toHaveBeenCalledTimes(
-      DexSchemaBootstrapService.STATEMENTS.length,
-    );
+    const executed = query.mock.calls.map((call) => call[0] as string);
     for (const statement of DexSchemaBootstrapService.STATEMENTS) {
-      expect(query).toHaveBeenCalledWith(statement);
+      expect(executed).toContain(statement);
     }
   });
 
   it('ensures the listed column and pair-history index idempotently', async () => {
     const query = jest.fn().mockResolvedValue(undefined);
-    const service = makeService(query);
+    const { service } = makeService(query);
 
     await service.onModuleInit();
 
@@ -53,19 +61,64 @@ describe('DexSchemaBootstrapService', () => {
     ).toBe(true);
   });
 
-  it('does not throw and continues when a statement fails', async () => {
-    const query = jest
-      .fn()
-      .mockRejectedValueOnce(new Error('boom'))
-      .mockResolvedValue(undefined);
-    const service = makeService(query);
+  it('creates the new feed/FK/listed indexes', async () => {
+    const query = jest.fn().mockResolvedValue(undefined);
+    const { service } = makeService(query);
+
+    await service.onModuleInit();
+
+    const executed = query.mock.calls.map((call) => call[0] as string).join('\n');
+    expect(executed).toMatch(/IDX_pair_transactions_created_at/);
+    expect(executed).toMatch(/IDX_pair_transactions_tx_type/);
+    expect(executed).toMatch(/IDX_pair_transactions_account_address/);
+    expect(executed).toMatch(/IDX_pairs_token0_address/);
+    expect(executed).toMatch(/IDX_pairs_token1_address/);
+    expect(executed).toMatch(/IDX_dex_tokens_listed/);
+  });
+
+  it('serialises DDL behind an advisory lock and always releases it', async () => {
+    const query = jest.fn().mockResolvedValue(undefined);
+    const { service, queryRunner } = makeService(query);
+
+    await service.onModuleInit();
+
+    const calls = query.mock.calls.map((call) => call[0] as string);
+    expect(calls[0]).toMatch(/pg_advisory_lock/);
+    expect(calls[calls.length - 1]).toMatch(/pg_advisory_unlock/);
+    expect(queryRunner.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('aborts startup when a REQUIRED statement fails (and still releases)', async () => {
+    // First non-lock statement is the required `listed` column ALTER.
+    const query = jest.fn().mockImplementation((sql: string) => {
+      if (/ALTER TABLE "dex_tokens"/.test(sql)) {
+        return Promise.reject(new Error('permission denied'));
+      }
+      return Promise.resolve(undefined);
+    });
+    const { service, queryRunner } = makeService(query);
+
+    await expect(service.onModuleInit()).rejects.toThrow('permission denied');
+
+    // Lock must be released and the connection returned even on failure.
+    const calls = query.mock.calls.map((call) => call[0] as string);
+    expect(calls.some((sql) => /pg_advisory_unlock/.test(sql))).toBe(true);
+    expect(queryRunner.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('continues (best-effort) when an INDEX statement fails', async () => {
+    const query = jest.fn().mockImplementation((sql: string) => {
+      if (/IDX_pair_transactions_created_at/.test(sql)) {
+        return Promise.reject(new Error('boom'));
+      }
+      return Promise.resolve(undefined);
+    });
+    const { service } = makeService(query);
 
     await expect(service.onModuleInit()).resolves.toBeUndefined();
-
-    // The failing first statement must not prevent the remaining ones.
-    expect(query).toHaveBeenCalledTimes(
-      DexSchemaBootstrapService.STATEMENTS.length,
-    );
     expect(Logger.prototype.error).toHaveBeenCalled();
+    // Later index statements still ran despite the earlier failure.
+    const executed = query.mock.calls.map((call) => call[0] as string).join('\n');
+    expect(executed).toMatch(/IDX_pairs_token0_address/);
   });
 });

--- a/src/dex/services/dex-schema-bootstrap.service.spec.ts
+++ b/src/dex/services/dex-schema-bootstrap.service.spec.ts
@@ -67,7 +67,9 @@ describe('DexSchemaBootstrapService', () => {
 
     await service.onModuleInit();
 
-    const executed = query.mock.calls.map((call) => call[0] as string).join('\n');
+    const executed = query.mock.calls
+      .map((call) => call[0] as string)
+      .join('\n');
     expect(executed).toMatch(/IDX_pair_transactions_created_at/);
     expect(executed).toMatch(/IDX_pair_transactions_tx_type/);
     expect(executed).toMatch(/IDX_pair_transactions_account_address/);
@@ -118,7 +120,9 @@ describe('DexSchemaBootstrapService', () => {
     await expect(service.onModuleInit()).resolves.toBeUndefined();
     expect(Logger.prototype.error).toHaveBeenCalled();
     // Later index statements still ran despite the earlier failure.
-    const executed = query.mock.calls.map((call) => call[0] as string).join('\n');
+    const executed = query.mock.calls
+      .map((call) => call[0] as string)
+      .join('\n');
     expect(executed).toMatch(/IDX_pairs_token0_address/);
   });
 });

--- a/src/dex/services/dex-schema-bootstrap.service.spec.ts
+++ b/src/dex/services/dex-schema-bootstrap.service.spec.ts
@@ -1,0 +1,71 @@
+import { Logger } from '@nestjs/common';
+import { DexSchemaBootstrapService } from './dex-schema-bootstrap.service';
+
+describe('DexSchemaBootstrapService', () => {
+  const makeService = (query: jest.Mock) => {
+    const dataSource = { query };
+    return new DexSchemaBootstrapService(dataSource as any);
+  };
+
+  beforeEach(() => {
+    jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('runs every bootstrap statement once on init', async () => {
+    const query = jest.fn().mockResolvedValue(undefined);
+    const service = makeService(query);
+
+    await service.onModuleInit();
+
+    expect(query).toHaveBeenCalledTimes(
+      DexSchemaBootstrapService.STATEMENTS.length,
+    );
+    for (const statement of DexSchemaBootstrapService.STATEMENTS) {
+      expect(query).toHaveBeenCalledWith(statement);
+    }
+  });
+
+  it('ensures the listed column and pair-history index idempotently', async () => {
+    const query = jest.fn().mockResolvedValue(undefined);
+    const service = makeService(query);
+
+    await service.onModuleInit();
+
+    const executed = query.mock.calls.map((call) => call[0] as string);
+    expect(
+      executed.some(
+        (sql) =>
+          /ALTER TABLE "dex_tokens"/.test(sql) &&
+          /ADD COLUMN IF NOT EXISTS "listed"/.test(sql),
+      ),
+    ).toBe(true);
+    expect(
+      executed.some(
+        (sql) =>
+          /CREATE INDEX IF NOT EXISTS "IDX_pair_transactions_pair_created_at"/.test(
+            sql,
+          ) && /\("pair_address", "created_at"\)/.test(sql),
+      ),
+    ).toBe(true);
+  });
+
+  it('does not throw and continues when a statement fails', async () => {
+    const query = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValue(undefined);
+    const service = makeService(query);
+
+    await expect(service.onModuleInit()).resolves.toBeUndefined();
+
+    // The failing first statement must not prevent the remaining ones.
+    expect(query).toHaveBeenCalledTimes(
+      DexSchemaBootstrapService.STATEMENTS.length,
+    );
+    expect(Logger.prototype.error).toHaveBeenCalled();
+  });
+});

--- a/src/dex/services/dex-schema-bootstrap.service.ts
+++ b/src/dex/services/dex-schema-bootstrap.service.ts
@@ -6,40 +6,93 @@ import { DataSource } from 'typeorm';
  * Ensures DEX schema additions that post-date the original tables exist in
  * every environment — including production, where TypeORM `synchronize` is
  * disabled (see src/configs/database.ts) and would otherwise never create the
- * new `dex_tokens.listed` column or the pair-history index.
+ * new `dex_tokens.listed` column or the performance indexes the DEX endpoints
+ * rely on.
  *
- * Every statement is idempotent (`IF NOT EXISTS`), so this is a no-op once the
- * schema is up to date and is safe to run on every boot. A failed statement is
- * logged but does not crash startup. This is a deliberate stop-gap until the
- * project adopts real TypeORM migrations.
+ * Every statement is idempotent (`IF NOT EXISTS`). The whole run is serialised
+ * across application instances with a Postgres advisory lock so that concurrent
+ * boots (rolling deploys, multiple pods) don't race or deadlock on the same
+ * DDL. Required statements (the `listed` column) fail fast — the rest of the
+ * module hard-depends on the column, so it is better to crash the boot than to
+ * serve 500s on every `/dex/tokens` query. Index creation is best-effort:
+ * indexes are performance, not correctness, so a failure is logged and boot
+ * continues.
+ *
+ * This is a deliberate stop-gap until the project adopts real TypeORM
+ * migrations. Note: index builds use a plain `CREATE INDEX` and therefore take
+ * a brief write lock on the target table; on a very large `pair_transactions`
+ * table a one-time migration with `CREATE INDEX CONCURRENTLY` is preferable.
  */
 @Injectable()
 export class DexSchemaBootstrapService implements OnModuleInit {
   private readonly logger = new Logger(DexSchemaBootstrapService.name);
 
-  // The index name MUST match the @Index decorator on PairTransaction so that
-  // synchronize-based environments and this bootstrap converge on a single
-  // index instead of creating two with different generated names.
-  static readonly STATEMENTS: readonly string[] = [
+  // Arbitrary, stable key so every instance contends on the same advisory lock.
+  private static readonly ADVISORY_LOCK_KEY = 4019283746;
+
+  // Correctness-critical: the module reads/writes this column, so a failure
+  // here must abort startup rather than be swallowed.
+  static readonly REQUIRED_STATEMENTS: readonly string[] = [
     `ALTER TABLE "dex_tokens" ADD COLUMN IF NOT EXISTS "listed" boolean NOT NULL DEFAULT false`,
-    `CREATE INDEX IF NOT EXISTS "IDX_pair_transactions_pair_created_at" ON "pair_transactions" ("pair_address", "created_at")`,
   ];
+
+  // Performance-only. The pair-history index name MUST match the @Index
+  // decorator on PairTransaction so synchronize-based environments and this
+  // bootstrap converge on a single index instead of two with different names.
+  static readonly INDEX_STATEMENTS: readonly string[] = [
+    `CREATE INDEX IF NOT EXISTS "IDX_pair_transactions_pair_created_at" ON "pair_transactions" ("pair_address", "created_at")`,
+    // Global transactions feed: ordering / from_date-to_date range when no pair filter is set.
+    `CREATE INDEX IF NOT EXISTS "IDX_pair_transactions_created_at" ON "pair_transactions" ("created_at")`,
+    // Feed filters by transaction type and by account.
+    `CREATE INDEX IF NOT EXISTS "IDX_pair_transactions_tx_type" ON "pair_transactions" ("tx_type")`,
+    `CREATE INDEX IF NOT EXISTS "IDX_pair_transactions_account_address" ON "pair_transactions" ("account_address")`,
+    // "pairs/transactions by token" filters and findBestPairForToken: FK columns
+    // are not auto-indexed by Postgres.
+    `CREATE INDEX IF NOT EXISTS "IDX_pairs_token0_address" ON "pairs" ("token0_address")`,
+    `CREATE INDEX IF NOT EXISTS "IDX_pairs_token1_address" ON "pairs" ("token1_address")`,
+    // ?listed=true is the common (small) filtered slice — a partial index keeps it tiny.
+    `CREATE INDEX IF NOT EXISTS "IDX_dex_tokens_listed" ON "dex_tokens" ("listed") WHERE "listed" = true`,
+  ];
+
+  /** Back-compat: the full ordered statement list (required first, then indexes). */
+  static get STATEMENTS(): readonly string[] {
+    return [...this.REQUIRED_STATEMENTS, ...this.INDEX_STATEMENTS];
+  }
 
   constructor(@InjectDataSource() private readonly dataSource: DataSource) {}
 
   async onModuleInit(): Promise<void> {
-    for (const statement of DexSchemaBootstrapService.STATEMENTS) {
+    // Use a single dedicated connection so the advisory lock and the DDL run on
+    // the same session (advisory locks are session-scoped).
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    try {
+      await queryRunner.query('SELECT pg_advisory_lock($1)', [
+        DexSchemaBootstrapService.ADVISORY_LOCK_KEY,
+      ]);
       try {
-        await this.dataSource.query(statement);
-      } catch (error) {
-        // Don't take the whole app down over a schema bootstrap hiccup;
-        // synchronize-based environments may already own the schema. Surface
-        // the failure loudly so a genuinely missing column is noticed.
-        this.logger.error(
-          `DEX schema bootstrap statement failed: ${statement}`,
-          error instanceof Error ? error.stack : String(error),
-        );
+        // Required: let failures propagate and abort startup.
+        for (const statement of DexSchemaBootstrapService.REQUIRED_STATEMENTS) {
+          await queryRunner.query(statement);
+        }
+        // Best-effort: log and continue so a missing-index hiccup never blocks boot.
+        for (const statement of DexSchemaBootstrapService.INDEX_STATEMENTS) {
+          try {
+            await queryRunner.query(statement);
+          } catch (error) {
+            this.logger.error(
+              `DEX schema bootstrap index statement failed: ${statement}`,
+              error instanceof Error ? error.stack : String(error),
+            );
+          }
+        }
+      } finally {
+        await queryRunner.query('SELECT pg_advisory_unlock($1)', [
+          DexSchemaBootstrapService.ADVISORY_LOCK_KEY,
+        ]);
       }
+    } finally {
+      await queryRunner.release();
     }
   }
 }

--- a/src/dex/services/dex-schema-bootstrap.service.ts
+++ b/src/dex/services/dex-schema-bootstrap.service.ts
@@ -1,0 +1,45 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { InjectDataSource } from '@nestjs/typeorm';
+import { DataSource } from 'typeorm';
+
+/**
+ * Ensures DEX schema additions that post-date the original tables exist in
+ * every environment — including production, where TypeORM `synchronize` is
+ * disabled (see src/configs/database.ts) and would otherwise never create the
+ * new `dex_tokens.listed` column or the pair-history index.
+ *
+ * Every statement is idempotent (`IF NOT EXISTS`), so this is a no-op once the
+ * schema is up to date and is safe to run on every boot. A failed statement is
+ * logged but does not crash startup. This is a deliberate stop-gap until the
+ * project adopts real TypeORM migrations.
+ */
+@Injectable()
+export class DexSchemaBootstrapService implements OnModuleInit {
+  private readonly logger = new Logger(DexSchemaBootstrapService.name);
+
+  // The index name MUST match the @Index decorator on PairTransaction so that
+  // synchronize-based environments and this bootstrap converge on a single
+  // index instead of creating two with different generated names.
+  static readonly STATEMENTS: readonly string[] = [
+    `ALTER TABLE "dex_tokens" ADD COLUMN IF NOT EXISTS "listed" boolean NOT NULL DEFAULT false`,
+    `CREATE INDEX IF NOT EXISTS "IDX_pair_transactions_pair_created_at" ON "pair_transactions" ("pair_address", "created_at")`,
+  ];
+
+  constructor(@InjectDataSource() private readonly dataSource: DataSource) {}
+
+  async onModuleInit(): Promise<void> {
+    for (const statement of DexSchemaBootstrapService.STATEMENTS) {
+      try {
+        await this.dataSource.query(statement);
+      } catch (error) {
+        // Don't take the whole app down over a schema bootstrap hiccup;
+        // synchronize-based environments may already own the schema. Surface
+        // the failure loudly so a genuinely missing column is noticed.
+        this.logger.error(
+          `DEX schema bootstrap statement failed: ${statement}`,
+          error instanceof Error ? error.stack : String(error),
+        );
+      }
+    }
+  }
+}

--- a/src/dex/services/dex-token.service.spec.ts
+++ b/src/dex/services/dex-token.service.spec.ts
@@ -136,6 +136,30 @@ describe('DexTokenService', () => {
       expect(best?.basePosition).toBe('token1');
     });
 
+    it('skips a zero-liquidity WAE pool in favor of an active non-WAE pool', async () => {
+      // A WAE pool exists but is empty; the only liquid pool is non-WAE. The
+      // empty WAE pool must NOT be chosen (it would yield empty charts).
+      const { service } = setupWithPairs([
+        makePair('ct_wae_empty', 'ct_token', DEX_CONTRACTS.wae, 1, 1, '0', '0'),
+        makePair('ct_active', 'ct_token', 'ct_mid', 1, 1, '500', '500'),
+      ]);
+
+      const best = await service.findBestPairForToken('ct_token');
+
+      expect(best?.pair.address).toBe('ct_active');
+    });
+
+    it('still prefers a liquid WAE pool over a deeper non-WAE pool', async () => {
+      const { service } = setupWithPairs([
+        makePair('ct_deep_nonwae', 'ct_token', 'ct_mid', 1, 1, '999', '999'),
+        makePair('ct_wae', 'ct_token', DEX_CONTRACTS.wae, 1, 1, '100', '100'),
+      ]);
+
+      const best = await service.findBestPairForToken('ct_token');
+
+      expect(best?.pair.address).toBe('ct_wae');
+    });
+
     it('falls back to the deepest pool when no WAE pair exists', async () => {
       const { service } = setupWithPairs([
         makePair('ct_shallow', 'ct_mid', 'ct_token', 1, 1, '10', '10'),
@@ -154,11 +178,7 @@ describe('DexTokenService', () => {
       // with mid at reserve 5 (tiny). Pair B: token 6 decimals reserve
       // 2_000_000 (=2.0 human) with mid reserve 10. Raw min would pick A's
       // mid-side 5; human-normalised depth should still pick the deeper pool B.
-      const withDecimals = (
-        address: string,
-        r0: string,
-        r1: string,
-      ): any => ({
+      const withDecimals = (address: string, r0: string, r1: string): any => ({
         address,
         token0: { address: 'ct_token', decimals: 6 },
         token1: { address: 'ct_mid', decimals: 18 },
@@ -178,7 +198,10 @@ describe('DexTokenService', () => {
 
   describe('setListed', () => {
     it('returns null when the token does not exist', async () => {
-      const repository = { findOne: jest.fn().mockResolvedValue(null), save: jest.fn() };
+      const repository = {
+        findOne: jest.fn().mockResolvedValue(null),
+        save: jest.fn(),
+      };
       const service = new DexTokenService(repository as any, {} as any);
 
       expect(await service.setListed('ct_missing', true)).toBeNull();

--- a/src/dex/services/dex-token.service.spec.ts
+++ b/src/dex/services/dex-token.service.spec.ts
@@ -80,21 +80,43 @@ describe('DexTokenService', () => {
   });
 
   describe('findBestPairForToken', () => {
+    // findBestPairForToken does a TARGETED query (only pairs containing the
+    // token) rather than loading the whole table, so we mock the query builder.
+    const setupWithPairs = (pairs: any[]) => {
+      const qb: any = {
+        leftJoinAndSelect: jest.fn(() => qb),
+        where: jest.fn(() => qb),
+        getMany: jest.fn().mockResolvedValue(pairs),
+      };
+      const pairRepository = {
+        createQueryBuilder: jest.fn(() => qb),
+      };
+      const service = new DexTokenService({} as any, pairRepository as any);
+      return { service, qb };
+    };
+
     it('returns null when the token has no pairs', async () => {
-      const { service } = setup();
-      jest
-        .spyOn(service, 'getAllPairsWithTokens')
-        .mockResolvedValue([
-          makePair('ct_other', 'ct_a', 'ct_b', 1, 1),
-        ] as any);
+      const { service } = setupWithPairs([]);
 
       expect(await service.findBestPairForToken('ct_token')).toBeNull();
     });
 
+    it('queries only the pairs that contain the token', async () => {
+      const { service, qb } = setupWithPairs([
+        makePair('ct_pair', 'ct_token', DEX_CONTRACTS.wae, 1, 1),
+      ]);
+
+      await service.findBestPairForToken('ct_token');
+
+      expect(qb.where).toHaveBeenCalledWith(
+        'token0.address = :tokenAddress OR token1.address = :tokenAddress',
+        { tokenAddress: 'ct_token' },
+      );
+    });
+
     it('prefers a WAE pair and quotes the token against WAE (basePosition)', async () => {
-      const { service } = setup();
       // Deepest pool is a non-WAE pair, but a WAE pair exists and must win.
-      jest.spyOn(service, 'getAllPairsWithTokens').mockResolvedValue([
+      const { service } = setupWithPairs([
         makePair('ct_deep_nonwae', 'ct_token', 'ct_mid', 1, 1, '999', '999'),
         makePair(
           'ct_wae_pair',
@@ -105,7 +127,7 @@ describe('DexTokenService', () => {
           '100',
           '100',
         ),
-      ] as any);
+      ]);
 
       const best = await service.findBestPairForToken('ct_token');
 
@@ -115,17 +137,42 @@ describe('DexTokenService', () => {
     });
 
     it('falls back to the deepest pool when no WAE pair exists', async () => {
-      const { service } = setup();
-      jest.spyOn(service, 'getAllPairsWithTokens').mockResolvedValue([
+      const { service } = setupWithPairs([
         makePair('ct_shallow', 'ct_mid', 'ct_token', 1, 1, '10', '10'),
         makePair('ct_deep', 'ct_mid', 'ct_token', 1, 1, '500', '500'),
-      ] as any);
+      ]);
 
       const best = await service.findBestPairForToken('ct_token');
 
       expect(best?.pair.address).toBe('ct_deep');
       // token is token1, so the base (quote) token is token0.
       expect(best?.basePosition).toBe('token0');
+    });
+
+    it('ranks depth in human units, not raw reserves (decimal-aware)', async () => {
+      // Pair A: token has 6 decimals, reserve 1_000_000 (=1.0 human) paired
+      // with mid at reserve 5 (tiny). Pair B: token 6 decimals reserve
+      // 2_000_000 (=2.0 human) with mid reserve 10. Raw min would pick A's
+      // mid-side 5; human-normalised depth should still pick the deeper pool B.
+      const withDecimals = (
+        address: string,
+        r0: string,
+        r1: string,
+      ): any => ({
+        address,
+        token0: { address: 'ct_token', decimals: 6 },
+        token1: { address: 'ct_mid', decimals: 18 },
+        reserve0: r0,
+        reserve1: r1,
+      });
+      const { service } = setupWithPairs([
+        withDecimals('ct_a', '1000000', '5000000000000000000'),
+        withDecimals('ct_b', '2000000', '10000000000000000000'),
+      ]);
+
+      const best = await service.findBestPairForToken('ct_token');
+
+      expect(best?.pair.address).toBe('ct_b');
     });
   });
 

--- a/src/dex/services/dex-token.service.spec.ts
+++ b/src/dex/services/dex-token.service.spec.ts
@@ -1,4 +1,8 @@
+import { paginate } from 'nestjs-typeorm-paginate';
 import { DexTokenService } from './dex-token.service';
+import { DEX_CONTRACTS } from '../config/dex-contracts.config';
+
+jest.mock('nestjs-typeorm-paginate');
 
 describe('DexTokenService', () => {
   const makePair = (
@@ -72,6 +76,128 @@ describe('DexTokenService', () => {
       price: expect.any(String),
       liquidity: expect.any(Number),
       confidence: expect.any(Number),
+    });
+  });
+
+  describe('findBestPairForToken', () => {
+    it('returns null when the token has no pairs', async () => {
+      const { service } = setup();
+      jest
+        .spyOn(service, 'getAllPairsWithTokens')
+        .mockResolvedValue([
+          makePair('ct_other', 'ct_a', 'ct_b', 1, 1),
+        ] as any);
+
+      expect(await service.findBestPairForToken('ct_token')).toBeNull();
+    });
+
+    it('prefers a WAE pair and quotes the token against WAE (basePosition)', async () => {
+      const { service } = setup();
+      // Deepest pool is a non-WAE pair, but a WAE pair exists and must win.
+      jest.spyOn(service, 'getAllPairsWithTokens').mockResolvedValue([
+        makePair('ct_deep_nonwae', 'ct_token', 'ct_mid', 1, 1, '999', '999'),
+        makePair(
+          'ct_wae_pair',
+          'ct_token',
+          DEX_CONTRACTS.wae,
+          1,
+          1,
+          '100',
+          '100',
+        ),
+      ] as any);
+
+      const best = await service.findBestPairForToken('ct_token');
+
+      expect(best?.pair.address).toBe('ct_wae_pair');
+      // token is token0, so the base (quote) token is token1 (WAE).
+      expect(best?.basePosition).toBe('token1');
+    });
+
+    it('falls back to the deepest pool when no WAE pair exists', async () => {
+      const { service } = setup();
+      jest.spyOn(service, 'getAllPairsWithTokens').mockResolvedValue([
+        makePair('ct_shallow', 'ct_mid', 'ct_token', 1, 1, '10', '10'),
+        makePair('ct_deep', 'ct_mid', 'ct_token', 1, 1, '500', '500'),
+      ] as any);
+
+      const best = await service.findBestPairForToken('ct_token');
+
+      expect(best?.pair.address).toBe('ct_deep');
+      // token is token1, so the base (quote) token is token0.
+      expect(best?.basePosition).toBe('token0');
+    });
+  });
+
+  describe('setListed', () => {
+    it('returns null when the token does not exist', async () => {
+      const repository = { findOne: jest.fn().mockResolvedValue(null), save: jest.fn() };
+      const service = new DexTokenService(repository as any, {} as any);
+
+      expect(await service.setListed('ct_missing', true)).toBeNull();
+      expect(repository.save).not.toHaveBeenCalled();
+    });
+
+    it('updates and persists the listed flag', async () => {
+      const token = { address: 'ct_token', listed: false };
+      const repository = {
+        findOne: jest.fn().mockResolvedValue(token),
+        save: jest.fn().mockImplementation((t) => Promise.resolve(t)),
+      };
+      const service = new DexTokenService(repository as any, {} as any);
+
+      const result = await service.setListed('ct_token', true);
+
+      expect(result?.listed).toBe(true);
+      expect(repository.save).toHaveBeenCalledWith(
+        expect.objectContaining({ address: 'ct_token', listed: true }),
+      );
+    });
+  });
+
+  describe('findAll listed filter', () => {
+    const makeQb = () => {
+      const qb: any = {};
+      qb.leftJoinAndSelect = jest.fn(() => qb);
+      qb.andWhere = jest.fn(() => qb);
+      qb.orderBy = jest.fn(() => qb);
+      return qb;
+    };
+
+    beforeEach(() => {
+      (paginate as jest.Mock).mockReset();
+      (paginate as jest.Mock).mockResolvedValue({ items: [], meta: {} });
+    });
+
+    it('filters by listed when the flag is provided', async () => {
+      const qb = makeQb();
+      const repository = { createQueryBuilder: jest.fn(() => qb) };
+      const service = new DexTokenService(repository as any, {} as any);
+
+      await service.findAll(
+        { page: 1, limit: 100 },
+        '',
+        'created_at',
+        'DESC',
+        true,
+      );
+
+      expect(qb.andWhere).toHaveBeenCalledWith('dexToken.listed = :listed', {
+        listed: true,
+      });
+    });
+
+    it('does not filter by listed when the flag is omitted', async () => {
+      const qb = makeQb();
+      const repository = { createQueryBuilder: jest.fn(() => qb) };
+      const service = new DexTokenService(repository as any, {} as any);
+
+      await service.findAll({ page: 1, limit: 100 }, '', 'created_at', 'DESC');
+
+      const listedClauses = qb.andWhere.mock.calls.filter((call: any[]) =>
+        String(call[0]).includes('listed'),
+      );
+      expect(listedClauses).toHaveLength(0);
     });
   });
 });

--- a/src/dex/services/dex-token.service.ts
+++ b/src/dex/services/dex-token.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import BigNumber from 'bignumber.js';
 import { DexToken } from '../entities/dex-token.entity';
 import {
   IPaginationOptions,
@@ -161,27 +162,34 @@ export class DexTokenService {
   async findBestPairForToken(
     tokenAddress: string,
   ): Promise<{ pair: Pair; basePosition: 'token0' | 'token1' } | null> {
-    const allPairs = await this.getAllPairsWithTokens();
-    const candidates = allPairs.filter(
-      (pair) =>
-        pair.token0?.address === tokenAddress ||
-        pair.token1?.address === tokenAddress,
-    );
+    // Targeted lookup: only the pairs that contain this token, instead of
+    // loading the entire pairs table into memory on every chart request.
+    const candidates = await this.pairRepository
+      .createQueryBuilder('pair')
+      .leftJoinAndSelect('pair.token0', 'token0')
+      .leftJoinAndSelect('pair.token1', 'token1')
+      .where(
+        'token0.address = :tokenAddress OR token1.address = :tokenAddress',
+        { tokenAddress },
+      )
+      .getMany();
     if (candidates.length === 0) {
       return null;
     }
 
-    // Liquidity-depth proxy: the smaller of the two reserves. NOTE this is a
-    // coarse heuristic — reserves are raw amounts in tokens that may have
-    // different decimals, so cross-pair comparison is not strictly apples to
-    // apples. It is only used to break ties when picking a charting pool (the
-    // WAE-preference below is what actually matters), so a slightly imperfect
-    // ranking is acceptable here.
-    const liquidity = (pair: Pair) =>
-      Math.min(
-        parseFloat(String(pair.reserve0 ?? '0')) || 0,
-        parseFloat(String(pair.reserve1 ?? '0')) || 0,
+    // Liquidity-depth proxy: the smaller of the two reserves, normalised to
+    // human units by each token's decimals so pools with different-decimal
+    // tokens are compared apples-to-apples. Used to pick the deepest charting
+    // pool (after the WAE-preference below, which is what actually matters).
+    const liquidity = (pair: Pair) => {
+      const r0 = new BigNumber(String(pair.reserve0 ?? '0')).shiftedBy(
+        -Number(pair.token0?.decimals ?? 18),
       );
+      const r1 = new BigNumber(String(pair.reserve1 ?? '0')).shiftedBy(
+        -Number(pair.token1?.decimals ?? 18),
+      );
+      return BigNumber.min(r0, r1).toNumber();
+    };
 
     const isWaePair = (pair: Pair) =>
       pair.token0?.address === DEX_CONTRACTS.wae ||
@@ -201,7 +209,7 @@ export class DexTokenService {
     return { pair, basePosition };
   }
 
-  async findByAddress(address: string): Promise<DexToken> {
+  async findByAddress(address: string): Promise<DexToken | null> {
     return this.dexTokenRepository
       .createQueryBuilder('dexToken')
       .leftJoinAndSelect('dexToken.summary', 'summary')

--- a/src/dex/services/dex-token.service.ts
+++ b/src/dex/services/dex-token.service.ts
@@ -51,10 +51,15 @@ export class DexTokenService {
     search: string = '',
     orderBy: string = 'created_at',
     orderDirection: 'ASC' | 'DESC' = 'DESC',
+    listed?: boolean,
   ): Promise<Pagination<DexToken>> {
     const query = this.dexTokenRepository
       .createQueryBuilder('dexToken')
       .leftJoinAndSelect('dexToken.summary', 'summary');
+
+    if (listed !== undefined) {
+      query.andWhere('dexToken.listed = :listed', { listed });
+    }
 
     const allowedOrderFields = [
       'pairs_count',
@@ -145,12 +150,73 @@ export class DexTokenService {
     return paginate(query, options);
   }
 
+  /**
+   * Find the most relevant pair to chart a single token's price.
+   * Prefers a pair quoted against WAE (so the price is expressed in AE),
+   * and among the candidates picks the one with the deepest liquidity.
+   * Returns the pair plus the position ('token0' | 'token1') of the quote
+   * (base) token, which callers pass as `fromToken` to PairHistoryService so
+   * the resulting price series is the requested token priced in the base token.
+   */
+  async findBestPairForToken(
+    tokenAddress: string,
+  ): Promise<{ pair: Pair; basePosition: 'token0' | 'token1' } | null> {
+    const allPairs = await this.getAllPairsWithTokens();
+    const candidates = allPairs.filter(
+      (pair) =>
+        pair.token0?.address === tokenAddress ||
+        pair.token1?.address === tokenAddress,
+    );
+    if (candidates.length === 0) {
+      return null;
+    }
+
+    // Liquidity-depth proxy: the smaller of the two reserves. NOTE this is a
+    // coarse heuristic — reserves are raw amounts in tokens that may have
+    // different decimals, so cross-pair comparison is not strictly apples to
+    // apples. It is only used to break ties when picking a charting pool (the
+    // WAE-preference below is what actually matters), so a slightly imperfect
+    // ranking is acceptable here.
+    const liquidity = (pair: Pair) =>
+      Math.min(
+        parseFloat(String(pair.reserve0 ?? '0')) || 0,
+        parseFloat(String(pair.reserve1 ?? '0')) || 0,
+      );
+
+    const isWaePair = (pair: Pair) =>
+      pair.token0?.address === DEX_CONTRACTS.wae ||
+      pair.token1?.address === DEX_CONTRACTS.wae;
+
+    const waePairs = candidates.filter(isWaePair);
+    const pool = waePairs.length > 0 ? waePairs : candidates;
+
+    const pair = pool.reduce((best, current) =>
+      liquidity(current) > liquidity(best) ? current : best,
+    );
+
+    // The base (quote) token is the one that is NOT the requested token.
+    const basePosition: 'token0' | 'token1' =
+      pair.token0?.address === tokenAddress ? 'token1' : 'token0';
+
+    return { pair, basePosition };
+  }
+
   async findByAddress(address: string): Promise<DexToken> {
     return this.dexTokenRepository
       .createQueryBuilder('dexToken')
       .leftJoinAndSelect('dexToken.summary', 'summary')
       .where('dexToken.address = :address', { address })
       .getOne();
+  }
+
+  /** Toggle the curated "listed" flag for a token. Returns the updated token. */
+  async setListed(address: string, listed: boolean): Promise<DexToken | null> {
+    const token = await this.dexTokenRepository.findOne({ where: { address } });
+    if (!token) {
+      return null;
+    }
+    token.listed = listed;
+    return this.dexTokenRepository.save(token);
   }
 
   async getTokenPrice(

--- a/src/dex/services/dex-token.service.ts
+++ b/src/dex/services/dex-token.service.ts
@@ -195,8 +195,15 @@ export class DexTokenService {
       pair.token0?.address === DEX_CONTRACTS.wae ||
       pair.token1?.address === DEX_CONTRACTS.wae;
 
-    const waePairs = candidates.filter(isWaePair);
-    const pool = waePairs.length > 0 ? waePairs : candidates;
+    // Prefer a WAE pair so the series is AE-denominated — but only among WAE
+    // pools that actually have liquidity. Otherwise an empty/zero-liquidity WAE
+    // pool would be chosen over an active non-WAE pool, producing useless or
+    // empty charts. With no liquid WAE pool, fall back to the deepest pool among
+    // all candidates.
+    const liquidWaePairs = candidates.filter(
+      (candidate) => isWaePair(candidate) && liquidity(candidate) > 0,
+    );
+    const pool = liquidWaePairs.length > 0 ? liquidWaePairs : candidates;
 
     const pair = pool.reduce((best, current) =>
       liquidity(current) > liquidity(best) ? current : best,

--- a/src/dex/services/pair-history.service.spec.ts
+++ b/src/dex/services/pair-history.service.spec.ts
@@ -1,10 +1,13 @@
+import { BadRequestException } from '@nestjs/common';
 import { PairHistoryService } from './pair-history.service';
 import { Pair } from '../entities/pair.entity';
+import { DEX_CONTRACTS } from '../config/dex-contracts.config';
 
 describe('PairHistoryService', () => {
   let service: PairHistoryService;
   let queryRunnerMock: { query: jest.Mock; release: jest.Mock };
   let dataSourceMock: { createQueryRunner: jest.Mock };
+  let aePricingMock: { getCurrencyRates: jest.Mock };
 
   beforeEach(() => {
     queryRunnerMock = {
@@ -14,11 +17,14 @@ describe('PairHistoryService', () => {
     dataSourceMock = {
       createQueryRunner: jest.fn().mockReturnValue(queryRunnerMock),
     };
+    aePricingMock = {
+      getCurrencyRates: jest.fn(),
+    };
 
     service = new PairHistoryService(
       {} as any,
       dataSourceMock as any,
-      {} as any,
+      aePricingMock as any,
     );
   });
 
@@ -27,6 +33,15 @@ describe('PairHistoryService', () => {
       address,
       token0: { symbol: 'TOK0' },
       token1: { symbol: 'TOK1' },
+    }) as any;
+
+  // A pair quoted against WAE: token1 is WAE, so with fromToken='token1' the
+  // base (quote) token is WAE and prices are AE-denominated → convertible.
+  const makeWaePair = (address = 'ct_waePair'): Pair =>
+    ({
+      address,
+      token0: { symbol: 'TOK', address: 'ct_token' },
+      token1: { symbol: 'WAE', address: DEX_CONTRACTS.wae },
     }) as any;
 
   describe('getPaginatedHistoricalData - SQL parameterization', () => {
@@ -149,6 +164,223 @@ describe('PairHistoryService', () => {
       expect(result[0].quote.close).toBe('1.8');
       // second interval's open should be the previous close
       expect(result[1].quote.open).toBe('1.8');
+    });
+  });
+
+  describe('getPaginatedHistoricalData - decimal normalization', () => {
+    // Token (token0, 6 decimals) priced against WAE (token1, 18 decimals).
+    // fromToken='token1' means WAE is the base, so the series is the token's
+    // price in AE. Stored ratios use RAW reserves, so the price must be scaled
+    // by 10^(quoteDecimals - baseDecimals) = 10^(6 - 18) = 10^-12.
+    const make6DecVsWaePair = (): Pair =>
+      ({
+        address: 'ct_token6dec_wae',
+        token0: { symbol: 'TOK', address: 'ct_token', decimals: 6 },
+        token1: { symbol: 'WAE', address: DEX_CONTRACTS.wae, decimals: 18 },
+      }) as any;
+
+    it('scales raw ratios to human price using the token decimals', async () => {
+      // Raw ratio1 = reserveWAE_raw / reserveTOK_raw. For 1000 WAE (1000e18)
+      // and 2000 TOK (2000e6): 1000e18 / 2000e6 = 5e11. Human price = 0.5 AE.
+      queryRunnerMock.query.mockResolvedValue([
+        {
+          timeOpen: new Date('2025-01-01T00:00:00Z'),
+          timeClose: new Date('2025-01-01T01:00:00Z'),
+          low: '500000000000',
+          high: '500000000000',
+          open: '500000000000',
+          close: '500000000000',
+          volume: '0',
+          timeMin: new Date('2025-01-01T00:05:00Z'),
+          timeMax: new Date('2025-01-01T00:55:00Z'),
+        },
+      ]);
+
+      const [result] = await service.getPaginatedHistoricalData({
+        pair: make6DecVsWaePair(),
+        interval: 3600,
+        page: 1,
+        limit: 10,
+        fromToken: 'token1',
+      });
+
+      expect(result.quote.close).toBe('0.5');
+      expect(result.quote.open).toBe('0.5');
+      // The charted token's symbol is the non-base token (TOK), not token0 blindly.
+      expect(result.quote.symbol).toBe('TOK');
+    });
+
+    it('leaves prices unscaled when both tokens share 18 decimals', async () => {
+      queryRunnerMock.query.mockResolvedValue([
+        {
+          timeOpen: new Date('2025-01-01T00:00:00Z'),
+          timeClose: new Date('2025-01-01T01:00:00Z'),
+          low: '1.0',
+          high: '2.0',
+          open: '1.5',
+          close: '1.8',
+          volume: '0',
+          timeMin: new Date('2025-01-01T00:05:00Z'),
+          timeMax: new Date('2025-01-01T00:55:00Z'),
+        },
+      ]);
+
+      const [result] = await service.getPaginatedHistoricalData({
+        pair: {
+          address: 'ct_equal',
+          token0: { symbol: 'A', address: 'ct_a', decimals: 18 },
+          token1: { symbol: 'B', address: 'ct_b', decimals: 18 },
+        } as any,
+        interval: 3600,
+        page: 1,
+        limit: 10,
+        fromToken: 'token0',
+      });
+
+      expect(result.quote.close).toBe('1.8');
+    });
+  });
+
+  describe('getPaginatedHistoricalData - currency conversion', () => {
+    const makeRow = (overrides: Record<string, unknown> = {}) => ({
+      timeOpen: new Date('2025-01-01T00:00:00Z'),
+      timeClose: new Date('2025-01-01T01:00:00Z'),
+      low: '1.0',
+      high: '2.0',
+      open: '1.5',
+      close: '1.8',
+      volume: '100',
+      market_cap: '5000',
+      total_supply: '10000',
+      timeMin: new Date('2025-01-01T00:05:00Z'),
+      timeMax: new Date('2025-01-01T00:55:00Z'),
+      ...overrides,
+    });
+
+    it('leaves values untouched and labels them "ae" by default (no fiat conversion)', async () => {
+      queryRunnerMock.query.mockResolvedValue([makeRow()]);
+
+      const [result] = await service.getPaginatedHistoricalData({
+        pair: makeWaePair(),
+        interval: 3600,
+        page: 1,
+        limit: 10,
+        fromToken: 'token1',
+      });
+
+      expect(result.quote.convertedTo).toBe('ae');
+      expect(result.quote.close).toBe('1.8');
+      expect(result.quote.volume).toBe(100);
+      // market_cap is not tracked for DEX pairs → null, not a fabricated value.
+      expect(result.quote.market_cap).toBeNull();
+      expect(result.quote.total_supply).toBeNull();
+      // No $5 currency parameter and no coin_prices join when not converting.
+      const [sql, params] = queryRunnerMock.query.mock.calls[0];
+      expect(params).toHaveLength(4);
+      expect(sql).not.toContain('coin_prices');
+      expect(aePricingMock.getCurrencyRates).not.toHaveBeenCalled();
+    });
+
+    it('joins coin_prices and passes the currency as $5 when converting', async () => {
+      queryRunnerMock.query.mockResolvedValue([
+        makeRow({ conversion_rate: '0.5' }),
+      ]);
+
+      await service.getPaginatedHistoricalData({
+        pair: makeWaePair(),
+        interval: 3600,
+        page: 2,
+        limit: 25,
+        fromToken: 'token1',
+        convertTo: 'usd',
+      });
+
+      const [sql, params] = queryRunnerMock.query.mock.calls[0];
+      expect(sql).toContain('coin_prices');
+      expect(sql).toContain('cp.rates->>$5');
+      expect(sql).toContain('as conversion_rate');
+      expect(params).toEqual(['ct_waePair', 3600, 25, 25, 'usd']);
+    });
+
+    it('converts each candle by its own historical rate from coin_prices', async () => {
+      // Two candles with different historical AE→USD rates.
+      queryRunnerMock.query.mockResolvedValue([
+        makeRow({ conversion_rate: '0.5' }),
+        makeRow({ open: '1.9', close: '2.2', conversion_rate: '2' }),
+      ]);
+
+      const result = await service.getPaginatedHistoricalData({
+        pair: makeWaePair(),
+        interval: 3600,
+        page: 1,
+        limit: 10,
+        fromToken: 'token1',
+        convertTo: 'usd',
+      });
+
+      expect(result[0].quote.convertedTo).toBe('usd');
+      expect(result[0].quote.high).toBe('1'); // 2.0 * 0.5
+      expect(result[0].quote.close).toBe('0.9'); // 1.8 * 0.5
+      expect(result[0].quote.volume).toBe(50); // 100 * 0.5
+      // market_cap / total_supply are not tracked for DEX pairs → null.
+      expect(result[0].quote.market_cap).toBeNull();
+      expect(result[0].quote.total_supply).toBeNull();
+      // Second candle uses its OWN rate (2), not the first candle's.
+      expect(result[1].quote.close).toBe('4.4'); // 2.2 * 2
+      // previous-close carry-over keeps the already-converted close
+      expect(result[1].quote.open).toBe('0.9');
+      expect(aePricingMock.getCurrencyRates).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the latest rate when a candle predates any coin_prices snapshot', async () => {
+      aePricingMock.getCurrencyRates.mockResolvedValue({ usd: 3 } as any);
+      queryRunnerMock.query.mockResolvedValue([
+        makeRow({ conversion_rate: null }),
+      ]);
+
+      const [result] = await service.getPaginatedHistoricalData({
+        pair: makeWaePair(),
+        interval: 3600,
+        page: 1,
+        limit: 10,
+        fromToken: 'token1',
+        convertTo: 'usd',
+      });
+
+      expect(aePricingMock.getCurrencyRates).toHaveBeenCalledTimes(1);
+      expect(result.quote.close).toBe('5.4'); // 1.8 * 3 (fallback)
+    });
+
+    it('rejects fiat conversion for a pool not quoted against WAE before querying', async () => {
+      await expect(
+        service.getPaginatedHistoricalData({
+          pair: makePair(), // tokens have no WAE address
+          interval: 3600,
+          page: 1,
+          limit: 10,
+          fromToken: 'token1',
+          convertTo: 'usd',
+        }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+
+      expect(queryRunnerMock.query).not.toHaveBeenCalled();
+      expect(aePricingMock.getCurrencyRates).not.toHaveBeenCalled();
+    });
+
+    it('rejects an unsupported convertTo currency before querying', async () => {
+      await expect(
+        service.getPaginatedHistoricalData({
+          pair: makeWaePair(),
+          interval: 3600,
+          page: 1,
+          limit: 10,
+          fromToken: 'token1',
+          convertTo: 'jpy',
+        }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+
+      expect(queryRunnerMock.query).not.toHaveBeenCalled();
+      expect(aePricingMock.getCurrencyRates).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/dex/services/pair-history.service.spec.ts
+++ b/src/dex/services/pair-history.service.spec.ts
@@ -241,6 +241,72 @@ describe('PairHistoryService', () => {
     });
   });
 
+  describe('getPaginatedHistoricalData - denomination & volume', () => {
+    const baseRow = (overrides: Record<string, unknown> = {}) => ({
+      timeOpen: new Date('2025-01-01T00:00:00Z'),
+      timeClose: new Date('2025-01-01T01:00:00Z'),
+      low: '1',
+      high: '1',
+      open: '1',
+      close: '1',
+      volume: '0',
+      timeMin: new Date('2025-01-01T00:05:00Z'),
+      timeMax: new Date('2025-01-01T00:55:00Z'),
+      ...overrides,
+    });
+
+    it('labels the series with the base token symbol for a non-WAE pool', async () => {
+      // makePair has no WAE token; with fromToken='token0' the base (quote)
+      // token is token0 (TOK0), so the series is priced in TOK0, NOT AE.
+      queryRunnerMock.query.mockResolvedValue([baseRow()]);
+
+      const [result] = await service.getPaginatedHistoricalData({
+        pair: makePair(),
+        interval: 3600,
+        page: 1,
+        limit: 10,
+        fromToken: 'token0',
+      });
+
+      expect(result.quote.convertedTo).toBe('TOK0');
+    });
+
+    it('normalizes volume to human base-token units (ae)', async () => {
+      // 5 WAE in aettos → human volume 5.
+      queryRunnerMock.query.mockResolvedValue([
+        baseRow({ volume: '5000000000000000000' }),
+      ]);
+
+      const [result] = await service.getPaginatedHistoricalData({
+        pair: makeWaePair(),
+        interval: 3600,
+        page: 1,
+        limit: 10,
+        fromToken: 'token1',
+      });
+
+      expect(result.quote.volume).toBe(5);
+    });
+
+    it('applies decimal normalization before the fiat rate for volume', async () => {
+      queryRunnerMock.query.mockResolvedValue([
+        baseRow({ volume: '5000000000000000000', conversion_rate: '2' }),
+      ]);
+
+      const [result] = await service.getPaginatedHistoricalData({
+        pair: makeWaePair(),
+        interval: 3600,
+        page: 1,
+        limit: 10,
+        fromToken: 'token1',
+        convertTo: 'usd',
+      });
+
+      // human 5 AE * rate 2 = 10 USD — NOT 5e18 * 2.
+      expect(result.quote.volume).toBe(10);
+    });
+  });
+
   describe('getPaginatedHistoricalData - currency conversion', () => {
     const makeRow = (overrides: Record<string, unknown> = {}) => ({
       timeOpen: new Date('2025-01-01T00:00:00Z'),
@@ -249,7 +315,8 @@ describe('PairHistoryService', () => {
       high: '2.0',
       open: '1.5',
       close: '1.8',
-      volume: '100',
+      // Raw base-token (WAE, 18 dp) volume of 100 → human volume 100.
+      volume: '100000000000000000000',
       market_cap: '5000',
       total_supply: '10000',
       timeMin: new Date('2025-01-01T00:05:00Z'),
@@ -270,6 +337,7 @@ describe('PairHistoryService', () => {
 
       expect(result.quote.convertedTo).toBe('ae');
       expect(result.quote.close).toBe('1.8');
+      // volume is normalized from raw base-token units (100e18) to human (100).
       expect(result.quote.volume).toBe(100);
       // market_cap is not tracked for DEX pairs → null, not a fabricated value.
       expect(result.quote.market_cap).toBeNull();
@@ -321,7 +389,8 @@ describe('PairHistoryService', () => {
       expect(result[0].quote.convertedTo).toBe('usd');
       expect(result[0].quote.high).toBe('1'); // 2.0 * 0.5
       expect(result[0].quote.close).toBe('0.9'); // 1.8 * 0.5
-      expect(result[0].quote.volume).toBe(50); // 100 * 0.5
+      // volume: 100e18 raw → human 100 → fiat 100 * 0.5 = 50
+      expect(result[0].quote.volume).toBe(50);
       // market_cap / total_supply are not tracked for DEX pairs → null.
       expect(result[0].quote.market_cap).toBeNull();
       expect(result[0].quote.total_supply).toBeNull();
@@ -349,6 +418,29 @@ describe('PairHistoryService', () => {
 
       expect(aePricingMock.getCurrencyRates).toHaveBeenCalledTimes(1);
       expect(result.quote.close).toBe('5.4'); // 1.8 * 3 (fallback)
+    });
+
+    it('omits candles with no rate and no usable fallback instead of using rate 1', async () => {
+      // getCurrencyRates returns nothing usable for usd → no fallback rate.
+      aePricingMock.getCurrencyRates.mockResolvedValue({} as any);
+      queryRunnerMock.query.mockResolvedValue([
+        makeRow({ conversion_rate: '2' }), // convertible
+        makeRow({ conversion_rate: null }), // no rate + no fallback → omitted
+      ]);
+
+      const result = await service.getPaginatedHistoricalData({
+        pair: makeWaePair(),
+        interval: 3600,
+        page: 1,
+        limit: 10,
+        fromToken: 'token1',
+        convertTo: 'usd',
+      });
+
+      // The un-convertible candle is dropped, NOT emitted at rate 1.
+      expect(result).toHaveLength(1);
+      expect(result[0].quote.convertedTo).toBe('usd');
+      expect(result[0].quote.close).toBe('3.6'); // 1.8 * 2
     });
 
     it('rejects fiat conversion for a pool not quoted against WAE before querying', async () => {

--- a/src/dex/services/pair-history.service.ts
+++ b/src/dex/services/pair-history.service.ts
@@ -70,19 +70,24 @@ export class PairHistoryService {
     const { fromToken, pair, interval, page, limit, convertTo = 'ae' } = props;
     const offset = (page - 1) * limit;
 
-    // The OHLC / market-cap / volume values produced below are denominated in
-    // the pair's base (quote) token — the `fromToken` side. When that base
-    // token is WAE the values are in AE and can be converted to a fiat
-    // currency. Conversion uses the AE→currency rate *as of each candle's time*
-    // (joined per-candle from the coin_prices snapshots, see the SQL below), so
-    // historical candles are priced with the historical rate rather than
-    // today's. We validate up front so an unsupported currency or a non-AE pool
-    // fails fast (400) before the expensive history query runs.
+    // The OHLC / volume values produced below are denominated in the pair's
+    // base (quote) token — the `fromToken` side. `value` selects the matching
+    // ratio/volume columns; baseToken/quoteToken drive decimal normalization
+    // and the denomination label.
+    const value = fromToken === 'token0' ? '0' : '1';
+    const baseToken = value === '0' ? pair.token0 : pair.token1;
+    const quoteToken = value === '0' ? pair.token1 : pair.token0;
+    const baseIsWae = baseToken?.address === DEX_CONTRACTS.wae;
+
+    // When the base token is WAE the values are in AE and can be converted to a
+    // fiat currency, using the AE→currency rate *as of each candle's time*
+    // (joined per-candle from the coin_prices snapshots, see the SQL below).
+    // We validate up front so an unsupported currency or a non-AE pool fails
+    // fast (400) before the expensive history query runs.
     const requestedCurrency = (convertTo || 'ae').toLowerCase();
     const convertToFiat = requestedCurrency !== 'ae';
     if (convertToFiat) {
-      const baseToken = fromToken === 'token0' ? pair.token0 : pair.token1;
-      if (baseToken?.address !== DEX_CONTRACTS.wae) {
+      if (!baseIsWae) {
         throw new BadRequestException(
           `Cannot convert price to ${requestedCurrency}: this pool is not quoted against AE (WAE).`,
         );
@@ -93,11 +98,17 @@ export class PairHistoryService {
         );
       }
     }
-    const convertedTo = convertToFiat ? requestedCurrency : 'ae';
+    // Denomination label. For a non-WAE pool the OHLC values are priced in the
+    // base token, NOT AE — label them with that token so clients don't treat
+    // the series as AE-denominated.
+    const convertedTo = convertToFiat
+      ? requestedCurrency
+      : baseIsWae
+        ? 'ae'
+        : (baseToken?.symbol ?? baseToken?.address ?? 'unknown');
 
     const queryRunner = this.dataSource.createQueryRunner();
     //"MAX(CAST(transactions.buy_price->>'ae' AS FLOAT)) AS max_buy_price",
-    const value = fromToken === 'token0' ? '0' : '1';
     // Per-candle historical AE→currency rate, sourced from the coin_prices
     // snapshots: the latest snapshot at/just-before the candle's open, falling
     // back to the earliest snapshot for candles older than any snapshot. Only
@@ -214,14 +225,19 @@ export class PairHistoryService {
           : null;
     }
 
-    const rateFor = (row: any): BigNumber => {
+    // Returns null when converting to fiat but no rate is available for this
+    // candle (no per-candle snapshot and no usable fallback from
+    // getCurrencyRates). Such candles must be omitted rather than emitted at
+    // rate 1 — that would leave AE-sized OHLC/volume mislabeled as the fiat
+    // currency.
+    const rateFor = (row: any): BigNumber | null => {
       if (!convertToFiat) {
         return new BigNumber(1);
       }
       if (row.conversion_rate != null) {
         return new BigNumber(row.conversion_rate);
       }
-      return fallbackRate ?? new BigNumber(1);
+      return fallbackRate;
     };
 
     // `ratio0`/`ratio1` are derived from RAW on-chain reserves, so a stored
@@ -231,11 +247,14 @@ export class PairHistoryService {
     // where the base (quote-currency) token is the `fromToken` side and the
     // quote (charted) token is the other side. Without this, prices for any
     // non-18-decimal token are off by 10^(18 - tokenDecimals).
-    const baseToken = value === '0' ? pair.token0 : pair.token1;
-    const quoteToken = value === '0' ? pair.token1 : pair.token0;
     const baseDecimals = Number(baseToken?.decimals ?? 18);
     const quoteDecimals = Number(quoteToken?.decimals ?? 18);
     const priceScale = new BigNumber(10).pow(quoteDecimals - baseDecimals);
+    // Volume is the SUM of raw base-token amounts (volume0/volume1). Normalise
+    // it to human units (÷ 10^baseDecimals) so it is consistent with the human
+    // prices and so fiat conversion (× rate) is correct instead of off by
+    // 10^baseDecimals.
+    const volumeScale = new BigNumber(10).pow(-baseDecimals);
 
     // Price-side conversion: raw ratio → human units (priceScale) → fiat (rate,
     // which is 1 for AE). Always applies priceScale, so AE prices are corrected
@@ -247,37 +266,46 @@ export class PairHistoryService {
         .toString();
 
     // Modify the mapping to handle the previous close price correctly
-    let lastClose = null;
-    return rawResults.map((row) => {
-      const rate = rateFor(row);
-      const close = toPriceString(row.close, rate);
-      const result = {
-        timeOpen: row.timeOpen,
-        timeClose: row.timeClose,
-        timeHigh: row.timeMax,
-        timeLow: row.timeMin,
-        quote: {
-          convertedTo,
-          open: lastClose !== null ? lastClose : toPriceString(row.open, rate),
-          high: toPriceString(row.high, rate),
-          low: toPriceString(row.low, rate),
-          close,
-          volume: convertToFiat
-            ? new BigNumber(row.volume || '0').multipliedBy(rate).toNumber()
-            : parseFloat(row.volume || '0'),
-          // market_cap and total_supply are not populated for DEX pairs (the
-          // sync layer never writes per-token market caps, and `total_supply`
-          // on a transaction is the sum of raw reserves, not the LP supply), so
-          // we return null rather than presenting a fabricated 0.
-          market_cap: null,
-          total_supply: null,
-          timestamp: row.timeClose,
-          symbol: quoteToken?.symbol ?? pair.token0?.symbol,
-        },
-      };
-      lastClose = close;
-      return result;
-    });
+    let lastClose: string | null = null;
+    return rawResults
+      .map((row) => {
+        const rate = rateFor(row);
+        if (rate === null) {
+          // Fiat conversion requested but no usable rate for this candle —
+          // omit it instead of mislabeling AE-sized values as the fiat currency.
+          return null;
+        }
+        const close = toPriceString(row.close, rate);
+        const result = {
+          timeOpen: row.timeOpen,
+          timeClose: row.timeClose,
+          timeHigh: row.timeMax,
+          timeLow: row.timeMin,
+          quote: {
+            convertedTo,
+            open:
+              lastClose !== null ? lastClose : toPriceString(row.open, rate),
+            high: toPriceString(row.high, rate),
+            low: toPriceString(row.low, rate),
+            close,
+            volume: new BigNumber(row.volume || '0')
+              .multipliedBy(volumeScale)
+              .multipliedBy(rate)
+              .toNumber(),
+            // market_cap and total_supply are not populated for DEX pairs (the
+            // sync layer never writes per-token market caps, and `total_supply`
+            // on a transaction is the sum of raw reserves, not the LP supply),
+            // so we return null rather than presenting a fabricated 0.
+            market_cap: null,
+            total_supply: null,
+            timestamp: row.timeClose,
+            symbol: quoteToken?.symbol ?? pair.token0?.symbol,
+          },
+        };
+        lastClose = close;
+        return result;
+      })
+      .filter((candle) => candle !== null);
   }
 
   // async getHistoricalData(

--- a/src/dex/services/pair-history.service.ts
+++ b/src/dex/services/pair-history.service.ts
@@ -1,8 +1,9 @@
 import { AePricingService } from '@/ae-pricing/ae-pricing.service';
 import { AeSdkService } from '@/ae/ae-sdk.service';
+import { CURRENCIES } from '@/configs';
 import { HistoricalDataDto } from '@/transactions/dto/historical-data.dto';
 import { Contract, Encoded } from '@aeternity/aepp-sdk';
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { InjectDataSource } from '@nestjs/typeorm';
 import BigNumber from 'bignumber.js';
 import moment, { Moment } from 'moment';
@@ -12,6 +13,11 @@ import { PairSummaryDto } from '../dto/pair-summary.dto';
 import { Pair } from '../entities/pair.entity';
 
 type ContractInstance = Awaited<ReturnType<typeof Contract.initialize>>;
+
+/** Fiat currencies we can convert AE-denominated prices into. */
+const SUPPORTED_CURRENCIES = new Set<string>(
+  CURRENCIES.map(({ code }) => code),
+);
 
 export interface IGetPaginatedHistoricalDataProps {
   pair: Pair;
@@ -64,9 +70,60 @@ export class PairHistoryService {
     const { fromToken, pair, interval, page, limit, convertTo = 'ae' } = props;
     const offset = (page - 1) * limit;
 
+    // The OHLC / market-cap / volume values produced below are denominated in
+    // the pair's base (quote) token — the `fromToken` side. When that base
+    // token is WAE the values are in AE and can be converted to a fiat
+    // currency. Conversion uses the AE→currency rate *as of each candle's time*
+    // (joined per-candle from the coin_prices snapshots, see the SQL below), so
+    // historical candles are priced with the historical rate rather than
+    // today's. We validate up front so an unsupported currency or a non-AE pool
+    // fails fast (400) before the expensive history query runs.
+    const requestedCurrency = (convertTo || 'ae').toLowerCase();
+    const convertToFiat = requestedCurrency !== 'ae';
+    if (convertToFiat) {
+      const baseToken = fromToken === 'token0' ? pair.token0 : pair.token1;
+      if (baseToken?.address !== DEX_CONTRACTS.wae) {
+        throw new BadRequestException(
+          `Cannot convert price to ${requestedCurrency}: this pool is not quoted against AE (WAE).`,
+        );
+      }
+      if (!SUPPORTED_CURRENCIES.has(requestedCurrency)) {
+        throw new BadRequestException(
+          `Unsupported convertTo currency: ${convertTo}`,
+        );
+      }
+    }
+    const convertedTo = convertToFiat ? requestedCurrency : 'ae';
+
     const queryRunner = this.dataSource.createQueryRunner();
     //"MAX(CAST(transactions.buy_price->>'ae' AS FLOAT)) AS max_buy_price",
     const value = fromToken === 'token0' ? '0' : '1';
+    // Per-candle historical AE→currency rate, sourced from the coin_prices
+    // snapshots: the latest snapshot at/just-before the candle's open, falling
+    // back to the earliest snapshot for candles older than any snapshot. Only
+    // added (with its $5 parameter) when actually converting to fiat.
+    const conversionRateColumn = convertToFiat
+      ? `,
+          COALESCE(
+            (
+              SELECT cp.rates->>$5
+              FROM coin_prices cp
+              WHERE cp.created_at <= interval_start
+              ORDER BY cp.created_at DESC
+              LIMIT 1
+            ),
+            (
+              SELECT cp.rates->>$5
+              FROM coin_prices cp
+              ORDER BY cp.created_at ASC
+              LIMIT 1
+            )
+          ) as conversion_rate`
+      : '';
+    const params: (string | number)[] = [pair.address, interval, offset, limit];
+    if (convertToFiat) {
+      params.push(requestedCurrency);
+    }
     let rawResults;
     try {
       rawResults = await queryRunner.query(
@@ -130,39 +187,95 @@ export class PairHistoryService {
           MAX(total_supply) as total_supply,
           MIN("timeMin") as "timeMin",
           MAX("timeMax") as "timeMax",
-          LAG(MAX(close)) OVER (ORDER BY interval_start) as previous_close
+          LAG(MAX(close)) OVER (ORDER BY interval_start) as previous_close${conversionRateColumn}
         FROM interval_stats
         GROUP BY interval_start
         ORDER BY interval_start ASC
       `,
-        [pair.address, interval, offset, limit],
+        params,
       );
     } finally {
       await queryRunner.release();
     }
 
+    // If any candle has no coin_prices snapshot at all (empty table), degrade
+    // to the latest known rate for those candles instead of dropping the
+    // conversion. Fetched once, only when needed.
+    let fallbackRate: BigNumber | null = null;
+    if (
+      convertToFiat &&
+      rawResults.some((row) => row.conversion_rate == null)
+    ) {
+      const rates = await this.aePricingService.getCurrencyRates();
+      const latest = rates[requestedCurrency as keyof typeof rates];
+      fallbackRate =
+        latest != null && Number.isFinite(Number(latest))
+          ? new BigNumber(latest)
+          : null;
+    }
+
+    const rateFor = (row: any): BigNumber => {
+      if (!convertToFiat) {
+        return new BigNumber(1);
+      }
+      if (row.conversion_rate != null) {
+        return new BigNumber(row.conversion_rate);
+      }
+      return fallbackRate ?? new BigNumber(1);
+    };
+
+    // `ratio0`/`ratio1` are derived from RAW on-chain reserves, so a stored
+    // ratio only equals a real price when both tokens share the same decimals.
+    // Normalise every candle's price to human units using the pair's token
+    // decimals: price_human = ratio_raw * 10^(quoteDecimals - baseDecimals),
+    // where the base (quote-currency) token is the `fromToken` side and the
+    // quote (charted) token is the other side. Without this, prices for any
+    // non-18-decimal token are off by 10^(18 - tokenDecimals).
+    const baseToken = value === '0' ? pair.token0 : pair.token1;
+    const quoteToken = value === '0' ? pair.token1 : pair.token0;
+    const baseDecimals = Number(baseToken?.decimals ?? 18);
+    const quoteDecimals = Number(quoteToken?.decimals ?? 18);
+    const priceScale = new BigNumber(10).pow(quoteDecimals - baseDecimals);
+
+    // Price-side conversion: raw ratio → human units (priceScale) → fiat (rate,
+    // which is 1 for AE). Always applies priceScale, so AE prices are corrected
+    // too — we can no longer preserve the raw string byte-for-byte.
+    const toPriceString = (raw: unknown, rate: BigNumber): string =>
+      new BigNumber((raw as any) || '0')
+        .multipliedBy(priceScale)
+        .multipliedBy(rate)
+        .toString();
+
     // Modify the mapping to handle the previous close price correctly
     let lastClose = null;
     return rawResults.map((row) => {
+      const rate = rateFor(row);
+      const close = toPriceString(row.close, rate);
       const result = {
         timeOpen: row.timeOpen,
         timeClose: row.timeClose,
         timeHigh: row.timeMax,
         timeLow: row.timeMin,
         quote: {
-          convertedTo: convertTo,
-          open: lastClose !== null ? lastClose : String(row.open || '0'),
-          high: String(row.high || '0'),
-          low: String(row.low || '0'),
-          close: String(row.close || '0'),
-          volume: parseFloat(row.volume || '0'),
-          market_cap: new BigNumber(row.market_cap || '0'),
-          total_supply: new BigNumber(row.total_supply || '0'),
+          convertedTo,
+          open: lastClose !== null ? lastClose : toPriceString(row.open, rate),
+          high: toPriceString(row.high, rate),
+          low: toPriceString(row.low, rate),
+          close,
+          volume: convertToFiat
+            ? new BigNumber(row.volume || '0').multipliedBy(rate).toNumber()
+            : parseFloat(row.volume || '0'),
+          // market_cap and total_supply are not populated for DEX pairs (the
+          // sync layer never writes per-token market caps, and `total_supply`
+          // on a transaction is the sum of raw reserves, not the LP supply), so
+          // we return null rather than presenting a fabricated 0.
+          market_cap: null,
+          total_supply: null,
           timestamp: row.timeClose,
-          symbol: pair.token0.symbol,
+          symbol: quoteToken?.symbol ?? pair.token0?.symbol,
         },
       };
-      lastClose = String(row.close || '0');
+      lastClose = close;
       return result;
     });
   }

--- a/src/dex/services/pair-transaction.service.spec.ts
+++ b/src/dex/services/pair-transaction.service.spec.ts
@@ -1,0 +1,113 @@
+import { BadRequestException } from '@nestjs/common';
+import { paginate } from 'nestjs-typeorm-paginate';
+import { PairTransactionService } from './pair-transaction.service';
+
+jest.mock('nestjs-typeorm-paginate');
+
+describe('PairTransactionService', () => {
+  const makeQb = () => {
+    const qb: any = {};
+    qb.leftJoinAndSelect = jest.fn(() => qb);
+    qb.andWhere = jest.fn(() => qb);
+    qb.orderBy = jest.fn(() => qb);
+    return qb;
+  };
+
+  const setup = () => {
+    const qb = makeQb();
+    const repository = {
+      createQueryBuilder: jest.fn(() => qb),
+    };
+    const service = new PairTransactionService(repository as any);
+    return { service, repository, qb };
+  };
+
+  beforeEach(() => {
+    (paginate as jest.Mock).mockReset();
+    (paginate as jest.Mock).mockResolvedValue({ items: [], meta: {} });
+  });
+
+  it('rejects an invalid order_by before touching the database', async () => {
+    const { service, repository } = setup();
+
+    await expect(
+      service.findAll({ page: 1, limit: 100 }, 'drop_table'),
+    ).rejects.toBeInstanceOf(BadRequestException);
+
+    expect(repository.createQueryBuilder).not.toHaveBeenCalled();
+  });
+
+  it('rejects an invalid from_date before touching the database', async () => {
+    const { service, repository } = setup();
+
+    await expect(
+      service.findAll(
+        { page: 1, limit: 100 },
+        'created_at',
+        'DESC',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        'not-a-date',
+      ),
+    ).rejects.toThrow(/Invalid from_date/);
+
+    expect(repository.createQueryBuilder).not.toHaveBeenCalled();
+  });
+
+  it('rejects an invalid to_date before touching the database', async () => {
+    const { service } = setup();
+
+    await expect(
+      service.findAll(
+        { page: 1, limit: 100 },
+        'created_at',
+        'DESC',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        'nope',
+      ),
+    ).rejects.toThrow(/Invalid to_date/);
+  });
+
+  it('applies created_at range filters when valid dates are provided', async () => {
+    const { service, qb } = setup();
+
+    const result = await service.findAll(
+      { page: 1, limit: 100 },
+      'created_at',
+      'DESC',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      '2024-01-01T00:00:00.000Z',
+      '2024-02-01T00:00:00.000Z',
+    );
+
+    expect(qb.andWhere).toHaveBeenCalledWith(
+      'pairTransaction.created_at >= :fromDate',
+      expect.objectContaining({ fromDate: expect.any(Date) }),
+    );
+    expect(qb.andWhere).toHaveBeenCalledWith(
+      'pairTransaction.created_at <= :toDate',
+      expect.objectContaining({ toDate: expect.any(Date) }),
+    );
+    expect(result).toEqual({ items: [], meta: {} });
+  });
+
+  it('does not add date filters when no dates are provided', async () => {
+    const { service, qb } = setup();
+
+    await service.findAll({ page: 1, limit: 100 });
+
+    const dateClauses = qb.andWhere.mock.calls.filter((call: any[]) =>
+      String(call[0]).includes('created_at'),
+    );
+    expect(dateClauses).toHaveLength(0);
+  });
+});

--- a/src/dex/services/pair-transaction.service.ts
+++ b/src/dex/services/pair-transaction.service.ts
@@ -26,6 +26,8 @@ export class PairTransactionService {
     txType?: string,
     account_address?: string,
     tokenAddress?: string,
+    fromDate?: string,
+    toDate?: string,
   ): Promise<Pagination<PairTransaction>> {
     if (!ALLOWED_ORDER_BY.has(orderBy)) {
       throw new BadRequestException(`Invalid order_by value: ${orderBy}`);
@@ -35,6 +37,10 @@ export class PairTransactionService {
         `Invalid order_direction value: ${orderDirection}`,
       );
     }
+
+    const parsedFromDate = this.parseDate(fromDate, 'from_date');
+    const parsedToDate = this.parseDate(toDate, 'to_date');
+
     const query = this.pairTransactionRepository
       .createQueryBuilder('pairTransaction')
       .leftJoinAndSelect('pairTransaction.pair', 'pair')
@@ -68,12 +74,37 @@ export class PairTransactionService {
       );
     }
 
+    // Filter by created_at time range if provided
+    if (parsedFromDate) {
+      query.andWhere('pairTransaction.created_at >= :fromDate', {
+        fromDate: parsedFromDate,
+      });
+    }
+    if (parsedToDate) {
+      query.andWhere('pairTransaction.created_at <= :toDate', {
+        toDate: parsedToDate,
+      });
+    }
+
     // Add ordering
     if (orderBy) {
       query.orderBy(`pairTransaction.${orderBy}`, orderDirection);
     }
 
     return paginate(query, options);
+  }
+
+  private parseDate(value: string | undefined, field: string): Date | undefined {
+    if (value === undefined || value === null || value === '') {
+      return undefined;
+    }
+    const parsed = new Date(value);
+    if (Number.isNaN(parsed.getTime())) {
+      throw new BadRequestException(
+        `Invalid ${field} value: ${value}. Expected an ISO-8601 date string.`,
+      );
+    }
+    return parsed;
   }
 
   async findByTxHash(txHash: string): Promise<PairTransaction> {

--- a/src/dex/services/pair-transaction.service.ts
+++ b/src/dex/services/pair-transaction.service.ts
@@ -94,7 +94,10 @@ export class PairTransactionService {
     return paginate(query, options);
   }
 
-  private parseDate(value: string | undefined, field: string): Date | undefined {
+  private parseDate(
+    value: string | undefined,
+    field: string,
+  ): Date | undefined {
     if (value === undefined || value === null || value === '') {
       return undefined;
     }

--- a/src/plugins/dex/services/dex-transaction-processor.service.spec.ts
+++ b/src/plugins/dex/services/dex-transaction-processor.service.spec.ts
@@ -61,6 +61,95 @@ describe('DexTransactionProcessorService', () => {
     expect(result?.pairAddress).toBe('ct_pair');
   });
 
+  it('normalizes string event topics to BigInt before decoding', async () => {
+    // The middleware stores topics as decimal strings; aepp-sdk matches them
+    // against BigInt event hashes with strict equality, so a string topic never
+    // matches and every event is silently dropped. The processor must convert
+    // topics to BigInt before calling $decodeEvents.
+    const { service } = setup();
+    jest
+      .spyOn(service as any, 'ensureContractsInitialized')
+      .mockResolvedValue(undefined);
+    const routerDecode = jest
+      .fn()
+      .mockReturnValue([
+        { contract: { name: 'IAedexV2Pair', address: 'ct_pair' } },
+      ]);
+    (service as any).routerContract = { $decodeEvents: routerDecode };
+    (service as any).factoryContract = { $decodeEvents: jest.fn() };
+    jest
+      .spyOn(service as any, 'getOrCreateToken')
+      .mockResolvedValueOnce({ address: 'ct_t0' })
+      .mockResolvedValueOnce({ address: 'ct_t1' });
+
+    const swapTokensHash =
+      '72742236172837736358043391645586411318758140104138559400527506523271326125229';
+
+    await (service as any).extractPairInfoFromTransaction({
+      hash: 'th_1',
+      function: TX_FUNCTIONS.add_liquidity,
+      raw: {
+        log: [
+          { address: 'ct_pair', data: 'cb_x', topics: [swapTokensHash, '1'] },
+        ],
+        arguments: [{ value: 'ct_t0' }, { value: 'ct_t1' }],
+      },
+    });
+
+    const passedLog = routerDecode.mock.calls[0][0];
+    expect(passedLog[0].topics.every((t: any) => typeof t === 'bigint')).toBe(
+      true,
+    );
+    expect(passedLog[0].topics[0]).toBe(BigInt(swapTokensHash));
+  });
+
+  it('does not abort decoding when one log entry has an unconvertible topic', async () => {
+    // A non-pair log line in the same tx may carry a null/empty/non-numeric
+    // topic. BigInt() throws on those, so converting them unguarded would abort
+    // extraction for the whole transaction — even though the valid pair event
+    // would decode after conversion.
+    const { service } = setup();
+    jest
+      .spyOn(service as any, 'ensureContractsInitialized')
+      .mockResolvedValue(undefined);
+    const routerDecode = jest
+      .fn()
+      .mockReturnValue([
+        { contract: { name: 'IAedexV2Pair', address: 'ct_pair' } },
+      ]);
+    (service as any).routerContract = { $decodeEvents: routerDecode };
+    (service as any).factoryContract = { $decodeEvents: jest.fn() };
+    jest
+      .spyOn(service as any, 'getOrCreateToken')
+      .mockResolvedValueOnce({ address: 'ct_t0' })
+      .mockResolvedValueOnce({ address: 'ct_t1' });
+
+    const validHash =
+      '72742236172837736358043391645586411318758140104138559400527506523271326125229';
+
+    const result = await (service as any).extractPairInfoFromTransaction({
+      hash: 'th_1',
+      function: TX_FUNCTIONS.add_liquidity,
+      raw: {
+        log: [
+          { address: 'ct_other', data: 'cb_x', topics: [null] }, // unconvertible
+          { address: 'ct_pair', data: 'cb_y', topics: [validHash, '1'] }, // valid
+        ],
+        arguments: [{ value: 'ct_t0' }, { value: 'ct_t1' }],
+      },
+    });
+
+    // The valid pair event was still decoded — the bad topic did not abort it.
+    expect(result?.pairAddress).toBe('ct_pair');
+    const passedLog = routerDecode.mock.calls[0][0];
+    // Valid entry fully converted to BigInt...
+    expect(passedLog[1].topics.every((t: any) => typeof t === 'bigint')).toBe(
+      true,
+    );
+    // ...and the unconvertible topic was left untouched (omitUnknown drops it).
+    expect(passedLog[0].topics[0]).toBeNull();
+  });
+
   it('loads pair relation after upsert when fetching saved tx', async () => {
     const { service } = setup();
     const pairTransactionRepository = {

--- a/src/plugins/dex/services/dex-transaction-processor.service.ts
+++ b/src/plugins/dex/services/dex-transaction-processor.service.ts
@@ -132,10 +132,35 @@ export class DexTransactionProcessorService {
     // Ensure contracts are initialized
     await this.ensureContractsInitialized();
 
+    // The middleware stores event `topics` as decimal strings, but aepp-sdk's
+    // `$decodeEvents` matches them against the BigInt event-name hash with
+    // strict equality (`BigInt(hash) === topic`). A string topic never matches,
+    // so with `omitUnknown: true` every event is silently dropped and the pair
+    // can never be extracted. Normalise topics to BigInt before decoding.
+    //
+    // Guard per-topic: a single unconvertible topic (null/empty/non-numeric)
+    // from an unrelated log line in the same transaction must NOT abort the
+    // whole batch. Leave such topics untouched — `omitUnknown` then drops only
+    // that entry, while the valid pair events still decode.
+    const toBigIntTopic = (topic: any): any => {
+      if (typeof topic === 'bigint') return topic;
+      try {
+        return BigInt(topic);
+      } catch {
+        return topic;
+      }
+    };
+    const eventLog = (tx.raw?.log ?? []).map((entry: any) => ({
+      ...entry,
+      topics: Array.isArray(entry?.topics)
+        ? entry.topics.map(toBigIntTopic)
+        : entry?.topics,
+    }));
+
     let decodedEvents = null;
     try {
       if (this.routerContract) {
-        decodedEvents = this.routerContract.$decodeEvents(tx.raw.log, {
+        decodedEvents = this.routerContract.$decodeEvents(eventLog, {
           omitUnknown: true,
         });
       }
@@ -146,7 +171,7 @@ export class DexTransactionProcessorService {
     if (!decodedEvents || decodedEvents.length === 0) {
       try {
         if (this.factoryContract) {
-          decodedEvents = this.factoryContract.$decodeEvents(tx.raw.log, {
+          decodedEvents = this.factoryContract.$decodeEvents(eventLog, {
             omitUnknown: true,
           });
         }

--- a/src/transactions/dto/historical-data.dto.ts
+++ b/src/transactions/dto/historical-data.dto.ts
@@ -7,8 +7,10 @@ export interface QuoteDto {
   low: number;
   close: number;
   volume: number;
-  total_supply: BigNumber;
-  market_cap: BigNumber;
+  // null for DEX pairs: LP total supply and per-token market cap are not tracked
+  // by the sync layer, so we return null rather than a fabricated value.
+  total_supply: BigNumber | null;
+  market_cap: BigNumber | null;
   // marketCap: number;
   timestamp: Date;
   symbol: string;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Boot-time DDL and advisory-locked index creation affect production deploys; history/pricing and listing admin paths change client-visible behavior and need careful rollout.
> 
> **Overview**
> Brings **deprecated dex-backend** behavior into this Nest DEX module so the swap UI and clients can migrate: **`GET /dex/swap-routes/:from/:to`** (legacy route array with `synchronized` + `liquidityInfo`), **`GET /dex/tokens/:address/history`** (OHLCV via best pool + `PairHistoryService`), and **`PATCH /dex/tokens/:address/listed`** behind **`ApiKeyGuard`**.
> 
> **Token listing** adds a **`listed`** column (entity/DTO + **`DexSchemaBootstrapService`** idempotent DDL and indexes on boot), **`?listed`** on token list with strict parsing (400 on garbage), and service support for **`findBestPairForToken`** (prefer liquid WAE, decimal-aware depth) and **`setListed`**.
> 
> **Pair transactions** gain **`from_date` / `to_date`** filters with ISO validation; **Swagger DTOs** are expanded for richer transaction payloads. **`PairHistoryService`** now normalizes prices/volume by token decimals, optional **fiat `convertTo`** via **`coin_prices`**, omits bad conversion candles, and returns **null** market cap/supply for DEX candles.
> 
> **Sync fix:** DEX tx processor converts event **topics to `BigInt`** (per-topic guard) so pair events decode instead of being dropped. Heavy **unit test** coverage accompanies the new/changed controllers and services.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dddc5b7fd2a6c6eac1ad4f1ac33b33eb9df8f9fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->