### PR TITLE
Feat/token gated notifications fix

### DIFF
--- a/src/migrations/1718900000009-TgrRoomMembershipEvent.ts
+++ b/src/migrations/1718900000009-TgrRoomMembershipEvent.ts
@@ -1,0 +1,96 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * TGR migration #9 (access-ledger plan §5): the access-transition ledger.
+ *
+ * Creates `room_membership_event` (append-only grant/revoke audit + push source)
+ * and adds the notification-facing access-state columns to `room_membership`
+ * (`access_state`, `access_changed_at`, `pending_revoke_since`,
+ * `pending_revoke_reason`).
+ *
+ * **Backfill (critical):** seeds every currently-added member as
+ * `access_state='granted'` so the deploy does NOT emit a "you're in" push to
+ * everyone already in a room. Effective access = `relay_state='added'` (independent
+ * of `eligible`, so room admins are seeded too).
+ */
+export class TgrRoomMembershipEvent1718900000009
+  implements MigrationInterface
+{
+  name = 'TgrRoomMembershipEvent1718900000009';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // ── access-transition ledger ───────────────────────────────────────────────
+    await queryRunner.query(
+      `CREATE TYPE "public"."room_membership_event_event_enum" AS ENUM('access_granted', 'access_revoked')`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "room_membership_event" (
+        "id" BIGSERIAL NOT NULL,
+        "sale_address" character varying NOT NULL,
+        "member_address" character varying NOT NULL,
+        "event" "public"."room_membership_event_event_enum" NOT NULL,
+        "reason" character varying NOT NULL,
+        "is_first_grant" boolean NOT NULL DEFAULT false,
+        "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+        "notified_at" TIMESTAMP WITH TIME ZONE,
+        CONSTRAINT "PK_room_membership_event_id" PRIMARY KEY ("id")
+      )`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_room_membership_event_sale_member" ON "room_membership_event" ("sale_address", "member_address", "created_at")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_room_membership_event_unnotified" ON "room_membership_event" ("notified_at") WHERE notified_at IS NULL`,
+    );
+
+    // ── access-state columns on room_membership ────────────────────────────────
+    await queryRunner.query(
+      `CREATE TYPE "public"."room_membership_access_state_enum" AS ENUM('none', 'granted')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "room_membership"
+        ADD COLUMN "access_state" "public"."room_membership_access_state_enum" NOT NULL DEFAULT 'none',
+        ADD COLUMN "access_changed_at" TIMESTAMP WITH TIME ZONE,
+        ADD COLUMN "pending_revoke_since" TIMESTAMP WITH TIME ZONE,
+        ADD COLUMN "pending_revoke_reason" character varying`,
+    );
+
+    // ── backfill: current members are already granted (no push storm on deploy) ─
+    await queryRunner.query(
+      `UPDATE "room_membership"
+        SET "access_state" = 'granted', "access_changed_at" = "updated_at"
+        WHERE "relay_state" = 'added'`,
+    );
+
+    // Partial index for the finalizer sweep (rows with an armed pending revoke).
+    await queryRunner.query(
+      `CREATE INDEX "idx_room_membership_pending_revoke" ON "room_membership" ("pending_revoke_since") WHERE pending_revoke_since IS NOT NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "public"."idx_room_membership_pending_revoke"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "room_membership"
+        DROP COLUMN "pending_revoke_reason",
+        DROP COLUMN "pending_revoke_since",
+        DROP COLUMN "access_changed_at",
+        DROP COLUMN "access_state"`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "public"."room_membership_access_state_enum"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."idx_room_membership_event_unnotified"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."idx_room_membership_event_sale_member"`,
+    );
+    await queryRunner.query(`DROP TABLE "room_membership_event"`);
+    await queryRunner.query(
+      `DROP TYPE "public"."room_membership_event_event_enum"`,
+    );
+  }
+}

--- a/src/migrations/1718900000009-TgrRoomMembershipEvent.ts
+++ b/src/migrations/1718900000009-TgrRoomMembershipEvent.ts
@@ -11,7 +11,10 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
  * **Backfill (critical):** seeds every currently-added member as
  * `access_state='granted'` so the deploy does NOT emit a "you're in" push to
  * everyone already in a room. Effective access = `relay_state='added'` (independent
- * of `eligible`, so room admins are seeded too).
+ * of `eligible`, so room admins are seeded too). It ALSO inserts a historical
+ * `access_granted` ledger row per backfilled member (reason `backfill`, pre-stamped
+ * `notified_at`) so post-deploy first-grant detection is correct — a later
+ * revoke→regain reads as "you're back", not a fresh "Welcome".
  */
 export class TgrRoomMembershipEvent1718900000009 implements MigrationInterface {
   name = 'TgrRoomMembershipEvent1718900000009';
@@ -58,6 +61,20 @@ export class TgrRoomMembershipEvent1718900000009 implements MigrationInterface {
       `UPDATE "room_membership"
         SET "access_state" = 'granted', "access_changed_at" = "updated_at"
         WHERE "relay_state" = 'added'`,
+    );
+
+    // Seed a historical `access_granted` ledger row per backfilled member so
+    // first-grant detection is correct AFTER deploy: their genuine first grant
+    // happened pre-ledger, so a later revoke→regain must read as "you're back"
+    // (is_first_grant=false), not a fresh "Welcome". `notified_at` is set (never
+    // pushed — these are historical, not enqueued) so they stay out of the
+    // unnotified index. `is_first_grant=true` records that this WAS their first grant.
+    await queryRunner.query(
+      `INSERT INTO "room_membership_event"
+        ("sale_address", "member_address", "event", "reason", "is_first_grant", "created_at", "notified_at")
+       SELECT "sale_address", "member_address", 'access_granted', 'backfill', true, "updated_at", "updated_at"
+       FROM "room_membership"
+       WHERE "relay_state" = 'added'`,
     );
 
     // Partial index for the finalizer sweep (rows with an armed pending revoke).

--- a/src/migrations/1718900000009-TgrRoomMembershipEvent.ts
+++ b/src/migrations/1718900000009-TgrRoomMembershipEvent.ts
@@ -13,9 +13,7 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
  * everyone already in a room. Effective access = `relay_state='added'` (independent
  * of `eligible`, so room admins are seeded too).
  */
-export class TgrRoomMembershipEvent1718900000009
-  implements MigrationInterface
-{
+export class TgrRoomMembershipEvent1718900000009 implements MigrationInterface {
   name = 'TgrRoomMembershipEvent1718900000009';
 
   public async up(queryRunner: QueryRunner): Promise<void> {

--- a/src/migrations/1718900000009-TgrRoomMembershipEvent.ts
+++ b/src/migrations/1718900000009-TgrRoomMembershipEvent.ts
@@ -8,10 +8,12 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
  * (`access_state`, `access_changed_at`, `pending_revoke_since`,
  * `pending_revoke_reason`).
  *
- * **Backfill (critical):** seeds every currently-added member as
- * `access_state='granted'` so the deploy does NOT emit a "you're in" push to
- * everyone already in a room. Effective access = `relay_state='added'` (independent
- * of `eligible`, so room admins are seeded too). It ALSO inserts a historical
+ * **Backfill (critical):** seeds every member **present on the relay**
+ * (`relay_state IN ('added','pending_remove')`, independent of `eligible` so room
+ * admins are seeded too) as `access_state='granted'` so the deploy does NOT emit a
+ * "you're in" push to everyone already in a room — AND so a member with a removal
+ * in flight still gets a "you no longer have access" push when it lands (else the
+ * remove ACK would bail at `access_state='none'`). It ALSO inserts a historical
  * `access_granted` ledger row per backfilled member (reason `backfill`, pre-stamped
  * `notified_at`) so post-deploy first-grant detection is correct — a later
  * revoke→regain reads as "you're back", not a fresh "Welcome".
@@ -57,10 +59,18 @@ export class TgrRoomMembershipEvent1718900000009 implements MigrationInterface {
     );
 
     // ── backfill: current members are already granted (no push storm on deploy) ─
+    // "Currently has effective access" at migration time = **present on the relay**,
+    // i.e. `relay_state IN ('added','pending_remove')`. `pending_remove` is a member
+    // with a removal in flight who (in the dominant added→pending_remove case) still
+    // has access; seeding them `granted` means the post-deploy remove ACK correctly
+    // arms a debounced revoke ("you no longer have access") instead of bailing at
+    // `access_state='none'`. The rare pending_add→pending_remove (never actually on
+    // the relay) case is absorbed by the grace window — a flap re-adds within grace
+    // and pushes nothing; only a durable removal notifies.
     await queryRunner.query(
       `UPDATE "room_membership"
         SET "access_state" = 'granted', "access_changed_at" = "updated_at"
-        WHERE "relay_state" = 'added'`,
+        WHERE "relay_state" IN ('added', 'pending_remove')`,
     );
 
     // Seed a historical `access_granted` ledger row per backfilled member so
@@ -74,7 +84,7 @@ export class TgrRoomMembershipEvent1718900000009 implements MigrationInterface {
         ("sale_address", "member_address", "event", "reason", "is_first_grant", "created_at", "notified_at")
        SELECT "sale_address", "member_address", 'access_granted', 'backfill', true, "updated_at", "updated_at"
        FROM "room_membership"
-       WHERE "relay_state" = 'added'`,
+       WHERE "relay_state" IN ('added', 'pending_remove')`,
     );
 
     // Partial index for the finalizer sweep (rows with an armed pending revoke).

--- a/src/token-gated-rooms/config/tgr.config.ts
+++ b/src/token-gated-rooms/config/tgr.config.ts
@@ -269,6 +269,18 @@ export default registerAs(TGR_CONFIG, () => ({
     min: 0,
   }),
 
+  /**
+   * Access-revoke debounce (access-ledger plan §4). When a member's room access is
+   * lost (`relay_state → removed`), the "you no longer have access" push is held
+   * this many seconds; if access is regained within the window (a transient
+   * eligibility flap) NEITHER push fires. Default 180s. `0` disables the debounce
+   * (revoke immediately) — not recommended while balances can flap.
+   */
+  accessRevokeGraceSec: parseDurationSeconds(
+    process.env.TG_ACCESS_REVOKE_GRACE_SEC,
+    180,
+  ),
+
   /** room-notify queue depth that trips the §7.1 circuit-breaker. */
   roomNotifyDepthBreak: parseNumber(
     process.env.TG_ROOM_NOTIFY_DEPTH_BREAK,

--- a/src/token-gated-rooms/entities/migrations.integration.spec.ts
+++ b/src/token-gated-rooms/entities/migrations.integration.spec.ts
@@ -15,9 +15,9 @@ import { TokenBalance } from './token-balance.entity';
 import { RoomBackfillState } from './room-backfill-state.entity';
 
 /**
- * DB integration (Task 00): apply the 7 ordered migrations on a real Postgres and
- * assert the 6 TGR tables + 4 Token columns + named indexes + enum types exist,
- * then revert and assert they are gone.
+ * DB integration (Task 00): apply the ordered TGR migrations on a real Postgres and
+ * assert the TGR tables + 4 Token columns + named indexes + enum types exist, then
+ * revert every migration and assert they are gone.
  *
  * Hermetic isolation (Task 02 harness): the migrations hard-code the `"public"`
  * schema and `ALTER TABLE "token"`, so a *dedicated schema* on the shared DB is
@@ -99,10 +99,11 @@ d('TGR migrations (integration)', () => {
     return rows.length > 0;
   };
 
-  it('creates all 6 TGR tables', async () => {
+  it('creates all TGR tables', async () => {
     for (const t of [
       'community_room',
       'room_membership',
+      'room_membership_event',
       'room_notification_preference',
       'room_message_seen',
       'token_balance',
@@ -167,11 +168,13 @@ d('TGR migrations (integration)', () => {
     }
   });
 
-  it('creates the 3 Postgres enum types', async () => {
+  it('creates the Postgres enum types', async () => {
     for (const e of [
       'token_nostr_room_state_enum',
       'room_membership_role_enum',
       'room_membership_relay_state_enum',
+      'room_membership_access_state_enum',
+      'room_membership_event_event_enum',
     ]) {
       expect(await enumExists(e)).toBe(true);
     }
@@ -199,14 +202,22 @@ d('TGR migrations (integration)', () => {
     });
   });
 
-  it('reverting all 7 removes the tables, Token columns and enum types', async () => {
-    for (let i = 0; i < 7; i++) {
-      await ds.undoLastMigration();
+  it('reverting every migration removes the tables, Token columns and enum types', async () => {
+    // Drain ALL applied migrations (count-independent, so adding a migration never
+    // silently leaves a hardcoded loop under-reverting). `undoLastMigration` throws
+    // once there is nothing left to revert.
+    for (let i = 0; i < 100; i++) {
+      try {
+        await ds.undoLastMigration();
+      } catch {
+        break;
+      }
     }
 
     for (const t of [
       'community_room',
       'room_membership',
+      'room_membership_event',
       'room_notification_preference',
       'room_message_seen',
       'token_balance',
@@ -226,6 +237,8 @@ d('TGR migrations (integration)', () => {
       'token_nostr_room_state_enum',
       'room_membership_role_enum',
       'room_membership_relay_state_enum',
+      'room_membership_access_state_enum',
+      'room_membership_event_event_enum',
     ]) {
       expect(await enumExists(e)).toBe(false);
     }

--- a/src/token-gated-rooms/entities/room-membership-event.entity.ts
+++ b/src/token-gated-rooms/entities/room-membership-event.entity.ts
@@ -1,0 +1,85 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+/** Access transition recorded in the ledger (access-ledger plan §3.3). */
+export type RoomMembershipEventType = 'access_granted' | 'access_revoked';
+
+export const ROOM_MEMBERSHIP_EVENT_TYPES: readonly RoomMembershipEventType[] = [
+  'access_granted',
+  'access_revoked',
+] as const;
+
+/**
+ * Append-only **access-transition ledger** (access-ledger plan §3.3). One row per
+ * *genuine* access change of a `(sale_address, member_address)` — the durable,
+ * restart-safe source for BOTH the "you're in" and "you lost access" pushes, and
+ * the audit trail used to see whether/why eligibility still flaps.
+ *
+ * Why a table (vs a Redis dedup key / a single column):
+ *  - durable dedup — survives process restarts (a Redis TTL does not);
+ *  - one uniform source drives grant + revoke pushes;
+ *  - `is_first_grant` distinguishes a genuine first join ("Welcome") from a
+ *    re-grant after a real lapse ("You're back");
+ *  - row-by-row history is exactly what's needed to diagnose flapping (each flap
+ *    = a granted/revoked pair, with reasons).
+ *
+ * Rows are written ONLY by {@link MembershipAccessService} on a real effective-access
+ * transition (grant immediately; revoke after the debounce grace). The push is
+ * enqueued off inserting a row; `notified_at` is stamped by the room-notify
+ * processor on successful dispatch (belt-and-suspenders dedup: never re-push a
+ * stamped event on a Bull retry).
+ */
+@Entity({ name: 'room_membership_event' })
+@Index('idx_room_membership_event_sale_member', [
+  'sale_address',
+  'member_address',
+  'created_at',
+])
+@Index('idx_room_membership_event_unnotified', ['notified_at'], {
+  where: 'notified_at IS NULL',
+})
+export class RoomMembershipEvent {
+  @PrimaryGeneratedColumn({ type: 'bigint' })
+  id: string;
+
+  @Column()
+  sale_address: string;
+
+  @Column()
+  member_address: string;
+
+  @Column({
+    type: 'enum',
+    enum: ROOM_MEMBERSHIP_EVENT_TYPES,
+  })
+  event: RoomMembershipEventType;
+
+  /**
+   * Why access changed — audit/telemetry. e.g. `join`, `regained` (grants);
+   * `eligibility_lost`, `room_deleted`, `reorg_evicted`, `access_lost` (revokes).
+   */
+  @Column({ type: 'varchar' })
+  reason: string;
+
+  /** True iff no prior `access_granted` exists for `(sale, member)` (copy). */
+  @Column({ default: false })
+  is_first_grant: boolean;
+
+  @CreateDateColumn({
+    type: 'timestamptz',
+    default: () => 'CURRENT_TIMESTAMP(6)',
+  })
+  created_at: Date;
+
+  /** Stamped when the push is dispatched; NULL = not yet pushed. */
+  @Column({
+    type: 'timestamptz',
+    nullable: true,
+  })
+  notified_at: Date;
+}

--- a/src/token-gated-rooms/entities/room-membership.entity.ts
+++ b/src/token-gated-rooms/entities/room-membership.entity.ts
@@ -16,6 +16,18 @@ export type RoomMembershipRelayState =
 /** NIP-29 role of a member within a room (plan §4.3). */
 export type RoomMembershipRole = 'member' | 'admin';
 
+/**
+ * Last **notified** effective-access state (access-ledger plan). Decoupled from
+ * `relay_state` (a sync signal that churns): notifications are driven off
+ * transitions of THIS field, so reconcile re-adds / `39002` regeneration / a
+ * transient flap absorbed within the grace window never re-notify.
+ * `granted` ⇔ the member currently has room access (was `relay_state='added'`).
+ */
+export type RoomMembershipAccessState = 'none' | 'granted';
+
+export const ROOM_MEMBERSHIP_ACCESS_STATES: readonly RoomMembershipAccessState[] =
+  ['none', 'granted'] as const;
+
 export const ROOM_MEMBERSHIP_ROLES: readonly RoomMembershipRole[] = [
   'member',
   'admin',
@@ -73,6 +85,45 @@ export class RoomMembership {
     default: 'pending_add',
   })
   relay_state: RoomMembershipRelayState;
+
+  /**
+   * Last **notified** effective-access state (access-ledger plan). Drives the
+   * membership push instead of the raw `relay_state` ACK, so relay-sync churn
+   * (reconcile re-adds, `39002` regeneration, flaps absorbed within the grace
+   * window) never re-notifies. Written only by `MembershipAccessService`.
+   */
+  @Column({
+    type: 'enum',
+    enum: ROOM_MEMBERSHIP_ACCESS_STATES,
+    default: 'none',
+  })
+  access_state: RoomMembershipAccessState;
+
+  /** When `access_state` last flipped (audit/observability). */
+  @Column({
+    type: 'timestamptz',
+    nullable: true,
+  })
+  access_changed_at: Date;
+
+  /**
+   * Debounce timer: set when access is lost (`relay_state → removed`); if still
+   * set + still-removed after `TG_ACCESS_REVOKE_GRACE_SEC`, the finalizer emits a
+   * single `access_revoked`. Cleared if access is regained first (flap absorbed —
+   * no push either way). NULL = no pending revoke.
+   */
+  @Column({
+    type: 'timestamptz',
+    nullable: true,
+  })
+  pending_revoke_since: Date;
+
+  /** Reason carried through the revoke debounce for the finalizer's event row. */
+  @Column({
+    type: 'varchar',
+    nullable: true,
+  })
+  pending_revoke_reason: string;
 
   /** Reorg eviction buffer: hold removal until this height passes (§6.5). */
   @Column({

--- a/src/token-gated-rooms/events.ts
+++ b/src/token-gated-rooms/events.ts
@@ -60,6 +60,17 @@ export interface TgrMembershipChangedPayload {
   memberAddress: string;
   /** New `room_membership.relay_state`. */
   relayState: 'pending_add' | 'added' | 'pending_remove' | 'removed';
+  /**
+   * Access-ledger event id (access-ledger plan). Set ONLY for genuine
+   * effective-access transitions emitted by `MembershipAccessService` (grant /
+   * debounced revoke); the room-notify processor stamps this event's `notified_at`
+   * on dispatch (durable dedup). Absent for thin role transitions.
+   */
+  accessEventId?: string;
+  /** True iff the member's first-ever access grant (drives "Welcome" copy). */
+  isFirstGrant?: boolean;
+  /** Why access changed (audit/telemetry) — e.g. `join`, `eligibility_lost`. */
+  reason?: string;
 }
 
 /** An address↔nostr identity link changed (Task 05; from address-links). */

--- a/src/token-gated-rooms/listeners/room-event.listener.ts
+++ b/src/token-gated-rooms/listeners/room-event.listener.ts
@@ -104,7 +104,13 @@ export class RoomEventListener {
       }
 
       await this.roomNotifyQueue.add(
-        { saleAddress, memberAddress, change },
+        {
+          saleAddress,
+          memberAddress,
+          change,
+          accessEventId: payload?.accessEventId,
+          isFirstGrant: payload?.isFirstGrant,
+        },
         roomNotifyJobOptions(),
       );
     } catch (error) {

--- a/src/token-gated-rooms/notifications/room-membership.notification.spec.ts
+++ b/src/token-gated-rooms/notifications/room-membership.notification.spec.ts
@@ -95,7 +95,7 @@ describe('RoomMembershipNotification', () => {
       change: 'added',
       isFirstGrant: false,
     }).toExpo();
-    expect(regained.body).toContain("back in");
+    expect(regained.body).toContain('back in');
     expect(regained.body).toContain('FOO');
   });
 

--- a/src/token-gated-rooms/notifications/room-membership.notification.spec.ts
+++ b/src/token-gated-rooms/notifications/room-membership.notification.spec.ts
@@ -57,6 +57,48 @@ describe('RoomMembershipNotification', () => {
     );
   });
 
+  it('keys the dedup on the ledger event id so distinct transitions never collapse', () => {
+    // Two DISTINCT access transitions (e.g. a grant then a real regain within the
+    // dedup TTL) both carry change='added' but different ledger event ids → the
+    // Redis dedup must NOT collapse them (that would drop the "you're back" push).
+    const grant = new RoomMembershipNotification({
+      saleAddress: SALE,
+      change: 'added',
+      accessEventId: '1',
+    });
+    const regain = new RoomMembershipNotification({
+      saleAddress: SALE,
+      change: 'added',
+      accessEventId: '2',
+    });
+    expect(grant.dedupKey({ address: ADDR })).toBe(
+      `room-membership:${SALE}:evt:1:${ADDR}`,
+    );
+    expect(regain.dedupKey({ address: ADDR })).not.toBe(
+      grant.dedupKey({ address: ADDR }),
+    );
+    // Same event redelivered (Bull retry) → SAME key (true-duplicate idempotency).
+    const grantRetry = new RoomMembershipNotification({
+      saleAddress: SALE,
+      change: 'added',
+      accessEventId: '1',
+    });
+    expect(grantRetry.dedupKey({ address: ADDR })).toBe(
+      grant.dedupKey({ address: ADDR }),
+    );
+  });
+
+  it('renders a "you\'re back" copy for a non-first-grant re-add', () => {
+    const regained = new RoomMembershipNotification({
+      saleAddress: SALE,
+      symbol: 'FOO',
+      change: 'added',
+      isFirstGrant: false,
+    }).toExpo();
+    expect(regained.body).toContain("back in");
+    expect(regained.body).toContain('FOO');
+  });
+
   it('renders distinct added vs removed copy and a data payload', () => {
     const added = new RoomMembershipNotification({
       saleAddress: SALE,

--- a/src/token-gated-rooms/notifications/room-membership.notification.ts
+++ b/src/token-gated-rooms/notifications/room-membership.notification.ts
@@ -16,6 +16,12 @@ export interface RoomMembershipParams {
   symbol?: string;
   /** Whether the holder was added to or removed from the room. */
   change: RoomMembershipChange;
+  /**
+   * For an `added` change: whether this is the member's first-ever access grant
+   * (access-ledger plan). `true` → a "welcome" copy; `false` → a "you're back"
+   * copy (access regained after a real lapse). Ignored for `removed`.
+   */
+  isFirstGrant?: boolean;
 }
 
 /**
@@ -53,10 +59,15 @@ export class RoomMembershipNotification implements AppNotification {
     const room = this.params.symbol
       ? `the ${this.params.symbol} room`
       : 'a room';
-    const body =
-      this.params.change === 'added'
-        ? `You now have access to ${room}.`
-        : `You no longer have access to ${room}.`;
+    let body: string;
+    if (this.params.change === 'added') {
+      body =
+        this.params.isFirstGrant === false
+          ? `You're back in ${room}.`
+          : `You now have access to ${room}.`;
+    } else {
+      body = `You no longer have access to ${room}.`;
+    }
     return {
       title: 'Room access',
       body,

--- a/src/token-gated-rooms/notifications/room-membership.notification.ts
+++ b/src/token-gated-rooms/notifications/room-membership.notification.ts
@@ -22,6 +22,15 @@ export interface RoomMembershipParams {
    * copy (access regained after a real lapse). Ignored for `removed`.
    */
   isFirstGrant?: boolean;
+  /**
+   * `room_membership_event.id` — the durable identity of THIS access transition
+   * (access-ledger plan). When present it keys the dedup so distinct transitions
+   * (e.g. a real regain within `NOTIF_DEDUP_TTL_MS`) never collapse onto an earlier
+   * push; the Redis dedup then only collapses true duplicates (Bull re-delivery of
+   * the same event), matching the `notified_at` guard. Falls back to the
+   * (room, change, recipient) key when absent (non-ledger callers).
+   */
+  accessEventId?: string;
 }
 
 /**
@@ -50,8 +59,17 @@ export class RoomMembershipNotification implements AppNotification {
   }
 
   dedupKey(notifiable: Notifiable): string {
-    // Distinct per (room, change, recipient): an add and a later remove never
-    // collapse, while repeated adds for the same room collapse to one push.
+    // Prefer the durable per-transition ledger id: distinct access transitions
+    // (a grant, a later revoke, a real regain) each get a UNIQUE key, so the Redis
+    // dedup only collapses true duplicates (Bull re-delivery of the SAME event) —
+    // never two legitimate transitions that happen to fall within the dedup TTL.
+    // This keeps the Redis backstop consistent with the ledger's `notified_at`
+    // guard (both keyed on the event), so a Redis-suppressed send can never mark an
+    // undelivered distinct transition as notified.
+    if (this.params.accessEventId) {
+      return `room-membership:${this.params.saleAddress}:evt:${this.params.accessEventId}:${notifiable.address}`;
+    }
+    // Fallback (non-ledger callers): per (room, change, recipient).
     return `room-membership:${this.params.saleAddress}:${this.params.change}:${notifiable.address}`;
   }
 

--- a/src/token-gated-rooms/queues/__tests__/reconcile.processor.spec.ts
+++ b/src/token-gated-rooms/queues/__tests__/reconcile.processor.spec.ts
@@ -1,5 +1,6 @@
 import type { Queue } from 'bull';
 import {
+  ACCESS_REVOKE_FINALIZE_JOB,
   RECONCILE_MEMBERSHIP_JOB,
   RECONCILE_MEMBERSHIP_QUEUE,
   REORG_FLUSH_JOB,
@@ -36,6 +37,11 @@ describe('ReconcileProcessor (unit)', () => {
         .fn()
         .mockResolvedValue({ published: 0, cancelled: 0 }),
     };
+    const membershipAccess = {
+      finalizeDueRevokes: jest
+        .fn()
+        .mockResolvedValue({ revoked: 0, cancelled: 0 }),
+    };
     const config = {
       reconcileIntervalSec: 600,
       nostrRelayUrl: relayConfigured ? 'ws://relay' : undefined,
@@ -45,38 +51,51 @@ describe('ReconcileProcessor (unit)', () => {
       queue as unknown as Queue,
       reconciliation as any,
       reorgEviction as any,
+      membershipAccess as any,
       config as any,
     );
-    return { processor, queue, reconciliation, reorgEviction };
+    return { processor, queue, reconciliation, reorgEviction, membershipAccess };
   };
 
   it('exposes the canonical worker-prefixed queue name', () => {
     expect(RECONCILE_MEMBERSHIP_QUEUE).toBe('worker:reconcile-membership');
   });
 
-  describe('onModuleInit (relay-gated)', () => {
-    it('schedules BOTH repeatable jobs when a relay is configured', async () => {
+  describe('onModuleInit', () => {
+    it('schedules the relay jobs + the finalizer when a relay is configured', async () => {
       const { processor, queue } = build(true);
 
       await processor.onModuleInit();
 
       const jobNames = queue.add.mock.calls.map((c) => c[0]);
       expect(jobNames).toEqual(
-        expect.arrayContaining([RECONCILE_MEMBERSHIP_JOB, REORG_FLUSH_JOB]),
+        expect.arrayContaining([
+          RECONCILE_MEMBERSHIP_JOB,
+          REORG_FLUSH_JOB,
+          ACCESS_REVOKE_FINALIZE_JOB,
+        ]),
       );
-      expect(queue.add).toHaveBeenCalledTimes(2);
-      // Both repeat on the configured interval (10m default → 600s).
+      expect(queue.add).toHaveBeenCalledTimes(3);
+      // The two relay jobs repeat on the configured interval (10m → 600s).
       for (const call of queue.add.mock.calls) {
-        expect(call[2].repeat).toEqual({ every: 600_000 });
+        if (call[0] === ACCESS_REVOKE_FINALIZE_JOB) {
+          // The finalizer runs more often: min(30s, interval).
+          expect(call[2].repeat).toEqual({ every: 30_000 });
+        } else {
+          expect(call[2].repeat).toEqual({ every: 600_000 });
+        }
       }
     });
 
-    it('schedules NOTHING when no relay is configured (boot-safe)', async () => {
+    it('still schedules the relay-independent finalizer when no relay is configured', async () => {
       const { processor, queue } = build(false);
 
       await processor.onModuleInit();
 
-      expect(queue.add).not.toHaveBeenCalled();
+      // Only the finalizer (pure DB + event-emit) — no relay read/publish jobs.
+      const jobNames = queue.add.mock.calls.map((c) => c[0]);
+      expect(jobNames).toEqual([ACCESS_REVOKE_FINALIZE_JOB]);
+      expect(queue.add).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -105,6 +124,14 @@ describe('ReconcileProcessor (unit)', () => {
 
       expect(reconciliation.reconcileBatch).not.toHaveBeenCalled();
       expect(reorgEviction.flushDueEvictions).not.toHaveBeenCalled();
+    });
+
+    it('finalizeRevokes() delegates regardless of relay config', async () => {
+      for (const relay of [true, false]) {
+        const { processor, membershipAccess } = build(relay);
+        await processor.finalizeRevokes();
+        expect(membershipAccess.finalizeDueRevokes).toHaveBeenCalledTimes(1);
+      }
     });
   });
 });

--- a/src/token-gated-rooms/queues/__tests__/reconcile.processor.spec.ts
+++ b/src/token-gated-rooms/queues/__tests__/reconcile.processor.spec.ts
@@ -54,7 +54,13 @@ describe('ReconcileProcessor (unit)', () => {
       membershipAccess as any,
       config as any,
     );
-    return { processor, queue, reconciliation, reorgEviction, membershipAccess };
+    return {
+      processor,
+      queue,
+      reconciliation,
+      reorgEviction,
+      membershipAccess,
+    };
   };
 
   it('exposes the canonical worker-prefixed queue name', () => {

--- a/src/token-gated-rooms/queues/reconcile.processor.ts
+++ b/src/token-gated-rooms/queues/reconcile.processor.ts
@@ -4,6 +4,7 @@ import { ConfigType } from '@nestjs/config';
 import { Queue } from 'bull';
 import tgrConfig, { isRelayConfigured } from '../config/tgr.config';
 import { prefixQueue, TGR_QUEUE_NAMES } from '../config/queue-prefix';
+import { MembershipAccessService } from '../services/membership-access.service';
 import { ReconciliationService } from '../services/reconciliation.service';
 import { ReorgEvictionService } from '../services/reorg-eviction.service';
 
@@ -34,6 +35,19 @@ export const RECONCILE_MEMBERSHIP_JOB = 'reconcile-membership-batch';
 export const REORG_FLUSH_JOB = 'reorg-eviction-flush';
 
 /**
+ * Access-revoke debounce finalizer (access-ledger plan §3.5). Emits the single
+ * `access_revoked` push for members whose access loss has outlived the grace
+ * window (and silently clears rows re-added within it). Unlike the other two jobs
+ * this is pure DB + event-emit, so it is scheduled + run **regardless of relay
+ * configuration** (a revoke can be armed by a room deletion even with no relay).
+ */
+export const ACCESS_REVOKE_FINALIZE_JOB = 'access-revoke-finalize';
+
+/** Finalizer cadence — frequent enough that the effective revoke latency is
+ * grace + at most this interval. Bounded to [30s, reconcileInterval]. */
+const REVOKE_FINALIZE_MIN_SEC = 30;
+
+/**
  * Consumer for `worker:reconcile-membership` (Task 11).
  *
  * Owns two repeatable jobs (both registered on boot, relay-gated):
@@ -55,6 +69,7 @@ export class ReconcileProcessor implements OnModuleInit {
     private readonly queue: Queue,
     private readonly reconciliation: ReconciliationService,
     private readonly reorgEviction: ReorgEvictionService,
+    private readonly membershipAccess: MembershipAccessService,
     @Inject(tgrConfig.KEY)
     private readonly config: ConfigType<typeof tgrConfig>,
   ) {}
@@ -66,10 +81,35 @@ export class ReconcileProcessor implements OnModuleInit {
    * (nothing to read back / publish).
    */
   async onModuleInit(): Promise<void> {
+    const everyMs = Math.max(1, this.config.reconcileIntervalSec) * 1000;
+
+    // The revoke finalizer is relay-independent (pure DB + event-emit): schedule it
+    // even when no relay is configured, so a room-deletion-armed revoke still fires.
+    const finalizeEveryMs =
+      Math.min(
+        Math.max(REVOKE_FINALIZE_MIN_SEC, 1),
+        Math.max(1, this.config.reconcileIntervalSec),
+      ) * 1000;
+    try {
+      await this.queue.add(
+        ACCESS_REVOKE_FINALIZE_JOB,
+        {},
+        {
+          jobId: ACCESS_REVOKE_FINALIZE_JOB,
+          repeat: { every: finalizeEveryMs },
+          removeOnComplete: true,
+          removeOnFail: true,
+        },
+      );
+    } catch (error: any) {
+      this.logger.error(
+        `failed to schedule access-revoke-finalize job: ${error?.message ?? error}`,
+      );
+    }
+
     if (!isRelayConfigured(this.config)) {
       return;
     }
-    const everyMs = Math.max(1, this.config.reconcileIntervalSec) * 1000;
     try {
       await this.queue.add(
         RECONCILE_MEMBERSHIP_JOB,
@@ -126,6 +166,21 @@ export class ReconcileProcessor implements OnModuleInit {
     if (published > 0 || cancelled > 0) {
       this.logger.debug(
         `[reorg-flush] published=${published} cancelled=${cancelled}`,
+      );
+    }
+  }
+
+  /**
+   * Emit debounced access-revoke pushes (relay-independent — always runs). A row
+   * re-added within the grace window is cleared silently (flap absorbed).
+   */
+  @Process({ name: ACCESS_REVOKE_FINALIZE_JOB, concurrency: 1 })
+  async finalizeRevokes(): Promise<void> {
+    const { revoked, cancelled } =
+      await this.membershipAccess.finalizeDueRevokes();
+    if (revoked > 0 || cancelled > 0) {
+      this.logger.debug(
+        `[access-revoke-finalize] revoked=${revoked} cancelled=${cancelled}`,
       );
     }
   }

--- a/src/token-gated-rooms/queues/room-notify.integration.spec.ts
+++ b/src/token-gated-rooms/queues/room-notify.integration.spec.ts
@@ -6,6 +6,7 @@ import { NotificationPreference } from '@/notifications/entities/notification-pr
 import { NotificationPreferencesService } from '@/notifications/services/notification-preferences.service';
 import { CommunityRoom } from '../entities/community-room.entity';
 import { RoomMembership } from '../entities/room-membership.entity';
+import { RoomMembershipEvent } from '../entities/room-membership-event.entity';
 import { RoomNotificationPreference } from '../entities/room-notification-preference.entity';
 import { RoomMessageSeen } from '../entities/room-message-seen.entity';
 import { TokenBalance } from '../entities/token-balance.entity';
@@ -73,6 +74,7 @@ d('RoomNotifyProcessor (integration)', () => {
         Token,
         CommunityRoom,
         RoomMembership,
+        RoomMembershipEvent,
         RoomNotificationPreference,
         RoomMessageSeen,
         TokenBalance,
@@ -109,6 +111,7 @@ d('RoomNotifyProcessor (integration)', () => {
     getActiveTokens = jest.fn().mockResolvedValue(['ExponentPushToken[x]']);
     processor = new RoomNotifyProcessor(
       tokenRepo,
+      ds.getRepository(RoomMembershipEvent),
       { getActiveTokens } as any,
       roomPreferences,
       { send } as any,

--- a/src/token-gated-rooms/queues/room-notify.processor.spec.ts
+++ b/src/token-gated-rooms/queues/room-notify.processor.spec.ts
@@ -8,6 +8,7 @@ describe('RoomNotifyProcessor', () => {
   const MEMBER = 'ak_member';
 
   let tokenRepo: { findOne: jest.Mock };
+  let eventRepo: { findOne: jest.Mock; update: jest.Mock };
   let devices: { getActiveTokens: jest.Mock };
   let roomPreferences: { isRoomEnabled: jest.Mock };
   let notifications: { send: jest.Mock };
@@ -25,6 +26,10 @@ describe('RoomNotifyProcessor', () => {
 
   beforeEach(() => {
     tokenRepo = { findOne: jest.fn().mockResolvedValue({ symbol: 'FOO' }) };
+    eventRepo = {
+      findOne: jest.fn().mockResolvedValue(null),
+      update: jest.fn().mockResolvedValue(undefined),
+    };
     devices = {
       getActiveTokens: jest.fn().mockResolvedValue(['ExponentPushToken[x]']),
     };
@@ -32,6 +37,7 @@ describe('RoomNotifyProcessor', () => {
     notifications = { send: jest.fn().mockResolvedValue({ outcome: 'sent' }) };
     processor = new RoomNotifyProcessor(
       tokenRepo as any,
+      eventRepo as any,
       devices as any,
       roomPreferences as any,
       notifications as any,

--- a/src/token-gated-rooms/queues/room-notify.processor.ts
+++ b/src/token-gated-rooms/queues/room-notify.processor.ts
@@ -87,6 +87,7 @@ export class RoomNotifyProcessor {
         symbol,
         change,
         isFirstGrant,
+        accessEventId,
       }),
     );
     if (outcome.outcome === 'failed') {

--- a/src/token-gated-rooms/queues/room-notify.processor.ts
+++ b/src/token-gated-rooms/queues/room-notify.processor.ts
@@ -7,6 +7,7 @@ import { Repository } from 'typeorm';
 import { Token } from '@/tokens/entities/token.entity';
 import { NotificationService } from '@/notifications/core/notification.service';
 import { DeviceService } from '@/notifications/services/device.service';
+import { RoomMembershipEvent } from '../entities/room-membership-event.entity';
 import { RoomMembershipNotification } from '../notifications/room-membership.notification';
 import { RoomPreferencesService } from '../services/room-preferences.service';
 import { ROOM_NOTIFY_QUEUE, type RoomNotifyJob } from './room-notify.types';
@@ -37,6 +38,8 @@ export class RoomNotifyProcessor {
   constructor(
     @InjectRepository(Token)
     private readonly tokenRepo: Repository<Token>,
+    @InjectRepository(RoomMembershipEvent)
+    private readonly eventRepo: Repository<RoomMembershipEvent>,
     private readonly devices: DeviceService,
     private readonly roomPreferences: RoomPreferencesService,
     private readonly notifications: NotificationService,
@@ -44,8 +47,15 @@ export class RoomNotifyProcessor {
 
   @Process()
   async process(job: Job<RoomNotifyJob>): Promise<void> {
-    const { saleAddress, memberAddress, change } = job.data;
+    const { saleAddress, memberAddress, change, accessEventId, isFirstGrant } =
+      job.data;
     if (!saleAddress || !memberAddress || !change) {
+      return;
+    }
+
+    // (0) Durable dedup: if this access-ledger event was already pushed (Bull
+    // retry / redelivery after a restart), do not push it again.
+    if (accessEventId && (await this.alreadyNotified(accessEventId))) {
       return;
     }
 
@@ -72,11 +82,53 @@ export class RoomNotifyProcessor {
     // (4) Dispatch (NotificationService re-applies the type-level chokepoint).
     const outcome = await this.notifications.send(
       { address: memberAddress as Encoded.AccountAddress },
-      new RoomMembershipNotification({ saleAddress, symbol, change }),
+      new RoomMembershipNotification({
+        saleAddress,
+        symbol,
+        change,
+        isFirstGrant,
+      }),
     );
     if (outcome.outcome === 'failed') {
       this.logger.warn(
         `room-membership notification failed for ${memberAddress} in ${saleAddress}: ${outcome.error}`,
+      );
+      return;
+    }
+
+    // (5) Stamp the ledger event dispatched (durable dedup). Best-effort — a stamp
+    // failure must not fail the job (it would only risk a duplicate push).
+    if (accessEventId) {
+      await this.markNotified(accessEventId);
+    }
+  }
+
+  /** True iff the access-ledger event has already been dispatched. */
+  private async alreadyNotified(accessEventId: string): Promise<boolean> {
+    try {
+      const event = await this.eventRepo.findOne({
+        where: { id: accessEventId },
+        select: ['id', 'notified_at'],
+      });
+      return !!event?.notified_at;
+    } catch {
+      // Fail open: a lookup blip should not silently swallow the notification.
+      return false;
+    }
+  }
+
+  /** Stamp `notified_at=now()` on the access-ledger event (best-effort). */
+  private async markNotified(accessEventId: string): Promise<void> {
+    try {
+      await this.eventRepo.update(
+        { id: accessEventId },
+        { notified_at: new Date() },
+      );
+    } catch (error) {
+      this.logger.warn(
+        `failed to stamp notified_at for access event ${accessEventId}: ${
+          (error as Error).message
+        }`,
       );
     }
   }

--- a/src/token-gated-rooms/queues/room-notify.types.ts
+++ b/src/token-gated-rooms/queues/room-notify.types.ts
@@ -24,6 +24,14 @@ export interface RoomNotifyJob {
   memberAddress: string;
   /** Whether the holder was added to or removed from the room. */
   change: RoomMembershipChange;
+  /**
+   * `room_membership_event.id` for this transition (access-ledger plan). The
+   * processor stamps `notified_at` on dispatch → durable dedup (never re-push the
+   * same access transition on a Bull retry / after a restart).
+   */
+  accessEventId?: string;
+  /** True iff the member's first-ever access grant (drives "Welcome" copy). */
+  isFirstGrant?: boolean;
 }
 
 /**

--- a/src/token-gated-rooms/room-notifications.module.ts
+++ b/src/token-gated-rooms/room-notifications.module.ts
@@ -9,6 +9,7 @@ import { NotificationRedisService } from '@/notifications/services/notification-
 import tgrConfig from './config/tgr.config';
 import { CommunityRoom } from './entities/community-room.entity';
 import { RoomMembership } from './entities/room-membership.entity';
+import { RoomMembershipEvent } from './entities/room-membership-event.entity';
 import { RoomMessageSeen } from './entities/room-message-seen.entity';
 import { RoomNotificationPreference } from './entities/room-notification-preference.entity';
 import { RoomPreferencesService } from './services/room-preferences.service';
@@ -43,6 +44,7 @@ import { ROOM_NOTIFY_QUEUE } from './queues/room-notify.types';
       RoomNotificationPreference,
       CommunityRoom,
       RoomMembership,
+      RoomMembershipEvent,
       RoomMessageSeen,
     ]),
     NotificationsModule,

--- a/src/token-gated-rooms/services/membership-access.service.spec.ts
+++ b/src/token-gated-rooms/services/membership-access.service.spec.ts
@@ -1,0 +1,201 @@
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { RoomMembership } from '../entities/room-membership.entity';
+import {
+  TGR_MEMBERSHIP_CHANGED,
+  type TgrMembershipChangedPayload,
+} from '../events';
+import { MembershipAccessService } from './membership-access.service';
+
+/**
+ * Unit coverage for the access-transition ledger (access-ledger plan §3.4/§3.5) —
+ * the fix for the ~hourly repeated "You now have access" push. Verifies:
+ *   - a genuine gain records ONE grant + emits (first-ever = `is_first_grant`);
+ *   - a re-add of an already-granted member (reconcile / `39002` regen) is a silent
+ *     no-op — the churn that caused the repeat;
+ *   - a loss ARMS the debounce (no push yet);
+ *   - the finalizer emits ONE revoke past the grace window, but a re-add within the
+ *     window is absorbed (NEITHER push).
+ */
+const SALE = 'ct_sale';
+const MEMBER = 'ak_member';
+
+function makeRow(over: Partial<RoomMembership> = {}): RoomMembership {
+  return {
+    id: 1,
+    sale_address: SALE,
+    member_address: MEMBER,
+    member_pubkey: 'p',
+    role: 'member',
+    eligible: true,
+    relay_state: 'added',
+    access_state: 'none',
+    access_changed_at: null as any,
+    pending_revoke_since: null as any,
+    pending_revoke_reason: null as any,
+    held_until_height: null as any,
+    last_published_at: null as any,
+    last_reconciled_at: null as any,
+    updated_at: new Date(),
+    ...over,
+  } as RoomMembership;
+}
+
+function setup(opts: { grace?: number; priorGrants?: number } = {}) {
+  const membershipRepo = {
+    update: jest.fn().mockResolvedValue(undefined),
+    find: jest.fn().mockResolvedValue([]),
+  };
+  let seq = 1;
+  const eventRepo = {
+    count: jest.fn().mockResolvedValue(opts.priorGrants ?? 0),
+    create: jest.fn((v) => v),
+    save: jest.fn(async (v) => ({ ...v, id: String(seq++) })),
+  };
+  const emitter = new EventEmitter2();
+  const emitted: TgrMembershipChangedPayload[] = [];
+  emitter.on(TGR_MEMBERSHIP_CHANGED, (p) => emitted.push(p));
+  const service = new MembershipAccessService(
+    membershipRepo as any,
+    eventRepo as any,
+    emitter,
+    { accessRevokeGraceSec: opts.grace ?? 180 } as any,
+  );
+  return { service, membershipRepo, eventRepo, emitted };
+}
+
+describe('MembershipAccessService — gains', () => {
+  it('none → granted records a first-grant + emits added(isFirstGrant=true)', async () => {
+    const h = setup({ priorGrants: 0 });
+    const row = makeRow({ access_state: 'none' });
+
+    await h.service.recordAccessTransition(row, true, 'access_gained');
+
+    expect(h.membershipRepo.update).toHaveBeenCalledWith(
+      { id: 1 },
+      expect.objectContaining({ access_state: 'granted' }),
+    );
+    expect(h.eventRepo.save).toHaveBeenCalledWith(
+      expect.objectContaining({ event: 'access_granted', reason: 'join', is_first_grant: true }),
+    );
+    expect(h.emitted).toHaveLength(1);
+    expect(h.emitted[0]).toMatchObject({
+      relayState: 'added',
+      isFirstGrant: true,
+      accessEventId: '1',
+    });
+  });
+
+  it('regained (prior grant exists) → reason regained, isFirstGrant=false', async () => {
+    const h = setup({ priorGrants: 1 });
+    const row = makeRow({ access_state: 'none' });
+
+    await h.service.recordAccessTransition(row, true, 'access_gained');
+
+    expect(h.eventRepo.save).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: 'regained', is_first_grant: false }),
+    );
+    expect(h.emitted[0]).toMatchObject({ isFirstGrant: false });
+  });
+
+  it('re-add of an already-granted member is a SILENT no-op (the flap/reconcile churn)', async () => {
+    const h = setup();
+    const row = makeRow({ access_state: 'granted' });
+
+    await h.service.recordAccessTransition(row, true, 'access_gained');
+
+    expect(h.eventRepo.save).not.toHaveBeenCalled();
+    expect(h.emitted).toHaveLength(0);
+  });
+
+  it('re-add of a granted member with an armed revoke cancels the revoke silently', async () => {
+    const h = setup();
+    const row = makeRow({
+      access_state: 'granted',
+      pending_revoke_since: new Date(),
+      pending_revoke_reason: 'eligibility_lost',
+    });
+
+    await h.service.recordAccessTransition(row, true, 'access_gained');
+
+    expect(h.membershipRepo.update).toHaveBeenCalledWith(
+      { id: 1 },
+      { pending_revoke_since: null, pending_revoke_reason: null },
+    );
+    expect(h.emitted).toHaveLength(0);
+  });
+});
+
+describe('MembershipAccessService — losses (debounced)', () => {
+  it('granted → lost ARMS pending_revoke and does NOT emit', async () => {
+    const h = setup();
+    const row = makeRow({ access_state: 'granted', relay_state: 'removed' });
+
+    await h.service.recordAccessTransition(row, false, 'eligibility_lost');
+
+    expect(h.membershipRepo.update).toHaveBeenCalledWith(
+      { id: 1 },
+      expect.objectContaining({
+        pending_revoke_since: expect.any(Date),
+        pending_revoke_reason: 'eligibility_lost',
+      }),
+    );
+    expect(h.emitted).toHaveLength(0);
+  });
+
+  it('loss on a never-granted (none) row is a no-op', async () => {
+    const h = setup();
+    const row = makeRow({ access_state: 'none', relay_state: 'removed' });
+
+    await h.service.recordAccessTransition(row, false, 'eligibility_lost');
+
+    expect(h.membershipRepo.update).not.toHaveBeenCalled();
+    expect(h.emitted).toHaveLength(0);
+  });
+});
+
+describe('MembershipAccessService — finalizeDueRevokes', () => {
+  it('still-removed past grace → ONE revoke emit + access_state=none', async () => {
+    const h = setup();
+    const armed = makeRow({
+      access_state: 'granted',
+      relay_state: 'removed',
+      pending_revoke_since: new Date(Date.now() - 10 * 60_000),
+      pending_revoke_reason: 'eligibility_lost',
+    });
+    h.membershipRepo.find = jest.fn().mockResolvedValue([armed]);
+
+    const result = await h.service.finalizeDueRevokes();
+
+    expect(result).toEqual({ revoked: 1, cancelled: 0 });
+    expect(h.membershipRepo.update).toHaveBeenCalledWith(
+      { id: 1 },
+      expect.objectContaining({ access_state: 'none' }),
+    );
+    expect(h.eventRepo.save).toHaveBeenCalledWith(
+      expect.objectContaining({ event: 'access_revoked', reason: 'eligibility_lost' }),
+    );
+    expect(h.emitted).toHaveLength(1);
+    expect(h.emitted[0]).toMatchObject({ relayState: 'removed', accessEventId: '1' });
+  });
+
+  it('re-added within grace (relay_state=added) → cancelled silently, NO push', async () => {
+    const h = setup();
+    const readded = makeRow({
+      access_state: 'granted',
+      relay_state: 'added', // came back before the finalizer ran
+      pending_revoke_since: new Date(Date.now() - 10 * 60_000),
+      pending_revoke_reason: 'eligibility_lost',
+    });
+    h.membershipRepo.find = jest.fn().mockResolvedValue([readded]);
+
+    const result = await h.service.finalizeDueRevokes();
+
+    expect(result).toEqual({ revoked: 0, cancelled: 1 });
+    expect(h.membershipRepo.update).toHaveBeenCalledWith(
+      { id: 1 },
+      { pending_revoke_since: null, pending_revoke_reason: null },
+    );
+    expect(h.eventRepo.save).not.toHaveBeenCalled();
+    expect(h.emitted).toHaveLength(0);
+  });
+});

--- a/src/token-gated-rooms/services/membership-access.service.spec.ts
+++ b/src/token-gated-rooms/services/membership-access.service.spec.ts
@@ -42,7 +42,8 @@ function makeRow(over: Partial<RoomMembership> = {}): RoomMembership {
 
 function setup(opts: { grace?: number; priorGrants?: number } = {}) {
   const membershipRepo = {
-    update: jest.fn().mockResolvedValue(undefined),
+    // update() returns an UpdateResult; `affected` drives the compare-and-set guard.
+    update: jest.fn().mockResolvedValue({ affected: 1 }),
     find: jest.fn().mockResolvedValue([]),
   };
   let seq = 1;
@@ -71,7 +72,7 @@ describe('MembershipAccessService — gains', () => {
     await h.service.recordAccessTransition(row, true, 'access_gained');
 
     expect(h.membershipRepo.update).toHaveBeenCalledWith(
-      { id: 1 },
+      { id: 1, access_state: 'none' }, // compare-and-set on the prior state
       expect.objectContaining({ access_state: 'granted' }),
     );
     expect(h.eventRepo.save).toHaveBeenCalledWith(
@@ -104,6 +105,19 @@ describe('MembershipAccessService — gains', () => {
   it('re-add of an already-granted member is a SILENT no-op (the flap/reconcile churn)', async () => {
     const h = setup();
     const row = makeRow({ access_state: 'granted' });
+
+    await h.service.recordAccessTransition(row, true, 'access_gained');
+
+    expect(h.eventRepo.save).not.toHaveBeenCalled();
+    expect(h.emitted).toHaveLength(0);
+  });
+
+  it('lost the none→granted CAS race (affected=0) → no ledger row, no push', async () => {
+    // Two concurrent ACKs both see access_state='none'; the DB compare-and-set only
+    // lets ONE win. The loser's UPDATE matches 0 rows → must not double-emit.
+    const h = setup();
+    h.membershipRepo.update = jest.fn().mockResolvedValue({ affected: 0 });
+    const row = makeRow({ access_state: 'none' });
 
     await h.service.recordAccessTransition(row, true, 'access_gained');
 
@@ -172,7 +186,7 @@ describe('MembershipAccessService — finalizeDueRevokes', () => {
 
     expect(result).toEqual({ revoked: 1, cancelled: 0 });
     expect(h.membershipRepo.update).toHaveBeenCalledWith(
-      { id: 1 },
+      { id: 1, access_state: 'granted' }, // compare-and-set on the prior state
       expect.objectContaining({ access_state: 'none' }),
     );
     expect(h.eventRepo.save).toHaveBeenCalledWith(
@@ -186,6 +200,24 @@ describe('MembershipAccessService — finalizeDueRevokes', () => {
       relayState: 'removed',
       accessEventId: '1',
     });
+  });
+
+  it('lost the revoke CAS race (affected=0) → no revoke row, no push', async () => {
+    const h = setup();
+    const armed = makeRow({
+      access_state: 'granted',
+      relay_state: 'removed',
+      pending_revoke_since: new Date(Date.now() - 10 * 60_000),
+      pending_revoke_reason: 'eligibility_lost',
+    });
+    h.membershipRepo.find = jest.fn().mockResolvedValue([armed]);
+    h.membershipRepo.update = jest.fn().mockResolvedValue({ affected: 0 });
+
+    const result = await h.service.finalizeDueRevokes();
+
+    expect(result).toEqual({ revoked: 0, cancelled: 0 });
+    expect(h.eventRepo.save).not.toHaveBeenCalled();
+    expect(h.emitted).toHaveLength(0);
   });
 
   it('re-added within grace (relay_state=added) → cancelled silently, NO push', async () => {

--- a/src/token-gated-rooms/services/membership-access.service.spec.ts
+++ b/src/token-gated-rooms/services/membership-access.service.spec.ts
@@ -75,7 +75,11 @@ describe('MembershipAccessService — gains', () => {
       expect.objectContaining({ access_state: 'granted' }),
     );
     expect(h.eventRepo.save).toHaveBeenCalledWith(
-      expect.objectContaining({ event: 'access_granted', reason: 'join', is_first_grant: true }),
+      expect.objectContaining({
+        event: 'access_granted',
+        reason: 'join',
+        is_first_grant: true,
+      }),
     );
     expect(h.emitted).toHaveLength(1);
     expect(h.emitted[0]).toMatchObject({
@@ -172,10 +176,16 @@ describe('MembershipAccessService — finalizeDueRevokes', () => {
       expect.objectContaining({ access_state: 'none' }),
     );
     expect(h.eventRepo.save).toHaveBeenCalledWith(
-      expect.objectContaining({ event: 'access_revoked', reason: 'eligibility_lost' }),
+      expect.objectContaining({
+        event: 'access_revoked',
+        reason: 'eligibility_lost',
+      }),
     );
     expect(h.emitted).toHaveLength(1);
-    expect(h.emitted[0]).toMatchObject({ relayState: 'removed', accessEventId: '1' });
+    expect(h.emitted[0]).toMatchObject({
+      relayState: 'removed',
+      accessEventId: '1',
+    });
   });
 
   it('re-added within grace (relay_state=added) → cancelled silently, NO push', async () => {

--- a/src/token-gated-rooms/services/membership-access.service.ts
+++ b/src/token-gated-rooms/services/membership-access.service.ts
@@ -97,7 +97,27 @@ export class MembershipAccessService {
       return;
     }
 
-    // Genuine transition none → granted.
+    // Genuine transition none → granted. **Atomic compare-and-set**: condition the
+    // flip on the prior `access_state='none'` so only ONE handler wins when the same
+    // relay ACK is processed concurrently (publish concurrency ≥ 2 → duplicate 9000
+    // ACKs for one member). A racing/duplicate handler matches 0 rows and returns
+    // WITHOUT inserting a ledger row or emitting — no duplicate event, no duplicate push.
+    const now = new Date();
+    const result = await this.membershipRepo.update(
+      { id: row.id, access_state: 'none' },
+      {
+        access_state: 'granted',
+        access_changed_at: now,
+        pending_revoke_since: null,
+        pending_revoke_reason: null,
+      },
+    );
+    if (!result.affected) {
+      return; // lost the race — another handler already granted this transition
+    }
+
+    // Only the winner counts + inserts (so `priorGrants` never includes this
+    // transition's own row → correct first-grant detection under concurrency).
     const priorGrants = await this.eventRepo.count({
       where: {
         sale_address: row.sale_address,
@@ -106,17 +126,6 @@ export class MembershipAccessService {
       },
     });
     const isFirst = priorGrants === 0;
-    const now = new Date();
-
-    await this.membershipRepo.update(
-      { id: row.id },
-      {
-        access_state: 'granted',
-        access_changed_at: now,
-        pending_revoke_since: null,
-        pending_revoke_reason: null,
-      },
-    );
 
     const event = await this.eventRepo.save(
       this.eventRepo.create({
@@ -191,8 +200,10 @@ export class MembershipAccessService {
 
         const reason = row.pending_revoke_reason || 'access_lost';
         const now = new Date();
-        await this.membershipRepo.update(
-          { id: row.id },
+        // Atomic compare-and-set (mirror the grant path): only flip a still-`granted`
+        // row so overlapping finalizer runs can't emit two `access_revoked` rows/pushes.
+        const result = await this.membershipRepo.update(
+          { id: row.id, access_state: 'granted' },
           {
             access_state: 'none',
             access_changed_at: now,
@@ -200,6 +211,9 @@ export class MembershipAccessService {
             pending_revoke_reason: null,
           },
         );
+        if (!result.affected) {
+          continue; // lost the race — already resolved elsewhere
+        }
         const event = await this.eventRepo.save(
           this.eventRepo.create({
             sale_address: row.sale_address,

--- a/src/token-gated-rooms/services/membership-access.service.ts
+++ b/src/token-gated-rooms/services/membership-access.service.ts
@@ -1,0 +1,248 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { ConfigType } from '@nestjs/config';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { InjectRepository } from '@nestjs/typeorm';
+import { LessThanOrEqual, Repository } from 'typeorm';
+import tgrConfig from '../config/tgr.config';
+import { RoomMembership } from '../entities/room-membership.entity';
+import { RoomMembershipEvent } from '../entities/room-membership-event.entity';
+import {
+  TGR_MEMBERSHIP_CHANGED,
+  type TgrMembershipChangedPayload,
+} from '../events';
+
+/**
+ * Access-transition detector + debounce finalizer (access-ledger plan §3.4/§3.5).
+ *
+ * ## Why this exists
+ * The membership push used to fire off the raw `relay_state: pending_add → added`
+ * ACK — a *relay-sync* signal that churns (reconcile re-adds, `39002`
+ * regeneration, a transient `eligible` flap cycling `added → removed → added`).
+ * Result: "You now have access to X" re-fired ~hourly (thinned only by the 1h
+ * Redis dedup TTL) for every room a holder was in.
+ *
+ * This service makes notifications fire off **effective-access transitions**
+ * (`effective access = relay_state === 'added'`), recorded in a durable ledger
+ * (`room_membership_event`) with a short **debounce** on loss:
+ *  - GAIN (`none → granted`): recorded + pushed immediately (first-ever = "join",
+ *    otherwise "regained").
+ *  - LOSS (`granted → …`): NOT pushed immediately — `pending_revoke_since` is armed;
+ *    a re-add within `TG_ACCESS_REVOKE_GRACE_SEC` cancels it silently (flap absorbed,
+ *    no push either way); otherwise the finalizer emits ONE `access_revoked`.
+ *
+ * Reconcile re-adds / `39002` regeneration never change `access_state`, so they
+ * never notify — the hourly repeat is fixed structurally, independent of whether
+ * the underlying balance flap is also fixed (that's the separate §8 follow-up).
+ *
+ * The emitted event is the existing `tgr.membership.changed`, now enriched with the
+ * ledger `accessEventId` + `isFirstGrant` so the room-notify processor can pick the
+ * copy and stamp `notified_at` (durable dedup across Bull retries / restarts).
+ */
+@Injectable()
+export class MembershipAccessService {
+  private readonly logger = new Logger(MembershipAccessService.name);
+
+  constructor(
+    @InjectRepository(RoomMembership)
+    private readonly membershipRepo: Repository<RoomMembership>,
+    @InjectRepository(RoomMembershipEvent)
+    private readonly eventRepo: Repository<RoomMembershipEvent>,
+    private readonly eventEmitter: EventEmitter2,
+    @Inject(tgrConfig.KEY)
+    private readonly config: ConfigType<typeof tgrConfig>,
+  ) {}
+
+  /**
+   * Fold a relay-state transition into the effective-access ledger. Called from
+   * every seam that writes `relay_state` (membership-sync `applyAck` +
+   * `handleDeletedRoom`).
+   *
+   * @param row       the membership row (pre-write access columns are read from it;
+   *                  `relay_state` has already been written by the caller).
+   * @param effective the NEW effective access (`relay_state === 'added'`).
+   * @param reason    the loss reason to persist through the debounce (grants derive
+   *                  their own `join`/`regained` reason and ignore this).
+   */
+  async recordAccessTransition(
+    row: RoomMembership,
+    effective: boolean,
+    reason: string,
+  ): Promise<void> {
+    try {
+      if (effective) {
+        await this.onAccessGained(row);
+      } else {
+        await this.onAccessLost(row, reason);
+      }
+    } catch (error) {
+      // Access bookkeeping must never break the membership-sync ACK loop.
+      this.logger.error(
+        `recordAccessTransition(${row.sale_address}, ${row.member_address}, effective=${effective}) failed`,
+        error as Error,
+      );
+    }
+  }
+
+  /** relay_state is now 'added' → the member has room access. */
+  private async onAccessGained(row: RoomMembership): Promise<void> {
+    if (row.access_state === 'granted') {
+      // Already granted. If a revoke was armed (a flap: removed then re-added
+      // within the grace window), cancel it silently — no push either way.
+      if (row.pending_revoke_since) {
+        await this.membershipRepo.update(
+          { id: row.id },
+          { pending_revoke_since: null, pending_revoke_reason: null },
+        );
+      }
+      return;
+    }
+
+    // Genuine transition none → granted.
+    const priorGrants = await this.eventRepo.count({
+      where: {
+        sale_address: row.sale_address,
+        member_address: row.member_address,
+        event: 'access_granted',
+      },
+    });
+    const isFirst = priorGrants === 0;
+    const now = new Date();
+
+    await this.membershipRepo.update(
+      { id: row.id },
+      {
+        access_state: 'granted',
+        access_changed_at: now,
+        pending_revoke_since: null,
+        pending_revoke_reason: null,
+      },
+    );
+
+    const event = await this.eventRepo.save(
+      this.eventRepo.create({
+        sale_address: row.sale_address,
+        member_address: row.member_address,
+        event: 'access_granted',
+        reason: isFirst ? 'join' : 'regained',
+        is_first_grant: isFirst,
+      }),
+    );
+
+    this.emit(row, 'added', event.id, isFirst, event.reason);
+  }
+
+  /** relay_state is now removed → arm the revoke debounce (no push yet). */
+  private async onAccessLost(
+    row: RoomMembership,
+    reason: string,
+  ): Promise<void> {
+    if (row.access_state !== 'granted') {
+      // Never had (notified) access — nothing to revoke (e.g. an unlinked member
+      // that was never granted, or an already-revoked row).
+      return;
+    }
+    if (row.pending_revoke_since) {
+      return; // already armed — keep the earliest arm time
+    }
+    await this.membershipRepo.update(
+      { id: row.id },
+      {
+        pending_revoke_since: new Date(),
+        pending_revoke_reason: reason || 'access_lost',
+      },
+    );
+  }
+
+  /**
+   * Finalize armed revokes whose grace window has elapsed (access-ledger plan §3.5).
+   * Pure DB + event-emit — safe to run regardless of relay configuration. Scheduled
+   * as a repeatable job by `ReconcileProcessor`.
+   *
+   * For each row with `pending_revoke_since <= now - grace`:
+   *  - re-added during grace (`relay_state='added'`) → clear the arm, no push (flap
+   *    absorbed);
+   *  - still removed → record ONE `access_revoked` + push, flip `access_state='none'`.
+   */
+  async finalizeDueRevokes(): Promise<{ revoked: number; cancelled: number }> {
+    const graceMs = Math.max(0, this.config.accessRevokeGraceSec) * 1000;
+    const cutoff = new Date(Date.now() - graceMs);
+
+    const due = await this.membershipRepo.find({
+      where: { pending_revoke_since: LessThanOrEqual(cutoff) },
+      take: 500,
+    });
+
+    let revoked = 0;
+    let cancelled = 0;
+    for (const row of due) {
+      try {
+        if (row.relay_state === 'added' || row.access_state !== 'granted') {
+          // Re-added during the grace window, or already resolved elsewhere —
+          // clear the arm silently.
+          await this.membershipRepo.update(
+            { id: row.id },
+            { pending_revoke_since: null, pending_revoke_reason: null },
+          );
+          if (row.relay_state === 'added') {
+            cancelled += 1;
+          }
+          continue;
+        }
+
+        const reason = row.pending_revoke_reason || 'access_lost';
+        const now = new Date();
+        await this.membershipRepo.update(
+          { id: row.id },
+          {
+            access_state: 'none',
+            access_changed_at: now,
+            pending_revoke_since: null,
+            pending_revoke_reason: null,
+          },
+        );
+        const event = await this.eventRepo.save(
+          this.eventRepo.create({
+            sale_address: row.sale_address,
+            member_address: row.member_address,
+            event: 'access_revoked',
+            reason,
+            is_first_grant: false,
+          }),
+        );
+        this.emit(row, 'removed', event.id, false, reason);
+        revoked += 1;
+      } catch (error) {
+        this.logger.error(
+          `finalizeDueRevokes: row ${row.id} (${row.sale_address}/${row.member_address}) failed`,
+          error as Error,
+        );
+      }
+    }
+
+    if (revoked > 0 || cancelled > 0) {
+      this.logger.debug(
+        `finalizeDueRevokes: revoked=${revoked} cancelled=${cancelled}`,
+      );
+    }
+    return { revoked, cancelled };
+  }
+
+  /** Emit the enriched `tgr.membership.changed` for a real access transition. */
+  private emit(
+    row: RoomMembership,
+    relayState: TgrMembershipChangedPayload['relayState'],
+    accessEventId: string,
+    isFirstGrant: boolean,
+    reason: string,
+  ): void {
+    const payload: TgrMembershipChangedPayload = {
+      saleAddress: row.sale_address,
+      memberAddress: row.member_address,
+      relayState,
+      accessEventId,
+      isFirstGrant,
+      reason,
+    };
+    this.eventEmitter.emit(TGR_MEMBERSHIP_CHANGED, payload);
+  }
+}

--- a/src/token-gated-rooms/services/membership-sync.service.integration.spec.ts
+++ b/src/token-gated-rooms/services/membership-sync.service.integration.spec.ts
@@ -10,6 +10,7 @@ import { DATABASE_CONFIG } from '@/configs/database';
 import { Token } from '@/tokens/entities/token.entity';
 import { CommunityRoom } from '../entities/community-room.entity';
 import { RoomMembership } from '../entities/room-membership.entity';
+import { RoomMembershipEvent } from '../entities/room-membership-event.entity';
 import { RoomNotificationPreference } from '../entities/room-notification-preference.entity';
 import { RoomMessageSeen } from '../entities/room-message-seen.entity';
 import { TokenBalance } from '../entities/token-balance.entity';
@@ -21,6 +22,7 @@ import {
   type TgrMembershipChangedPayload,
 } from '../events';
 import type { PublishNip29Job } from '../queues/publish-nip29.types';
+import { MembershipAccessService } from './membership-access.service';
 import { MembershipSyncService } from './membership-sync.service';
 
 if (typeof (globalThis as { WebSocket?: unknown }).WebSocket === 'undefined') {
@@ -101,6 +103,7 @@ d('MembershipSyncService (integration)', () => {
         Token,
         CommunityRoom,
         RoomMembership,
+        RoomMembershipEvent,
         RoomNotificationPreference,
         RoomMessageSeen,
         TokenBalance,
@@ -123,6 +126,13 @@ d('MembershipSyncService (integration)', () => {
     publishQueue = { add: jest.fn().mockResolvedValue({ id: 'p' }) } as any;
     isConfiguredAdmin = jest.fn().mockReturnValue(false);
 
+    const membershipAccess = new MembershipAccessService(
+      membershipRepo,
+      ds.getRepository(RoomMembershipEvent),
+      emitter,
+      { accessRevokeGraceSec: 180 } as any,
+    );
+
     service = new MembershipSyncService(
       membershipRepo,
       roomRepo,
@@ -136,6 +146,8 @@ d('MembershipSyncService (integration)', () => {
         reconcileBatchSize: 2,
         reconcileIntervalSec: 600,
       } as any,
+      undefined, // groupMissing (optional)
+      membershipAccess,
     );
   });
 
@@ -228,9 +240,18 @@ d('MembershipSyncService (integration)', () => {
     });
     expect(row.relay_state).toBe('added');
     expect(row.last_published_at).toBeInstanceOf(Date);
-    expect(seen).toEqual([
-      { saleAddress: SALE, memberAddress: MEMBER, relayState: 'added' },
-    ]);
+    // The push is now emitted by the access-transition ledger with the enriched
+    // payload (ledger event id + first-grant flag).
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toMatchObject({
+      saleAddress: SALE,
+      memberAddress: MEMBER,
+      relayState: 'added',
+      isFirstGrant: true,
+    });
+    expect(seen[0].accessEventId).toBeDefined();
+    // The row's effective-access state flips to granted.
+    expect(row.access_state).toBe('granted');
   });
 
   it('eligibility off → 9001 enqueued, ACK → relay_state=removed', async () => {

--- a/src/token-gated-rooms/services/membership-sync.service.spec.ts
+++ b/src/token-gated-rooms/services/membership-sync.service.spec.ts
@@ -48,6 +48,10 @@ function makeMembership(over: Partial<RoomMembership> = {}): RoomMembership {
     role: 'member',
     eligible: true,
     relay_state: 'pending_add',
+    access_state: 'none',
+    access_changed_at: null as any,
+    pending_revoke_since: null as any,
+    pending_revoke_reason: null as any,
     held_until_height: null as any,
     last_published_at: null as any,
     last_reconciled_at: null as any,
@@ -74,6 +78,7 @@ interface Harness {
   roomAdmins: { isConfiguredAdmin: jest.Mock };
   emitter: EventEmitter2;
   emitted: TgrMembershipChangedPayload[];
+  membershipAccess: { recordAccessTransition: jest.Mock };
   scheduler: {
     addInterval: jest.Mock;
     deleteInterval: jest.Mock;
@@ -125,6 +130,10 @@ function setup(
     doesExist: jest.fn().mockReturnValue(false),
   };
 
+  const membershipAccess = {
+    recordAccessTransition: jest.fn().mockResolvedValue(undefined),
+  };
+
   const service = new MembershipSyncService(
     membershipRepo,
     communityRoomRepo,
@@ -143,6 +152,8 @@ function setup(
       reconcileBatchSize: 500,
       reconcileIntervalSec: 600,
     } as any,
+    undefined, // groupMissing (optional)
+    membershipAccess as any, // access-transition ledger (sole push emitter)
   );
 
   return {
@@ -154,6 +165,7 @@ function setup(
     roomAdmins,
     emitter,
     emitted,
+    membershipAccess,
     scheduler,
   };
 }
@@ -346,9 +358,12 @@ describe('MembershipSyncService — ACK-driven relay_state flips (§6.3)', () =>
         last_published_at: expect.any(Date),
       }),
     );
-    expect(h.emitted).toEqual([
-      { saleAddress: SALE, memberAddress: 'ak_member', relayState: 'added' },
-    ]);
+    // The push is emitted by the access-transition ledger, not applyAck directly.
+    expect(h.membershipAccess.recordAccessTransition).toHaveBeenCalledWith(
+      row,
+      true,
+      'access_gained',
+    );
   });
 
   it('9001 ACK → relay_state="removed" + emits removed', async () => {
@@ -366,9 +381,12 @@ describe('MembershipSyncService — ACK-driven relay_state flips (§6.3)', () =>
       { id: row.id },
       expect.objectContaining({ relay_state: 'removed' }),
     );
-    expect(h.emitted).toEqual([
-      { saleAddress: SALE, memberAddress: 'ak_member', relayState: 'removed' },
-    ]);
+    // Access loss folds into the ledger (which arms the debounced revoke).
+    expect(h.membershipAccess.recordAccessTransition).toHaveBeenCalledWith(
+      row,
+      false,
+      'eligibility_lost',
+    );
   });
 
   it('re-observed 9000 ACK on an already-added row is a no-op (no write, no event)', async () => {
@@ -384,6 +402,7 @@ describe('MembershipSyncService — ACK-driven relay_state flips (§6.3)', () =>
 
     expect(h.membershipRepo.update).not.toHaveBeenCalled();
     expect(h.emitted).toHaveLength(0);
+    expect(h.membershipAccess.recordAccessTransition).not.toHaveBeenCalled();
   });
 
   it('re-observed 9001 ACK on an already-removed row is a no-op', async () => {
@@ -399,6 +418,7 @@ describe('MembershipSyncService — ACK-driven relay_state flips (§6.3)', () =>
 
     expect(h.membershipRepo.update).not.toHaveBeenCalled();
     expect(h.emitted).toHaveLength(0);
+    expect(h.membershipAccess.recordAccessTransition).not.toHaveBeenCalled();
   });
 
   it('failed ACK (ok=false) leaves pending state untouched', async () => {
@@ -457,7 +477,17 @@ describe('MembershipSyncService — community deletion → 9008 (§4.7, terminal
       { id: 2 },
       expect.objectContaining({ relay_state: 'removed' }),
     );
-    expect(h.emitted.map((e) => e.relayState)).toEqual(['removed', 'removed']);
+    // Both rows fold into the access ledger as a room_deleted access loss.
+    expect(h.membershipAccess.recordAccessTransition).toHaveBeenCalledWith(
+      rowA,
+      false,
+      'room_deleted',
+    );
+    expect(h.membershipAccess.recordAccessTransition).toHaveBeenCalledWith(
+      rowB,
+      false,
+      'room_deleted',
+    );
   });
 
   it('non-deleted community upsert → no delete-group enqueued', async () => {

--- a/src/token-gated-rooms/services/membership-sync.service.ts
+++ b/src/token-gated-rooms/services/membership-sync.service.ts
@@ -551,7 +551,11 @@ export class MembershipSyncService
     reason: string,
   ): Promise<void> {
     if (this.membershipAccess) {
-      await this.membershipAccess.recordAccessTransition(row, effective, reason);
+      await this.membershipAccess.recordAccessTransition(
+        row,
+        effective,
+        reason,
+      );
     }
   }
 

--- a/src/token-gated-rooms/services/membership-sync.service.ts
+++ b/src/token-gated-rooms/services/membership-sync.service.ts
@@ -20,12 +20,10 @@ import { RoomMembership } from '../entities/room-membership.entity';
 import {
   TGR_COMMUNITY_UPSERTED,
   TGR_ELIGIBILITY_CHANGED,
-  TGR_MEMBERSHIP_CHANGED,
   TGR_PUBLISH_ACK,
   TGR_ROOM_CREATED,
   type TgrCommunityUpsertedPayload,
   type TgrEligibilityChangedPayload,
-  type TgrMembershipChangedPayload,
   type TgrPublishAckPayload,
   type TgrRoomCreatedPayload,
 } from '../events';
@@ -42,6 +40,7 @@ import { PUBLISH_NIP29_QUEUE } from '../queues/publish-nip29.processor';
 import type { PublishNip29Job } from '../queues/publish-nip29.types';
 import { RoomAdminsService } from './room-admins.service';
 import { GroupMissingTracker } from './group-missing-tracker.service';
+import { MembershipAccessService } from './membership-access.service';
 
 /** NIP-29 relay role tokens (mirrors `room-admins.service.ts`). */
 const NIP29_ROLE_ADMIN = 'admin';
@@ -133,6 +132,13 @@ export class MembershipSyncService
     // DI container always provides it in the running app.
     @Optional()
     private readonly groupMissing?: GroupMissingTracker,
+    // Access-transition ledger (access-ledger plan): the sole emitter of the
+    // membership push. `applyAck`/`handleDeletedRoom` fold relay-state transitions
+    // into it instead of emitting `tgr.membership.changed` directly — so relay-sync
+    // churn (reconcile re-adds, `39002` regen, flaps) no longer re-notifies. Optional
+    // for the same positional-construction test reason; always DI-provided in-app.
+    @Optional()
+    private readonly membershipAccess?: MembershipAccessService,
   ) {}
 
   /**
@@ -501,7 +507,8 @@ export class MembershipSyncService
         { id: row.id },
         { relay_state: 'added', last_published_at: now },
       );
-      this.emitMembershipChanged(row, 'added');
+      // Effective access GAINED — the ledger emits the (deduped) push.
+      await this.recordAccess(row, true, 'access_gained');
       return;
     }
 
@@ -513,18 +520,38 @@ export class MembershipSyncService
         { id: row.id },
         { relay_state: 'removed', last_published_at: now },
       );
-      this.emitMembershipChanged(row, 'removed');
+      // Effective access LOST — the ledger arms the debounce (no push yet; a
+      // re-add within the grace window cancels it, absorbing a flap).
+      await this.recordAccess(row, false, 'eligibility_lost');
       return;
     }
 
     if (kind === NIP29_KIND.SET_ROLES) {
-      // Role publish confirmed — stamp the publish time + emit a role transition.
+      // Role publish confirmed — stamp the publish time. A role change does NOT
+      // change effective access (the member stays 'added'), so folding it into the
+      // ledger is a no-op that will never produce a spurious "you now have access"
+      // push (the old direct `emitMembershipChanged(row, 'role')` did).
       await this.membershipRepo.update(
         { id: row.id },
         { last_published_at: now },
       );
-      this.emitMembershipChanged(row, 'role');
+      await this.recordAccess(row, row.relay_state === 'added', 'role');
       return;
+    }
+  }
+
+  /**
+   * Fold a relay-state transition into the access-transition ledger (the sole
+   * emitter of the membership push). No-op when the ledger service is absent (the
+   * positional-construction unit tests) so relay_state bookkeeping still runs.
+   */
+  private async recordAccess(
+    row: RoomMembership,
+    effective: boolean,
+    reason: string,
+  ): Promise<void> {
+    if (this.membershipAccess) {
+      await this.membershipAccess.recordAccessTransition(row, effective, reason);
     }
   }
 
@@ -711,7 +738,9 @@ export class MembershipSyncService
         { id: row.id },
         { relay_state: 'removed', last_published_at: new Date() },
       );
-      this.emitMembershipChanged(row, 'removed');
+      // Fold into the access ledger — arms the debounced revoke (reason
+      // room_deleted) for members who currently have access.
+      await this.recordAccess(row, false, 'room_deleted');
     }
     this.logger.log(
       `community ${saleAddress} deleted: enqueued 9008 and removed ${rows.length} membership row(s)`,
@@ -746,24 +775,5 @@ export class MembershipSyncService
       },
       publishNip29JobOptions(this.config.publishMaxRetries),
     );
-  }
-
-  /** Emit `tgr.membership.changed` (non-blocking; mirror `live-indexer.service.ts:93`). */
-  private emitMembershipChanged(
-    row: RoomMembership,
-    change: 'added' | 'removed' | 'role',
-  ): void {
-    const relayState: TgrMembershipChangedPayload['relayState'] =
-      change === 'added'
-        ? 'added'
-        : change === 'removed'
-          ? 'removed'
-          : row.relay_state;
-    const payload: TgrMembershipChangedPayload = {
-      saleAddress: row.sale_address,
-      memberAddress: row.member_address,
-      relayState,
-    };
-    this.eventEmitter.emit(TGR_MEMBERSHIP_CHANGED, payload);
   }
 }

--- a/src/token-gated-rooms/token-gated-rooms.module.ts
+++ b/src/token-gated-rooms/token-gated-rooms.module.ts
@@ -10,6 +10,7 @@ import tgrConfig from './config/tgr.config';
 import { prefixQueue, TGR_QUEUE_NAMES } from './config/queue-prefix';
 import { CommunityRoom } from './entities/community-room.entity';
 import { RoomMembership } from './entities/room-membership.entity';
+import { RoomMembershipEvent } from './entities/room-membership-event.entity';
 import { RoomNotificationPreference } from './entities/room-notification-preference.entity';
 import { RoomMessageSeen } from './entities/room-message-seen.entity';
 import { TokenBalance } from './entities/token-balance.entity';
@@ -17,6 +18,7 @@ import { RoomBackfillState } from './entities/room-backfill-state.entity';
 import { IdentityService } from './services/identity.service';
 import { IdentityBackfillService } from './services/identity-backfill.service';
 import { EligibilityService } from './services/eligibility.service';
+import { MembershipAccessService } from './services/membership-access.service';
 import { RoomAdminsService } from './services/room-admins.service';
 import { RelayAdminHealthService } from './nostr/relay-admin-health';
 import { PublishNip29Module } from './queues/publish-nip29.module';
@@ -52,6 +54,7 @@ import { TgrObservabilityModule } from './observability/tgr-observability.module
 const TGR_ENTITIES = [
   CommunityRoom,
   RoomMembership,
+  RoomMembershipEvent,
   RoomNotificationPreference,
   RoomMessageSeen,
   TokenBalance,
@@ -116,6 +119,10 @@ const TGR_ENTITIES = [
     // Indexer-driven desired-state (Postgres writes + enqueue only).
     IdentityBackfillService,
     EligibilityService,
+    // Access-transition ledger (durable membership-push dedup + debounced revoke).
+    // Injected by MembershipSyncService (grant/revoke folding) + ReconcileProcessor
+    // (the finalize job).
+    MembershipAccessService,
     // Relay actuators — construct always, self-gate on `isRelayConfigured`.
     RoomAdminsService,
     RelayAdminHealthService,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Schema migration with production backfill and a redesigned membership notification path; behavior is heavily tested but deploy timing and grace-window tuning affect when users see revoke pushes.
> 
> **Overview**
> Fixes **repeated “You now have access” pushes** caused by firing notifications on noisy `relay_state` ACKs (reconcile re-adds, relay regen, eligibility flaps). Membership pushes now follow **effective-access transitions** (`access_state` on `room_membership`), not raw relay sync.
> 
> Adds **`room_membership_event`** (append-only grant/revoke ledger) plus **`MembershipAccessService`**: grants push immediately with compare-and-set; losses **arm a debounce** (`TG_ACCESS_REVOKE_GRACE_SEC`, default 180s) and a new **`access-revoke-finalize`** Bull job finalizes revokes or silently cancels if access returns within grace. **`MembershipSyncService`** folds ACKs into the ledger instead of emitting `tgr.membership.changed` directly.
> 
> The **notify path** carries `accessEventId` / `isFirstGrant` (welcome vs “you’re back” copy), Redis dedup keys per ledger event, and **`notified_at`** stamping after dispatch. Migration **#9 backfills** existing relay-present members as already granted (with historical ledger rows) to avoid a deploy push storm.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a7b49111df5b69394f08840173814045e54feb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->