### PR TITLE
Improve popular ranking

### DIFF
--- a/docs/popular-post-ranking.md
+++ b/docs/popular-post-ranking.md
@@ -46,7 +46,7 @@ This means popularity is computed within the newest all-time candidate pool, not
 Each candidate gets a score from accumulated engagement and content signals:
 
 ```text
-score =
+baseScore =
   w_comments * log(1 + comments) +
   w_tips_amount * log(1 + tipsAmountAE) +
   w_tips_count * log(1 + tipsCount) +
@@ -55,10 +55,16 @@ score =
   w_trending * trendingBoost +
   w_quality * contentQuality +
   w_fresh * freshnessFactor +
-  w_velocity * log(1 + interactionsPerHour) * freshnessFactor
+  w_velocity * log(1 + interactionsPerHour) * freshnessFactor +
+  w_iph * log(1 + interactionsPerHour)
 ```
 
-There is no time-decay divisor. The live boost is additive and bounded, so it helps new content without permanently overriding all-time engagement.
+Velocity contributes twice, on purpose:
+
+- `w_iph` is the **always-on momentum baseline** — a post gaining interactions
+  quickly gets credit at any age.
+- `w_velocity` is a **freshness-gated early-life amplifier** — new posts that
+  are also accelerating get an extra, temporary lift.
 
 Freshness is linear over the first 24 hours:
 
@@ -66,7 +72,21 @@ Freshness is linear over the first 24 hours:
 freshnessFactor = max(0, 1 - ageHours / 24)
 ```
 
-After 24 hours, both `freshnessFactor` and the velocity boost are zero. The post then ranks by normal accumulated engagement.
+After 24 hours, `freshnessFactor` and the amplifier are zero; the always-on
+momentum baseline keeps counting.
+
+For the `24h` and `7d` windows the score is `baseScore` as-is — those feeds are
+already bounded by their time filter. The `all` window additionally applies a
+gentle gravity-style age decay so old high-total posts cannot occupy the top
+forever:
+
+```text
+score(all) = baseScore / (ageHours + 2) ^ ALL_WINDOW_GRAVITY
+```
+
+Because every engagement signal is log-dampened, score gaps between posts stay
+small, so the gravity exponent must stay gentle (`0.25` today, sane range
+roughly `0.15..0.4`). Values near `1` would turn the feed into pure recency.
 
 ## Current weights
 
@@ -81,9 +101,11 @@ WEIGHTS: {
   trendingBoost: 0.5,
   contentQuality: 0.3,
   reads: 1.5,
-  freshnessBoost: 0.9,
-  velocityBoost: 0.6,
+  freshnessBoost: 1.5,
+  velocityBoost: 0.6, // freshness-gated early-life amplifier
+  interactionsPerHour: 0.6, // always-on momentum baseline
 }
+ALL_WINDOW_GRAVITY: 0.25
 ```
 
 ### What matters most
@@ -213,7 +235,7 @@ A post is most likely to rank highly when it is:
 - being read actively,
 - connected to a trending topic,
 - written with enough substance to avoid quality penalties,
-- less than 24 hours old or gaining early interaction velocity.
+- gaining interaction velocity (at any age), with an extra amplifier while less than 24 hours old.
 
 ## Files involved
 
@@ -231,9 +253,9 @@ A post is most likely to rank highly when it is:
 
 Most numeric signals use `log(1 + x)` so the ranking favors meaningful activity without letting one giant raw number dominate forever.
 
-### Why there is no global time decay
+### Why time decay applies only to the `all` window
 
-This is not a Hacker News-style feed where every post steadily decays. In a low-activity network, posts need time to gather signal. The algorithm instead uses all-time engagement plus a 24-hour additive boost, so new posts get initial visibility and then settle into the normal ranking.
+The `24h` and `7d` feeds are already bounded by their time filter, so they need no decay. The `all` feed is different: log-dampened engagement never shrinks, so without decay the oldest high-total posts would occupy the top permanently. A gentle gravity divisor (`(ageHours + 2)^0.25`) keeps that feed churning while still letting genuinely evergreen content outrank mediocre new posts. New posts additionally get a 24-hour additive freshness boost so they have discovery room in a low-activity network.
 
 ### Why there are no score floors
 

--- a/docs/popular-post-ranking.md
+++ b/docs/popular-post-ranking.md
@@ -1,6 +1,6 @@
 ## Popular post ranking
 
-The popular post endpoint ranks content all-time, then adds a short-lived live boost so newer posts can surface in a low-activity network. The result is a "Top + fresh" feed: durable engagement still wins over time, but new posts get discovery room during their first day.
+The popular post endpoint ranks content all-time, then adds a short-lived live boost so newer posts can surface in a low-activity network. The result is a "Top + fresh" feed: durable engagement still wins over time, but new posts get discovery room during their first two days.
 
 The current implementation rewards posts that attract:
 
@@ -66,13 +66,25 @@ Velocity contributes twice, on purpose:
 - `w_velocity` is a **freshness-gated early-life amplifier** — new posts that
   are also accelerating get an extra, temporary lift.
 
-Freshness is linear over the first 24 hours:
+`interactionsPerHour` is measured over a recent window, not the post's
+lifetime:
 
 ```text
-freshnessFactor = max(0, 1 - ageHours / 24)
+interactionsPerHour = interactionsInLast48h / min(ageHours, 48)
 ```
 
-After 24 hours, `freshnessFactor` and the amplifier are zero; the always-on
+so an old post that catches fire today registers full velocity instead of
+having its new activity averaged away over months. (Plugin content without
+interaction timestamps falls back to the lifetime average.)
+
+Freshness is linear over the first `FRESHNESS_BOOST_HOURS` (48 — generous on
+purpose: on a low-activity network posts need longer to gather signal):
+
+```text
+freshnessFactor = max(0, 1 - ageHours / 48)
+```
+
+After 48 hours, `freshnessFactor` and the amplifier are zero; the always-on
 momentum baseline keeps counting.
 
 For the `24h` and `7d` windows the score is `baseScore` as-is — those feeds are
@@ -105,6 +117,10 @@ WEIGHTS: {
   velocityBoost: 0.6, // freshness-gated early-life amplifier
   interactionsPerHour: 0.6, // always-on momentum baseline
 }
+FRESHNESS_BOOST_HOURS: 48
+VELOCITY_WINDOW_HOURS: 48
+READS_PER_INTERACTION_CAP: 100
+TIE_ROTATION_EPSILON: 0.05
 ALL_WINDOW_GRAVITY: 0.25
 ```
 
@@ -116,7 +132,7 @@ The biggest direct drivers are:
 - `uniqueTippers`
 - `reads`
 - `tipsAmountAE`
-- temporary freshness and velocity for posts less than 24 hours old
+- always-on interaction velocity, with temporary freshness boosts for posts less than 48 hours old
 
 Because logarithms are used for all count- and amount-based signals, they have diminishing returns. Doubling activity helps, but not linearly forever.
 
@@ -128,7 +144,7 @@ Tipping is a rare action on this network. The weight for `tipsAmountAE` (2.0) is
 
 ### 1. Comments
 
-The score counts comments (replies) on the post, excluding the post author's own replies. This prevents authors from inflating their ranking by replying to their own posts.
+The score counts the post's **entire reply thread** (replies to replies included, via a recursive query), excluding replies authored by the post's own author. This prevents authors from inflating their ranking by replying to their own posts, while a deep discussion under a few top-level comments is credited at its real size. Hidden comments prune their whole subtree.
 
 More discussion helps a post rank higher, but through `log(1 + comments)`, so going from 0 to 5 comments matters more than going from 500 to 505.
 
@@ -152,10 +168,17 @@ The number of distinct addresses that tipped a post (excluding self-tips). This 
 
 Reads are pulled from `post_reads_daily` and summed for all available candidate posts.
 
-The ranking uses raw reads:
+Reads are the easiest signal to inflate, so they are hardened twice:
+
+- **At recording time**, a read counts once per viewer (IP+UA hash), post, and
+  UTC day — a request loop from one client cannot inflate the counter. The
+  dedup fails open if Redis is unavailable. Bot user agents are ignored.
+- **At scoring time**, counted reads are capped at
+  `READS_PER_INTERACTION_CAP × (1 + comments + tipsCount + uniqueTippers)`,
+  so passive volume alone cannot outvote real engagement indefinitely:
 
 ```text
-log(1 + reads)
+log(1 + min(reads, cap))
 ```
 
 Reads are not normalized by age. Freshness is handled by the bounded new-post boost.
@@ -211,19 +234,29 @@ The service:
 
 This keeps each page full while preventing one active user from dominating the popular tab.
 
+## Tie rotation
+
+Every score also carries a small deterministic jitter in `[0, TIE_ROTATION_EPSILON)` derived from the post id and the current hour. Posts with meaningfully different engagement are unaffected (their score gaps are much larger than the epsilon), but near-tied posts — mostly the zero-engagement tail, whose scores differ only by content quality — rotate their relative order every hour instead of being frozen in the same sequence between recomputes. This spreads exposure across posts that haven't had a chance to gather signal yet, without any stored state.
+
 ## Caching behavior
 
-Computed rankings are stored in the Redis sorted set `popular:all`.
+Computed rankings are stored in the Redis sorted sets `popular:24h`, `popular:7d`, and `popular:all`.
 
-TTL is currently:
+Crons refresh each window at a cadence matched to how fast it changes — `24h`
+every minute, `7d` every 5 minutes, `all` (10k candidates, slow-moving) every
+10 minutes — and the TTL is kept far above the slowest cadence:
 
 ```ts
-REDIS_TTL_SECONDS: 30;
+REDIS_TTL_SECONDS: 1800;
 ```
 
-So the feed is intentionally refreshed often.
-
-When the cache is empty (cold start or after TTL expiry with no cron), recompute is triggered with a mutex to prevent stampede. The current request falls back to recent posts while the cache is being rebuilt.
+so user requests essentially never pay recompute latency — a key only goes
+cold if refreshes fail repeatedly. Each refresh takes a short-lived Redis
+`SET NX` lock per window, so running multiple app instances does not multiply
+the recompute work. On a cold cache (startup, repeated cron failures)
+recompute is still triggered lazily with a per-window mutex to prevent
+stampede, and the current request falls back to recent posts while the cache
+is being rebuilt.
 
 ## Practical interpretation
 
@@ -235,7 +268,7 @@ A post is most likely to rank highly when it is:
 - being read actively,
 - connected to a trending topic,
 - written with enough substance to avoid quality penalties,
-- gaining interaction velocity (at any age), with an extra amplifier while less than 24 hours old.
+- gaining interaction velocity (at any age), with an extra amplifier while less than 48 hours old.
 
 ## Files involved
 
@@ -255,7 +288,7 @@ Most numeric signals use `log(1 + x)` so the ranking favors meaningful activity 
 
 ### Why time decay applies only to the `all` window
 
-The `24h` and `7d` feeds are already bounded by their time filter, so they need no decay. The `all` feed is different: log-dampened engagement never shrinks, so without decay the oldest high-total posts would occupy the top permanently. A gentle gravity divisor (`(ageHours + 2)^0.25`) keeps that feed churning while still letting genuinely evergreen content outrank mediocre new posts. New posts additionally get a 24-hour additive freshness boost so they have discovery room in a low-activity network.
+The `24h` and `7d` feeds are already bounded by their time filter, so they need no decay. The `all` feed is different: log-dampened engagement never shrinks, so without decay the oldest high-total posts would occupy the top permanently. A gentle gravity divisor (`(ageHours + 2)^0.25`) keeps that feed churning while still letting genuinely evergreen content outrank mediocre new posts. New posts additionally get a 48-hour additive freshness boost so they have discovery room in a low-activity network.
 
 ### Why there are no score floors
 

--- a/src/configs/constants.ts
+++ b/src/configs/constants.ts
@@ -251,7 +251,8 @@ export const POPULAR_RANKING_CONFIG = {
     contentQuality: 0.3, // w_q (anti-spam)
     reads: 1.5, // w_reads (common passive signal)
     freshnessBoost: 1.5, // w_fresh (temporary new-post lift)
-    velocityBoost: 0.6, // w_vel (temporary lift for posts gaining activity quickly)
+    velocityBoost: 0.6, // w_vel (freshness-gated early-life amplifier)
+    interactionsPerHour: 0.6, // w_iph (always-on momentum baseline, counts at any age)
   },
 
   // user-facing scale controls tune relative importance instead of exposing raw weights
@@ -260,9 +261,6 @@ export const POPULAR_RANKING_CONFIG = {
       low: 0.6,
       med: 1,
       high: 1.5,
-    },
-    ADDITIONAL_SIGNAL_WEIGHTS: {
-      interactionsPerHour: 1.1,
     },
   },
 
@@ -279,6 +277,13 @@ export const POPULAR_RANKING_CONFIG = {
 
   // live popular behavior
   FRESHNESS_BOOST_HOURS: 24,
+
+  // 'all' window age decay: score / (ageHours + 2)^gravity. Scores are
+  // log-dampened so their spread stays small — gravity must stay gentle
+  // (~0.15..0.4); near 1 the divisor outgrows any achievable score gap and
+  // 'all' degenerates into a recency feed. Raise slightly if old posts still
+  // dominate, lower if evergreen content churns out too fast.
+  ALL_WINDOW_GRAVITY: 0.25,
   AUTHOR_DIVERSITY: {
     ENABLED: true,
     OVERSAMPLE_MULTIPLIER: 4,

--- a/src/configs/constants.ts
+++ b/src/configs/constants.ts
@@ -275,8 +275,27 @@ export const POPULAR_RANKING_CONFIG = {
   // trending scaling
   TRENDING_MAX_SCORE: 100, // scale trending tag score to [0..1]
 
-  // live popular behavior
-  FRESHNESS_BOOST_HOURS: 24,
+  // live popular behavior — 48h, not 24h: on a low-activity network posts
+  // need longer to gather their fair share of signal
+  FRESHNESS_BOOST_HOURS: 48,
+
+  // velocity looks at interactions inside this window (divided by post age
+  // when the post is younger), so an old post catching fire still registers
+  VELOCITY_WINDOW_HOURS: 48,
+
+  // recursion guard for whole-thread comment counting — real threads never
+  // approach this, it only bounds pathological reply chains
+  THREAD_COUNT_MAX_DEPTH: 50,
+
+  // reads counted toward the score are capped at this many per (1 + active
+  // interaction) — reads are the easiest signal to inflate, so passive volume
+  // alone cannot outvote real engagement indefinitely
+  READS_PER_INTERACTION_CAP: 100,
+
+  // deterministic per-hour score jitter in [0, epsilon) rotating near-tied
+  // posts (mostly the zero-engagement tail) so their order isn't frozen;
+  // keep well below typical engaged-post score gaps
+  TIE_ROTATION_EPSILON: 0.05,
 
   // 'all' window age decay: score / (ageHours + 2)^gravity. Scores are
   // log-dampened so their spread stays small — gravity must stay gentle
@@ -296,7 +315,10 @@ export const POPULAR_RANKING_CONFIG = {
     popular7d: 'popular:7d',
     popularAll: 'popular:all',
   },
-  REDIS_TTL_SECONDS: 30,
+  // Kept far above the slowest cron refresh cadence (10 min for 'all') so a
+  // key only goes cold if refreshes fail repeatedly; requests then hit the
+  // lazy recompute fallback.
+  REDIS_TTL_SECONDS: 1800,
 
   // Bot UA denylist (lowercase substrings)
   BOT_UA_DENYLIST: [

--- a/src/social/entities/post.entity.ts
+++ b/src/social/entities/post.entity.ts
@@ -16,6 +16,9 @@ import { Topic } from './topic.entity';
 })
 @Index('IDX_POSTS_CREATED_AT', ['created_at'])
 @Index('IDX_POSTS_SENDER_ADDRESS_CREATED_AT', ['sender_address', 'created_at'])
+// Serves comment lookups and each level of the popular-ranking thread CTE;
+// Postgres does not index FK columns automatically.
+@Index('IDX_POSTS_POST_ID', ['post_id'])
 export class Post {
   @PrimaryColumn()
   id: string;

--- a/src/social/services/popular-ranking.service.spec.ts
+++ b/src/social/services/popular-ranking.service.spec.ts
@@ -23,6 +23,7 @@ jest.mock('ioredis', () => {
 });
 
 import { PopularRankingService } from './popular-ranking.service';
+import { POPULAR_RANKING_CONFIG } from '@/configs/constants';
 
 function createCandidateQueryBuilder(posts: Array<{ id: string }>) {
   return {
@@ -844,7 +845,9 @@ describe('PopularRankingService', () => {
       };
       const svc = buildScoredService([dayOldPost, olderPost, freshPost], {});
 
-      const result = await svc.getPopularPostsPage('all', 10, 0, undefined, {
+      // 7d window: the 'all' window now applies age gravity, so equal-score
+      // posts of different ages are only expected on time-bounded windows.
+      const result = await svc.getPopularPostsPage('7d', 10, 0, undefined, {
         comments: 'med',
       });
       const scores = new Map(
@@ -1016,6 +1019,118 @@ describe('PopularRankingService', () => {
 
       expect(explanation.map((item) => item.id)).toEqual(
         result.items.map((item) => item.id),
+      );
+    });
+  });
+
+  describe('scoring math (velocity, gravity, emoji)', () => {
+    const noTrending = new Map<string, number>();
+
+    function scoreInput(ageHours: number, overrides: Record<string, any> = {}) {
+      return {
+        content: 'a perfectly reasonable amount of content',
+        comments: 0,
+        tipsAmountAE: 0,
+        tipsCount: 0,
+        uniqueTippers: 0,
+        reads: 0,
+        topics: [],
+        createdAt: new Date(
+          Date.now() - ageHours * 60 * 60 * 1000,
+        ).toISOString(),
+        ...overrides,
+      };
+    }
+
+    it('seeds interactionsPerHour weight from config for the default feed', () => {
+      const weights = (service as any).resolveWeights();
+      expect(weights.interactionsPerHour).toBe(
+        POPULAR_RANKING_CONFIG.WEIGHTS.interactionsPerHour,
+      );
+      expect(weights.interactionsPerHour).toBeGreaterThan(0);
+    });
+
+    it('scales the interactionsPerHour override from the config default', () => {
+      const weights = (service as any).resolveWeights({
+        interactionsPerHour: 'high',
+      });
+      expect(weights.interactionsPerHour).toBeCloseTo(
+        POPULAR_RANKING_CONFIG.WEIGHTS.interactionsPerHour *
+          POPULAR_RANKING_CONFIG.CUSTOMIZATION.SCALE_MULTIPLIERS.high,
+      );
+    });
+
+    it('keeps a positive velocity contribution past the freshness window on default weights', () => {
+      // Both posts are past FRESHNESS_BOOST_HOURS with identical totals, so
+      // freshness-gated terms are zero for both and any score gap comes from
+      // the always-on interactionsPerHour term.
+      const weights = (service as any).resolveWeights();
+      const momentum = (service as any).computeScore(
+        noTrending,
+        scoreInput(POPULAR_RANKING_CONFIG.FRESHNESS_BOOST_HOURS + 10, {
+          comments: 48,
+        }),
+        weights,
+        '7d',
+      );
+      const slowBurn = (service as any).computeScore(
+        noTrending,
+        scoreInput(160, { comments: 48 }),
+        weights,
+        '7d',
+      );
+      expect(momentum).toBeGreaterThan(slowBurn);
+    });
+
+    it("decays older posts in the 'all' window given identical engagement", () => {
+      const weights = (service as any).resolveWeights();
+      const newer = (service as any).computeScore(
+        noTrending,
+        scoreInput(24, { comments: 20, reads: 100 }),
+        weights,
+        'all',
+      );
+      const older = (service as any).computeScore(
+        noTrending,
+        scoreInput(24 * 30, { comments: 20, reads: 100 }),
+        weights,
+        'all',
+      );
+      expect(newer).toBeGreaterThan(older);
+    });
+
+    it("does not decay time-bounded windows' scores by age gravity", () => {
+      // Same totals, same age: gravity applies only to 'all', so the '24h'
+      // score must be strictly higher than the gravity-divided 'all' score.
+      const weights = (service as any).resolveWeights();
+      const input = scoreInput(10, { comments: 20 });
+      const windowed = (service as any).computeScore(
+        noTrending,
+        input,
+        weights,
+        '24h',
+      );
+      const allWindow = (service as any).computeScore(
+        noTrending,
+        input,
+        weights,
+        'all',
+      );
+      expect(windowed).toBeGreaterThan(allWindow);
+    });
+
+    it('counts every emoji, not just the first match', () => {
+      const svc = service as any;
+      expect(svc.countEmojis('nice 😀 post 😀 with 😀 five 😀 emojis 😀')).toBe(
+        5,
+      );
+      expect(svc.countEmojis('plain text with 123 #hash and *star')).toBe(0);
+    });
+
+    it('penalizes short emoji-only posts in content quality', () => {
+      const svc = service as any;
+      expect(svc.computeContentQuality('😂😂😂😂😂')).toBeLessThan(
+        svc.computeContentQuality('hello'),
       );
     });
   });

--- a/src/social/services/popular-ranking.service.spec.ts
+++ b/src/social/services/popular-ranking.service.spec.ts
@@ -11,6 +11,7 @@ const redisMock = {
   quit: jest.fn().mockResolvedValue('OK'),
   ping: jest.fn().mockResolvedValue('PONG'),
   del: jest.fn().mockResolvedValue(1),
+  set: jest.fn().mockResolvedValue('OK'),
   zcard: jest.fn().mockResolvedValue(1),
   pipeline: jest.fn().mockReturnValue(pipelineMock),
 };
@@ -61,15 +62,7 @@ describe('PopularRankingService', () => {
       addSelect: jest.fn().mockReturnThis(),
       where: jest.fn().mockReturnThis(),
       andWhere: jest.fn().mockReturnThis(),
-      groupBy: jest.fn().mockReturnThis(),
-      getRawMany: jest.fn().mockResolvedValue([]),
-    };
-    const commentQueryBuilder = {
-      innerJoin: jest.fn().mockReturnThis(),
-      select: jest.fn().mockReturnThis(),
-      addSelect: jest.fn().mockReturnThis(),
-      where: jest.fn().mockReturnThis(),
-      andWhere: jest.fn().mockReturnThis(),
+      setParameter: jest.fn().mockReturnThis(),
       groupBy: jest.fn().mockReturnThis(),
       getRawMany: jest.fn().mockResolvedValue([]),
     };
@@ -83,10 +76,8 @@ describe('PopularRankingService', () => {
     };
 
     postRepository = {
-      createQueryBuilder: jest
-        .fn()
-        .mockReturnValueOnce(candidateQueryBuilder)
-        .mockReturnValueOnce(commentQueryBuilder),
+      createQueryBuilder: jest.fn().mockReturnValue(candidateQueryBuilder),
+      query: jest.fn().mockResolvedValue([]),
       find: jest.fn().mockResolvedValue([defaultPost]),
       findBy: jest.fn().mockResolvedValue([defaultPost]),
     };
@@ -125,20 +116,17 @@ describe('PopularRankingService', () => {
     );
   });
 
-  it('excludes self-comments from ranking comment count', async () => {
+  it('counts whole threads while excluding the root author from comment count', async () => {
     await service.recompute('7d', 10);
 
-    const commentQueryBuilder =
-      postRepository.createQueryBuilder.mock.results[1].value;
+    const [sql, params] = postRepository.query.mock.calls[0];
 
-    expect(commentQueryBuilder.innerJoin).toHaveBeenCalledWith(
-      expect.any(Function),
-      'parent',
-      'parent.id = comment.post_id',
-    );
-    expect(commentQueryBuilder.andWhere).toHaveBeenCalledWith(
-      'comment.sender_address != parent.sender_address',
-    );
+    expect(sql).toContain('WITH RECURSIVE');
+    expect(sql).toContain('c.sender_address != t.root_sender');
+    expect(sql).toContain('c.is_hidden = false');
+    expect(sql).toContain('t.depth <');
+    expect(params[0]).toEqual(['post-1']);
+    expect(params[1]).toBeInstanceOf(Date);
   });
 
   it('falls back to window-filtered recent posts when Redis cache is empty', async () => {
@@ -205,6 +193,7 @@ describe('PopularRankingService', () => {
       addSelect: jest.fn().mockReturnThis(),
       where: jest.fn().mockReturnThis(),
       andWhere: jest.fn().mockReturnThis(),
+      setParameter: jest.fn().mockReturnThis(),
       groupBy: jest.fn().mockReturnThis(),
       getRawMany: jest.fn().mockResolvedValue([
         {
@@ -212,25 +201,15 @@ describe('PopularRankingService', () => {
           amount_sum: '0',
           count: '2',
           unique_tippers: '2',
+          recent_count: '2',
         },
         {
           post_id: 'post-fast',
           amount_sum: '0',
           count: '2',
           unique_tippers: '2',
+          recent_count: '2',
         },
-      ]),
-    };
-    const commentQueryBuilder = {
-      innerJoin: jest.fn().mockReturnThis(),
-      select: jest.fn().mockReturnThis(),
-      addSelect: jest.fn().mockReturnThis(),
-      where: jest.fn().mockReturnThis(),
-      andWhere: jest.fn().mockReturnThis(),
-      groupBy: jest.fn().mockReturnThis(),
-      getRawMany: jest.fn().mockResolvedValue([
-        { parent_id: 'post-old', count: '4' },
-        { parent_id: 'post-fast', count: '4' },
       ]),
     };
     const readsQueryBuilder = {
@@ -246,10 +225,11 @@ describe('PopularRankingService', () => {
     };
 
     postRepository = {
-      createQueryBuilder: jest
-        .fn()
-        .mockReturnValueOnce(candidateQueryBuilder)
-        .mockReturnValueOnce(commentQueryBuilder),
+      createQueryBuilder: jest.fn().mockReturnValue(candidateQueryBuilder),
+      query: jest.fn().mockResolvedValue([
+        { root_id: 'post-old', count: '4', recent_count: '4' },
+        { root_id: 'post-fast', count: '4', recent_count: '4' },
+      ]),
       find: jest.fn().mockResolvedValue([oldPost, fastPost]),
       findBy: jest.fn().mockResolvedValue([oldPost, fastPost]),
     };
@@ -386,23 +366,13 @@ describe('PopularRankingService', () => {
         topics: [],
       };
       const candidateQB = createCandidateQueryBuilder([post]);
-      const commentQB = {
-        innerJoin: jest.fn().mockReturnThis(),
-        select: jest.fn().mockReturnThis(),
-        addSelect: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        andWhere: jest.fn().mockReturnThis(),
-        groupBy: jest.fn().mockReturnThis(),
-        getRawMany: jest
-          .fn()
-          .mockResolvedValue([{ parent_id: 'post-w', count: '5' }]),
-      };
       const tipQB = {
         select: jest.fn().mockReturnThis(),
         innerJoin: jest.fn().mockReturnThis(),
         addSelect: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
         andWhere: jest.fn().mockReturnThis(),
+        setParameter: jest.fn().mockReturnThis(),
         groupBy: jest.fn().mockReturnThis(),
         getRawMany: jest.fn().mockResolvedValue([
           {
@@ -410,6 +380,7 @@ describe('PopularRankingService', () => {
             amount_sum: '100',
             count: '3',
             unique_tippers: '2',
+            recent_count: '3',
           },
         ]),
       };
@@ -425,10 +396,12 @@ describe('PopularRankingService', () => {
       };
 
       const repo = {
-        createQueryBuilder: jest
+        createQueryBuilder: jest.fn().mockReturnValue(candidateQB),
+        query: jest
           .fn()
-          .mockReturnValueOnce(candidateQB)
-          .mockReturnValueOnce(commentQB),
+          .mockResolvedValue([
+            { root_id: 'post-w', count: '5', recent_count: '5' },
+          ]),
         find: jest.fn().mockResolvedValue([post]),
         findBy: jest.fn().mockResolvedValue([post]),
       };
@@ -481,23 +454,13 @@ describe('PopularRankingService', () => {
   describe('computeInteractionsPerHour edge cases', () => {
     function buildServiceWith(post: any) {
       const candidateQB = createCandidateQueryBuilder([post]);
-      const commentQB = {
-        innerJoin: jest.fn().mockReturnThis(),
-        select: jest.fn().mockReturnThis(),
-        addSelect: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        andWhere: jest.fn().mockReturnThis(),
-        groupBy: jest.fn().mockReturnThis(),
-        getRawMany: jest
-          .fn()
-          .mockResolvedValue([{ parent_id: post.id, count: '3' }]),
-      };
       const tipQB = {
         select: jest.fn().mockReturnThis(),
         innerJoin: jest.fn().mockReturnThis(),
         addSelect: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
         andWhere: jest.fn().mockReturnThis(),
+        setParameter: jest.fn().mockReturnThis(),
         groupBy: jest.fn().mockReturnThis(),
         getRawMany: jest.fn().mockResolvedValue([
           {
@@ -505,6 +468,7 @@ describe('PopularRankingService', () => {
             amount_sum: '0',
             count: '1',
             unique_tippers: '1',
+            recent_count: '1',
           },
         ]),
       };
@@ -519,10 +483,12 @@ describe('PopularRankingService', () => {
 
       return new PopularRankingService(
         {
-          createQueryBuilder: jest
+          createQueryBuilder: jest.fn().mockReturnValue(candidateQB),
+          query: jest
             .fn()
-            .mockReturnValueOnce(candidateQB)
-            .mockReturnValueOnce(commentQB),
+            .mockResolvedValue([
+              { root_id: post.id, count: '3', recent_count: '3' },
+            ]),
           find: jest.fn().mockResolvedValue([post]),
           findBy: jest.fn().mockResolvedValue([post]),
         } as any,
@@ -567,13 +533,13 @@ describe('PopularRankingService', () => {
       expect(result.scoredItems![0].score).toBeGreaterThanOrEqual(0);
     });
 
-    it('caps effectiveHours to window size for 24h window', async () => {
+    it('caps velocity hours so equal recent activity favors the younger post', async () => {
       const now = Date.now();
       const very_old_post = {
         id: 'post-capped',
         sender_address: 'ak_capped',
-        created_at: new Date(now - 48 * 60 * 60 * 1000).toISOString(),
-        content: 'old post that should be capped at 24h',
+        created_at: new Date(now - 200 * 60 * 60 * 1000).toISOString(),
+        content: 'old post whose velocity divisor is capped',
         topics: [],
       };
       const recent_post = {
@@ -588,24 +554,13 @@ describe('PopularRankingService', () => {
         very_old_post,
         recent_post,
       ]);
-      const commentQB = {
-        innerJoin: jest.fn().mockReturnThis(),
-        select: jest.fn().mockReturnThis(),
-        addSelect: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        andWhere: jest.fn().mockReturnThis(),
-        groupBy: jest.fn().mockReturnThis(),
-        getRawMany: jest.fn().mockResolvedValue([
-          { parent_id: 'post-capped', count: '5' },
-          { parent_id: 'post-recent', count: '5' },
-        ]),
-      };
       const tipQB = {
         select: jest.fn().mockReturnThis(),
         innerJoin: jest.fn().mockReturnThis(),
         addSelect: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
         andWhere: jest.fn().mockReturnThis(),
+        setParameter: jest.fn().mockReturnThis(),
         groupBy: jest.fn().mockReturnThis(),
         getRawMany: jest.fn().mockResolvedValue([
           {
@@ -613,12 +568,14 @@ describe('PopularRankingService', () => {
             amount_sum: '0',
             count: '2',
             unique_tippers: '2',
+            recent_count: '2',
           },
           {
             post_id: 'post-recent',
             amount_sum: '0',
             count: '2',
             unique_tippers: '2',
+            recent_count: '2',
           },
         ]),
       };
@@ -636,10 +593,11 @@ describe('PopularRankingService', () => {
 
       const svc = new PopularRankingService(
         {
-          createQueryBuilder: jest
-            .fn()
-            .mockReturnValueOnce(candidateQB)
-            .mockReturnValueOnce(commentQB),
+          createQueryBuilder: jest.fn().mockReturnValue(candidateQB),
+          query: jest.fn().mockResolvedValue([
+            { root_id: 'post-capped', count: '5', recent_count: '5' },
+            { root_id: 'post-recent', count: '5', recent_count: '5' },
+          ]),
           find: jest.fn().mockResolvedValue([very_old_post, recent_post]),
           findBy: jest.fn().mockResolvedValue([very_old_post, recent_post]),
         } as any,
@@ -649,7 +607,7 @@ describe('PopularRankingService', () => {
         [],
       );
 
-      const result = await svc.getPopularPostsPage('24h', 10, 0, undefined, {
+      const result = await svc.getPopularPostsPage('all', 10, 0, undefined, {
         interactionsPerHour: 'high',
       });
 
@@ -685,26 +643,13 @@ describe('PopularRankingService', () => {
       comments: Record<string, string>,
     ) {
       const candidateQB = createCandidateQueryBuilder(posts);
-      const commentQB = {
-        innerJoin: jest.fn().mockReturnThis(),
-        select: jest.fn().mockReturnThis(),
-        addSelect: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        andWhere: jest.fn().mockReturnThis(),
-        groupBy: jest.fn().mockReturnThis(),
-        getRawMany: jest.fn().mockResolvedValue(
-          Object.entries(comments).map(([parent_id, count]) => ({
-            parent_id,
-            count,
-          })),
-        ),
-      };
       const tipQB = {
         select: jest.fn().mockReturnThis(),
         innerJoin: jest.fn().mockReturnThis(),
         addSelect: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
         andWhere: jest.fn().mockReturnThis(),
+        setParameter: jest.fn().mockReturnThis(),
         groupBy: jest.fn().mockReturnThis(),
         getRawMany: jest.fn().mockResolvedValue([]),
       };
@@ -719,10 +664,14 @@ describe('PopularRankingService', () => {
 
       return new PopularRankingService(
         {
-          createQueryBuilder: jest
-            .fn()
-            .mockReturnValueOnce(candidateQB)
-            .mockReturnValueOnce(commentQB),
+          createQueryBuilder: jest.fn().mockReturnValue(candidateQB),
+          query: jest.fn().mockResolvedValue(
+            Object.entries(comments).map(([root_id, count]) => ({
+              root_id,
+              count,
+              recent_count: count,
+            })),
+          ),
           find: jest.fn().mockResolvedValue(posts),
           findBy: jest.fn().mockResolvedValue(posts),
         } as any,
@@ -760,23 +709,13 @@ describe('PopularRankingService', () => {
           .fn()
           .mockResolvedValue([{ id: 'topic-heavy' }, { id: 'target-post' }]),
       };
-      const commentQB = {
-        innerJoin: jest.fn().mockReturnThis(),
-        select: jest.fn().mockReturnThis(),
-        addSelect: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        andWhere: jest.fn().mockReturnThis(),
-        groupBy: jest.fn().mockReturnThis(),
-        getRawMany: jest
-          .fn()
-          .mockResolvedValue([{ parent_id: 'target-post', count: '4' }]),
-      };
       const tipQB = {
         select: jest.fn().mockReturnThis(),
         innerJoin: jest.fn().mockReturnThis(),
         addSelect: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
         andWhere: jest.fn().mockReturnThis(),
+        setParameter: jest.fn().mockReturnThis(),
         groupBy: jest.fn().mockReturnThis(),
         getRawMany: jest.fn().mockResolvedValue([]),
       };
@@ -789,10 +728,12 @@ describe('PopularRankingService', () => {
         getRawMany: jest.fn().mockResolvedValue([]),
       };
       const repo = {
-        createQueryBuilder: jest
+        createQueryBuilder: jest.fn().mockReturnValue(candidateQB),
+        query: jest
           .fn()
-          .mockReturnValueOnce(candidateQB)
-          .mockReturnValueOnce(commentQB),
+          .mockResolvedValue([
+            { root_id: 'target-post', count: '4', recent_count: '4' },
+          ]),
         find: jest.fn().mockResolvedValue([targetPost, topicHeavyPost]),
         findBy: jest.fn().mockResolvedValue([targetPost, topicHeavyPost]),
       };
@@ -820,8 +761,9 @@ describe('PopularRankingService', () => {
       ]);
     });
 
-    it('boosts fresh posts and removes that boost after 24 hours', async () => {
+    it('boosts fresh posts and removes that boost after the freshness window', async () => {
       const now = Date.now();
+      const boostHours = POPULAR_RANKING_CONFIG.FRESHNESS_BOOST_HOURS;
       const freshPost = {
         id: 'post-fresh',
         sender_address: 'ak_fresh',
@@ -829,21 +771,28 @@ describe('PopularRankingService', () => {
         content: 'same quality content',
         topics: [],
       };
-      const dayOldPost = {
-        id: 'post-day-old',
-        sender_address: 'ak_day_old',
-        created_at: new Date(now - 25 * 60 * 60 * 1000).toISOString(),
+      const pastWindowPost = {
+        id: 'post-past-window',
+        sender_address: 'ak_past_window',
+        created_at: new Date(
+          now - (boostHours + 2) * 60 * 60 * 1000,
+        ).toISOString(),
         content: 'same quality content',
         topics: [],
       };
       const olderPost = {
         id: 'post-older',
         sender_address: 'ak_older',
-        created_at: new Date(now - 48 * 60 * 60 * 1000).toISOString(),
+        created_at: new Date(
+          now - (boostHours + 26) * 60 * 60 * 1000,
+        ).toISOString(),
         content: 'same quality content',
         topics: [],
       };
-      const svc = buildScoredService([dayOldPost, olderPost, freshPost], {});
+      const svc = buildScoredService(
+        [pastWindowPost, olderPost, freshPost],
+        {},
+      );
 
       // 7d window: the 'all' window now applies age gravity, so equal-score
       // posts of different ages are only expected on time-bounded windows.
@@ -855,9 +804,13 @@ describe('PopularRankingService', () => {
       );
 
       expect(scores.get('post-fresh')).toBeGreaterThan(
-        scores.get('post-day-old')!,
+        scores.get('post-past-window')!,
       );
-      expect(scores.get('post-day-old')).toBeCloseTo(scores.get('post-older')!);
+      // Past the window both posts carry no freshness or velocity — scores
+      // may differ only by the deterministic tie-rotation jitter.
+      expect(
+        Math.abs(scores.get('post-past-window')! - scores.get('post-older')!),
+      ).toBeLessThanOrEqual(POPULAR_RANKING_CONFIG.TIE_ROTATION_EPSILON);
     });
 
     it('avoids duplicate authors within a page when alternatives exist', async () => {
@@ -1119,12 +1072,132 @@ describe('PopularRankingService', () => {
       expect(windowed).toBeGreaterThan(allWindow);
     });
 
+    it('registers momentum for an old post catching fire via recent interactions', () => {
+      // Same lifetime totals, same age (so identical gravity); only the
+      // recent-interaction count differs.
+      const weights = (service as any).resolveWeights();
+      const catchingFire = (service as any).computeScore(
+        noTrending,
+        scoreInput(24 * 90, { comments: 100, recentInteractions: 50 }),
+        weights,
+        'all',
+      );
+      const dormant = (service as any).computeScore(
+        noTrending,
+        scoreInput(24 * 90, { comments: 100, recentInteractions: 0 }),
+        weights,
+        'all',
+      );
+      expect(catchingFire).toBeGreaterThan(dormant);
+    });
+
+    it('caps read contribution relative to active engagement', () => {
+      const weights = (service as any).resolveWeights();
+      const cap = POPULAR_RANKING_CONFIG.READS_PER_INTERACTION_CAP;
+
+      // Zero active interactions: a million reads score the same as the cap.
+      const inflated = (service as any).computeScore(
+        noTrending,
+        scoreInput(10, { reads: 1_000_000 }),
+        weights,
+        '24h',
+      );
+      const atCap = (service as any).computeScore(
+        noTrending,
+        scoreInput(10, { reads: cap }),
+        weights,
+        '24h',
+      );
+      expect(inflated).toBeCloseTo(atCap, 10);
+
+      // Active engagement raises the cap, so real interactions unlock more
+      // read credit.
+      const engaged = (service as any).computeScore(
+        noTrending,
+        scoreInput(10, { comments: 10, reads: 1_000_000 }),
+        weights,
+        '24h',
+      );
+      const engagedAtCap = (service as any).computeScore(
+        noTrending,
+        scoreInput(10, { comments: 10, reads: cap * 11 }),
+        weights,
+        '24h',
+      );
+      expect(engaged).toBeCloseTo(engagedAtCap, 10);
+      expect(engaged).toBeGreaterThan(inflated);
+    });
+
+    it('applies bounded, deterministic tie rotation per post id', () => {
+      const svc = service as any;
+      const first = svc.computeTieRotation('post-a');
+      const second = svc.computeTieRotation('post-a');
+      const other = svc.computeTieRotation('post-b');
+
+      expect(first).toBe(second);
+      expect(first).toBeGreaterThanOrEqual(0);
+      expect(first).toBeLessThan(POPULAR_RANKING_CONFIG.TIE_ROTATION_EPSILON);
+      expect(other).not.toBe(first);
+      expect(svc.computeTieRotation(undefined)).toBe(0);
+    });
+
     it('counts every emoji, not just the first match', () => {
       const svc = service as any;
       expect(svc.countEmojis('nice 😀 post 😀 with 😀 five 😀 emojis 😀')).toBe(
         5,
       );
       expect(svc.countEmojis('plain text with 123 #hash and *star')).toBe(0);
+      // ZWJ sequences count per pictographic component, variation-selector
+      // emoji count once — both nonzero so the ratio penalty can trigger.
+      expect(svc.countEmojis('👨‍👩‍👧')).toBe(3);
+      expect(svc.countEmojis('❤️')).toBe(1);
+    });
+
+    it('computes velocity from recent interactions capped at the velocity window', () => {
+      const svc = service as any;
+      const window = POPULAR_RANKING_CONFIG.VELOCITY_WINDOW_HOURS;
+
+      // Old post: divisor is the velocity window, not the post age.
+      expect(
+        svc.computeInteractionsPerHour(
+          scoreInput(200, { recentInteractions: window * 2 }),
+          'all',
+        ),
+      ).toBeCloseTo(2);
+
+      // Very young post: divisor clamps to 1 hour so a burst in the first
+      // minutes is not multiplied into an absurd hourly rate.
+      expect(
+        svc.computeInteractionsPerHour(
+          scoreInput(0.1, { recentInteractions: 5 }),
+          '24h',
+        ),
+      ).toBeCloseTo(5);
+
+      // No recent data (plugin items): lifetime-average fallback.
+      expect(
+        svc.computeInteractionsPerHour(scoreInput(2, { comments: 4 }), '24h'),
+      ).toBeCloseTo(2);
+    });
+
+    it('scores the all window safely when createdAt is missing or invalid', () => {
+      const weights = (service as any).resolveWeights();
+      for (const createdAt of [undefined, 'not-a-date']) {
+        const score = (service as any).computeScore(
+          noTrending,
+          { ...scoreInput(1, { comments: 5 }), createdAt },
+          weights,
+          'all',
+        );
+        expect(Number.isFinite(score)).toBe(true);
+        expect(score).toBeGreaterThanOrEqual(0);
+      }
+    });
+
+    it('returns zero tie rotation for missing or empty ids', () => {
+      const svc = service as any;
+      expect(svc.computeTieRotation(undefined)).toBe(0);
+      expect(svc.computeTieRotation('')).toBe(0);
     });
 
     it('penalizes short emoji-only posts in content quality', () => {
@@ -1132,6 +1205,66 @@ describe('PopularRankingService', () => {
       expect(svc.computeContentQuality('😂😂😂😂😂')).toBeLessThan(
         svc.computeContentQuality('hello'),
       );
+    });
+  });
+
+  describe('scheduled refresh locking', () => {
+    let recomputeSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      redisMock.set.mockReset();
+      recomputeSpy = jest
+        .spyOn(service as any, 'awaitOrTriggerRecompute')
+        .mockResolvedValue(undefined);
+    });
+
+    afterEach(() => {
+      recomputeSpy.mockRestore();
+      redisMock.set.mockResolvedValue('OK');
+    });
+
+    it('recomputes when the per-window lock is acquired', async () => {
+      redisMock.set.mockResolvedValue('OK');
+
+      await service.refreshPopular24h();
+
+      expect(redisMock.set).toHaveBeenCalledWith(
+        'popular:refresh-lock:24h',
+        '1',
+        'EX',
+        expect.any(Number),
+        'NX',
+      );
+      expect(recomputeSpy).toHaveBeenCalledWith('24h');
+    });
+
+    it('skips the tick when another instance holds the lock', async () => {
+      redisMock.set.mockResolvedValue(null);
+
+      await service.refreshPopular7d();
+
+      expect(recomputeSpy).not.toHaveBeenCalled();
+    });
+
+    it('skips the tick when Redis is unreachable', async () => {
+      redisMock.set.mockRejectedValue(new Error('redis down'));
+
+      await service.refreshPopularAll();
+
+      expect(recomputeSpy).not.toHaveBeenCalled();
+    });
+
+    it('uses lock TTLs below each window refresh interval', async () => {
+      redisMock.set.mockResolvedValue('OK');
+
+      await service.refreshPopular24h();
+      await service.refreshPopular7d();
+      await service.refreshPopularAll();
+
+      const ttls = redisMock.set.mock.calls.map((call: any[]) => call[3]);
+      expect(ttls[0]).toBeLessThan(60);
+      expect(ttls[1]).toBeLessThan(300);
+      expect(ttls[2]).toBeLessThan(600);
     });
   });
 
@@ -1172,21 +1305,13 @@ describe('PopularRankingService', () => {
         topics: [],
       };
       const candidateQB = createCandidateQueryBuilder([post]);
-      const commentQB = {
-        innerJoin: jest.fn().mockReturnThis(),
-        select: jest.fn().mockReturnThis(),
-        addSelect: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        andWhere: jest.fn().mockReturnThis(),
-        groupBy: jest.fn().mockReturnThis(),
-        getRawMany: jest.fn().mockResolvedValue([]),
-      };
       const tipQB = {
         select: jest.fn().mockReturnThis(),
         innerJoin: jest.fn().mockReturnThis(),
         addSelect: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
         andWhere: jest.fn().mockReturnThis(),
+        setParameter: jest.fn().mockReturnThis(),
         groupBy: jest.fn().mockReturnThis(),
         getRawMany: jest.fn().mockResolvedValue([]),
       };
@@ -1201,10 +1326,8 @@ describe('PopularRankingService', () => {
 
       const svc = new PopularRankingService(
         {
-          createQueryBuilder: jest
-            .fn()
-            .mockReturnValueOnce(candidateQB)
-            .mockReturnValueOnce(commentQB),
+          createQueryBuilder: jest.fn().mockReturnValue(candidateQB),
+          query: jest.fn().mockResolvedValue([]),
           find: jest.fn().mockResolvedValue([post]),
           findBy: jest.fn().mockResolvedValue([post]),
         } as any,

--- a/src/social/services/popular-ranking.service.ts
+++ b/src/social/services/popular-ranking.service.ts
@@ -46,15 +46,10 @@ export type PopularRankingWeightOverrides = Partial<
   Record<PopularCustomizableWeightKey, PopularRankingWeightScale | undefined>
 >;
 
-type Mutable<T> = {
-  -readonly [K in keyof T]: T[K];
-};
-
-type PopularRankingResolvedWeights = Mutable<
-  typeof POPULAR_RANKING_CONFIG.WEIGHTS
-> & {
-  interactionsPerHour: number;
-};
+type PopularRankingResolvedWeights = Record<
+  keyof typeof POPULAR_RANKING_CONFIG.WEIGHTS,
+  number
+>;
 
 interface PopularScoreInput {
   content: string;
@@ -129,7 +124,6 @@ export class PopularRankingService implements OnModuleDestroy {
   ): PopularRankingResolvedWeights {
     const resolved: PopularRankingResolvedWeights = {
       ...POPULAR_RANKING_CONFIG.WEIGHTS,
-      interactionsPerHour: 0,
     };
 
     if (!this.hasWeightOverrides(overrides)) {
@@ -143,11 +137,7 @@ export class PopularRankingService implements OnModuleDestroy {
       }
 
       const multiplier = multipliers[value];
-      if (key === 'interactionsPerHour') {
-        resolved.interactionsPerHour =
-          POPULAR_RANKING_CONFIG.CUSTOMIZATION.ADDITIONAL_SIGNAL_WEIGHTS
-            .interactionsPerHour * multiplier;
-      } else if (key in resolved) {
+      if (key in resolved) {
         (resolved as Record<string, number>)[key] *= multiplier;
       }
     }
@@ -963,7 +953,7 @@ export class PopularRankingService implements OnModuleDestroy {
     const interactionsPerHour = this.computeInteractionsPerHour(input, window);
     const freshnessFactor = this.computeFreshnessFactor(input);
 
-    return (
+    const baseScore =
       weights.comments * Math.log(1 + comments) +
       weights.tipsAmountAE * Math.log(1 + tipsAmountAE) +
       weights.tipsCount * Math.log(1 + tipsCount) +
@@ -975,7 +965,19 @@ export class PopularRankingService implements OnModuleDestroy {
       weights.velocityBoost *
         Math.log(1 + interactionsPerHour) *
         freshnessFactor +
-      weights.interactionsPerHour * Math.log(1 + interactionsPerHour)
+      weights.interactionsPerHour * Math.log(1 + interactionsPerHour);
+
+    if (window !== 'all') {
+      return baseScore;
+    }
+
+    // Log-dampened engagement never decays on its own, so without gravity old
+    // high-total posts pin the 'all' feed forever. +2 keeps brand-new posts
+    // from being divided by ~0.
+    const ageHours = this.computeAgeHours(input.createdAt, 1) ?? 1;
+    return (
+      baseScore /
+      Math.pow(ageHours + 2, POPULAR_RANKING_CONFIG.ALL_WINDOW_GRAVITY)
     );
   }
 
@@ -1040,21 +1042,28 @@ export class PopularRankingService implements OnModuleDestroy {
     }));
   }
 
+  private countEmojis(content: string): number {
+    try {
+      // Extended_Pictographic instead of Emoji: \p{Emoji} also matches digits,
+      // '#' and '*'. Global flag so every occurrence counts, not just the first.
+      return (content.match(/\p{Extended_Pictographic}/gu) || []).length;
+    } catch {
+      return 0;
+    }
+  }
+
   private computeContentQuality(content: string): number {
     if (!content) return 0;
     const cfg = POPULAR_RANKING_CONFIG.CONTENT;
-    const len = content.length;
+    // Code-point length, not UTF-16 length: emoji are surrogate pairs, so an
+    // emoji-only post would otherwise cap emojiRatio at 0.5 and dodge the
+    // short-and-emoji-heavy penalty.
+    const len = [...content].length;
     const lengthScore = Math.max(
       0,
       Math.min(1, (len - cfg.minLengthForNoPenalty) / cfg.maxReferenceLength),
     );
-    let emojis = 0;
-    try {
-      const emojiRegex = /[\p{Emoji_Presentation}\p{Emoji}\u200d]+/u;
-      emojis = (content.match(emojiRegex) || []).length;
-    } catch {
-      emojis = 0;
-    }
+    const emojis = this.countEmojis(content);
     const emojiRatio = Math.min(1, emojis / Math.max(1, len));
     const alnumMatches = content.match(/[A-Za-z0-9]/g) || [];
     const alnumRatio = Math.min(1, alnumMatches.length / Math.max(1, len));

--- a/src/social/services/popular-ranking.service.ts
+++ b/src/social/services/popular-ranking.service.ts
@@ -5,6 +5,7 @@ import {
   OnModuleDestroy,
   Optional,
 } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
 import { InjectRepository } from '@nestjs/typeorm';
 import { In, Repository } from 'typeorm';
 import { Post } from '../entities/post.entity';
@@ -52,12 +53,19 @@ type PopularRankingResolvedWeights = Record<
 >;
 
 interface PopularScoreInput {
+  id?: string;
   content: string;
   comments: number;
   tipsAmountAE: number;
   tipsCount: number;
   uniqueTippers: number;
   reads: number;
+  /**
+   * Interactions within VELOCITY_WINDOW_HOURS. When absent (sources without
+   * interaction timestamps, e.g. plugin items) velocity falls back to the
+   * lifetime average.
+   */
+  recentInteractions?: number;
   topics?: Array<{ name?: string }>;
   createdAt?: Date | string;
 }
@@ -404,6 +412,56 @@ export class PopularRankingService implements OnModuleDestroy {
     await task;
   }
 
+  /**
+   * Scheduled refresh so user requests almost never pay recompute latency —
+   * on a low-traffic instance the lazy path would otherwise find a cold cache
+   * on nearly every request. Cadence is staggered by how fast each feed
+   * actually changes ('all' scores 10k candidates; no point doing that every
+   * minute), and the lazy recompute stays as cold-start fallback.
+   */
+  @Cron(CronExpression.EVERY_MINUTE)
+  refreshPopular24h(): Promise<void> {
+    return this.refreshWindowLocked('24h', 55);
+  }
+
+  @Cron(CronExpression.EVERY_5_MINUTES)
+  refreshPopular7d(): Promise<void> {
+    return this.refreshWindowLocked('7d', 295);
+  }
+
+  @Cron(CronExpression.EVERY_10_MINUTES)
+  refreshPopularAll(): Promise<void> {
+    return this.refreshWindowLocked('all', 595);
+  }
+
+  /**
+   * A short-lived Redis lock (TTL just under the window's cron interval)
+   * keeps multiple app instances from recomputing the same window in
+   * parallel — whoever grabs the lock does the work, the rest skip the tick.
+   */
+  private async refreshWindowLocked(
+    window: PopularWindow,
+    lockTtlSeconds: number,
+  ): Promise<void> {
+    try {
+      const acquired = await this.redis.set(
+        `popular:refresh-lock:${window}`,
+        '1',
+        'EX',
+        lockTtlSeconds,
+        'NX',
+      );
+      if (acquired === null) {
+        return;
+      }
+    } catch {
+      // Redis unreachable — recompute could not cache its result anyway.
+      return;
+    }
+
+    await this.awaitOrTriggerRecompute(window);
+  }
+
   private async hydrateRankedItems(
     window: PopularWindow,
     ids: string[],
@@ -649,8 +707,11 @@ export class PopularRankingService implements OnModuleDestroy {
 
     const ids = candidates.map((c) => c.id);
     let tipsByPost = new Map<string, any>();
-    let commentsByPost = new Map<string, number>();
+    let commentsByPost = new Map<string, { count: number; recent: number }>();
     let readsByPost = new Map<string, number>();
+    const recentSince = new Date(
+      Date.now() - POPULAR_RANKING_CONFIG.VELOCITY_WINDOW_HOURS * 3600 * 1000,
+    );
 
     if (ids.length > 0) {
       const tipsRaw = await this.tipRepository
@@ -663,30 +724,65 @@ export class PopularRankingService implements OnModuleDestroy {
         )
         .addSelect('COUNT(*)', 'count')
         .addSelect('COUNT(DISTINCT tip.sender_address)', 'unique_tippers')
+        .addSelect(
+          'COUNT(*) FILTER (WHERE tip.created_at >= :recentSince)',
+          'recent_count',
+        )
         .where('tip.post_id IN (:...ids)', { ids })
         .andWhere('tip.sender_address != post.sender_address')
+        .setParameter('recentSince', recentSince)
         .groupBy('tip.post_id')
         .getRawMany<{
           post_id: string;
           amount_sum: string;
           count: string;
           unique_tippers: string;
+          recent_count: string;
         }>();
       tipsByPost = new Map(tipsRaw.map((t) => [t.post_id, t] as const));
 
-      const commentsRaw = await this.postRepository
-        .createQueryBuilder('comment')
-        .innerJoin(Post, 'parent', 'parent.id = comment.post_id')
-        .select('comment.post_id', 'parent_id')
-        .addSelect('COUNT(*)', 'count')
-        .where('comment.post_id IN (:...ids)', { ids })
-        .andWhere('comment.is_hidden = false')
-        .andWhere('comment.sender_address != parent.sender_address')
-        .groupBy('comment.post_id')
-        .getRawMany<{ parent_id: string; count: string }>();
+      // Whole-thread comment count: replies to comments attach to the
+      // comment's id, so counting direct children only would score a deep
+      // 30-message discussion as its handful of top-level comments. Replies
+      // authored by the root post's author are excluded (same anti-self-boost
+      // rule as before), and hidden comments prune their entire subtree.
+      const commentsRaw: Array<{
+        root_id: string;
+        count: string;
+        recent_count: string;
+      }> = await this.postRepository.query(
+        `WITH RECURSIVE thread AS (
+           SELECT p.id, p.id AS root_id, p.sender_address AS root_sender,
+                  0 AS depth
+           FROM posts p
+           WHERE p.id = ANY($1)
+           UNION ALL
+           SELECT c.id, t.root_id, t.root_sender, t.depth + 1
+           FROM posts c
+           INNER JOIN thread t ON c.post_id = t.id
+           WHERE c.is_hidden = false
+             AND t.depth < ${POPULAR_RANKING_CONFIG.THREAD_COUNT_MAX_DEPTH}
+         )
+         SELECT t.root_id AS root_id,
+                COUNT(*) AS count,
+                COUNT(*) FILTER (WHERE c.created_at >= $2) AS recent_count
+         FROM thread t
+         INNER JOIN posts c ON c.id = t.id
+         WHERE t.id != t.root_id
+           AND c.sender_address != t.root_sender
+         GROUP BY t.root_id`,
+        [ids, recentSince],
+      );
       commentsByPost = new Map(
         commentsRaw.map(
-          (r) => [r.parent_id, parseInt(r.count || '0', 10)] as const,
+          (r) =>
+            [
+              r.root_id,
+              {
+                count: parseInt(r.count || '0', 10),
+                recent: parseInt(r.recent_count || '0', 10),
+              },
+            ] as const,
         ),
       );
 
@@ -717,19 +813,25 @@ export class PopularRankingService implements OnModuleDestroy {
 
     const scoredPosts: PopularScoreItem[] = candidates.map((post) => {
       const tipsAgg = tipsByPost.get(post.id);
+      const commentsAgg = commentsByPost.get(post.id);
+      const recentInteractions =
+        (commentsAgg?.recent || 0) +
+        (tipsAgg ? parseInt(tipsAgg.recent_count || '0', 10) : 0);
       return {
         postId: post.id,
         score: this.computeScore(
           trendingByTag,
           {
+            id: post.id,
             content: post.content,
-            comments: commentsByPost.get(post.id) || 0,
+            comments: commentsAgg?.count || 0,
             tipsAmountAE: tipsAgg ? parseFloat(tipsAgg.amount_sum || '0') : 0,
             tipsCount: tipsAgg ? parseInt(tipsAgg.count || '0', 10) : 0,
             uniqueTippers: tipsAgg
               ? parseInt(tipsAgg.unique_tippers || '0', 10)
               : 0,
             reads: readsByPost.get(post.id) || 0,
+            recentInteractions,
             topics: post.topics,
             createdAt: post.created_at,
           },
@@ -746,6 +848,7 @@ export class PopularRankingService implements OnModuleDestroy {
         score: this.computeScore(
           trendingByTag,
           {
+            id: item.id,
             content: item.content,
             comments: item.total_comments || 0,
             tipsAmountAE: 0,
@@ -880,6 +983,17 @@ export class PopularRankingService implements OnModuleDestroy {
       return 0;
     }
 
+    // Recent interactions over the velocity window (or the post's age when
+    // younger): an old post catching fire today registers full velocity
+    // instead of having new activity averaged over its lifetime.
+    if (input.recentInteractions !== undefined) {
+      const velocityHours = Math.min(
+        ageHours,
+        POPULAR_RANKING_CONFIG.VELOCITY_WINDOW_HOURS,
+      );
+      return input.recentInteractions / Math.max(1, velocityHours);
+    }
+
     const effectiveHours =
       window === 'all'
         ? ageHours
@@ -909,6 +1023,30 @@ export class PopularRankingService implements OnModuleDestroy {
     return Math.max(
       minimumHours,
       (Date.now() - date.getTime()) / (60 * 60 * 1000),
+    );
+  }
+
+  /**
+   * Deterministic per-hour jitter in [0, TIE_ROTATION_EPSILON) that rotates
+   * near-tied posts (mostly the zero-engagement tail) so their relative order
+   * changes every hour instead of being frozen between recomputes. Added
+   * before gravity, so it scales down with everything else on 'all'.
+   */
+  private computeTieRotation(id?: string): number {
+    if (!id) {
+      return 0;
+    }
+
+    const hourBucket = Math.floor(Date.now() / (60 * 60 * 1000));
+    const seed = `${id}:${hourBucket}`;
+    let hash = 0x811c9dc5; // FNV-1a
+    for (let i = 0; i < seed.length; i++) {
+      hash ^= seed.charCodeAt(i);
+      hash = Math.imul(hash, 0x01000193);
+    }
+
+    return (
+      ((hash >>> 0) / 0x100000000) * POPULAR_RANKING_CONFIG.TIE_ROTATION_EPSILON
     );
   }
 
@@ -953,19 +1091,30 @@ export class PopularRankingService implements OnModuleDestroy {
     const interactionsPerHour = this.computeInteractionsPerHour(input, window);
     const freshnessFactor = this.computeFreshnessFactor(input);
 
+    // Reads are the easiest signal to inflate (a request with a browser UA is
+    // enough), so their counted volume is capped relative to active
+    // engagement — passive signal alone cannot outvote real interactions.
+    const activeInteractions = comments + tipsCount + uniqueTippers;
+    const effectiveReads = Math.min(
+      reads,
+      POPULAR_RANKING_CONFIG.READS_PER_INTERACTION_CAP *
+        (1 + activeInteractions),
+    );
+
     const baseScore =
       weights.comments * Math.log(1 + comments) +
       weights.tipsAmountAE * Math.log(1 + tipsAmountAE) +
       weights.tipsCount * Math.log(1 + tipsCount) +
       weights.uniqueTippers * Math.log(1 + uniqueTippers) +
-      weights.reads * Math.log(1 + reads) +
+      weights.reads * Math.log(1 + effectiveReads) +
       weights.trendingBoost * trendingBoost +
       weights.contentQuality * contentQuality +
       weights.freshnessBoost * freshnessFactor +
       weights.velocityBoost *
         Math.log(1 + interactionsPerHour) *
         freshnessFactor +
-      weights.interactionsPerHour * Math.log(1 + interactionsPerHour);
+      weights.interactionsPerHour * Math.log(1 + interactionsPerHour) +
+      this.computeTieRotation(input.id);
 
     if (window !== 'all') {
       return baseScore;

--- a/src/social/services/reads.service.spec.ts
+++ b/src/social/services/reads.service.spec.ts
@@ -1,0 +1,115 @@
+const redisSetMock = jest.fn();
+const redisMock = {
+  on: jest.fn().mockReturnThis(),
+  quit: jest.fn().mockResolvedValue('OK'),
+  set: redisSetMock,
+};
+
+jest.mock('ioredis', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => redisMock),
+}));
+
+import { ReadsService } from './reads.service';
+
+describe('ReadsService', () => {
+  let repo: any;
+  let service: ReadsService;
+
+  const buildReq = (ua = 'Mozilla/5.0', ip = '1.2.3.4') =>
+    ({
+      headers: { 'user-agent': ua },
+      ip,
+      socket: { remoteAddress: ip },
+    }) as any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    repo = { query: jest.fn().mockResolvedValue(undefined) };
+    service = new ReadsService(repo);
+  });
+
+  it('counts the first read of a viewer per post per day', async () => {
+    redisSetMock.mockResolvedValue('OK');
+
+    await service.recordRead('post-1', buildReq());
+
+    expect(redisSetMock).toHaveBeenCalledWith(
+      expect.stringContaining('reads:seen:'),
+      '1',
+      'EX',
+      expect.any(Number),
+      'NX',
+    );
+    expect(repo.query).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips repeat reads from the same viewer on the same day', async () => {
+    redisSetMock.mockResolvedValue(null);
+
+    await service.recordRead('post-1', buildReq());
+
+    expect(repo.query).not.toHaveBeenCalled();
+  });
+
+  it('fails open and counts the read when Redis is unavailable', async () => {
+    redisSetMock.mockRejectedValue(new Error('redis down'));
+
+    await service.recordRead('post-1', buildReq());
+
+    expect(repo.query).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores bot user agents entirely', async () => {
+    await service.recordRead('post-1', buildReq('curl/8.0.1'));
+
+    expect(redisSetMock).not.toHaveBeenCalled();
+    expect(repo.query).not.toHaveBeenCalled();
+  });
+
+  it('treats a missing user agent as a bot', async () => {
+    await service.recordRead('post-1', { headers: {} } as any);
+
+    expect(redisSetMock).not.toHaveBeenCalled();
+    expect(repo.query).not.toHaveBeenCalled();
+  });
+
+  it('fails open when the viewer IP cannot be determined', async () => {
+    const req = {
+      headers: { 'user-agent': 'Mozilla/5.0' },
+      socket: {},
+    } as any;
+
+    await service.recordRead('post-1', req);
+
+    expect(redisSetMock).not.toHaveBeenCalled();
+    expect(repo.query).toHaveBeenCalledTimes(1);
+  });
+
+  it('identifies the viewer by the first x-forwarded-for hop only', async () => {
+    redisSetMock.mockResolvedValue('OK');
+    const reqWithXff = (xff: string) =>
+      ({
+        headers: { 'user-agent': 'Mozilla/5.0', 'x-forwarded-for': xff },
+        ip: '10.0.0.1',
+        socket: { remoteAddress: '10.0.0.1' },
+      }) as any;
+
+    await service.recordRead('post-1', reqWithXff('1.1.1.1, 2.2.2.2'));
+    await service.recordRead('post-1', reqWithXff('1.1.1.1, 9.9.9.9'));
+    await service.recordRead('post-1', reqWithXff('3.3.3.3, 2.2.2.2'));
+
+    const keys = redisSetMock.mock.calls.map((call) => call[0]);
+    expect(keys[0]).toBe(keys[1]);
+    expect(keys[2]).not.toBe(keys[0]);
+  });
+
+  it('never throws when the reads upsert fails', async () => {
+    redisSetMock.mockResolvedValue('OK');
+    repo.query.mockRejectedValue(new Error('db down'));
+
+    await expect(
+      service.recordRead('post-1', buildReq()),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/social/services/reads.service.ts
+++ b/src/social/services/reads.service.ts
@@ -1,18 +1,32 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import { createHash } from 'crypto';
+import Redis from 'ioredis';
 import { PostReadsDaily } from '../entities/post-reads.entity';
 import type { Request } from 'express';
 import { POPULAR_RANKING_CONFIG } from '@/configs/constants';
+import { REDIS_CONFIG } from '@/configs/redis';
 
 @Injectable()
-export class ReadsService {
+export class ReadsService implements OnModuleDestroy {
   private readonly logger = new Logger(ReadsService.name);
+  private readonly redis = new Redis(REDIS_CONFIG);
+  // Keys embed the UTC date, so a fixed TTL just past a full day is enough.
+  private static readonly DEDUP_TTL_SECONDS = 25 * 60 * 60;
 
   constructor(
     @InjectRepository(PostReadsDaily)
     private readonly postReadsRepository: Repository<PostReadsDaily>,
-  ) {}
+  ) {
+    this.redis.on('error', (error) => {
+      this.logger.error('Reads dedup Redis connection error', error);
+    });
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await this.redis.quit();
+  }
 
   async recordRead(postId: string, req: Request): Promise<void> {
     try {
@@ -25,6 +39,14 @@ export class ReadsService {
       const dd = String(today.getUTCDate()).padStart(2, '0');
       const dateOnly = `${yyyy}-${mm}-${dd}`;
 
+      const isFirstReadToday = await this.isFirstReadToday(
+        postId,
+        dateOnly,
+        req,
+        ua,
+      );
+      if (!isFirstReadToday) return;
+
       // upsert reads += 1 for (post_id, date) using raw SQL for increment
       await this.postReadsRepository.query(
         `INSERT INTO post_reads_daily (post_id, date, reads)
@@ -35,6 +57,46 @@ export class ReadsService {
       );
     } catch (e) {
       this.logger.debug('recordRead skipped', e as any);
+    }
+  }
+
+  /**
+   * One counted read per viewer, post, and UTC day. Viewer identity is an
+   * IP+UA hash — coarse, but it stops a single client from inflating reads
+   * with a request loop. Fails open (counts the read) when the viewer cannot
+   * be identified or Redis is unavailable.
+   */
+  private async isFirstReadToday(
+    postId: string,
+    dateOnly: string,
+    req: Request,
+    ua: string,
+  ): Promise<boolean> {
+    const forwarded = (req?.headers?.['x-forwarded-for'] as string) || '';
+    const ip =
+      forwarded.split(',')[0]?.trim() ||
+      req?.ip ||
+      req?.socket?.remoteAddress ||
+      '';
+    if (!ip) return true;
+
+    const viewer = createHash('sha256')
+      .update(`${ip}:${ua}`)
+      .digest('hex')
+      .slice(0, 16);
+    const key = `reads:seen:${dateOnly}:${postId}:${viewer}`;
+
+    try {
+      const created = await this.redis.set(
+        key,
+        '1',
+        'EX',
+        ReadsService.DEDUP_TTL_SECONDS,
+        'NX',
+      );
+      return created !== null;
+    } catch {
+      return true;
     }
   }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes feed ordering and adds heavier recompute (recursive comment SQL, crons); mis-tuned weights or gravity could skew discovery, though lazy recompute and fallbacks remain.
> 
> **Overview**
> **Popular ranking** gets a substantial scoring and ops overhaul: freshness and velocity windows move from **24h to 48h**, with **always-on** `interactionsPerHour` momentum plus a **freshness-gated** velocity term driven by **recent** tips/comments in the last 48h (not lifetime averages). The **`all`** window now applies gentle **age gravity**; **`24h`/`7d`** do not. Comments are counted across **whole reply threads** (recursive SQL), reads are **capped vs active engagement**, and **hourly tie rotation** shuffles near-tied zero-engagement posts. **`interactionsPerHour`** is a first-class config weight (replacing the old customization-only signal).
> 
> **Caching**: scheduled **crons** refresh `popular:24h` / `7d` / `all` on staggered intervals with **Redis `SET NX` locks** per window; **Redis TTL** rises from 30s to **1800s**. **`IDX_POSTS_POST_ID`** supports the thread CTE.
> 
> **Reads**: **`ReadsService`** deduplicates **one read per viewer (IP+UA hash), post, UTC day** via Redis (fail-open), still blocking bot UAs.
> 
> Docs and broad unit tests cover the new math, cron locking, and read dedup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fddbfd0f51b64387460ba8dd8513681a304c4f3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->