### PR TITLE
fix: be able to mention token from different collections

### DIFF
--- a/src/social/controllers/posts.controller.spec.ts
+++ b/src/social/controllers/posts.controller.spec.ts
@@ -117,4 +117,99 @@ describe('PostsController', () => {
       expect.any(Object),
     );
   });
+
+  describe('trend mention performance', () => {
+    const attachTrendMentions = (
+      items: Array<{ id: string; content: string }>,
+      tokens: Array<Record<string, any>>,
+    ) => {
+      const tokenQueryBuilder = {
+        leftJoinAndMapOne: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue(tokens),
+      };
+      const tokenRepository = {
+        createQueryBuilder: jest.fn().mockReturnValue(tokenQueryBuilder),
+      };
+      const trendController = new PostsController(
+        {} as any,
+        tokenRepository as any,
+        {} as any,
+        {} as any,
+        {} as any,
+      );
+
+      return {
+        tokenQueryBuilder,
+        run: () =>
+          (trendController as any).attachTrendMentionsPerformance(items),
+      };
+    };
+
+    it('resolves a hashtag naming a token from a non-Latin collection', async () => {
+      const items = [{ id: 'post-1', content: 'accumulating #汉字 早期' }];
+      const { tokenQueryBuilder, run } = attachTrendMentions(items, [
+        { symbol: '汉字', sale_address: 'ct_chinese', performance: { pct: 1 } },
+      ]);
+
+      await run();
+
+      expect(tokenQueryBuilder.andWhere).toHaveBeenCalledWith(
+        'UPPER(token.symbol) IN (:...names)',
+        { names: ['汉字'] },
+      );
+      expect((items[0] as any).trend_mentions).toEqual([
+        {
+          name: '汉字',
+          sale_address: 'ct_chinese',
+          performance: { pct: 1 },
+        },
+      ]);
+    });
+
+    it('resolves a lowercase Cyrillic hashtag onto the uppercase symbol', async () => {
+      const items = [{ id: 'post-2', content: 'держим #привет' }];
+      const { tokenQueryBuilder, run } = attachTrendMentions(items, [
+        { symbol: 'ПРИВЕТ', sale_address: 'ct_russian', performance: null },
+      ]);
+
+      await run();
+
+      expect(tokenQueryBuilder.andWhere).toHaveBeenCalledWith(
+        'UPPER(token.symbol) IN (:...names)',
+        { names: ['ПРИВЕТ'] },
+      );
+      expect((items[0] as any).trend_mentions).toEqual([
+        { name: 'ПРИВЕТ', sale_address: 'ct_russian', performance: null },
+      ]);
+    });
+
+    it('resolves Latin and non-Latin hashtags in the same post', async () => {
+      const items = [{ id: 'post-3', content: 'swapping #WORDS-1 for #汉字' }];
+      const { run } = attachTrendMentions(items, [
+        { symbol: 'WORDS-1', sale_address: 'ct_words', performance: null },
+        { symbol: '汉字', sale_address: 'ct_chinese', performance: null },
+      ]);
+
+      await run();
+
+      expect((items[0] as any).trend_mentions).toEqual([
+        { name: 'WORDS-1', sale_address: 'ct_words', performance: null },
+        { name: '汉字', sale_address: 'ct_chinese', performance: null },
+      ]);
+    });
+
+    it('reports a mention with no matching token as an unresolved trend', async () => {
+      const items = [{ id: 'post-4', content: 'hyping #汉字' }];
+      const { run } = attachTrendMentions(items, []);
+
+      await run();
+
+      expect((items[0] as any).trend_mentions).toEqual([
+        { name: '汉字', sale_address: null, performance: null },
+      ]);
+    });
+  });
 });

--- a/src/social/utils/content-parser.util.spec.ts
+++ b/src/social/utils/content-parser.util.spec.ts
@@ -124,6 +124,29 @@ describe('Content Parser Utilities', () => {
         'CAMELCASE',
       ]);
     });
+
+    it('extracts mentions of tokens from the non-Latin collections', () => {
+      expect(extractTrendMentions('buying #汉字 today')).toEqual(['汉字']);
+      expect(extractTrendMentions('buying #مرحبا today')).toEqual(['مرحبا']);
+      expect(extractTrendMentions('buying #ПРИВЕТ today')).toEqual(['ПРИВЕТ']);
+    });
+
+    it('uppercases a Cyrillic mention to the symbol the token is stored under', () => {
+      // The RUSSIAN collection only permits А-Я, so the on-chain symbol is
+      // uppercase; a lowercase hashtag has to fold onto it to resolve.
+      expect(extractTrendMentions('держим #привет крепко')).toEqual(['ПРИВЕТ']);
+      expect(extractTrendMentions('и #ёлка тоже')).toEqual(['ЁЛКА']);
+    });
+
+    it('extracts Latin and non-Latin mentions from the same post', () => {
+      expect(
+        extractTrendMentions('swapping #WORDS-1 for #汉字 and #привет'),
+      ).toEqual(['WORDS-1', '汉字', 'ПРИВЕТ']);
+    });
+
+    it('deduplicates a non-Latin mention repeated in one post', () => {
+      expect(extractTrendMentions('#汉字 then #汉字 again')).toEqual(['汉字']);
+    });
   });
 
   describe('extractMedia', () => {

--- a/src/social/utils/token-mentions-sql.util.spec.ts
+++ b/src/social/utils/token-mentions-sql.util.spec.ts
@@ -1,0 +1,138 @@
+import { BCL_FACTORY } from '@/configs/contracts';
+import {
+  TOKEN_HASHTAG_REGEX_SOURCE,
+  buildNormalizedTokenMentionSelectSql,
+  buildTokenMentionExistsSql,
+} from './token-mentions-sql.util';
+
+const HYPHEN = 0x2d;
+
+const matchAll = (content: string): string[] => {
+  const matches = content.match(new RegExp(TOKEN_HASHTAG_REGEX_SOURCE, 'g'));
+  return (matches ?? []).map((match) => match.slice(1));
+};
+
+/** Every codepoint a collection permits, as a flat list. */
+const allowedCodepoints = (collection: {
+  allowed_name_chars: { [key: string]: number[] }[];
+}): number[] => {
+  const codepoints: number[] = [];
+
+  for (const entry of collection.allowed_name_chars) {
+    if (Array.isArray(entry.SingleChar)) {
+      codepoints.push(entry.SingleChar[0]);
+    }
+    if (Array.isArray(entry.CharRangeFromTo)) {
+      codepoints.push(entry.CharRangeFromTo[0], entry.CharRangeFromTo[1]);
+    }
+  }
+
+  return codepoints;
+};
+
+describe('token-mentions-sql util', () => {
+  describe('TOKEN_HASHTAG_REGEX_SOURCE', () => {
+    it('matches hashtags naming tokens from every non-Latin collection', () => {
+      expect(matchAll('look at #汉字 rising')).toEqual(['汉字']);
+      expect(matchAll('look at #مرحبا rising')).toEqual(['مرحبا']);
+      expect(matchAll('look at #ПРИВЕТ rising')).toEqual(['ПРИВЕТ']);
+      expect(matchAll('look at #ЁЛКА rising')).toEqual(['ЁЛКА']);
+    });
+
+    it('still matches the Latin hashtags it always did', () => {
+      expect(matchAll('buy #WORDS-1 and #beta_2 now')).toEqual([
+        'WORDS-1',
+        'beta_2',
+      ]);
+    });
+
+    it('picks up several scripts out of one post', () => {
+      expect(matchAll('#汉字 vs #WORDS vs #привет vs #مرحبا')).toEqual([
+        '汉字',
+        'WORDS',
+        'привет',
+        'مرحبا',
+      ]);
+    });
+
+    it('accepts a hyphen inside a symbol but not as its first character', () => {
+      expect(matchAll('#WORDS-1')).toEqual(['WORDS-1']);
+      expect(matchAll('#-nope')).toEqual([]);
+    });
+
+    it('caps a symbol at 50 characters', () => {
+      expect(matchAll('#' + 'A'.repeat(50))).toEqual(['A'.repeat(50)]);
+      expect(matchAll('#' + 'A'.repeat(60))).toEqual(['A'.repeat(50)]);
+      expect(matchAll('#' + '汉'.repeat(60))).toEqual(['汉'.repeat(50)]);
+    });
+
+    it('ignores a bare hash', () => {
+      expect(matchAll('# not a tag #')).toEqual([]);
+    });
+
+    /**
+     * The guard that keeps this honest: the class is derived from the factory
+     * config, so a collection added later is covered without editing this file —
+     * and if its charset somehow is not matched, this fails.
+     */
+    it('matches a symbol built from any collection the factory allows', () => {
+      const collections = Object.values(BCL_FACTORY).flatMap((factory) =>
+        Object.values(factory.collections),
+      );
+
+      expect(collections.length).toBeGreaterThan(0);
+
+      for (const collection of collections) {
+        const symbol = allowedCodepoints(collection)
+          .filter((codepoint) => codepoint !== HYPHEN)
+          .map((codepoint) => String.fromCodePoint(codepoint))
+          .join('');
+
+        expect(matchAll(`mentioning #${symbol} here`)).toEqual([symbol]);
+
+        // People type the symbol in whichever case is convenient; both the JS
+        // parser and Postgres UPPER() fold it back to the stored symbol.
+        const lowercased = symbol.toLowerCase();
+        expect(matchAll(`mentioning #${lowercased} here`)).toEqual([
+          lowercased,
+        ]);
+      }
+    });
+
+    /**
+     * This exact string is interpolated into Postgres `regexp_matches(...)` as
+     * well as passed to `new RegExp(...)`. `\uXXXX` is the only escape both
+     * engines read the same way — a JS-only construct (`\p{L}`, `\u{...}`) would
+     * still pass the JS tests here while silently matching nothing in SQL.
+     */
+    it('uses only escape syntax that Postgres and JS both understand', () => {
+      expect(TOKEN_HASHTAG_REGEX_SOURCE).toMatch(
+        /^#\(\[(?:\\u[0-9A-F]{4}|-)+\]\[(?:\\u[0-9A-F]{4}|-)+\]\{0,49\}\)$/,
+      );
+      expect(TOKEN_HASHTAG_REGEX_SOURCE).not.toContain('\\p{');
+      expect(TOKEN_HASHTAG_REGEX_SOURCE).not.toContain('\\u{');
+    });
+
+    it('does not leak an unescaped quote into the SQL string literal', () => {
+      expect(TOKEN_HASHTAG_REGEX_SOURCE).not.toContain("'");
+    });
+  });
+
+  describe('SQL builders', () => {
+    it('embeds the shared pattern in the content fallback', () => {
+      const sql = buildNormalizedTokenMentionSelectSql('post');
+
+      expect(sql).toContain(`'${TOKEN_HASHTAG_REGEX_SOURCE}'`);
+      expect(sql).toContain('UPPER(mention.symbol)');
+      expect(sql).toContain('post.token_mentions');
+    });
+
+    it('scopes the exists check to the given alias and symbol', () => {
+      const sql = buildTokenMentionExistsSql('post', '$2');
+
+      expect(sql).toContain('EXISTS (');
+      expect(sql).toContain('normalized_mentions.symbol = $2');
+      expect(sql).toContain(`'${TOKEN_HASHTAG_REGEX_SOURCE}'`);
+    });
+  });
+});

--- a/src/social/utils/token-mentions-sql.util.ts
+++ b/src/social/utils/token-mentions-sql.util.ts
@@ -1,4 +1,196 @@
-export const TOKEN_HASHTAG_REGEX_SOURCE = '#([A-Za-z0-9_][A-Za-z0-9_-]{0,49})';
+import { Logger } from '@nestjs/common';
+import { BCL_FACTORY } from '@/configs/contracts';
+
+const logger = new Logger('TokenMentionsSqlUtil');
+
+/**
+ * A BCL token's symbol is its on-chain community name verbatim, and each factory
+ * collection declares exactly which characters such a name may contain
+ * (`allowed_name_chars`). The hashtag character class is therefore derived from
+ * that config instead of being hardcoded: adding a collection (CHINESE, ARABIC,
+ * RUSSIAN, ...) makes its tokens mentionable without touching this file.
+ *
+ * The source string below is consumed verbatim by two regex engines — JS
+ * `RegExp` and Postgres ARE (`regexp_matches`) — so every codepoint is emitted
+ * as a `\uXXXX` escape. That is the one form both engines read identically, and
+ * it keeps regex-special characters (`-`, `]`, `^`) from ever landing in the
+ * bracket expression raw.
+ */
+
+/** Inclusive `[start, end]` codepoint interval. */
+type CodepointRange = [number, number];
+
+/** Accepted long before collections existed; kept so old mentions still parse. */
+const UNDERSCORE = 0x5f;
+
+/** Legal inside a symbol, never as its first character. */
+const HYPHEN = 0x2d;
+
+/** Total symbol length cap (first character + tail). */
+const MAX_SYMBOL_LENGTH = 50;
+
+/** A `\uXXXX` escape is exactly 4 hex digits in both engines. */
+const BMP_MAX = 0xffff;
+
+/**
+ * Every codepoint any collection permits, across every network.
+ */
+function collectionRanges(): CodepointRange[] {
+  const ranges: CodepointRange[] = [[UNDERSCORE, UNDERSCORE]];
+
+  for (const factory of Object.values(BCL_FACTORY)) {
+    for (const collection of Object.values(factory.collections ?? {})) {
+      for (const entry of collection.allowed_name_chars ?? []) {
+        const single = entry.SingleChar;
+        if (Array.isArray(single) && single.length > 0) {
+          ranges.push([single[0], single[0]]);
+        }
+
+        const range = entry.CharRangeFromTo;
+        if (Array.isArray(range) && range.length > 1) {
+          ranges.push([range[0], range[1]]);
+        }
+      }
+    }
+  }
+
+  return ranges;
+}
+
+/**
+ * Collections declare the *stored* casing (WORDS allows `A-Z`, RUSSIAN `А-Я`),
+ * but people type `#words` and `#привет`. Both the JS parser and Postgres
+ * `UPPER()` fold a mention up to the stored symbol, so the class has to admit
+ * either case on the way in.
+ */
+function withCaseCounterparts(ranges: CodepointRange[]): CodepointRange[] {
+  const expanded: CodepointRange[] = [...ranges];
+
+  for (const [start, end] of ranges) {
+    for (let codepoint = start; codepoint <= end; codepoint++) {
+      const character = String.fromCodePoint(codepoint);
+
+      for (const variant of [
+        character.toLowerCase(),
+        character.toUpperCase(),
+      ]) {
+        // Some characters case-fold to multiple characters (ß -> SS); such a
+        // fold has no single codepoint to add to the class.
+        if (variant.length === 1 && variant !== character) {
+          const variantCodepoint = variant.codePointAt(0) as number;
+          expanded.push([variantCodepoint, variantCodepoint]);
+        }
+      }
+    }
+  }
+
+  return expanded;
+}
+
+/** Sorts and coalesces overlapping or adjacent intervals. */
+function mergeRanges(ranges: CodepointRange[]): CodepointRange[] {
+  const sorted = [...ranges].sort((a, b) => a[0] - b[0] || a[1] - b[1]);
+  const merged: CodepointRange[] = [];
+
+  for (const [start, end] of sorted) {
+    const previous = merged[merged.length - 1];
+
+    if (previous && start <= previous[1] + 1) {
+      previous[1] = Math.max(previous[1], end);
+      continue;
+    }
+
+    merged.push([start, end]);
+  }
+
+  return merged;
+}
+
+/**
+ * Astral codepoints would need `\u{...}` in JS but `\Uxxxxxxxx` in Postgres, so
+ * there is no shared escape for them. No collection uses any today; warn loudly
+ * rather than silently failing to match if one ever does.
+ */
+function toBasicMultilingualPlane(ranges: CodepointRange[]): CodepointRange[] {
+  const kept: CodepointRange[] = [];
+  let dropped = false;
+
+  for (const [start, end] of ranges) {
+    if (start > BMP_MAX) {
+      dropped = true;
+      continue;
+    }
+
+    if (end > BMP_MAX) {
+      dropped = true;
+      kept.push([start, BMP_MAX]);
+      continue;
+    }
+
+    kept.push([start, end]);
+  }
+
+  if (dropped) {
+    logger.warn(
+      'A BCL collection allows codepoints above U+FFFF. Hashtags using them will not be indexed: ' +
+        'JS and Postgres have no common escape syntax for astral codepoints.',
+    );
+  }
+
+  return kept;
+}
+
+/** Removes a single codepoint from a set of intervals, splitting where needed. */
+function withoutCodepoint(
+  ranges: CodepointRange[],
+  codepoint: number,
+): CodepointRange[] {
+  const remaining: CodepointRange[] = [];
+
+  for (const [start, end] of ranges) {
+    if (codepoint < start || codepoint > end) {
+      remaining.push([start, end]);
+      continue;
+    }
+
+    if (start <= codepoint - 1) {
+      remaining.push([start, codepoint - 1]);
+    }
+
+    if (codepoint + 1 <= end) {
+      remaining.push([codepoint + 1, end]);
+    }
+  }
+
+  return remaining;
+}
+
+const escapeCodepoint = (codepoint: number): string =>
+  `\\u${codepoint.toString(16).toUpperCase().padStart(4, '0')}`;
+
+/** Renders intervals as the inside of a bracket expression, fully escaped. */
+function toCharClass(ranges: CodepointRange[]): string {
+  return ranges
+    .map(([start, end]) =>
+      start === end
+        ? escapeCodepoint(start)
+        : `${escapeCodepoint(start)}-${escapeCodepoint(end)}`,
+    )
+    .join('');
+}
+
+const ALLOWED_RANGES = mergeRanges(
+  toBasicMultilingualPlane(
+    withCaseCounterparts(mergeRanges(collectionRanges())),
+  ),
+);
+
+const TAIL_CLASS = toCharClass(ALLOWED_RANGES);
+const FIRST_CLASS = toCharClass(withoutCodepoint(ALLOWED_RANGES, HYPHEN));
+
+export const TOKEN_HASHTAG_REGEX_SOURCE = `#([${FIRST_CLASS}][${TAIL_CLASS}]{0,${
+  MAX_SYMBOL_LENGTH - 1
+}})`;
 
 export function buildNormalizedTokenMentionSelectSql(
   postAlias: string,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes shared parsing/SQL regex used for indexing and trend resolution; mis-sync between JS and Postgres or charset gaps could miss mentions, but coverage is strong and scope is social token mentions only.
> 
> **Overview**
> **Token hashtag matching** is no longer limited to Latin `A-Za-z0-9_-`. `TOKEN_HASHTAG_REGEX_SOURCE` is built from `BCL_FACTORY` collection `allowed_name_chars`, so Chinese, Arabic, Russian, and future collections are mentionable without changing the regex by hand. The pattern uses `\uXXXX` escapes so the **same string** works in JS `RegExp` and Postgres `regexp_matches`, with case variants included so tags like `#привет` normalize to stored symbols via `UPPER()`.
> 
> **Tests** cover non-Latin and mixed-script hashtags in `extractTrendMentions`, SQL builder embedding, and `attachTrendMentionsPerformance` (lookup by `UPPER(token.symbol)`, unresolved mentions when no token exists).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18d4003e7d51edeacb9a6cac0ea44b475341b68a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->