### PR TITLE
fix: be able to mention token from different collections

### DIFF
--- a/src/common/validation/request-validation.spec.ts
+++ b/src/common/validation/request-validation.spec.ts
@@ -6,6 +6,7 @@ import {
   AeContractAddressPipe,
   AeTransactionHashPipe,
   OpaqueIdPipe,
+  TopicParamPipe,
 } from './request-validation';
 
 describe('request validation pipes', () => {
@@ -54,5 +55,41 @@ describe('request validation pipes', () => {
     expect(() => pipe.transform('../secret', { data: 'id' })).toThrow(
       BadRequestException,
     );
+  });
+
+  describe('TopicParamPipe', () => {
+    const pipe = new TopicParamPipe();
+
+    it('accepts topics in the scripts the token collections allow', () => {
+      // GET /api/topics/name/%D8%A3%D9%86%D8%A7
+      expect(pipe.transform('أنا', { data: 'name' })).toBe('أنا');
+      expect(pipe.transform('汉字', { data: 'name' })).toBe('汉字');
+      expect(pipe.transform('ПРИВЕТ', { data: 'name' })).toBe('ПРИВЕТ');
+      expect(pipe.transform('привет', { data: 'name' })).toBe('привет');
+    });
+
+    it('still accepts the Latin topics it always did', () => {
+      expect(pipe.transform('WORDS-1', { data: 'name' })).toBe('WORDS-1');
+      expect(pipe.transform('some topic_name.v2', { data: 'name' })).toBe(
+        'some topic_name.v2',
+      );
+    });
+
+    it('keeps rejecting traversal and separator characters', () => {
+      for (const value of ['../secret', 'a/b', 'a\\b', '.hidden', '-lead']) {
+        expect(() => pipe.transform(value, { data: 'name' })).toThrow(
+          BadRequestException,
+        );
+      }
+    });
+
+    it('rejects an empty or over-long topic', () => {
+      expect(() => pipe.transform('', { data: 'name' })).toThrow(
+        BadRequestException,
+      );
+      expect(() => pipe.transform('汉'.repeat(129), { data: 'name' })).toThrow(
+        BadRequestException,
+      );
+    });
   });
 });

--- a/src/common/validation/request-validation.ts
+++ b/src/common/validation/request-validation.ts
@@ -10,7 +10,11 @@ const CHAIN_NAME_PATTERN = /^[a-z0-9][a-z0-9-]{0,62}\.chain$/i;
 const INVITE_CODE_PATTERN = /^[a-z0-9]{1,64}$/i;
 const PROVIDER_PATTERN = /^[a-z][a-z0-9_-]{0,31}$/i;
 const POST_ID_PATTERN = /^[\p{L}\p{N}][\p{L}\p{N}._~:-]{0,127}$/u;
-const TOPIC_PATTERN = /^[A-Za-z0-9][A-Za-z0-9 _.-]{0,127}$/;
+// Topics carry whatever script the post was written in (`extractTopics` strips no
+// characters), and tokens now come from non-Latin collections, so `#أنا` and `#汉字`
+// are real topic names. Letters/numbers in any script, matching POST_ID_PATTERN.
+// Still excludes `/`, `\` and a leading `.`, so no path traversal.
+const TOPIC_PATTERN = /^[\p{L}\p{N}][\p{L}\p{N} _.-]{0,127}$/u;
 
 type ValidatorFn = (value: string) => boolean;
 

--- a/src/plugins/social/services/topic-management.service.ts
+++ b/src/plugins/social/services/topic-management.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, EntityManager } from 'typeorm';
 import { Topic } from '@/social/entities/topic.entity';
 import { Post } from '@/social/entities/post.entity';
+import { normalizeTopicName } from '@/social/utils/topic-name.util';
 
 @Injectable()
 export class TopicManagementService {
@@ -31,7 +32,7 @@ export class TopicManagementService {
         continue;
       }
 
-      const normalizedName = topicName.trim().toLowerCase();
+      const normalizedName = normalizeTopicName(topicName);
 
       // Try to find existing topic
       let topic = await this.topicRepository.findOne({

--- a/src/social/controllers/topics.controller.spec.ts
+++ b/src/social/controllers/topics.controller.spec.ts
@@ -37,4 +37,71 @@ describe('TopicsController', () => {
     );
     expect(paginate).toHaveBeenCalledWith(queryBuilder, { page: 1, limit: 50 });
   });
+
+  describe('lookup by name', () => {
+    // Topics are written lowercased, so a lookup has to fold the caller's input
+    // the same way or an uppercase Cyrillic tag never resolves.
+    const lookupController = (found: unknown) => {
+      const findOne = jest.fn().mockResolvedValue(found);
+      return {
+        findOne,
+        controller: new TopicsController({ findOne } as any),
+      };
+    };
+
+    it('folds an uppercase Cyrillic name onto the stored lowercase topic', async () => {
+      const stored = { id: 'uuid-1', name: 'привет' };
+      const { findOne, controller: c } = lookupController(stored);
+
+      await expect(c.getByName('ПРИВЕТ')).resolves.toBe(stored);
+      expect(findOne).toHaveBeenCalledWith({
+        where: { name: 'привет' },
+        relations: ['posts'],
+      });
+    });
+
+    it('folds case for Latin names too, and trims', async () => {
+      const stored = { id: 'uuid-2', name: 'governance' };
+      const { findOne, controller: c } = lookupController(stored);
+
+      await expect(c.getByName('  GoVeRnAnCe  ')).resolves.toBe(stored);
+      expect(findOne).toHaveBeenCalledWith({
+        where: { name: 'governance' },
+        relations: ['posts'],
+      });
+    });
+
+    it('passes caseless scripts through unchanged', async () => {
+      const stored = { id: 'uuid-3', name: '汉字' };
+      const { findOne, controller: c } = lookupController(stored);
+
+      await expect(c.getByName('汉字')).resolves.toBe(stored);
+      expect(findOne).toHaveBeenCalledWith({
+        where: { name: '汉字' },
+        relations: ['posts'],
+      });
+    });
+
+    it('folds case on the name branch of getById as well', async () => {
+      const stored = { id: 'uuid-4', name: 'привет' };
+      const { findOne, controller: c } = lookupController(stored);
+
+      await expect(c.getById('ПРИВЕТ')).resolves.toBe(stored);
+      expect(findOne).toHaveBeenCalledWith({
+        where: { name: 'привет' },
+        relations: ['posts'],
+      });
+    });
+
+    it('still treats a UUID as an id, not a name', async () => {
+      const stored = { id: '3f2504e0-4f89-11d3-9a0c-0305e82c3301' };
+      const { findOne, controller: c } = lookupController(stored);
+
+      await c.getById('3F2504E0-4F89-11D3-9A0C-0305E82C3301');
+      expect(findOne).toHaveBeenCalledWith({
+        where: { id: '3F2504E0-4F89-11D3-9A0C-0305E82C3301' },
+        relations: ['posts'],
+      });
+    });
+  });
 });

--- a/src/social/controllers/topics.controller.ts
+++ b/src/social/controllers/topics.controller.ts
@@ -21,6 +21,7 @@ import { Repository } from 'typeorm';
 import { Topic } from '../entities/topic.entity';
 import { ApiOkResponsePaginated } from '@/utils/api-type';
 import { TopicParamPipe } from '@/common/validation/request-validation';
+import { normalizeTopicName } from '../utils/topic-name.util';
 
 const ALLOWED_ORDER_BY = new Set(['name', 'post_count', 'created_at']);
 const ALLOWED_ORDER_DIRECTIONS = new Set(['ASC', 'DESC']);
@@ -120,7 +121,7 @@ export class TopicsController {
       );
 
     const topic = await this.topicRepository.findOne({
-      where: isUUID ? { id } : { name: id },
+      where: isUUID ? { id } : { name: normalizeTopicName(id) },
       relations: ['posts'],
     });
     if (!topic) {
@@ -144,7 +145,7 @@ export class TopicsController {
   @Get('name/:name')
   async getByName(@Param('name', TopicParamPipe) name: string) {
     const topic = await this.topicRepository.findOne({
-      where: { name },
+      where: { name: normalizeTopicName(name) },
       relations: ['posts'],
     });
     if (!topic) {

--- a/src/social/services/popular-ranking.service.spec.ts
+++ b/src/social/services/popular-ranking.service.spec.ts
@@ -1206,6 +1206,30 @@ describe('PopularRankingService', () => {
         svc.computeContentQuality('hello'),
       );
     });
+
+    it('scores non-Latin posts on par with Latin ones of the same length', () => {
+      // The alphanumeric ratio used an ASCII-only class, so a wholly Chinese,
+      // Arabic or Cyrillic post scored 0 on that term and ranked below an
+      // otherwise identical Latin post.
+      const svc = service as any;
+      const latin = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+      const baseline = svc.computeContentQuality(latin);
+
+      for (const content of [
+        '汉'.repeat(latin.length),
+        'م'.repeat(latin.length),
+        'п'.repeat(latin.length),
+      ]) {
+        expect(svc.computeContentQuality(content)).toBeCloseTo(baseline, 10);
+      }
+    });
+
+    it('still discounts a post of pure punctuation', () => {
+      const svc = service as any;
+      expect(svc.computeContentQuality('!'.repeat(30))).toBeLessThan(
+        svc.computeContentQuality('a'.repeat(30)),
+      );
+    });
   });
 
   describe('scheduled refresh locking', () => {

--- a/src/social/services/popular-ranking.service.ts
+++ b/src/social/services/popular-ranking.service.ts
@@ -1214,7 +1214,10 @@ export class PopularRankingService implements OnModuleDestroy {
     );
     const emojis = this.countEmojis(content);
     const emojiRatio = Math.min(1, emojis / Math.max(1, len));
-    const alnumMatches = content.match(/[A-Za-z0-9]/g) || [];
+    // Letters/numbers in any script: an ASCII-only class scores a wholly Chinese,
+    // Arabic or Cyrillic post at a 0 ratio, permanently forfeiting this term and
+    // ranking non-Latin posts below identical Latin ones.
+    const alnumMatches = content.match(/[\p{L}\p{N}]/gu) || [];
     const alnumRatio = Math.min(1, alnumMatches.length / Math.max(1, len));
 
     let quality = 0.6 * lengthScore + 0.2 * alnumRatio + 0.2 * (1 - emojiRatio);

--- a/src/social/services/post.service.ts
+++ b/src/social/services/post.service.ts
@@ -29,6 +29,7 @@ import {
 } from '../interfaces/post.interfaces';
 import { parsePostContent } from '../utils/content-parser.util';
 import { refreshTrendingScoresForPostSafely } from '../utils/token-mentions.util';
+import { normalizeTopicName } from '../utils/topic-name.util';
 import { TokensService } from '@/tokens/tokens.service';
 
 @Injectable()
@@ -962,7 +963,7 @@ export class PostService {
         continue;
       }
 
-      const normalizedName = topicName.trim().toLowerCase();
+      const normalizedName = normalizeTopicName(topicName);
 
       // Try to find existing topic
       let topic = await this.topicRepository.findOne({

--- a/src/social/utils/content-parser.util.spec.ts
+++ b/src/social/utils/content-parser.util.spec.ts
@@ -99,6 +99,56 @@ describe('Content Parser Utilities', () => {
 
       expect(topics).toEqual(['VALID']);
     });
+
+    it('finds a hashtag with no whitespace before it, as CJK is written', () => {
+      // Chinese has no inter-word spaces, so a split-on-whitespace scan sees one
+      // long "word" that does not start with '#' and yields nothing.
+      expect(extractTopics('我喜欢#汉字')).toEqual(['汉字']);
+      expect(extractTopics('看看#汉字，很好')).toEqual(['汉字']);
+    });
+
+    it('ends an undelimited hashtag greedily, exactly as it does in ASCII', () => {
+      // With no space or punctuation after it there is no boundary to find, so
+      // the trailing character is absorbed. This is the same semantics ASCII has
+      // always had ('#WORDSfoo' -> 'WORDSFOO'), not a CJK-specific regression.
+      expect(extractTopics('看看#汉字和吧')).toEqual(['汉字和吧']);
+      expect(extractTopics('buy #WORDSfoo now')).toEqual(['WORDSFOO']);
+    });
+
+    it('agrees with extractTrendMentions on which hashtags exist', () => {
+      // The two extractors used to disagree for CJK: mentions used a regex scan,
+      // topics split on whitespace. They must find the same set.
+      for (const content of [
+        '我喜欢#汉字',
+        '看看#汉字，很好',
+        '看看#汉字和吧',
+      ]) {
+        expect(extractTopics(content)).toEqual(
+          extractTrendMentions(content).map((m) => m.toUpperCase()),
+        );
+      }
+    });
+
+    it('drops trailing punctuation so the topic stays addressable', () => {
+      // `#汉字。` used to be stored as `汉字。`, which TopicParamPipe rejects with a
+      // 400 — the topic existed but its own page was unreachable.
+      expect(extractTopics('i like #汉字。 a lot')).toEqual(['汉字']);
+      expect(extractTopics('i like #مرحبا؟ a lot')).toEqual(['مرحبا']);
+      expect(extractTopics('wow #hello! there')).toEqual(['HELLO']);
+    });
+
+    it('produces topic names the topic param validator accepts', () => {
+      const TOPIC_PATTERN = /^[\p{L}\p{N}][\p{L}\p{N} _.-]{0,127}$/u;
+      const content =
+        '#汉字。 #مرحبا؟ #ПРИВЕТ! #hello! #CamelCase #valid_tag #123 #-lead #_lead';
+
+      const topics = extractTopics(content, 20);
+
+      expect(topics.length).toBeGreaterThan(0);
+      for (const topic of topics) {
+        expect(TOPIC_PATTERN.test(topic)).toBe(true);
+      }
+    });
   });
 
   describe('extractTrendMentions', () => {

--- a/src/social/utils/content-parser.util.ts
+++ b/src/social/utils/content-parser.util.ts
@@ -50,11 +50,25 @@ export function parsePostContent(
 }
 
 /**
+ * A hashtag, scanned rather than split on whitespace: Chinese is written without
+ * spaces, so `我喜欢#汉字` has no whitespace-delimited word starting with `#` and a
+ * split-based scan finds nothing — while `extractTrendMentions` (a real regex
+ * scan) does find the token. The two extractors have to agree.
+ *
+ * The body is exactly what `TOPIC_PATTERN` in the request validation accepts, so
+ * a topic we store is always addressable at `/topics/name/:name`.
+ */
+const TOPIC_HASHTAG_PATTERN = /#([\p{L}\p{N}][\p{L}\p{N}_.-]*)/gu;
+
+/** Characters `TOPIC_PATTERN` would reject, e.g. `。`, `؟`, `!`, emoji. */
+const TOPIC_DISALLOWED_CHARS = /[^\p{L}\p{N}_.-]+/gu;
+
+/**
  * Normalize topic name according to business rules:
  * - Convert camelCase to kebab-case
  * - Convert to uppercase
- * - Keep all characters (no removal)
- * - Clean up multiple hyphens and leading/trailing hyphens
+ * - Drop characters a topic name may not contain
+ * - Clean up hyphens, and ensure it starts with a letter or number
  */
 function normalizeTopic(topic: string): string {
   // Remove the # prefix if present
@@ -63,11 +77,17 @@ function normalizeTopic(topic: string): string {
   // First, convert camelCase to kebab-case
   const kebabCase = withoutHash.replace(/([a-z])([A-Z])/g, '$1-$2');
 
-  // Convert to uppercase (but keep all characters)
-  const normalized = kebabCase.toUpperCase();
-
-  // Clean up multiple hyphens and leading/trailing hyphens
-  return normalized.replace(/-+/g, '-').replace(/^-|-$/g, '');
+  return (
+    kebabCase
+      .toUpperCase()
+      // CJK/Arabic terminal punctuation clings to a hashtag (there is no
+      // separating space), so `#汉字。` would otherwise be stored as `汉字。` — a
+      // name TopicParamPipe rejects, making the topic's own page 400.
+      .replace(TOPIC_DISALLOWED_CHARS, '')
+      .replace(/-+/g, '-')
+      .replace(/^[_.-]+/, '')
+      .replace(/-$/, '')
+  );
 }
 
 /**
@@ -81,9 +101,7 @@ export function extractTopics(
     return [];
   }
 
-  const topics = content
-    .split(/\s+/)
-    .filter((word) => word.startsWith('#') && word.length > 1)
+  const topics = (content.match(TOPIC_HASHTAG_PATTERN) ?? [])
     .map((topic) => normalizeTopic(topic))
     .filter((topic) => topic.length > 0 && topic.length <= 50) // Reasonable length limits
     .slice(0, maxTopics);

--- a/src/social/utils/topic-name.util.ts
+++ b/src/social/utils/topic-name.util.ts
@@ -1,0 +1,11 @@
+/**
+ * Topic rows are stored under a lowercased name, so every lookup has to fold the
+ * caller's input the same way the writer did — otherwise `/topics/name/ПРИВЕТ`
+ * misses the row stored as `привет`.
+ *
+ * `toLowerCase()` is Unicode-aware, so this covers Cyrillic as well as Latin.
+ * Chinese and Arabic are caseless and pass through unchanged.
+ */
+export function normalizeTopicName(name: string): string {
+  return name.trim().toLowerCase();
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Topic parsing and normalization semantics change (regex extraction, punctuation stripping), which can affect how new hashtags are stored and resolved; changes are localized to social/topics/ranking with broad tests but touch ingestion and ranking behavior.
> 
> **Overview**
> **Non-Latin hashtags** (`#汉字`, `#أنا`, `#привет`) are now first-class: URL validation uses Unicode letters/numbers in `TopicParamPipe`, and `extractTopics` scans with a regex instead of splitting on whitespace so CJK text without spaces still picks up tags.
> 
> **Stored topic names** are normalized so API routes work: trailing punctuation is stripped when parsing, and `normalizeTopicName` (trim + Unicode `toLowerCase`) is used when creating topics and in `getByName` / non-UUID `getById` lookups so Cyrillic case variants resolve.
> 
> **Popular feed content quality** counts `[\p{L}\p{N}]` in any script instead of ASCII-only alnum, so otherwise similar non-Latin posts are not ranked below Latin ones.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e3069b369f943a9270cf6a313875646dde3f93f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->