### PR TITLE
Release

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -109,19 +109,10 @@ NOTIFICATIONS_ENABLED=false
 ANNOUNCEMENTS_ENABLED=false
 
 # Token-gated rooms (NIP-29 / groups_relay)
-# ONE always-on process (worker mode removed — see
-# agent/api/tasks/token-gated-room/deworker-plan.md). The HTTP API, the chain
-# indexer, AND the relay duties (writer/subscriber + Bull consumers +
-# backfill/reconcile/membership-sync) all run in this single process. The relay
-# duties self-enable iff a relay is configured: set BOTH TG_RELAY_URL and
-# TG_BOT_NSEC below. Leave them blank to run the API + indexer with NIP-29
-# publishing disabled (rooms/membership won't be created — useful for local dev/CI).
-# All other knobs (publish rate/concurrency, batch sizes, reconcile/notify
-# intervals, reorg depth, msg throttling, subscriber shards, observability
-# thresholds, test-harness) have safe defaults — see
-# src/token-gated-rooms/config/tgr.config.ts (plan §18 lists them all).
-# groups_relay websocket endpoint (ws:// or wss://). Set with TG_BOT_NSEC to enable
-# the relay duties.
+# Set BOTH TG_RELAY_URL and TG_BOT_NSEC to enable relay duties (room/membership
+# publishing). Leave blank to run API + indexer only — useful for local dev/CI.
+# All other knobs have safe defaults — see src/token-gated-rooms/config/tgr.config.ts.
+# groups_relay websocket endpoint (ws:// or wss://).
 TG_RELAY_URL=
 # SECRET. Set with TG_RELAY_URL to enable the relay duties. MUST be the relay admin
 # key (D7) — the bot provisions rooms and manages membership, which the relay only

--- a/.env.example
+++ b/.env.example
@@ -107,3 +107,41 @@ EXPO_ACCESS_TOKEN=
 
 NOTIFICATIONS_ENABLED=false
 ANNOUNCEMENTS_ENABLED=false
+
+# Token-gated rooms (NIP-29 / groups_relay)
+# ONE always-on process (worker mode removed — see
+# agent/api/tasks/token-gated-room/deworker-plan.md). The HTTP API, the chain
+# indexer, AND the relay duties (writer/subscriber + Bull consumers +
+# backfill/reconcile/membership-sync) all run in this single process. The relay
+# duties self-enable iff a relay is configured: set BOTH TG_RELAY_URL and
+# TG_BOT_NSEC below. Leave them blank to run the API + indexer with NIP-29
+# publishing disabled (rooms/membership won't be created — useful for local dev/CI).
+# All other knobs (publish rate/concurrency, batch sizes, reconcile/notify
+# intervals, reorg depth, msg throttling, subscriber shards, observability
+# thresholds, test-harness) have safe defaults — see
+# src/token-gated-rooms/config/tgr.config.ts (plan §18 lists them all).
+# groups_relay websocket endpoint (ws:// or wss://). Set with TG_BOT_NSEC to enable
+# the relay duties.
+TG_RELAY_URL=
+# SECRET. Set with TG_RELAY_URL to enable the relay duties. MUST be the relay admin
+# key (D7) — the bot provisions rooms and manages membership, which the relay only
+# allows for admins.
+TG_BOT_NSEC=
+# Comma-separated nostr pubkeys (npub or hex) seeded as admins in every room (D9).
+TG_ROOM_ADMINS=
+# Optional relay-admin pubkey fallback for the Task 08 health-check; only used when
+# the relay's NIP-11 omits "pubkey" (groups_relay advertises it, so normally unset).
+TG_RELAY_ADMIN_PUBKEY=
+# Trigger the eager ~54k-room backfill on boot (requires a configured relay;
+# default off → trigger explicitly). Runs in onApplicationBootstrap (after the app
+# is fully up). The 5-min provisioning cron covers steady state.
+TG_BACKFILL_ON_BOOT=false
+# Rooms per eager-backfill page. Hard-capped at 100 (an over-cap value falls back
+# to the default) so a page can't saturate the DB pool. 1..100, default 100.
+TG_BACKFILL_BATCH_SIZE=100
+# Delay (ms) between eager-backfill pages — paces the sweep so back-to-back pages
+# don't sustain DB/relay pressure. 0 chains immediately. default 1000.
+TG_BACKFILL_PAGE_DELAY_MS=1000
+# Tokens provisioned per tick of the 5-min roomless-token cron (room_id IS NULL).
+# Hard-capped at 100 (over-cap falls back to default). 1..100, default 100.
+TG_ROOM_PROVISION_BATCH=100

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,6 @@ RUN npm prune --omit=dev
 RUN chown -R node:node /src
 USER node
 
-CMD ["npm", "run", "start:prod"]
+# Run pending DB migrations (synchronize is off), then start the app.
+# For multiple replicas, run migrate:prod once as a pre-deploy Job instead.
+CMD ["sh", "-c", "npm run migrate:prod && npm run start:prod"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,17 @@ RUN chown -R node:node /src
 USER node
 
 # Run pending DB migrations (synchronize is off), then start the app.
-# For multiple replicas, run migrate:prod once as a pre-deploy Job instead.
-CMD ["sh", "-c", "npm run migrate:prod && npm run start:prod"]
+# `migrate:prod:locked` wraps migration:run in a Postgres advisory lock so
+# concurrent replica starts (rolling deploy, autoscaling) serialize on the
+# migration instead of racing DDL — only one replica actually migrates, the
+# rest block on the lock and then no-op against the already-applied history.
+#
+# `exec node dist/main` (NOT `npm run start:prod`) so the Node process REPLACES
+# the shell and becomes PID 1: Docker's SIGTERM on a rolling deploy then reaches
+# Node directly, so `enableShutdownHooks()` runs and every OnModuleDestroy /
+# OnApplicationShutdown teardown (Redis/Bull quit, websocket close, TGR relay
+# duties, indexer intervals) executes gracefully instead of being hard-killed
+# after the grace period. `exec node …` is required rather than `exec npm …`
+# because npm would stay PID 1 and spawn Node as a child that never sees the
+# signal.
+CMD ["sh", "-c", "npm run migrate:prod:locked && exec node dist/main"]

--- a/docs/popular-post-ranking.md
+++ b/docs/popular-post-ranking.md
@@ -46,7 +46,7 @@ This means popularity is computed within the newest all-time candidate pool, not
 Each candidate gets a score from accumulated engagement and content signals:
 
 ```text
-score =
+baseScore =
   w_comments * log(1 + comments) +
   w_tips_amount * log(1 + tipsAmountAE) +
   w_tips_count * log(1 + tipsCount) +
@@ -55,10 +55,16 @@ score =
   w_trending * trendingBoost +
   w_quality * contentQuality +
   w_fresh * freshnessFactor +
-  w_velocity * log(1 + interactionsPerHour) * freshnessFactor
+  w_velocity * log(1 + interactionsPerHour) * freshnessFactor +
+  w_iph * log(1 + interactionsPerHour)
 ```
 
-There is no time-decay divisor. The live boost is additive and bounded, so it helps new content without permanently overriding all-time engagement.
+Velocity contributes twice, on purpose:
+
+- `w_iph` is the **always-on momentum baseline** — a post gaining interactions
+  quickly gets credit at any age.
+- `w_velocity` is a **freshness-gated early-life amplifier** — new posts that
+  are also accelerating get an extra, temporary lift.
 
 Freshness is linear over the first 24 hours:
 
@@ -66,7 +72,21 @@ Freshness is linear over the first 24 hours:
 freshnessFactor = max(0, 1 - ageHours / 24)
 ```
 
-After 24 hours, both `freshnessFactor` and the velocity boost are zero. The post then ranks by normal accumulated engagement.
+After 24 hours, `freshnessFactor` and the amplifier are zero; the always-on
+momentum baseline keeps counting.
+
+For the `24h` and `7d` windows the score is `baseScore` as-is — those feeds are
+already bounded by their time filter. The `all` window additionally applies a
+gentle gravity-style age decay so old high-total posts cannot occupy the top
+forever:
+
+```text
+score(all) = baseScore / (ageHours + 2) ^ ALL_WINDOW_GRAVITY
+```
+
+Because every engagement signal is log-dampened, score gaps between posts stay
+small, so the gravity exponent must stay gentle (`0.25` today, sane range
+roughly `0.15..0.4`). Values near `1` would turn the feed into pure recency.
 
 ## Current weights
 
@@ -81,9 +101,11 @@ WEIGHTS: {
   trendingBoost: 0.5,
   contentQuality: 0.3,
   reads: 1.5,
-  freshnessBoost: 0.9,
-  velocityBoost: 0.6,
+  freshnessBoost: 1.5,
+  velocityBoost: 0.6, // freshness-gated early-life amplifier
+  interactionsPerHour: 0.6, // always-on momentum baseline
 }
+ALL_WINDOW_GRAVITY: 0.25
 ```
 
 ### What matters most
@@ -213,7 +235,7 @@ A post is most likely to rank highly when it is:
 - being read actively,
 - connected to a trending topic,
 - written with enough substance to avoid quality penalties,
-- less than 24 hours old or gaining early interaction velocity.
+- gaining interaction velocity (at any age), with an extra amplifier while less than 24 hours old.
 
 ## Files involved
 
@@ -231,9 +253,9 @@ A post is most likely to rank highly when it is:
 
 Most numeric signals use `log(1 + x)` so the ranking favors meaningful activity without letting one giant raw number dominate forever.
 
-### Why there is no global time decay
+### Why time decay applies only to the `all` window
 
-This is not a Hacker News-style feed where every post steadily decays. In a low-activity network, posts need time to gather signal. The algorithm instead uses all-time engagement plus a 24-hour additive boost, so new posts get initial visibility and then settle into the normal ranking.
+The `24h` and `7d` feeds are already bounded by their time filter, so they need no decay. The `all` feed is different: log-dampened engagement never shrinks, so without decay the oldest high-total posts would occupy the top permanently. A gentle gravity divisor (`(ageHours + 2)^0.25`) keeps that feed churning while still letting genuinely evergreen content outrank mediocre new posts. New posts additionally get a 24-hour additive freshness boost so they have discovery room in a low-activity network.
 
 ### Why there are no score floors
 

--- a/docs/popular-post-ranking.md
+++ b/docs/popular-post-ranking.md
@@ -1,6 +1,6 @@
 ## Popular post ranking
 
-The popular post endpoint ranks content all-time, then adds a short-lived live boost so newer posts can surface in a low-activity network. The result is a "Top + fresh" feed: durable engagement still wins over time, but new posts get discovery room during their first day.
+The popular post endpoint ranks content all-time, then adds a short-lived live boost so newer posts can surface in a low-activity network. The result is a "Top + fresh" feed: durable engagement still wins over time, but new posts get discovery room during their first two days.
 
 The current implementation rewards posts that attract:
 
@@ -66,13 +66,25 @@ Velocity contributes twice, on purpose:
 - `w_velocity` is a **freshness-gated early-life amplifier** — new posts that
   are also accelerating get an extra, temporary lift.
 
-Freshness is linear over the first 24 hours:
+`interactionsPerHour` is measured over a recent window, not the post's
+lifetime:
 
 ```text
-freshnessFactor = max(0, 1 - ageHours / 24)
+interactionsPerHour = interactionsInLast48h / min(ageHours, 48)
 ```
 
-After 24 hours, `freshnessFactor` and the amplifier are zero; the always-on
+so an old post that catches fire today registers full velocity instead of
+having its new activity averaged away over months. (Plugin content without
+interaction timestamps falls back to the lifetime average.)
+
+Freshness is linear over the first `FRESHNESS_BOOST_HOURS` (48 — generous on
+purpose: on a low-activity network posts need longer to gather signal):
+
+```text
+freshnessFactor = max(0, 1 - ageHours / 48)
+```
+
+After 48 hours, `freshnessFactor` and the amplifier are zero; the always-on
 momentum baseline keeps counting.
 
 For the `24h` and `7d` windows the score is `baseScore` as-is — those feeds are
@@ -105,6 +117,10 @@ WEIGHTS: {
   velocityBoost: 0.6, // freshness-gated early-life amplifier
   interactionsPerHour: 0.6, // always-on momentum baseline
 }
+FRESHNESS_BOOST_HOURS: 48
+VELOCITY_WINDOW_HOURS: 48
+READS_PER_INTERACTION_CAP: 100
+TIE_ROTATION_EPSILON: 0.05
 ALL_WINDOW_GRAVITY: 0.25
 ```
 
@@ -116,7 +132,7 @@ The biggest direct drivers are:
 - `uniqueTippers`
 - `reads`
 - `tipsAmountAE`
-- temporary freshness and velocity for posts less than 24 hours old
+- always-on interaction velocity, with temporary freshness boosts for posts less than 48 hours old
 
 Because logarithms are used for all count- and amount-based signals, they have diminishing returns. Doubling activity helps, but not linearly forever.
 
@@ -128,7 +144,7 @@ Tipping is a rare action on this network. The weight for `tipsAmountAE` (2.0) is
 
 ### 1. Comments
 
-The score counts comments (replies) on the post, excluding the post author's own replies. This prevents authors from inflating their ranking by replying to their own posts.
+The score counts the post's **entire reply thread** (replies to replies included, via a recursive query), excluding replies authored by the post's own author. This prevents authors from inflating their ranking by replying to their own posts, while a deep discussion under a few top-level comments is credited at its real size. Hidden comments prune their whole subtree.
 
 More discussion helps a post rank higher, but through `log(1 + comments)`, so going from 0 to 5 comments matters more than going from 500 to 505.
 
@@ -152,10 +168,17 @@ The number of distinct addresses that tipped a post (excluding self-tips). This 
 
 Reads are pulled from `post_reads_daily` and summed for all available candidate posts.
 
-The ranking uses raw reads:
+Reads are the easiest signal to inflate, so they are hardened twice:
+
+- **At recording time**, a read counts once per viewer (IP+UA hash), post, and
+  UTC day — a request loop from one client cannot inflate the counter. The
+  dedup fails open if Redis is unavailable. Bot user agents are ignored.
+- **At scoring time**, counted reads are capped at
+  `READS_PER_INTERACTION_CAP × (1 + comments + tipsCount + uniqueTippers)`,
+  so passive volume alone cannot outvote real engagement indefinitely:
 
 ```text
-log(1 + reads)
+log(1 + min(reads, cap))
 ```
 
 Reads are not normalized by age. Freshness is handled by the bounded new-post boost.
@@ -211,19 +234,29 @@ The service:
 
 This keeps each page full while preventing one active user from dominating the popular tab.
 
+## Tie rotation
+
+Every score also carries a small deterministic jitter in `[0, TIE_ROTATION_EPSILON)` derived from the post id and the current hour. Posts with meaningfully different engagement are unaffected (their score gaps are much larger than the epsilon), but near-tied posts — mostly the zero-engagement tail, whose scores differ only by content quality — rotate their relative order every hour instead of being frozen in the same sequence between recomputes. This spreads exposure across posts that haven't had a chance to gather signal yet, without any stored state.
+
 ## Caching behavior
 
-Computed rankings are stored in the Redis sorted set `popular:all`.
+Computed rankings are stored in the Redis sorted sets `popular:24h`, `popular:7d`, and `popular:all`.
 
-TTL is currently:
+Crons refresh each window at a cadence matched to how fast it changes — `24h`
+every minute, `7d` every 5 minutes, `all` (10k candidates, slow-moving) every
+10 minutes — and the TTL is kept far above the slowest cadence:
 
 ```ts
-REDIS_TTL_SECONDS: 30;
+REDIS_TTL_SECONDS: 1800;
 ```
 
-So the feed is intentionally refreshed often.
-
-When the cache is empty (cold start or after TTL expiry with no cron), recompute is triggered with a mutex to prevent stampede. The current request falls back to recent posts while the cache is being rebuilt.
+so user requests essentially never pay recompute latency — a key only goes
+cold if refreshes fail repeatedly. Each refresh takes a short-lived Redis
+`SET NX` lock per window, so running multiple app instances does not multiply
+the recompute work. On a cold cache (startup, repeated cron failures)
+recompute is still triggered lazily with a per-window mutex to prevent
+stampede, and the current request falls back to recent posts while the cache
+is being rebuilt.
 
 ## Practical interpretation
 
@@ -235,7 +268,7 @@ A post is most likely to rank highly when it is:
 - being read actively,
 - connected to a trending topic,
 - written with enough substance to avoid quality penalties,
-- gaining interaction velocity (at any age), with an extra amplifier while less than 24 hours old.
+- gaining interaction velocity (at any age), with an extra amplifier while less than 48 hours old.
 
 ## Files involved
 
@@ -255,7 +288,7 @@ Most numeric signals use `log(1 + x)` so the ranking favors meaningful activity 
 
 ### Why time decay applies only to the `all` window
 
-The `24h` and `7d` feeds are already bounded by their time filter, so they need no decay. The `all` feed is different: log-dampened engagement never shrinks, so without decay the oldest high-total posts would occupy the top permanently. A gentle gravity divisor (`(ageHours + 2)^0.25`) keeps that feed churning while still letting genuinely evergreen content outrank mediocre new posts. New posts additionally get a 24-hour additive freshness boost so they have discovery room in a low-activity network.
+The `24h` and `7d` feeds are already bounded by their time filter, so they need no decay. The `all` feed is different: log-dampened engagement never shrinks, so without decay the oldest high-total posts would occupy the top permanently. A gentle gravity divisor (`(ageHours + 2)^0.25`) keeps that feed churning while still letting genuinely evergreen content outrank mediocre new posts. New posts additionally get a 48-hour additive freshness boost so they have discovery room in a low-activity network.
 
 ### Why there are no score floors
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "keyv": "^5.5.3",
         "moment": "^2.30.1",
         "nestjs-typeorm-paginate": "^4.1.0",
-        "nostr-tools": "^2.23.3",
+        "nostr-tools": "^2.23.5",
         "pg": "^8.12.0",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.2",
@@ -10612,9 +10612,9 @@
       }
     },
     "node_modules/nostr-tools": {
-      "version": "2.23.3",
-      "resolved": "https://registry.npmjs.org/nostr-tools/-/nostr-tools-2.23.3.tgz",
-      "integrity": "sha512-AALyt9k8xPdF4UV2mlLJ2mgCn4kpTB0DZ8t2r6wjdUh6anfx2cTVBsHUlo9U0EY/cKC5wcNyiMAmRJV5OVEalA==",
+      "version": "2.23.5",
+      "resolved": "https://registry.npmjs.org/nostr-tools/-/nostr-tools-2.23.5.tgz",
+      "integrity": "sha512-Fa7ZlUdjfUW1P4E7H3yBexhOHYi18XNyvd2n7eNHkYR085xADX6Y8V8Vm7nT/XQajaFOBrptXmVIGkJ2E4vfVw==",
       "license": "Unlicense",
       "dependencies": {
         "@noble/ciphers": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "typeorm": "node -r ts-node/register -r tsconfig-paths/register ./node_modules/typeorm/cli.js",
     "migration:run": "npm run typeorm -- migration:run -d src/data-source.ts",
     "migrate:prod": "node ./node_modules/typeorm/cli.js migration:run -d dist/data-source.js",
+    "migrate:prod:locked": "node ./scripts/migrate-with-lock.js",
     "migration:revert": "npm run typeorm -- migration:revert -d src/data-source.ts",
     "migration:generate": "npm run typeorm -- migration:generate -d src/data-source.ts",
     "migration:create": "npm run typeorm -- migration:create",
@@ -109,7 +110,6 @@
     "transformIgnorePatterns": [
       "node_modules/(?!(?:.pnpm/)?(?:nostr-tools|@noble|@scure)/)"
     ],
-    "forceExit": true,
     "collectCoverageFrom": [
       "**/*.(t|j)s"
     ],

--- a/package.json
+++ b/package.json
@@ -21,6 +21,11 @@
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "smoke:dex": "node scripts/smoke-dex-invariants.mjs",
     "smoke:dex:diff": "node scripts/smoke-dex-differential.mjs",
+    "typeorm": "node -r ts-node/register -r tsconfig-paths/register ./node_modules/typeorm/cli.js",
+    "migration:run": "npm run typeorm -- migration:run -d src/data-source.ts",
+    "migration:revert": "npm run typeorm -- migration:revert -d src/data-source.ts",
+    "migration:generate": "npm run typeorm -- migration:generate -d src/data-source.ts",
+    "migration:create": "npm run typeorm -- migration:create",
     "postinstall": "node ./scripts/update-package-type.js && rm -rf ./node_modules/bctsl-sdk/.build && tsc -b ./node_modules/bctsl-sdk/tsconfig.cjs.json ./node_modules/bctsl-sdk/tsconfig.esm.json ./node_modules/bctsl-sdk/tsconfig.types.json"
   },
   "dependencies": {
@@ -58,7 +63,7 @@
     "keyv": "^5.5.3",
     "moment": "^2.30.1",
     "nestjs-typeorm-paginate": "^4.1.0",
-    "nostr-tools": "^2.23.3",
+    "nostr-tools": "^2.23.5",
     "pg": "^8.12.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.2",
@@ -100,13 +105,17 @@
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },
+    "transformIgnorePatterns": [
+      "node_modules/(?!(?:.pnpm/)?(?:nostr-tools|@noble|@scure)/)"
+    ],
+    "forceExit": true,
     "collectCoverageFrom": [
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
     "testEnvironment": "node",
     "moduleNameMapper": {
-      "^@/test/(.*)$": "<rootDir>/../$1",
+      "^@/test/(.*)$": "<rootDir>/../test/$1",
       "^@/(.*)$": "<rootDir>/$1"
     }
   }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "smoke:dex:diff": "node scripts/smoke-dex-differential.mjs",
     "typeorm": "node -r ts-node/register -r tsconfig-paths/register ./node_modules/typeorm/cli.js",
     "migration:run": "npm run typeorm -- migration:run -d src/data-source.ts",
+    "migrate:prod": "node ./node_modules/typeorm/cli.js migration:run -d dist/data-source.js",
     "migration:revert": "npm run typeorm -- migration:revert -d src/data-source.ts",
     "migration:generate": "npm run typeorm -- migration:generate -d src/data-source.ts",
     "migration:create": "npm run typeorm -- migration:create",

--- a/scripts/migrate-with-lock.js
+++ b/scripts/migrate-with-lock.js
@@ -9,10 +9,20 @@
  * migrations; every other replica blocks on the same lock and, once it
  * acquires it in turn, runs migration:run itself — which is then a no-op
  * because TypeORM has already recorded those migrations as applied.
+ *
+ * The lock is session-scoped (`pg_advisory_lock`) and TypeORM runs the
+ * migration in a SEPARATE process on its OWN connection, so the lock-holding
+ * connection here sits idle for the whole migration. If that idle connection
+ * is closed — a managed-Postgres `idle_session_timeout`, a connection pooler,
+ * or an idle-TCP middlebox — the lock is silently released and another replica
+ * can acquire it and migrate concurrently. To prevent that we keep this
+ * session from ever being idle: TCP keepalives at the socket layer, a periodic
+ * lightweight ping so the server never sees an idle session, and disabling the
+ * server-side idle-session reaper for this session.
  */
 
 const { Client } = require('pg');
-const { spawnSync } = require('child_process');
+const { spawn } = require('child_process');
 
 // Arbitrary fixed pair of int32 keys identifying this app's migration lock
 // (the `pg_advisory_lock(int, int)` overload). Only their fixed, unique
@@ -20,24 +30,19 @@ const { spawnSync } = require('child_process');
 const LOCK_KEY_1 = 0x53_75_70_45;
 const LOCK_KEY_2 = 0x72_41_70_69;
 
-async function main() {
-  const client = new Client({
-    host: process.env.DB_HOST,
-    port: Number(process.env.DB_PORT) || 5432,
-    user: process.env.DB_USER,
-    password: process.env.DB_PASSWORD,
-    database: process.env.DB_DATABASE,
-  });
+// How often to ping the lock-holding session so it never sits idle long enough
+// for a server or middlebox idle timeout to reap it. Comfortably below the
+// idle timeouts seen on managed Postgres / poolers (typically >= 60s).
+const KEEPALIVE_INTERVAL_MS = 15_000;
 
-  await client.connect();
-  try {
-    // Blocks until no other replica running this script holds the lock.
-    await client.query('SELECT pg_advisory_lock($1, $2)', [
-      LOCK_KEY_1,
-      LOCK_KEY_2,
-    ]);
-
-    const result = spawnSync(
+/**
+ * Run TypeORM's migration in a child process. Uses async `spawn` (not the
+ * blocking `spawnSync`) so the event loop stays free to fire keepalive pings
+ * on the lock-holding connection while the migration runs.
+ */
+function runMigration() {
+  return new Promise((resolve) => {
+    const child = spawn(
       process.execPath,
       [
         './node_modules/typeorm/cli.js',
@@ -47,9 +52,75 @@ async function main() {
       ],
       { stdio: 'inherit' },
     );
+    child.on('close', (code) => resolve(code ?? 1));
+    child.on('error', (error) => {
+      console.error(
+        '[migrate-with-lock] failed to spawn migration process',
+        error,
+      );
+      resolve(1);
+    });
+  });
+}
 
-    process.exitCode = result.status ?? 1;
+async function main() {
+  const client = new Client({
+    host: process.env.DB_HOST,
+    port: Number(process.env.DB_PORT) || 5432,
+    user: process.env.DB_USER,
+    password: process.env.DB_PASSWORD,
+    database: process.env.DB_DATABASE,
+    // Socket-level keepalives stop NAT/load-balancer middleboxes from dropping
+    // the (otherwise idle) connection while the migration runs.
+    keepAlive: true,
+  });
+
+  await client.connect();
+
+  let keepAliveTimer = null;
+  try {
+    // Blocks until no other replica running this script holds the lock. The
+    // session is "active" (waiting on the lock) here, not idle, so the reaper
+    // concerns below only apply once we own the lock and the migration starts.
+    await client.query('SELECT pg_advisory_lock($1, $2)', [
+      LOCK_KEY_1,
+      LOCK_KEY_2,
+    ]);
+
+    // Belt-and-suspenders alongside the pings: turn off the server's
+    // idle-session reaper for this one session. Ignored where the GUC does not
+    // exist (Postgres < 14) or cannot be set — the pings remain the primary
+    // defense.
+    try {
+      await client.query('SET idle_session_timeout = 0');
+    } catch (error) {
+      console.error(
+        '[migrate-with-lock] could not disable idle_session_timeout; relying on keepalive pings',
+        error,
+      );
+    }
+
+    // Keep the lock-holding session from ever being idle. A failed ping means
+    // the connection (and thus the advisory lock) may have been lost — log it
+    // loudly, but do not touch the migration's exit code.
+    keepAliveTimer = setInterval(() => {
+      client.query('SELECT 1').catch((error) => {
+        console.error(
+          '[migrate-with-lock] keepalive ping failed — the advisory lock may have been lost, risking a concurrent migration',
+          error,
+        );
+      });
+    }, KEEPALIVE_INTERVAL_MS);
+    // Don't let the keepalive timer itself keep the process alive.
+    if (typeof keepAliveTimer.unref === 'function') {
+      keepAliveTimer.unref();
+    }
+
+    process.exitCode = await runMigration();
   } finally {
+    if (keepAliveTimer) {
+      clearInterval(keepAliveTimer);
+    }
     // Best-effort cleanup: `pg_advisory_lock` is session-scoped, so it is
     // released automatically once this connection closes even if the
     // explicit unlock (or the close itself) fails. A cleanup failure here
@@ -58,10 +129,17 @@ async function main() {
     // Docker `migrate && start` chain never reaches `start:prod`, even
     // though the schema change already landed.
     try {
-      await client.query('SELECT pg_advisory_unlock($1, $2)', [
-        LOCK_KEY_1,
-        LOCK_KEY_2,
-      ]);
+      const unlock = await client.query(
+        'SELECT pg_advisory_unlock($1, $2) AS released',
+        [LOCK_KEY_1, LOCK_KEY_2],
+      );
+      // `released` is false when this session did NOT hold the lock at unlock
+      // time — i.e. it was reset mid-migration and the protection lapsed.
+      if (unlock.rows[0] && unlock.rows[0].released === false) {
+        console.error(
+          '[migrate-with-lock] advisory lock was not held at unlock time — the session may have been reset mid-migration, so a concurrent migration was possible',
+        );
+      }
     } catch (error) {
       console.error(
         '[migrate-with-lock] failed to release advisory lock (released automatically when the connection closes)',

--- a/scripts/migrate-with-lock.js
+++ b/scripts/migrate-with-lock.js
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Wraps `migration:run` with a Postgres session advisory lock so that
+ * multiple replicas starting at once (rolling deploy, autoscaling) serialize
+ * on the schema migration instead of racing DDL against each other. The
+ * first replica to connect acquires the lock and runs the pending
+ * migrations; every other replica blocks on the same lock and, once it
+ * acquires it in turn, runs migration:run itself — which is then a no-op
+ * because TypeORM has already recorded those migrations as applied.
+ */
+
+const { Client } = require('pg');
+const { spawnSync } = require('child_process');
+
+// Arbitrary fixed pair of int32 keys identifying this app's migration lock
+// (the `pg_advisory_lock(int, int)` overload). Only their fixed, unique
+// combination matters — they carry no other meaning.
+const LOCK_KEY_1 = 0x53_75_70_45;
+const LOCK_KEY_2 = 0x72_41_70_69;
+
+async function main() {
+  const client = new Client({
+    host: process.env.DB_HOST,
+    port: Number(process.env.DB_PORT) || 5432,
+    user: process.env.DB_USER,
+    password: process.env.DB_PASSWORD,
+    database: process.env.DB_DATABASE,
+  });
+
+  await client.connect();
+  try {
+    // Blocks until no other replica running this script holds the lock.
+    await client.query('SELECT pg_advisory_lock($1, $2)', [
+      LOCK_KEY_1,
+      LOCK_KEY_2,
+    ]);
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        './node_modules/typeorm/cli.js',
+        'migration:run',
+        '-d',
+        'dist/data-source.js',
+      ],
+      { stdio: 'inherit' },
+    );
+
+    process.exitCode = result.status ?? 1;
+  } finally {
+    // Best-effort cleanup: `pg_advisory_lock` is session-scoped, so it is
+    // released automatically once this connection closes even if the
+    // explicit unlock (or the close itself) fails. A cleanup failure here
+    // must never override the exit code the migration itself already set —
+    // otherwise a successful migration gets reported as a failure and the
+    // Docker `migrate && start` chain never reaches `start:prod`, even
+    // though the schema change already landed.
+    try {
+      await client.query('SELECT pg_advisory_unlock($1, $2)', [
+        LOCK_KEY_1,
+        LOCK_KEY_2,
+      ]);
+    } catch (error) {
+      console.error(
+        '[migrate-with-lock] failed to release advisory lock (released automatically when the connection closes)',
+        error,
+      );
+    }
+    try {
+      await client.end();
+    } catch (error) {
+      console.error(
+        '[migrate-with-lock] failed to close db connection cleanly',
+        error,
+      );
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error('[migrate-with-lock] failed', error);
+  process.exitCode = 1;
+});

--- a/scripts/verify-collections.sql
+++ b/scripts/verify-collections.sql
@@ -1,0 +1,46 @@
+-- Verifies the multi-collection migration (1718900000010-TokenCollectionNameIdx)
+-- and the resulting data. Run via psql against the target Postgres.
+
+-- 1. Migration applied
+SELECT name, timestamp
+FROM migrations
+WHERE name = 'TokenCollectionNameIdx1718900000010';
+
+-- 2. token.collection column exists
+SELECT column_name, data_type, is_nullable
+FROM information_schema.columns
+WHERE table_name = 'token' AND column_name = 'collection';
+
+-- 3. Index exists with the expected expression
+SELECT indexname, indexdef
+FROM pg_indexes
+WHERE tablename = 'token' AND indexname = 'idx_token_collection_name';
+
+-- 4. Planner actually uses the index for the tokens.controller.ts filter
+--    (look for "Index Scan" / "Bitmap Index Scan" on idx_token_collection_name,
+--    not "Seq Scan")
+EXPLAIN
+SELECT sale_address FROM token
+WHERE LOWER(split_part(collection, '-ak_', 1)) = LOWER('WORDS');
+
+-- 5. Real data spans multiple collections, across network ids
+SELECT
+  split_part(collection, '-ak_', 1) AS collection_name,
+  COUNT(*) AS token_count,
+  COUNT(DISTINCT collection) AS distinct_collection_ids
+FROM token
+WHERE collection IS NOT NULL
+GROUP BY split_part(collection, '-ak_', 1)
+ORDER BY token_count DESC;
+
+-- 6. Backfill progress (fix-tokens.service.ts) — should shrink toward 0
+SELECT COUNT(*) AS tokens_missing_collection
+FROM token
+WHERE collection IS NULL;
+
+-- 7. Sample rows to eyeball
+SELECT sale_address, name, symbol, collection, created_at
+FROM token
+WHERE collection IS NOT NULL
+ORDER BY created_at DESC
+LIMIT 20;

--- a/src/account/controllers/accounts.controller.spec.ts
+++ b/src/account/controllers/accounts.controller.spec.ts
@@ -12,6 +12,9 @@ describe('AccountsController', () => {
     leftJoin: jest.fn().mockReturnThis(),
     andWhere: jest.fn().mockReturnThis(),
     orderBy: jest.fn().mockReturnThis(),
+    select: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    getMany: jest.fn().mockResolvedValue([]),
   });
 
   let controller: AccountsController;
@@ -285,6 +288,52 @@ describe('AccountsController', () => {
       const svgBuffer = (result as StreamableFile).getStream().read() as Buffer;
       expect(svgBuffer.toString()).toContain('<svg');
       expect(svgBuffer.toString()).not.toContain('<path');
+    });
+  });
+
+  describe('resolveByNostr', () => {
+    const HEX_A = 'a'.repeat(64);
+    const HEX_B = 'b'.repeat(64);
+    const HEX_C = 'c'.repeat(64);
+
+    it('returns only the matched accounts, normalized', async () => {
+      queryBuilder.getMany.mockResolvedValue([
+        {
+          address: 'ak_alice',
+          chain_name: 'alice.chain',
+          links: { nostr: HEX_A },
+        },
+        { address: 'ak_bob', chain_name: null, links: { nostr: HEX_C } },
+      ]);
+
+      const result = await controller.resolveByNostr(`${HEX_A},${HEX_B}`);
+
+      expect(queryBuilder.where).toHaveBeenCalledWith(
+        "account.links->>'nostr' IS NOT NULL",
+      );
+      expect(result).toEqual([
+        { nostr_pubkey: HEX_A, address: 'ak_alice', chain_name: 'alice.chain' },
+      ]);
+    });
+
+    it('returns [] and does not query for empty input', async () => {
+      const result = await controller.resolveByNostr('  ,  ');
+      expect(result).toEqual([]);
+      expect(accountRepository.createQueryBuilder).not.toHaveBeenCalled();
+    });
+
+    it('returns [] when no requested pubkey is a valid hex/npub', async () => {
+      const result = await controller.resolveByNostr('not-a-pubkey,also-bad');
+      expect(result).toEqual([]);
+      expect(accountRepository.createQueryBuilder).not.toHaveBeenCalled();
+    });
+
+    it('rejects more than 200 pubkeys', async () => {
+      const many = Array.from({ length: 201 }, () => HEX_A).join(',');
+      await expect(controller.resolveByNostr(many)).rejects.toThrow(
+        'At most 200 pubkeys per request',
+      );
+      expect(accountRepository.createQueryBuilder).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/account/controllers/accounts.controller.ts
+++ b/src/account/controllers/accounts.controller.ts
@@ -32,6 +32,8 @@ import { GetPortfolioHistoryQueryDto } from '../dto/get-portfolio-history-query.
 import { PortfolioHistorySnapshotDto } from '../dto/portfolio-history-response.dto';
 import { TradingStatsQueryDto } from '../dto/trading-stats-query.dto';
 import { TradingStatsResponseDto } from '../dto/trading-stats-response.dto';
+import { NostrAccountRefDto } from '../dto/nostr-account-ref.dto';
+import { normalizePubkey } from '@/token-gated-rooms/nostr/pubkey';
 import { ProfileReadService } from '@/profile/services/profile-read.service';
 import { ProfileCache } from '@/profile/entities/profile-cache.entity';
 import {
@@ -100,6 +102,14 @@ export class AccountsController {
     required: false,
   })
   @ApiQuery({ name: 'order_direction', enum: ['ASC', 'DESC'], required: false })
+  @ApiQuery({
+    name: 'has_nostr',
+    type: 'boolean',
+    required: false,
+    description:
+      'When true, only return accounts that have linked a Nostr key ' +
+      "(`links->>'nostr' IS NOT NULL`) — e.g. to suggest chat contacts.",
+  })
   @ApiOperation({ operationId: 'listAll' })
   @CacheTTL(60_000)
   @Get()
@@ -109,6 +119,7 @@ export class AccountsController {
     @Query('limit', new DefaultValuePipe(100), ParseIntPipe) limit = 100,
     @Query('order_by') orderBy: string = 'total_volume',
     @Query('order_direction') orderDirection: 'ASC' | 'DESC' = 'DESC',
+    @Query('has_nostr') hasNostr?: string,
   ) {
     if (page < 1) {
       throw new BadRequestException('Page must be greater than or equal to 1');
@@ -168,10 +179,86 @@ export class AccountsController {
       );
     }
 
+    // Chat-contact suggestions: only accounts that linked a Nostr key can be
+    // messaged, so allow filtering the list down to them. `links` is a `jsonb`
+    // column; `->>'nostr'` extracts the linked npub/hex (NULL when absent).
+    if (hasNostr === 'true' || hasNostr === '1') {
+      query.andWhere("account.links->>'nostr' IS NOT NULL");
+      query.andWhere("account.links->>'nostr' <> ''");
+    }
+
     if (orderBy) {
       query.orderBy(`account.${orderBy}`, orderDirection);
     }
     return paginate(query, { page, limit });
+  }
+
+  /**
+   * Reverse lookup: resolve nostr pubkeys → the aeternity accounts that linked
+   * them, so a client can show the AE identity (chain name / `ak_`) for a nostr
+   * pubkey instead of the raw hex (e.g. a NIP-29 group's member list + membership
+   * system lines). `pubkeys` is a CSV of npub/hex (each normalized to hex; an
+   * `npub` and its hex resolve identically). Only matched accounts are returned —
+   * unlinked pubkeys are simply absent. Declared before `:address` so the literal
+   * segment isn't captured as an address param.
+   *
+   * `links->>'nostr'` may store hex OR npub, so we can't match the raw value in
+   * SQL; we narrow to nostr-linked accounts then normalize each in memory (same
+   * approach as `IdentityService.getAddressForPubkey`). The nostr-linked set is
+   * small today; revisit with a hex+npub `IN (…)` filter if it grows.
+   */
+  @ApiOperation({ operationId: 'resolveByNostr' })
+  @ApiQuery({
+    name: 'pubkeys',
+    type: 'string',
+    required: true,
+    description:
+      'Comma-separated nostr pubkeys (npub or 64-char hex), max 200.',
+  })
+  @ApiOkResponse({ type: [NostrAccountRefDto] })
+  @CacheTTL(60_000)
+  @Get('by-nostr')
+  async resolveByNostr(
+    @Query('pubkeys') pubkeysCsv?: string,
+  ): Promise<NostrAccountRefDto[]> {
+    const requested = (pubkeysCsv ?? '')
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+    if (!requested.length) return [];
+    if (requested.length > 200) {
+      throw new BadRequestException('At most 200 pubkeys per request');
+    }
+
+    // Target set: normalized hex pubkeys we were asked about.
+    const wanted = new Set<string>();
+    for (const p of requested) {
+      const hex = normalizePubkey(p);
+      if (hex) wanted.add(hex);
+    }
+    if (!wanted.size) return [];
+
+    const candidates = await this.accountRepository
+      .createQueryBuilder('account')
+      .select(['account.address', 'account.chain_name', 'account.links'])
+      .where("account.links->>'nostr' IS NOT NULL")
+      .andWhere("account.links->>'nostr' <> ''")
+      .getMany();
+
+    const out: NostrAccountRefDto[] = [];
+    const seen = new Set<string>();
+    for (const account of candidates) {
+      const hex = normalizePubkey(account.links?.nostr);
+      if (hex && wanted.has(hex) && !seen.has(hex)) {
+        seen.add(hex);
+        out.push({
+          nostr_pubkey: hex,
+          address: account.address,
+          chain_name: account.chain_name ?? null,
+        });
+      }
+    }
+    return out;
   }
 
   /**

--- a/src/account/dto/nostr-account-ref.dto.ts
+++ b/src/account/dto/nostr-account-ref.dto.ts
@@ -1,0 +1,29 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+/**
+ * A resolved nostr-pubkey → aeternity-account reference. Returned by
+ * `GET /api/accounts/by-nostr` so clients can show the AE identity (chain name /
+ * `ak_` address) for a nostr pubkey instead of the raw hex key — e.g. in a
+ * NIP-29 group's member list and membership system lines.
+ */
+export class NostrAccountRefDto {
+  @ApiProperty({
+    description:
+      'The matched nostr pubkey, normalized to lowercase 64-char hex.',
+    example: '3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d',
+  })
+  nostr_pubkey: string;
+
+  @ApiProperty({
+    description: 'The aeternity account that linked this nostr pubkey.',
+    example: 'ak_2EdPu7gFkFsUojaCBz4XV3vBrSrEK19gtb3iX7uHzMNkMVaqYJ',
+  })
+  address: string;
+
+  @ApiProperty({
+    description: "The account's `.chain` name, if any.",
+    nullable: true,
+    example: 'alice.chain',
+  })
+  chain_name: string | null;
+}

--- a/src/ae/community-factory.service.spec.ts
+++ b/src/ae/community-factory.service.spec.ts
@@ -114,4 +114,91 @@ describe('CommunityFactoryService', () => {
     expect(result.collections['name-ak_1']).toBeDefined();
     expect(result.collections['name-ak_1'].allowed_name_length).toBe('10');
   });
+
+  describe('mapCollectionInfo', () => {
+    const collectionId = 'CHINESE-ak_deployer' as const;
+    const factory = {
+      collections: {
+        [collectionId]: {
+          id: collectionId,
+          name: 'CHINESE',
+          description: 'Chinese collection',
+          allowed_name_length: '20',
+          // Bulky per-char rules that must NOT leak into the trimmed output.
+          allowed_name_chars: [{ ascii: [97, 98, 99] }],
+        },
+      },
+    } as unknown as ICommunityFactorySchema;
+
+    it('maps a known collection id to its trimmed metadata', () => {
+      expect(service.mapCollectionInfo(factory, collectionId)).toEqual({
+        id: collectionId,
+        name: 'CHINESE',
+        description: 'Chinese collection',
+        allowed_name_length: '20',
+      });
+    });
+
+    it('omits allowed_name_chars from the mapped result', () => {
+      const result = service.mapCollectionInfo(factory, collectionId);
+      expect(result).not.toHaveProperty('allowed_name_chars');
+    });
+
+    it('returns null for an unknown collection id', () => {
+      expect(service.mapCollectionInfo(factory, 'UNKNOWN-ak_x')).toBeNull();
+    });
+
+    it.each([[undefined], [null], ['']])(
+      'returns null for an empty collection id (%p)',
+      (collection) => {
+        expect(
+          service.mapCollectionInfo(factory, collection as any),
+        ).toBeNull();
+      },
+    );
+  });
+
+  describe('getCollectionInfo', () => {
+    const collectionId = 'CHINESE-ak_deployer' as const;
+
+    beforeEach(() => {
+      const factoryAddress = 'ct_cached' as Encoded.ContractAddress;
+      BCL_FACTORY[ACTIVE_NETWORK.networkId] = {
+        address: factoryAddress,
+      } as ICommunityFactorySchema;
+      // Prime the cache so getCurrentFactory resolves without touching the chain.
+      service.cachedFactorySchema[factoryAddress] = {
+        address: factoryAddress,
+        collections: {
+          [collectionId]: {
+            id: collectionId,
+            name: 'CHINESE',
+            description: 'Chinese collection',
+            allowed_name_length: '20',
+            allowed_name_chars: [],
+          },
+        },
+      } as unknown as ICommunityFactorySchema;
+    });
+
+    it('resolves a known collection id against the current factory', async () => {
+      await expect(service.getCollectionInfo(collectionId)).resolves.toEqual({
+        id: collectionId,
+        name: 'CHINESE',
+        description: 'Chinese collection',
+        allowed_name_length: '20',
+      });
+    });
+
+    it('short-circuits to null for an empty id without loading the factory', async () => {
+      await expect(service.getCollectionInfo('')).resolves.toBeNull();
+      expect(initCommunityFactory).not.toHaveBeenCalled();
+    });
+
+    it('returns null when the id is unknown to the current factory', async () => {
+      await expect(
+        service.getCollectionInfo('UNKNOWN-ak_x'),
+      ).resolves.toBeNull();
+    });
+  });
 });

--- a/src/ae/community-factory.service.ts
+++ b/src/ae/community-factory.service.ts
@@ -2,7 +2,7 @@ import { Encoded } from '@aeternity/aepp-sdk';
 import { Injectable } from '@nestjs/common';
 import { CommunityFactory, initCommunityFactory } from 'bctsl-sdk';
 import { ACTIVE_NETWORK, BCL_FACTORY } from '@/configs';
-import { ICommunityFactorySchema } from '@/utils/types';
+import { ICollectionInfo, ICommunityFactorySchema } from '@/utils/types';
 import { AeSdkService } from './ae-sdk.service';
 
 @Injectable()
@@ -85,5 +85,44 @@ export class CommunityFactoryService {
     this.cachedFactorySchema[factory.address] = factory;
 
     return factory;
+  }
+
+  /**
+   * Maps a token's stored collection id (the "<NAME>-ak_<deployer>" string) to
+   * its trimmed collection metadata using an already-loaded factory schema.
+   * Returns null when the token has no collection or the collection is unknown.
+   * Prefer this over {@link getCollectionInfo} when enriching many items — load
+   * the factory once and reuse it instead of awaiting per item.
+   */
+  mapCollectionInfo(
+    factory: ICommunityFactorySchema,
+    collectionId?: string | null,
+  ): ICollectionInfo | null {
+    const collection = collectionId
+      ? factory.collections?.[collectionId]
+      : undefined;
+    if (!collection) {
+      return null;
+    }
+    return {
+      id: collection.id,
+      name: collection.name,
+      description: collection.description,
+      allowed_name_length: collection.allowed_name_length,
+    };
+  }
+
+  /**
+   * Resolves the trimmed collection metadata for a single collection id.
+   * Returns null when the id is empty or unknown to the current factory.
+   */
+  async getCollectionInfo(
+    collectionId?: string | null,
+  ): Promise<ICollectionInfo | null> {
+    if (!collectionId) {
+      return null;
+    }
+    const factory = await this.getCurrentFactory();
+    return this.mapCollectionInfo(factory, collectionId);
   }
 }

--- a/src/ae/websocket.service.ts
+++ b/src/ae/websocket.service.ts
@@ -32,6 +32,7 @@ export class WebSocketService implements OnModuleDestroy {
   subscribersQueue: IMiddlewareWebSocketSubscriptionMessage[] = [];
   isWsConnected = false;
   reconnectInterval: NodeJS.Timeout;
+  private openPollInterval?: NodeJS.Timeout;
 
   private readonly boundOpen = this.handleWebsocketOpen.bind(this);
   private readonly boundClose = this.handleWebsocketClose.bind(this);
@@ -56,12 +57,18 @@ export class WebSocketService implements OnModuleDestroy {
 
   async handleWebsocketOpen() {
     await new Promise((resolve) => {
-      const interval = setInterval(() => {
+      // Tracked on the instance (not a bare local) so `onModuleDestroy` can
+      // clear it even if the socket never reaches OPEN (e.g. no network
+      // access in a test/CI environment) — otherwise this polls forever and
+      // keeps the process alive. `.unref()` so it never blocks exit either way.
+      this.openPollInterval = setInterval(() => {
         if (this.wsClient.readyState === WebSocket.OPEN) {
-          clearInterval(interval);
+          clearInterval(this.openPollInterval);
+          this.openPollInterval = undefined;
           resolve(true);
         }
       }, 100);
+      this.openPollInterval.unref?.();
     });
 
     this.isWsConnected = true;
@@ -70,9 +77,10 @@ export class WebSocketService implements OnModuleDestroy {
         this.wsClient.send(JSON.stringify(message));
       });
     } catch (error) {
-      setTimeout(() => {
+      const timer = setTimeout(() => {
         this.handleWebsocketOpen();
       }, WEB_SOCKET_RECONNECT_TIMEOUT);
+      timer.unref?.();
     }
   }
 
@@ -140,6 +148,7 @@ export class WebSocketService implements OnModuleDestroy {
         this.reconnect();
       }
     }, WEB_SOCKET_RECONNECT_TIMEOUT);
+    this.reconnectInterval.unref?.();
   }
 
   private reconnect() {
@@ -300,6 +309,10 @@ export class WebSocketService implements OnModuleDestroy {
 
   onModuleDestroy() {
     clearInterval(this.reconnectInterval);
+    if (this.openPollInterval) {
+      clearInterval(this.openPollInterval);
+      this.openPollInterval = undefined;
+    }
     this.disconnect();
   }
 
@@ -310,7 +323,10 @@ export class WebSocketService implements OnModuleDestroy {
       this.disconnect();
       // Wait for 1 second to ensure complete disconnection
     }
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await new Promise((resolve) => {
+      const timer = setTimeout(resolve, 1000);
+      timer.unref?.();
+    });
     this.connect(ACTIVE_NETWORK.websocketUrl);
   }
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -38,6 +38,7 @@ import { StabilizationModule } from './stabilization/stabilization.module';
 import { AddressLinksModule } from './plugins/address-links/address-links.module';
 import { NotificationsModule } from './notifications/notifications.module';
 import { AnnouncementsModule } from './announcements/announcements.module';
+import { TokenGatedRoomsModule } from './token-gated-rooms/token-gated-rooms.module';
 
 @Module({
   imports: [
@@ -106,6 +107,11 @@ import { AnnouncementsModule } from './announcements/announcements.module';
     AddressLinksModule,
     NotificationsModule,
     AnnouncementsModule,
+    // Token-gated rooms (NIP-29). Single always-on process — indexing listeners,
+    // HTTP read API, and the relay duties (writer/subscriber + Bull consumers)
+    // all load here; the relay duties self-enable iff a relay is configured
+    // (`TG_RELAY_URL` + `TG_BOT_NSEC`). See deworker-plan.md.
+    TokenGatedRoomsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/common/validation/request-validation.spec.ts
+++ b/src/common/validation/request-validation.spec.ts
@@ -6,6 +6,7 @@ import {
   AeContractAddressPipe,
   AeTransactionHashPipe,
   OpaqueIdPipe,
+  TopicParamPipe,
 } from './request-validation';
 
 describe('request validation pipes', () => {
@@ -54,5 +55,41 @@ describe('request validation pipes', () => {
     expect(() => pipe.transform('../secret', { data: 'id' })).toThrow(
       BadRequestException,
     );
+  });
+
+  describe('TopicParamPipe', () => {
+    const pipe = new TopicParamPipe();
+
+    it('accepts topics in the scripts the token collections allow', () => {
+      // GET /api/topics/name/%D8%A3%D9%86%D8%A7
+      expect(pipe.transform('أنا', { data: 'name' })).toBe('أنا');
+      expect(pipe.transform('汉字', { data: 'name' })).toBe('汉字');
+      expect(pipe.transform('ПРИВЕТ', { data: 'name' })).toBe('ПРИВЕТ');
+      expect(pipe.transform('привет', { data: 'name' })).toBe('привет');
+    });
+
+    it('still accepts the Latin topics it always did', () => {
+      expect(pipe.transform('WORDS-1', { data: 'name' })).toBe('WORDS-1');
+      expect(pipe.transform('some topic_name.v2', { data: 'name' })).toBe(
+        'some topic_name.v2',
+      );
+    });
+
+    it('keeps rejecting traversal and separator characters', () => {
+      for (const value of ['../secret', 'a/b', 'a\\b', '.hidden', '-lead']) {
+        expect(() => pipe.transform(value, { data: 'name' })).toThrow(
+          BadRequestException,
+        );
+      }
+    });
+
+    it('rejects an empty or over-long topic', () => {
+      expect(() => pipe.transform('', { data: 'name' })).toThrow(
+        BadRequestException,
+      );
+      expect(() => pipe.transform('汉'.repeat(129), { data: 'name' })).toThrow(
+        BadRequestException,
+      );
+    });
   });
 });

--- a/src/common/validation/request-validation.ts
+++ b/src/common/validation/request-validation.ts
@@ -10,7 +10,11 @@ const CHAIN_NAME_PATTERN = /^[a-z0-9][a-z0-9-]{0,62}\.chain$/i;
 const INVITE_CODE_PATTERN = /^[a-z0-9]{1,64}$/i;
 const PROVIDER_PATTERN = /^[a-z][a-z0-9_-]{0,31}$/i;
 const POST_ID_PATTERN = /^[\p{L}\p{N}][\p{L}\p{N}._~:-]{0,127}$/u;
-const TOPIC_PATTERN = /^[A-Za-z0-9][A-Za-z0-9 _.-]{0,127}$/;
+// Topics carry whatever script the post was written in (`extractTopics` strips no
+// characters), and tokens now come from non-Latin collections, so `#أنا` and `#汉字`
+// are real topic names. Letters/numbers in any script, matching POST_ID_PATTERN.
+// Still excludes `/`, `\` and a leading `.`, so no path traversal.
+const TOPIC_PATTERN = /^[\p{L}\p{N}][\p{L}\p{N} _.-]{0,127}$/u;
 
 type ValidatorFn = (value: string) => boolean;
 

--- a/src/configs/constants.ts
+++ b/src/configs/constants.ts
@@ -251,7 +251,8 @@ export const POPULAR_RANKING_CONFIG = {
     contentQuality: 0.3, // w_q (anti-spam)
     reads: 1.5, // w_reads (common passive signal)
     freshnessBoost: 1.5, // w_fresh (temporary new-post lift)
-    velocityBoost: 0.6, // w_vel (temporary lift for posts gaining activity quickly)
+    velocityBoost: 0.6, // w_vel (freshness-gated early-life amplifier)
+    interactionsPerHour: 0.6, // w_iph (always-on momentum baseline, counts at any age)
   },
 
   // user-facing scale controls tune relative importance instead of exposing raw weights
@@ -260,9 +261,6 @@ export const POPULAR_RANKING_CONFIG = {
       low: 0.6,
       med: 1,
       high: 1.5,
-    },
-    ADDITIONAL_SIGNAL_WEIGHTS: {
-      interactionsPerHour: 1.1,
     },
   },
 
@@ -279,6 +277,13 @@ export const POPULAR_RANKING_CONFIG = {
 
   // live popular behavior
   FRESHNESS_BOOST_HOURS: 24,
+
+  // 'all' window age decay: score / (ageHours + 2)^gravity. Scores are
+  // log-dampened so their spread stays small — gravity must stay gentle
+  // (~0.15..0.4); near 1 the divisor outgrows any achievable score gap and
+  // 'all' degenerates into a recency feed. Raise slightly if old posts still
+  // dominate, lower if evergreen content churns out too fast.
+  ALL_WINDOW_GRAVITY: 0.25,
   AUTHOR_DIVERSITY: {
     ENABLED: true,
     OVERSAMPLE_MULTIPLIER: 4,

--- a/src/configs/constants.ts
+++ b/src/configs/constants.ts
@@ -275,8 +275,27 @@ export const POPULAR_RANKING_CONFIG = {
   // trending scaling
   TRENDING_MAX_SCORE: 100, // scale trending tag score to [0..1]
 
-  // live popular behavior
-  FRESHNESS_BOOST_HOURS: 24,
+  // live popular behavior — 48h, not 24h: on a low-activity network posts
+  // need longer to gather their fair share of signal
+  FRESHNESS_BOOST_HOURS: 48,
+
+  // velocity looks at interactions inside this window (divided by post age
+  // when the post is younger), so an old post catching fire still registers
+  VELOCITY_WINDOW_HOURS: 48,
+
+  // recursion guard for whole-thread comment counting — real threads never
+  // approach this, it only bounds pathological reply chains
+  THREAD_COUNT_MAX_DEPTH: 50,
+
+  // reads counted toward the score are capped at this many per (1 + active
+  // interaction) — reads are the easiest signal to inflate, so passive volume
+  // alone cannot outvote real engagement indefinitely
+  READS_PER_INTERACTION_CAP: 100,
+
+  // deterministic per-hour score jitter in [0, epsilon) rotating near-tied
+  // posts (mostly the zero-engagement tail) so their order isn't frozen;
+  // keep well below typical engaged-post score gaps
+  TIE_ROTATION_EPSILON: 0.05,
 
   // 'all' window age decay: score / (ageHours + 2)^gravity. Scores are
   // log-dampened so their spread stays small — gravity must stay gentle
@@ -296,7 +315,10 @@ export const POPULAR_RANKING_CONFIG = {
     popular7d: 'popular:7d',
     popularAll: 'popular:all',
   },
-  REDIS_TTL_SECONDS: 30,
+  // Kept far above the slowest cron refresh cadence (10 min for 'all') so a
+  // key only goes cold if refreshes fail repeatedly; requests then hit the
+  // lazy recompute fallback.
+  REDIS_TTL_SECONDS: 1800,
 
   // Bot UA denylist (lowercase substrings)
   BOT_UA_DENYLIST: [

--- a/src/data-source.ts
+++ b/src/data-source.ts
@@ -1,0 +1,26 @@
+import 'dotenv/config';
+import { DataSource, DataSourceOptions } from 'typeorm';
+import { DATABASE_CONFIG } from './configs/database';
+
+/**
+ * TypeORM `DataSource` for the migration CLI (`migration:run`/`migration:revert`).
+ *
+ * Reuses {@link DATABASE_CONFIG} (the same connection the app uses) but:
+ *   - forces `synchronize: false` — schema must come from migrations, never the
+ *     destructive `synchronize` path (see `src/configs/database.ts`);
+ *   - points `entities` at the same glob the app uses so `migration:generate`/diff
+ *     sees the live entity definitions;
+ *   - registers the ordered migration files + the `migrations` history table.
+ *
+ * Invoked via `typeorm-ts-node-commonjs -d src/data-source.ts` so `.ts` migrations
+ * run without a build step.
+ */
+const AppDataSource = new DataSource({
+  ...(DATABASE_CONFIG as DataSourceOptions),
+  synchronize: false,
+  entities: [__dirname + '/**/entities/*.entity{.ts,.js}'],
+  migrations: [__dirname + '/migrations/*{.ts,.js}'],
+  migrationsTableName: 'migrations',
+});
+
+export default AppDataSource;

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,29 +12,13 @@ import {
   hasExplicitAllowlist,
   parseAllowedOrigins,
 } from './configs/allowed-origins';
+import { registerProcessGuards } from './process-guards';
 
 const IS_PRODUCTION = process.env.NODE_ENV === 'production';
 
 // Global process-level guards to surface and prevent silent killers
-// NOTE: After logging we explicitly exit with code 1 so that the process
-// manager (Docker, PM2, systemd, etc.) can restart the service. Continuing
-// after these events is unsafe.
-process.on('uncaughtException', (error: unknown) => {
-  // eslint-disable-next-line no-console
-  console.error('UNCAUGHT EXCEPTION, process will exit:', error);
-  process.exit(1);
-});
-
-process.on('unhandledRejection', (reason: unknown) => {
-  // eslint-disable-next-line no-console
-  console.error('UNHANDLED REJECTION, process will exit:', reason);
-  process.exit(1);
-});
-
-process.on('exit', (code: number) => {
-  // eslint-disable-next-line no-console
-  console.error('Process exiting with code', code);
-});
+// (uncaughtException / unhandledRejection → log + exit 1).
+registerProcessGuards();
 
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule, {
@@ -109,4 +93,11 @@ async function bootstrap() {
 
   await app.listen(process.env.APP_PORT ?? 3000);
 }
+
+// One image, ONE process (worker mode removed — see
+// `agent/api/tasks/token-gated-room/deworker-plan.md`): HTTP API + chain indexer
+// AND the NIP-29 relay duties (writer/subscriber + Bull consumers +
+// backfill/reconcile/membership-sync) all run here. The relay duties self-enable
+// iff a relay is configured (`TG_RELAY_URL` + `TG_BOT_NSEC`); otherwise they stay
+// dormant and the API still boots and indexes.
 void bootstrap();

--- a/src/mdw-sync/services/indexer.service.ts
+++ b/src/mdw-sync/services/indexer.service.ts
@@ -110,6 +110,11 @@ export class IndexerService implements OnModuleInit {
         await this.sync();
       }
     }, syncIntervalMs);
+    // Don't keep the process alive solely for this poll — onModuleDestroy
+    // clears it on a real shutdown, but a test that skips that lifecycle
+    // hook (e.g. constructs the service without closing the Nest app)
+    // should not hang on a live interval.
+    this.syncInterval.unref?.();
   }
 
   async sync() {

--- a/src/migrations/1718900000001-TgrTokenColumns.ts
+++ b/src/migrations/1718900000001-TgrTokenColumns.ts
@@ -1,0 +1,50 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * TGR migration #1 (plan §4.1 / §4.6): add the four `Token` columns + the
+ * `nostr_room_state` Postgres enum + the partial index used by the publish-pending
+ * scan (`WHERE nostr_room_state <> 'created'`).
+ */
+export class TgrTokenColumns1718900000001 implements MigrationInterface {
+  name = 'TgrTokenColumns1718900000001';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "public"."token_nostr_room_state_enum" AS ENUM('none', 'pending', 'created', 'failed', 'deleted')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "token" ADD "nostr_group_id" character varying`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "token" ADD "has_nostr_room" boolean NOT NULL DEFAULT false`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "token" ADD "nostr_room_created_at" TIMESTAMP WITH TIME ZONE`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "token" ADD "nostr_room_state" "public"."token_nostr_room_state_enum" NOT NULL DEFAULT 'none'`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_token_nostr_group_id" ON "token" ("nostr_group_id")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_token_nostr_room_state_pending" ON "token" ("nostr_room_state") WHERE nostr_room_state <> 'created'`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "public"."idx_token_nostr_room_state_pending"`,
+    );
+    await queryRunner.query(`DROP INDEX "public"."IDX_token_nostr_group_id"`);
+    await queryRunner.query(
+      `ALTER TABLE "token" DROP COLUMN "nostr_room_state"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "token" DROP COLUMN "nostr_room_created_at"`,
+    );
+    await queryRunner.query(`ALTER TABLE "token" DROP COLUMN "has_nostr_room"`);
+    await queryRunner.query(`ALTER TABLE "token" DROP COLUMN "nostr_group_id"`);
+    await queryRunner.query(`DROP TYPE "public"."token_nostr_room_state_enum"`);
+  }
+}

--- a/src/migrations/1718900000002-TgrCommunityRoom.ts
+++ b/src/migrations/1718900000002-TgrCommunityRoom.ts
@@ -1,0 +1,56 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * TGR migration #2 (plan §4.2): `community_room` (PK `sale_address`) — indexed
+ * RoomManagement state. Indexes on `(is_private)`, `(state_synced_at)`, and GIN
+ * on the `moderators`/`muted` jsonb columns.
+ */
+export class TgrCommunityRoom1718900000002 implements MigrationInterface {
+  name = 'TgrCommunityRoom1718900000002';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "community_room" (
+        "sale_address" character varying NOT NULL,
+        "token_address" character varying NOT NULL,
+        "symbol" character varying NOT NULL,
+        "owner_address" character varying NOT NULL,
+        "is_private" boolean NOT NULL DEFAULT false,
+        "min_token_threshold" numeric NOT NULL DEFAULT '0',
+        "moderators" jsonb,
+        "muted" jsonb,
+        "is_community" boolean NOT NULL DEFAULT false,
+        "state_synced_at" TIMESTAMP WITH TIME ZONE,
+        "created_height" integer,
+        "deleted" boolean NOT NULL DEFAULT false,
+        CONSTRAINT "PK_community_room_sale_address" PRIMARY KEY ("sale_address")
+      )`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_community_room_is_private" ON "community_room" ("is_private")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_community_room_state_synced_at" ON "community_room" ("state_synced_at")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_community_room_moderators" ON "community_room" USING GIN ("moderators")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_community_room_muted" ON "community_room" USING GIN ("muted")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "public"."idx_community_room_muted"`);
+    await queryRunner.query(
+      `DROP INDEX "public"."idx_community_room_moderators"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."idx_community_room_state_synced_at"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."idx_community_room_is_private"`,
+    );
+    await queryRunner.query(`DROP TABLE "community_room"`);
+  }
+}

--- a/src/migrations/1718900000003-TgrRoomMembership.ts
+++ b/src/migrations/1718900000003-TgrRoomMembership.ts
@@ -1,0 +1,68 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * TGR migration #3 (plan §4.3): `room_membership` (generated PK `id`) — desired
+ * membership ledger. Creates the `role`/`relay_state` enum types, the unique
+ * `(sale_address, member_address)`, the `(sale_address, relay_state)` scan index,
+ * `(member_address)`, and the partial `(sale_address) WHERE eligible=true`.
+ */
+export class TgrRoomMembership1718900000003 implements MigrationInterface {
+  name = 'TgrRoomMembership1718900000003';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "public"."room_membership_role_enum" AS ENUM('member', 'admin')`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."room_membership_relay_state_enum" AS ENUM('pending_add', 'added', 'pending_remove', 'removed')`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "room_membership" (
+        "id" SERIAL NOT NULL,
+        "sale_address" character varying NOT NULL,
+        "member_address" character varying NOT NULL,
+        "member_pubkey" character varying,
+        "role" "public"."room_membership_role_enum" NOT NULL DEFAULT 'member',
+        "eligible" boolean NOT NULL DEFAULT false,
+        "relay_state" "public"."room_membership_relay_state_enum" NOT NULL DEFAULT 'pending_add',
+        "held_until_height" integer,
+        "last_published_at" TIMESTAMP WITH TIME ZONE,
+        "last_reconciled_at" TIMESTAMP WITH TIME ZONE,
+        "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+        CONSTRAINT "PK_room_membership_id" PRIMARY KEY ("id")
+      )`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "uq_room_membership_sale_member" ON "room_membership" ("sale_address", "member_address")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_room_membership_sale_relay_state" ON "room_membership" ("sale_address", "relay_state")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_room_membership_member_address" ON "room_membership" ("member_address")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_room_membership_eligible" ON "room_membership" ("sale_address") WHERE eligible = true`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "public"."idx_room_membership_eligible"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."idx_room_membership_member_address"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."idx_room_membership_sale_relay_state"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."uq_room_membership_sale_member"`,
+    );
+    await queryRunner.query(`DROP TABLE "room_membership"`);
+    await queryRunner.query(
+      `DROP TYPE "public"."room_membership_relay_state_enum"`,
+    );
+    await queryRunner.query(`DROP TYPE "public"."room_membership_role_enum"`);
+  }
+}

--- a/src/migrations/1718900000004-TgrRoomNotificationPreference.ts
+++ b/src/migrations/1718900000004-TgrRoomNotificationPreference.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * TGR migration #4 (plan §4.4): `room_notification_preference` — per-room mute,
+ * composite PK `(address, sale_address)`.
+ */
+export class TgrRoomNotificationPreference1718900000004 implements MigrationInterface {
+  name = 'TgrRoomNotificationPreference1718900000004';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "room_notification_preference" (
+        "address" character varying NOT NULL,
+        "sale_address" character varying NOT NULL,
+        "muted" boolean NOT NULL DEFAULT false,
+        "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+        CONSTRAINT "PK_room_notification_preference" PRIMARY KEY ("address", "sale_address")
+      )`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "room_notification_preference"`);
+  }
+}

--- a/src/migrations/1718900000005-TgrRoomMessageSeen.ts
+++ b/src/migrations/1718900000005-TgrRoomMessageSeen.ts
@@ -1,0 +1,30 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * TGR migration #5 (plan §7.1): `room_message_seen` — new-message dedup key,
+ * PK `event_id`. Indexed by `sale_address`.
+ */
+export class TgrRoomMessageSeen1718900000005 implements MigrationInterface {
+  name = 'TgrRoomMessageSeen1718900000005';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "room_message_seen" (
+        "event_id" character varying NOT NULL,
+        "sale_address" character varying NOT NULL,
+        "seen_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_room_message_seen_event_id" PRIMARY KEY ("event_id")
+      )`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_room_message_seen_sale_address" ON "room_message_seen" ("sale_address")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "public"."idx_room_message_seen_sale_address"`,
+    );
+    await queryRunner.query(`DROP TABLE "room_message_seen"`);
+  }
+}

--- a/src/migrations/1718900000006-TgrTokenBalance.ts
+++ b/src/migrations/1718900000006-TgrTokenBalance.ts
@@ -1,0 +1,26 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * TGR migration #6 (plan §4.5): `token_balance` — authoritative AEX9 balances in
+ * raw base units, composite PK `(token_address, holder_address)`.
+ */
+export class TgrTokenBalance1718900000006 implements MigrationInterface {
+  name = 'TgrTokenBalance1718900000006';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "token_balance" (
+        "token_address" character varying NOT NULL,
+        "holder_address" character varying NOT NULL,
+        "balance" numeric NOT NULL DEFAULT '0',
+        "updated_height" integer NOT NULL DEFAULT 0,
+        "last_reconciled_at" TIMESTAMP WITH TIME ZONE,
+        CONSTRAINT "PK_token_balance" PRIMARY KEY ("token_address", "holder_address")
+      )`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "token_balance"`);
+  }
+}

--- a/src/migrations/1718900000007-TgrRoomBackfillState.ts
+++ b/src/migrations/1718900000007-TgrRoomBackfillState.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * TGR migration #7 (plan §4.6 / §6.2): `room_backfill_state` — single-row resume
+ * cursor for the eager room backfill, fixed PK `id='global'`.
+ */
+export class TgrRoomBackfillState1718900000007 implements MigrationInterface {
+  name = 'TgrRoomBackfillState1718900000007';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "room_backfill_state" (
+        "id" character varying NOT NULL DEFAULT 'global',
+        "last_height" integer,
+        "batch_offset" integer NOT NULL DEFAULT 0,
+        "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+        CONSTRAINT "PK_room_backfill_state_id" PRIMARY KEY ("id")
+      )`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "room_backfill_state"`);
+  }
+}

--- a/src/migrations/1718900000008-TgrTokenRoomId.ts
+++ b/src/migrations/1718900000008-TgrTokenRoomId.ts
@@ -1,0 +1,30 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * TGR migration #8: add `Token.room_id` — the source of truth for "room created".
+ *
+ * `room_id` holds the NIP-29 group id (= `sale_address`) once the room is
+ * CONFIRMED created on the relay; NULL = no room yet. It is set on the `9007` ok
+ * ACK (`RoomBackfillService.onPublishAck`) alongside `has_nostr_room` /
+ * `nostr_room_created_at`, and the 5-minute provisioning cron selects roomless
+ * tokens by `room_id IS NULL`. A partial index (`WHERE room_id IS NULL`, mirroring
+ * the partial index in migration #1) keeps that selection cheap as the roomless
+ * set shrinks toward empty.
+ */
+export class TgrTokenRoomId1718900000008 implements MigrationInterface {
+  name = 'TgrTokenRoomId1718900000008';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "token" ADD "room_id" character varying`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_token_room_id_null" ON "token" ("room_id") WHERE room_id IS NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "public"."idx_token_room_id_null"`);
+    await queryRunner.query(`ALTER TABLE "token" DROP COLUMN "room_id"`);
+  }
+}

--- a/src/migrations/1718900000009-TgrRoomMembershipEvent.ts
+++ b/src/migrations/1718900000009-TgrRoomMembershipEvent.ts
@@ -1,0 +1,96 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * TGR migration #9 (access-ledger plan §5): the access-transition ledger.
+ *
+ * Creates `room_membership_event` (append-only grant/revoke audit + push source)
+ * and adds the notification-facing access-state columns to `room_membership`
+ * (`access_state`, `access_changed_at`, `pending_revoke_since`,
+ * `pending_revoke_reason`).
+ *
+ * **Backfill (critical):** seeds every currently-added member as
+ * `access_state='granted'` so the deploy does NOT emit a "you're in" push to
+ * everyone already in a room. Effective access = `relay_state='added'` (independent
+ * of `eligible`, so room admins are seeded too).
+ */
+export class TgrRoomMembershipEvent1718900000009
+  implements MigrationInterface
+{
+  name = 'TgrRoomMembershipEvent1718900000009';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // ── access-transition ledger ───────────────────────────────────────────────
+    await queryRunner.query(
+      `CREATE TYPE "public"."room_membership_event_event_enum" AS ENUM('access_granted', 'access_revoked')`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "room_membership_event" (
+        "id" BIGSERIAL NOT NULL,
+        "sale_address" character varying NOT NULL,
+        "member_address" character varying NOT NULL,
+        "event" "public"."room_membership_event_event_enum" NOT NULL,
+        "reason" character varying NOT NULL,
+        "is_first_grant" boolean NOT NULL DEFAULT false,
+        "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+        "notified_at" TIMESTAMP WITH TIME ZONE,
+        CONSTRAINT "PK_room_membership_event_id" PRIMARY KEY ("id")
+      )`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_room_membership_event_sale_member" ON "room_membership_event" ("sale_address", "member_address", "created_at")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_room_membership_event_unnotified" ON "room_membership_event" ("notified_at") WHERE notified_at IS NULL`,
+    );
+
+    // ── access-state columns on room_membership ────────────────────────────────
+    await queryRunner.query(
+      `CREATE TYPE "public"."room_membership_access_state_enum" AS ENUM('none', 'granted')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "room_membership"
+        ADD COLUMN "access_state" "public"."room_membership_access_state_enum" NOT NULL DEFAULT 'none',
+        ADD COLUMN "access_changed_at" TIMESTAMP WITH TIME ZONE,
+        ADD COLUMN "pending_revoke_since" TIMESTAMP WITH TIME ZONE,
+        ADD COLUMN "pending_revoke_reason" character varying`,
+    );
+
+    // ── backfill: current members are already granted (no push storm on deploy) ─
+    await queryRunner.query(
+      `UPDATE "room_membership"
+        SET "access_state" = 'granted', "access_changed_at" = "updated_at"
+        WHERE "relay_state" = 'added'`,
+    );
+
+    // Partial index for the finalizer sweep (rows with an armed pending revoke).
+    await queryRunner.query(
+      `CREATE INDEX "idx_room_membership_pending_revoke" ON "room_membership" ("pending_revoke_since") WHERE pending_revoke_since IS NOT NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "public"."idx_room_membership_pending_revoke"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "room_membership"
+        DROP COLUMN "pending_revoke_reason",
+        DROP COLUMN "pending_revoke_since",
+        DROP COLUMN "access_changed_at",
+        DROP COLUMN "access_state"`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "public"."room_membership_access_state_enum"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."idx_room_membership_event_unnotified"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."idx_room_membership_event_sale_member"`,
+    );
+    await queryRunner.query(`DROP TABLE "room_membership_event"`);
+    await queryRunner.query(
+      `DROP TYPE "public"."room_membership_event_event_enum"`,
+    );
+  }
+}

--- a/src/migrations/1718900000009-TgrRoomMembershipEvent.ts
+++ b/src/migrations/1718900000009-TgrRoomMembershipEvent.ts
@@ -11,7 +11,10 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
  * **Backfill (critical):** seeds every currently-added member as
  * `access_state='granted'` so the deploy does NOT emit a "you're in" push to
  * everyone already in a room. Effective access = `relay_state='added'` (independent
- * of `eligible`, so room admins are seeded too).
+ * of `eligible`, so room admins are seeded too). It ALSO inserts a historical
+ * `access_granted` ledger row per backfilled member (reason `backfill`, pre-stamped
+ * `notified_at`) so post-deploy first-grant detection is correct — a later
+ * revoke→regain reads as "you're back", not a fresh "Welcome".
  */
 export class TgrRoomMembershipEvent1718900000009 implements MigrationInterface {
   name = 'TgrRoomMembershipEvent1718900000009';
@@ -58,6 +61,20 @@ export class TgrRoomMembershipEvent1718900000009 implements MigrationInterface {
       `UPDATE "room_membership"
         SET "access_state" = 'granted', "access_changed_at" = "updated_at"
         WHERE "relay_state" = 'added'`,
+    );
+
+    // Seed a historical `access_granted` ledger row per backfilled member so
+    // first-grant detection is correct AFTER deploy: their genuine first grant
+    // happened pre-ledger, so a later revoke→regain must read as "you're back"
+    // (is_first_grant=false), not a fresh "Welcome". `notified_at` is set (never
+    // pushed — these are historical, not enqueued) so they stay out of the
+    // unnotified index. `is_first_grant=true` records that this WAS their first grant.
+    await queryRunner.query(
+      `INSERT INTO "room_membership_event"
+        ("sale_address", "member_address", "event", "reason", "is_first_grant", "created_at", "notified_at")
+       SELECT "sale_address", "member_address", 'access_granted', 'backfill', true, "updated_at", "updated_at"
+       FROM "room_membership"
+       WHERE "relay_state" = 'added'`,
     );
 
     // Partial index for the finalizer sweep (rows with an armed pending revoke).

--- a/src/migrations/1718900000009-TgrRoomMembershipEvent.ts
+++ b/src/migrations/1718900000009-TgrRoomMembershipEvent.ts
@@ -13,9 +13,7 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
  * everyone already in a room. Effective access = `relay_state='added'` (independent
  * of `eligible`, so room admins are seeded too).
  */
-export class TgrRoomMembershipEvent1718900000009
-  implements MigrationInterface
-{
+export class TgrRoomMembershipEvent1718900000009 implements MigrationInterface {
   name = 'TgrRoomMembershipEvent1718900000009';
 
   public async up(queryRunner: QueryRunner): Promise<void> {

--- a/src/migrations/1718900000009-TgrRoomMembershipEvent.ts
+++ b/src/migrations/1718900000009-TgrRoomMembershipEvent.ts
@@ -8,10 +8,12 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
  * (`access_state`, `access_changed_at`, `pending_revoke_since`,
  * `pending_revoke_reason`).
  *
- * **Backfill (critical):** seeds every currently-added member as
- * `access_state='granted'` so the deploy does NOT emit a "you're in" push to
- * everyone already in a room. Effective access = `relay_state='added'` (independent
- * of `eligible`, so room admins are seeded too). It ALSO inserts a historical
+ * **Backfill (critical):** seeds every member **present on the relay**
+ * (`relay_state IN ('added','pending_remove')`, independent of `eligible` so room
+ * admins are seeded too) as `access_state='granted'` so the deploy does NOT emit a
+ * "you're in" push to everyone already in a room — AND so a member with a removal
+ * in flight still gets a "you no longer have access" push when it lands (else the
+ * remove ACK would bail at `access_state='none'`). It ALSO inserts a historical
  * `access_granted` ledger row per backfilled member (reason `backfill`, pre-stamped
  * `notified_at`) so post-deploy first-grant detection is correct — a later
  * revoke→regain reads as "you're back", not a fresh "Welcome".
@@ -57,10 +59,18 @@ export class TgrRoomMembershipEvent1718900000009 implements MigrationInterface {
     );
 
     // ── backfill: current members are already granted (no push storm on deploy) ─
+    // "Currently has effective access" at migration time = **present on the relay**,
+    // i.e. `relay_state IN ('added','pending_remove')`. `pending_remove` is a member
+    // with a removal in flight who (in the dominant added→pending_remove case) still
+    // has access; seeding them `granted` means the post-deploy remove ACK correctly
+    // arms a debounced revoke ("you no longer have access") instead of bailing at
+    // `access_state='none'`. The rare pending_add→pending_remove (never actually on
+    // the relay) case is absorbed by the grace window — a flap re-adds within grace
+    // and pushes nothing; only a durable removal notifies.
     await queryRunner.query(
       `UPDATE "room_membership"
         SET "access_state" = 'granted', "access_changed_at" = "updated_at"
-        WHERE "relay_state" = 'added'`,
+        WHERE "relay_state" IN ('added', 'pending_remove')`,
     );
 
     // Seed a historical `access_granted` ledger row per backfilled member so
@@ -74,7 +84,7 @@ export class TgrRoomMembershipEvent1718900000009 implements MigrationInterface {
         ("sale_address", "member_address", "event", "reason", "is_first_grant", "created_at", "notified_at")
        SELECT "sale_address", "member_address", 'access_granted', 'backfill', true, "updated_at", "updated_at"
        FROM "room_membership"
-       WHERE "relay_state" = 'added'`,
+       WHERE "relay_state" IN ('added', 'pending_remove')`,
     );
 
     // Partial index for the finalizer sweep (rows with an armed pending revoke).

--- a/src/migrations/1718900000010-TokenCollectionNameIdx.ts
+++ b/src/migrations/1718900000010-TokenCollectionNameIdx.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * `GET /tokens?collection=<name>` (tokens.controller.ts) filters with
+ * `LOWER(split_part(token.collection, '-ak_', 1)) = LOWER(:collectionName)`
+ * so a collection name (e.g. "CHINESE") matches every network's id for that
+ * collection without the caller needing the `-ak_...` suffix. Index the same
+ * expression so that filter doesn't fall back to a sequential scan as the
+ * token table grows.
+ */
+export class TokenCollectionNameIdx1718900000010 implements MigrationInterface {
+  name = 'TokenCollectionNameIdx1718900000010';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE INDEX "idx_token_collection_name" ON "token" (LOWER(split_part("collection", '-ak_', 1)))`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "public"."idx_token_collection_name"`);
+  }
+}

--- a/src/migrations/1718900000011-PostsPostIdIdx.ts
+++ b/src/migrations/1718900000011-PostsPostIdIdx.ts
@@ -1,0 +1,31 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * `Post` (`post.entity.ts`) declares `@Index('IDX_POSTS_POST_ID', ['post_id'])`
+ * but no migration ever created it — with `synchronize` off in production the
+ * index never landed. The recursive thread CTE joins `posts` on `post_id` for
+ * up to 10k popular candidates per level, so without this index it degrades
+ * into repeated sequential scans as the table grows.
+ *
+ * `IF NOT EXISTS` (and `IF EXISTS` on the way down) because this is an
+ * entity-declared index on the pre-existing, entity-managed `posts` table:
+ * any environment that ever ran with `synchronize: true` (dev/testnet, or a
+ * schema the migration tests build from entities) already has it, and a bare
+ * `CREATE INDEX` would fail there and block the whole migration chain. On
+ * production (synchronize off) the index is absent and gets created here.
+ */
+export class PostsPostIdIdx1718900000011 implements MigrationInterface {
+  name = 'PostsPostIdIdx1718900000011';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_POSTS_POST_ID" ON "posts" ("post_id")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "public"."IDX_POSTS_POST_ID"`,
+    );
+  }
+}

--- a/src/notifications/notification-catalog.spec.ts
+++ b/src/notifications/notification-catalog.spec.ts
@@ -1,0 +1,22 @@
+import {
+  NOTIFICATION_CATALOG,
+  NOTIFICATION_CATALOG_BY_TYPE,
+} from './notification-catalog';
+
+describe('NOTIFICATION_CATALOG — room types (Task 12)', () => {
+  it('contains both room-membership and room-messages', () => {
+    const types = NOTIFICATION_CATALOG.map((m) => m.type);
+    expect(types).toContain('room-membership');
+    expect(types).toContain('room-messages');
+  });
+
+  it('whitelists both room types in the by-type map (so applyPartial accepts them)', () => {
+    expect(NOTIFICATION_CATALOG_BY_TYPE.has('room-membership')).toBe(true);
+    expect(NOTIFICATION_CATALOG_BY_TYPE.has('room-messages')).toBe(true);
+  });
+
+  it('has unique type ids', () => {
+    const types = NOTIFICATION_CATALOG.map((m) => m.type);
+    expect(new Set(types).size).toBe(types.length);
+  });
+});

--- a/src/notifications/notification-catalog.ts
+++ b/src/notifications/notification-catalog.ts
@@ -3,6 +3,8 @@ import { IncomingTransferNotification } from './notifications/incoming-transfer.
 import { AnnouncementNotification } from './notifications/announcement.notification';
 import { InvitationClaimedNotification } from './notifications/invitation-claimed.notification';
 import { PostCommentNotification } from './notifications/post-comment.notification';
+import { RoomMembershipNotification } from '@/token-gated-rooms/notifications/room-membership.notification';
+import { RoomMessageNotification } from '@/token-gated-rooms/notifications/room-message.notification';
 
 /**
  * Catalog of every notification type the user can opt into / out of. Source of
@@ -20,6 +22,8 @@ export const NOTIFICATION_CATALOG: ReadonlyArray<NotificationMeta> = [
   AnnouncementNotification.META,
   InvitationClaimedNotification.META,
   PostCommentNotification.META,
+  RoomMembershipNotification.META,
+  RoomMessageNotification.META,
 ];
 
 /** O(1) lookup used to whitelist incoming `type` strings in update payloads. */

--- a/src/notifications/services/device-challenge.room-mute.spec.ts
+++ b/src/notifications/services/device-challenge.room-mute.spec.ts
@@ -1,0 +1,127 @@
+import { BadRequestException, UnauthorizedException } from '@nestjs/common';
+
+jest.mock('@/profile/services/profile-signature.util', () => ({
+  verifyAeAddressSignature: jest.fn(),
+}));
+
+import { verifyAeAddressSignature } from '@/profile/services/profile-signature.util';
+import { DeviceChallengeService } from './device-challenge.service';
+import { buildRoomMuteMessage } from '@/token-gated-rooms/notifications/room-mute.message';
+import { buildPreferencesUpdateMessage } from '../notifications.constants';
+
+const verifyMock = verifyAeAddressSignature as jest.Mock;
+
+const ADDR = 'ak_alice';
+const SALE = 'ct_sale';
+
+/**
+ * Task 13 — the additive `verifyAndConsumeForRoomMute` on the SHARED challenge
+ * service. Mirrors the preferences-intent tests: same nonce table, distinct
+ * body-bound message, single-use consume.
+ */
+describe('DeviceChallengeService.verifyAndConsumeForRoomMute', () => {
+  let repo: any;
+  let service: DeviceChallengeService;
+  const config = {
+    challengeTtlMs: 300_000,
+    challengeMaxPendingPerAddress: 5,
+  } as any;
+
+  const validChallenge = () => ({
+    nonce: 'n1',
+    address: ADDR,
+    consumed_at: null,
+    expires_at: new Date(Date.now() + 60_000),
+  });
+
+  beforeEach(() => {
+    verifyMock.mockReset();
+    repo = {
+      findOne: jest.fn(),
+      update: jest.fn().mockResolvedValue({ affected: 1 }),
+    };
+    service = new DeviceChallengeService(repo, config);
+  });
+
+  it('verifies against the body-bound room-mute message', async () => {
+    repo.findOne.mockResolvedValue(validChallenge());
+    verifyMock.mockReturnValue(true);
+    await service.verifyAndConsumeForRoomMute(
+      'n1',
+      ADDR,
+      SALE,
+      true,
+      false,
+      'sg_ok',
+    );
+    expect(verifyMock).toHaveBeenCalledWith(
+      ADDR,
+      buildRoomMuteMessage(ADDR, 'n1', SALE, true, false),
+      'sg_ok',
+    );
+  });
+
+  it('consumes the nonce atomically on success (single-use)', async () => {
+    repo.findOne.mockResolvedValue(validChallenge());
+    verifyMock.mockReturnValue(true);
+    await service.verifyAndConsumeForRoomMute(
+      'n1',
+      ADDR,
+      SALE,
+      true,
+      undefined,
+      'sg_ok',
+    );
+    expect(repo.update).toHaveBeenCalledWith(
+      expect.objectContaining({ nonce: 'n1' }),
+      expect.objectContaining({ consumed_at: expect.any(Date) }),
+    );
+  });
+
+  it('rejects when the nonce was already used', async () => {
+    repo.findOne.mockResolvedValue({
+      ...validChallenge(),
+      consumed_at: new Date(),
+    });
+    await expect(
+      service.verifyAndConsumeForRoomMute(
+        'n1',
+        ADDR,
+        SALE,
+        true,
+        false,
+        'sg_ok',
+      ),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('rejects a swapped body (sig for muted=true replayed as muted=false)', async () => {
+    repo.findOne.mockResolvedValue(validChallenge());
+    // The verifier is fed buildRoomMuteMessage(..., muted=false); a sig captured
+    // for muted=true does not match → false.
+    verifyMock.mockReturnValue(false);
+    await expect(
+      service.verifyAndConsumeForRoomMute(
+        'n1',
+        ADDR,
+        SALE,
+        false,
+        false,
+        'sg_for_muted_true',
+      ),
+    ).rejects.toBeInstanceOf(UnauthorizedException);
+    expect(verifyMock).toHaveBeenCalledWith(
+      ADDR,
+      buildRoomMuteMessage(ADDR, 'n1', SALE, false, false),
+      'sg_for_muted_true',
+    );
+  });
+
+  it('a preferences-intent message differs from the room-mute message (no cross-replay)', () => {
+    const roomMsg = buildRoomMuteMessage(ADDR, 'n1', SALE, true, false);
+    const prefMsg = buildPreferencesUpdateMessage(ADDR, 'n1', [
+      { type: 'room-messages', enabled: false },
+    ]);
+    expect(roomMsg).not.toBe(prefMsg);
+  });
+});

--- a/src/notifications/services/device-challenge.service.ts
+++ b/src/notifications/services/device-challenge.service.ts
@@ -20,6 +20,7 @@ import {
   buildDeviceUnlinkMessage,
   buildPreferencesUpdateMessage,
 } from '../notifications.constants';
+import { buildRoomMuteMessage } from '@/token-gated-rooms/notifications/room-mute.message';
 import notificationsConfig from '../notifications.config';
 
 export interface IssuedChallenge {
@@ -133,6 +134,29 @@ export class DeviceChallengeService {
       address,
       signature,
       buildPreferencesUpdateMessage(address, nonce, preferences),
+    );
+  }
+
+  /**
+   * Same atomic verify, but against the **room-mute** message (Task 13). The
+   * shared nonce table is reused; the distinct intent line (`Superhero Rooms\nMute
+   * <saleAddress> for <address>`) plus the body hash over `(muted, mute_all)`
+   * prevent cross-replay from the prefs/device intents AND prevent the mute flags
+   * (or the target room) from being swapped on a captured nonce+sig.
+   */
+  async verifyAndConsumeForRoomMute(
+    nonce: string,
+    address: string,
+    saleAddress: string,
+    muted: boolean,
+    muteAll: boolean | undefined,
+    signature: string,
+  ): Promise<void> {
+    await this.verifyWithMessage(
+      nonce,
+      address,
+      signature,
+      buildRoomMuteMessage(address, nonce, saleAddress, muted, muteAll),
     );
   }
 

--- a/src/plugins/address-links/address-links-plugin-sync.service.spec.ts
+++ b/src/plugins/address-links/address-links-plugin-sync.service.spec.ts
@@ -1,6 +1,7 @@
 import { Test } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { decode } from '@aeternity/aepp-sdk';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { SyncDirectionEnum } from '@/mdw-sync/types/sync-direction';
 import { AddressLinksPluginSyncService } from './address-links-plugin-sync.service';
 import { Account } from '@/account/entities/account.entity';
@@ -8,6 +9,7 @@ import { AeSdkService } from '@/ae/ae-sdk.service';
 import { ProfileCacheService } from '@/profile/services/profile-cache.service';
 import { ProfileXPostingRewardService } from '@/profile/services/profile-x-posting-reward.service';
 import { Tx } from '@/mdw-sync/entities/tx.entity';
+import { TGR_LINK_CHANGED } from '@/token-gated-rooms/events';
 
 const SIGNER_ADDRESS = 'ak_2EZDUTjrzPUikzNereYcBHMYHXaLTn9F6SJJhw6kDEiP4F4Amo';
 const SIGNER_ADDRESS_INT = BigInt(
@@ -32,6 +34,7 @@ describe('AddressLinksPluginSyncService', () => {
     where: jest.Mock;
   };
   let profileCacheService: { syncFromAccountLinks: jest.Mock };
+  let eventEmitter: { emit: jest.Mock };
 
   beforeEach(async () => {
     queryBuilder = {
@@ -55,6 +58,8 @@ describe('AddressLinksPluginSyncService', () => {
       syncFromAccountLinks: jest.fn().mockResolvedValue(undefined),
     };
 
+    eventEmitter = { emit: jest.fn() };
+
     const moduleRef = await Test.createTestingModule({
       providers: [
         AddressLinksPluginSyncService,
@@ -72,6 +77,10 @@ describe('AddressLinksPluginSyncService', () => {
         {
           provide: ProfileCacheService,
           useValue: profileCacheService,
+        },
+        {
+          provide: EventEmitter2,
+          useValue: eventEmitter,
         },
       ],
     }).compile();
@@ -291,5 +300,70 @@ describe('AddressLinksPluginSyncService', () => {
     );
 
     fetchSpy.mockRestore();
+  });
+
+  describe('tgr.link.changed seam (Task 05)', () => {
+    it('emits tgr.link.changed on a nostr link', async () => {
+      await service.processTransaction(
+        baseTx({
+          function: 'link',
+          hash: 'th_nostr_link',
+          raw: {
+            arguments: [
+              { type: 'address', value: SIGNER_ADDRESS },
+              { type: 'string', value: 'nostr' },
+              { type: 'string', value: 'npub1abc' },
+              { type: 'int', value: '1' },
+            ],
+          },
+        }),
+        SyncDirectionEnum.Live,
+      );
+
+      expect(eventEmitter.emit).toHaveBeenCalledWith(TGR_LINK_CHANGED, {
+        address: SIGNER_ADDRESS,
+      });
+    });
+
+    it('emits tgr.link.changed on a nostr unlink', async () => {
+      await service.processTransaction(
+        baseTx({
+          function: 'unlink',
+          hash: 'th_nostr_unlink',
+          raw: {
+            arguments: [
+              { type: 'address', value: SIGNER_ADDRESS },
+              { type: 'string', value: 'nostr' },
+              { type: 'int', value: '1' },
+            ],
+          },
+        }),
+        SyncDirectionEnum.Live,
+      );
+
+      expect(eventEmitter.emit).toHaveBeenCalledWith(TGR_LINK_CHANGED, {
+        address: SIGNER_ADDRESS,
+      });
+    });
+
+    it('does NOT emit tgr.link.changed for a non-nostr provider', async () => {
+      await service.processTransaction(
+        baseTx({
+          function: 'link',
+          hash: 'th_site_link',
+          raw: {
+            arguments: [
+              { type: 'address', value: SIGNER_ADDRESS },
+              { type: 'string', value: 'site' },
+              { type: 'string', value: 'www.wikipedia.org' },
+              { type: 'int', value: '1' },
+            ],
+          },
+        }),
+        SyncDirectionEnum.Live,
+      );
+
+      expect(eventEmitter.emit).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/plugins/address-links/address-links-plugin-sync.service.ts
+++ b/src/plugins/address-links/address-links-plugin-sync.service.ts
@@ -1,7 +1,8 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, Optional } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { encode, Encoding } from '@aeternity/aepp-sdk';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { Tx } from '@/mdw-sync/entities/tx.entity';
 import { Account } from '@/account/entities/account.entity';
 import { AeSdkService } from '@/ae/ae-sdk.service';
@@ -11,6 +12,18 @@ import { BasePluginSyncService } from '../base-plugin-sync.service';
 import { SyncDirection } from '../plugin.interface';
 import { ACTIVE_NETWORK } from '@/configs/network';
 import { ADDRESS_LINK_CONTRACT_ADDRESS } from './address-links.constants';
+import {
+  TGR_LINK_CHANGED,
+  TgrLinkChangedPayload,
+} from '@/token-gated-rooms/events';
+
+/**
+ * Token-gated-rooms link provider (default `nostr`, env-overridable). Token-gated
+ * rooms only care about the nostr link, so the `tgr.link.changed` seam below
+ * fires only for this provider to avoid waking the identity pipeline on unrelated
+ * link/unlink (x/site/bio/…). Kept in lockstep with `tgrConfig.nostrLinkProvider`
+ * via the same `NOSTR_LINK_PROVIDER` env var. */
+const NOSTR_LINK_PROVIDER = process.env.NOSTR_LINK_PROVIDER || 'nostr';
 
 const LINK_EVENT_HASH =
   '6SB35NM6QMV5IG8BGTLL5O77IU72C5E3OC63PB4KHNDNSS83HAOG====';
@@ -30,8 +43,28 @@ export class AddressLinksPluginSyncService extends BasePluginSyncService {
     private readonly accountRepo: Repository<Account>,
     private readonly profileXPostingRewardService: ProfileXPostingRewardService,
     private readonly profileCacheService: ProfileCacheService,
+    // Optional so the existing unit DI (which builds a minimal testing module)
+    // still resolves; the global EventEmitterModule provides it in the real app.
+    // This is the Task 05 seam: emit `tgr.link.changed` on nostr link/unlink so
+    // the identity-resolution pipeline (IdentityService) re-resolves member_pubkey
+    // and the eligibility service (Task 06) re-evaluates. Reactive correctness for
+    // existing links is covered by IdentityBackfillService at startup.
+    @Optional()
+    private readonly eventEmitter?: EventEmitter2,
   ) {
     super(aeSdkService);
+  }
+
+  /**
+   * Notify the token-gated-rooms identity pipeline that an account's nostr link
+   * changed. Fires only for the nostr provider (token-gated rooms ignore other
+   * providers) and is a no-op when no EventEmitter is wired (e.g. minimal tests).
+   */
+  private emitTgrLinkChanged(provider: string, address: string): void {
+    if (provider !== NOSTR_LINK_PROVIDER) return;
+    if (!this.eventEmitter) return;
+    const payload: TgrLinkChangedPayload = { address };
+    this.eventEmitter.emit(TGR_LINK_CHANGED, payload);
   }
 
   async processTransaction(
@@ -275,6 +308,9 @@ export class AddressLinksPluginSyncService extends BasePluginSyncService {
       tx.micro_time?.toString?.(),
     );
 
+    // Task 05 seam: tell the identity pipeline this nostr link changed.
+    this.emitTgrLinkChanged(provider, address);
+
     if (provider === 'x') {
       // TODO(reward-program): The X posting reward is disabled right now (see
       // PROFILE_REWARDS_DISABLED / PROFILE_X_POSTING_REWARD_ENABLED), so this
@@ -323,5 +359,8 @@ export class AddressLinksPluginSyncService extends BasePluginSyncService {
       address,
       tx.micro_time?.toString?.(),
     );
+
+    // Task 05 seam: tell the identity pipeline this nostr link was removed.
+    this.emitTgrLinkChanged(provider, address);
   }
 }

--- a/src/plugins/bcl/bcl-plugin.module.ts
+++ b/src/plugins/bcl/bcl-plugin.module.ts
@@ -12,6 +12,7 @@ import { TokenHolder } from '@/tokens/entities/token-holders.entity';
 import { Token } from '@/tokens/entities/token.entity';
 import { AccountModule } from '@/account/account.module';
 import { PULL_TOKEN_INFO_QUEUE } from '@/tokens/queues/constants';
+import { Aex9TransferPluginModule } from '@/token-gated-rooms/plugins/aex9-transfer-plugin.module';
 import { BclPlugin } from './bcl.plugin';
 import { BclPluginSyncService } from './bcl-plugin-sync.service';
 import { TransactionsService } from './services/transactions.service';
@@ -36,6 +37,11 @@ import { TokenHolderService } from './services/token-holder.service';
     AccountModule,
     AePricingModule,
     AeModule,
+    // `TokenHolderService` mirrors buy/sell deltas into `token_balance` via
+    // `BalanceIndexerService` (see its module doc) — buy/sell never reaches
+    // `Aex9TransferSyncService` since those calls target the sale contract,
+    // not the AEX9 token contract itself.
+    Aex9TransferPluginModule,
     BullModule.registerQueue({
       name: PULL_TOKEN_INFO_QUEUE,
     }),

--- a/src/plugins/bcl/config/bcl.config.ts
+++ b/src/plugins/bcl/config/bcl.config.ts
@@ -12,10 +12,6 @@ export const BCL_CONTRACT = {
   get contractAddress(): Encoded.ContractAddress {
     return BCL_FACTORY[ACTIVE_NETWORK_ID]?.address as Encoded.ContractAddress;
   },
-  get collectionAddress(): string {
-    const collections = BCL_FACTORY[ACTIVE_NETWORK_ID]?.collections;
-    return (collections && Object.keys(collections)[0]) ?? '';
-  },
   get startHeight(): number {
     return BCL_FACTORY[ACTIVE_NETWORK_ID]?.deployed_at_block_height ?? 0;
   },

--- a/src/plugins/bcl/services/token-holder.service.spec.ts
+++ b/src/plugins/bcl/services/token-holder.service.spec.ts
@@ -14,7 +14,10 @@ describe('TokenHolderService', () => {
     update: jest.Mock;
     loadAndSaveTokenHoldersFromMdw: jest.Mock;
   };
-  let eventEmitter: { emit: jest.Mock };
+  let balanceIndexer: {
+    applyDelta: jest.Mock;
+    emitBalanceChanged: jest.Mock;
+  };
 
   beforeEach(() => {
     const queryBuilder = {
@@ -35,22 +38,25 @@ describe('TokenHolderService', () => {
       loadAndSaveTokenHoldersFromMdw: jest.fn().mockResolvedValue(undefined),
     };
 
-    eventEmitter = { emit: jest.fn() };
+    balanceIndexer = {
+      applyDelta: jest.fn().mockResolvedValue(new BigNumber('1')),
+      emitBalanceChanged: jest.fn(),
+    };
 
     service = new TokenHolderService(
       repository as any,
       tokenService as any,
-      eventEmitter as any,
+      balanceIndexer as any,
     );
   });
 
-  it('emits tgr.balance.changed after a balance update so room eligibility recomputes', async () => {
+  it('standalone (no manager): mirrors the buy delta into token_balance and emits immediately', async () => {
     repository.findOne.mockResolvedValue({
       id: 'ak_user_ct_token',
       balance: new BigNumber('1000000000000000000'),
     });
 
-    await service.updateTokenHolder(
+    const deferred = await service.updateTokenHolder(
       { address: 'ct_token', sale_address: 'ct_sale', holders_count: 1 } as any,
       {
         function: BCL_FUNCTIONS.buy,
@@ -61,10 +67,108 @@ describe('TokenHolderService', () => {
       new BigNumber(1),
     );
 
-    expect(eventEmitter.emit).toHaveBeenCalledWith('tgr.balance.changed', {
-      tokenAddress: 'ct_token',
-      holderAddress: 'ak_user',
+    // No outer transaction → applyDelta gets no manager and emit fires now.
+    expect(balanceIndexer.applyDelta).toHaveBeenCalledWith(
+      'ct_token',
+      'ak_user',
+      expect.any(BigNumber),
+      12,
+      undefined,
+    );
+    const [, , appliedDelta] = balanceIndexer.applyDelta.mock.calls[0];
+    expect(appliedDelta.isPositive()).toBe(true);
+    expect(balanceIndexer.emitBalanceChanged).toHaveBeenCalledWith(
+      'ct_token',
+      'ak_user',
+    );
+    // Nothing left for a caller to fire post-commit.
+    expect(deferred).toBeNull();
+  });
+
+  it('transactional (manager): routes the write through the manager and DEFERS the emit until the returned callback fires', async () => {
+    repository.findOne.mockResolvedValue({
+      id: 'ak_user_ct_token',
+      balance: new BigNumber('1000000000000000000'),
     });
+    const manager = { getRepository: jest.fn() } as any;
+
+    const deferred = await service.updateTokenHolder(
+      { address: 'ct_token', sale_address: 'ct_sale', holders_count: 1 } as any,
+      {
+        function: BCL_FUNCTIONS.buy,
+        caller_id: 'ak_user',
+        hash: 'th_buy3',
+        block_height: 14,
+      } as any,
+      new BigNumber(1),
+      manager,
+    );
+
+    // The token_balance write must join the outer transaction (manager passed).
+    expect(balanceIndexer.applyDelta).toHaveBeenCalledWith(
+      'ct_token',
+      'ak_user',
+      expect.any(BigNumber),
+      14,
+      manager,
+    );
+    // Crucially: NOT emitted yet — a rollback after this point must discard it.
+    expect(balanceIndexer.emitBalanceChanged).not.toHaveBeenCalled();
+
+    // The caller fires it only after commit.
+    expect(typeof deferred).toBe('function');
+    deferred!();
+    expect(balanceIndexer.emitBalanceChanged).toHaveBeenCalledWith(
+      'ct_token',
+      'ak_user',
+    );
+  });
+
+  it('transactional (manager): no balance change → no deferred callback, no emit', async () => {
+    balanceIndexer.applyDelta.mockResolvedValue(null);
+    repository.findOne.mockResolvedValue({
+      id: 'ak_user_ct_token',
+      balance: new BigNumber('1000000000000000000'),
+    });
+    const manager = { getRepository: jest.fn() } as any;
+
+    const deferred = await service.updateTokenHolder(
+      { address: 'ct_token', sale_address: 'ct_sale', holders_count: 1 } as any,
+      {
+        function: BCL_FUNCTIONS.buy,
+        caller_id: 'ak_user',
+        hash: 'th_buy4',
+        block_height: 15,
+      } as any,
+      new BigNumber(1),
+      manager,
+    );
+
+    expect(deferred).toBeNull();
+    expect(balanceIndexer.emitBalanceChanged).not.toHaveBeenCalled();
+  });
+
+  it('mirrors the sell delta as negative and skips the emit when applyDelta reports no change', async () => {
+    balanceIndexer.applyDelta.mockResolvedValue(null);
+    repository.findOne.mockResolvedValue({
+      id: 'ak_user_ct_token',
+      balance: new BigNumber('2000000000000000000'),
+    });
+
+    await service.updateTokenHolder(
+      { address: 'ct_token', sale_address: 'ct_sale', holders_count: 1 } as any,
+      {
+        function: BCL_FUNCTIONS.sell,
+        caller_id: 'ak_user',
+        hash: 'th_sell2',
+        block_height: 13,
+      } as any,
+      new BigNumber(1),
+    );
+
+    const [, , appliedDelta] = balanceIndexer.applyDelta.mock.calls[0];
+    expect(appliedDelta.isNegative()).toBe(true);
+    expect(balanceIndexer.emitBalanceChanged).not.toHaveBeenCalled();
   });
 
   it('removes a holder from the count when they sell their full balance', async () => {

--- a/src/plugins/bcl/services/token-holder.service.spec.ts
+++ b/src/plugins/bcl/services/token-holder.service.spec.ts
@@ -14,6 +14,7 @@ describe('TokenHolderService', () => {
     update: jest.Mock;
     loadAndSaveTokenHoldersFromMdw: jest.Mock;
   };
+  let eventEmitter: { emit: jest.Mock };
 
   beforeEach(() => {
     const queryBuilder = {
@@ -34,7 +35,36 @@ describe('TokenHolderService', () => {
       loadAndSaveTokenHoldersFromMdw: jest.fn().mockResolvedValue(undefined),
     };
 
-    service = new TokenHolderService(repository as any, tokenService as any);
+    eventEmitter = { emit: jest.fn() };
+
+    service = new TokenHolderService(
+      repository as any,
+      tokenService as any,
+      eventEmitter as any,
+    );
+  });
+
+  it('emits tgr.balance.changed after a balance update so room eligibility recomputes', async () => {
+    repository.findOne.mockResolvedValue({
+      id: 'ak_user_ct_token',
+      balance: new BigNumber('1000000000000000000'),
+    });
+
+    await service.updateTokenHolder(
+      { address: 'ct_token', sale_address: 'ct_sale', holders_count: 1 } as any,
+      {
+        function: BCL_FUNCTIONS.buy,
+        caller_id: 'ak_user',
+        hash: 'th_buy2',
+        block_height: 12,
+      } as any,
+      new BigNumber(1),
+    );
+
+    expect(eventEmitter.emit).toHaveBeenCalledWith('tgr.balance.changed', {
+      tokenAddress: 'ct_token',
+      holderAddress: 'ak_user',
+    });
   });
 
   it('removes a holder from the count when they sell their full balance', async () => {

--- a/src/plugins/bcl/services/token-holder.service.ts
+++ b/src/plugins/bcl/services/token-holder.service.ts
@@ -1,16 +1,12 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { EventEmitter2 } from '@nestjs/event-emitter';
 import { Repository, EntityManager } from 'typeorm';
 import { Tx } from '@/mdw-sync/entities/tx.entity';
 import { Token } from '@/tokens/entities/token.entity';
 import { TokenHolder } from '@/tokens/entities/token-holders.entity';
 import { TokensService } from '@/tokens/tokens.service';
 import { BCL_FUNCTIONS } from '@/configs';
-import {
-  TGR_BALANCE_CHANGED,
-  type TgrBalanceChangedPayload,
-} from '@/token-gated-rooms/events';
+import { BalanceIndexerService } from '@/token-gated-rooms/services/balance-indexer.service';
 import { Encoded } from '@aeternity/aepp-sdk';
 import BigNumber from 'bignumber.js';
 
@@ -22,7 +18,7 @@ export class TokenHolderService {
     @InjectRepository(TokenHolder)
     private tokenHolderRepository: Repository<TokenHolder>,
     private readonly tokenService: TokensService,
-    private readonly eventEmitter: EventEmitter2,
+    private readonly balanceIndexer: BalanceIndexerService,
   ) {}
 
   /**
@@ -87,20 +83,32 @@ export class TokenHolderService {
   /**
    * Update token holder based on transaction
    * Optimized for performance with single query and simplified logic
+   *
+   * Returns a post-commit callback the caller MUST invoke *after* the
+   * surrounding transaction commits (when a transactional `manager` is passed),
+   * or `null` when there is nothing to emit. The `tgr.balance.changed` emit is
+   * deferred this way so it never fires on a balance the outer transaction then
+   * rolls back, and so `EligibilityService` never recomputes off a value that is
+   * not yet visible on other connections. In the standalone path (no `manager`,
+   * so no outer transaction) the emit fires immediately and `null` is returned.
    */
   async updateTokenHolder(
     token: Token,
     tx: Tx,
     volume: BigNumber,
     manager?: EntityManager,
-  ): Promise<void> {
+  ): Promise<(() => void) | null> {
     // Early return if token.address is null (token not yet initialized)
     if (!token.address) {
-      return;
+      return null;
     }
 
     // Determine transaction type upfront
     const isBuy = this.isBuyTransaction(tx, volume);
+
+    // Set inside the try when a balance change is persisted; returned to the
+    // caller to fire AFTER the surrounding transaction commits (see doc above).
+    let emitBalanceChanged: (() => void) | null = null;
 
     try {
       const bigNumberVolume = new BigNumber(volume).multipliedBy(10 ** 18);
@@ -142,7 +150,7 @@ export class TokenHolderService {
         // Create new holder (only for buy transactions)
         if (!isBuy) {
           // Can't create holder for sell transaction
-          return;
+          return null;
         }
 
         await repository.save({
@@ -163,16 +171,43 @@ export class TokenHolderService {
         await this.updateTokenHoldersCount(token, tokenHolderCount, manager);
       }
 
-      // Notify token-gated-rooms that this holder's balance for `token.address`
-      // (the AEX9 contract) changed, so room eligibility backed by this token is
-      // recomputed reactively (buy/sell is the primary acquisition path). In-process
-      // EventEmitter2, main process only — `EligibilityService.onBalanceChanged`
-      // consumes it. `token.address` is non-null here (early-returned above); the
-      // sell-with-no-holder case returned before this point (no balance change).
-      this.eventEmitter.emit(TGR_BALANCE_CHANGED, {
-        tokenAddress: token.address,
-        holderAddress: tx.caller_id,
-      } as TgrBalanceChangedPayload);
+      // Mirror this delta into `token_balance` — the AEX9 indexer's ledger that
+      // `EligibilityService` reads for room eligibility (Task 06). Buy/sell calls
+      // hit the sale/bonding-curve contract, not the AEX9 token contract itself,
+      // so `Aex9TransferSyncService` never sees these txs and `token_balance`
+      // would otherwise never reflect buy/sell balance changes. Going through
+      // `BalanceIndexerService.applyDelta` (same helper the AEX9 indexer uses)
+      // keeps both ledgers consistent, and emitting only when it reports a real
+      // change avoids waking `EligibilityService.onBalanceChanged` on a stale or
+      // no-op balance. `token.address` is non-null here (early-returned above);
+      // the sell-with-no-holder case returned before this point.
+      //
+      // Pass `manager` so this write joins the SAME transaction as the
+      // `token_holders` update above: an outer rollback must revert both
+      // ledgers atomically, never leave `token_balance` ahead of real holdings.
+      const tokenAddress = token.address;
+      const holderAddress = tx.caller_id;
+      const delta = isBuy ? bigNumberVolume : bigNumberVolume.negated();
+      const changed = await this.balanceIndexer.applyDelta(
+        tokenAddress,
+        holderAddress,
+        delta,
+        tx.block_height ?? 0,
+        manager,
+      );
+      if (changed !== null) {
+        // Defer the emit past the outer transaction's commit (the caller fires
+        // the returned callback). Emitting here — before commit — would let
+        // `EligibilityService` recompute off a balance that is not yet visible
+        // on its connection, or one a rollback then discards. With no `manager`
+        // there is no outer transaction, so emit immediately and return null.
+        emitBalanceChanged = () =>
+          this.balanceIndexer.emitBalanceChanged(tokenAddress, holderAddress);
+        if (!manager) {
+          emitBalanceChanged();
+          emitBalanceChanged = null;
+        }
+      }
     } catch (error) {
       this.logger.error('Error updating token holder', error);
       throw error;
@@ -192,5 +227,7 @@ export class TokenHolderService {
         );
       }
     }
+
+    return emitBalanceChanged;
   }
 }

--- a/src/plugins/bcl/services/token-holder.service.ts
+++ b/src/plugins/bcl/services/token-holder.service.ts
@@ -1,11 +1,16 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { Repository, EntityManager } from 'typeorm';
 import { Tx } from '@/mdw-sync/entities/tx.entity';
 import { Token } from '@/tokens/entities/token.entity';
 import { TokenHolder } from '@/tokens/entities/token-holders.entity';
 import { TokensService } from '@/tokens/tokens.service';
 import { BCL_FUNCTIONS } from '@/configs';
+import {
+  TGR_BALANCE_CHANGED,
+  type TgrBalanceChangedPayload,
+} from '@/token-gated-rooms/events';
 import { Encoded } from '@aeternity/aepp-sdk';
 import BigNumber from 'bignumber.js';
 
@@ -17,6 +22,7 @@ export class TokenHolderService {
     @InjectRepository(TokenHolder)
     private tokenHolderRepository: Repository<TokenHolder>,
     private readonly tokenService: TokensService,
+    private readonly eventEmitter: EventEmitter2,
   ) {}
 
   /**
@@ -156,6 +162,17 @@ export class TokenHolderService {
 
         await this.updateTokenHoldersCount(token, tokenHolderCount, manager);
       }
+
+      // Notify token-gated-rooms that this holder's balance for `token.address`
+      // (the AEX9 contract) changed, so room eligibility backed by this token is
+      // recomputed reactively (buy/sell is the primary acquisition path). In-process
+      // EventEmitter2, main process only — `EligibilityService.onBalanceChanged`
+      // consumes it. `token.address` is non-null here (early-returned above); the
+      // sell-with-no-holder case returned before this point (no balance change).
+      this.eventEmitter.emit(TGR_BALANCE_CHANGED, {
+        tokenAddress: token.address,
+        holderAddress: tx.caller_id,
+      } as TgrBalanceChangedPayload);
     } catch (error) {
       this.logger.error('Error updating token holder', error);
       throw error;

--- a/src/plugins/bcl/services/transaction-processor.service.ts
+++ b/src/plugins/bcl/services/transaction-processor.service.ts
@@ -59,6 +59,11 @@ export class TransactionProcessorService {
 
     const saleAddress = validation.saleAddress;
 
+    // Deferred `tgr.balance.changed` emit from updateTokenHolder — fired only
+    // AFTER the transaction below commits, so room eligibility never recomputes
+    // off a balance a rollback discards (or one not yet visible to its reader).
+    let emitBalanceChanged: (() => void) | null = null;
+
     // Wrap all DB operations in a single transaction
     const result = await this.transactionRepository.manager.transaction(
       async (manager) => {
@@ -222,8 +227,9 @@ export class TransactionProcessorService {
         if (syncDirection === SyncDirectionEnum.Live) {
           await this.tokenService.syncTokenPrice(transactionToken, manager);
 
-          // Update token holder
-          await this.tokenHolderService.updateTokenHolder(
+          // Update token holder. The balance-changed emit is deferred and
+          // fired after this transaction commits (see below).
+          emitBalanceChanged = await this.tokenHolderService.updateTokenHolder(
             transactionToken,
             decodedTx,
             parsedData.volume,
@@ -239,6 +245,12 @@ export class TransactionProcessorService {
         };
       },
     );
+
+    // Transaction committed — now it is safe to wake room eligibility off the
+    // freshly-persisted (and durable) token_balance. If the transaction had
+    // rolled back, `.transaction()` would have thrown and we would never reach
+    // this line, so a discarded balance never emits.
+    emitBalanceChanged?.();
 
     // Update token trending score (non-critical operation outside transaction)
     if (result?.isSupported && syncDirection === SyncDirectionEnum.Live) {

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -16,6 +16,10 @@ import { GovernancePopularRankingService } from './governance/services/governanc
 import { PopularRankingContributor } from './popular-ranking.interface';
 import { AddressLinksPlugin } from './address-links/address-links.plugin';
 import { AddressLinksPluginModule } from './address-links/address-links-plugin.module';
+import { Aex9TransferPlugin } from '@/token-gated-rooms/plugins/aex9-transfer.plugin';
+import { Aex9TransferPluginModule } from '@/token-gated-rooms/plugins/aex9-transfer-plugin.module';
+import { CommunityRoomStatePlugin } from '@/token-gated-rooms/plugins/community-room-state.plugin';
+import { CommunityRoomStatePluginModule } from '@/token-gated-rooms/plugins/community-room-state-plugin.module';
 
 /**
  * Export all plugin modules
@@ -29,6 +33,8 @@ export const PLUGIN_MODULES: Type[] = [
   BclAffiliationPluginModule,
   GovernancePluginModule,
   AddressLinksPluginModule,
+  Aex9TransferPluginModule,
+  CommunityRoomStatePluginModule,
 ];
 
 /**
@@ -46,6 +52,8 @@ export const getPluginProvider = (): Provider => ({
     bclAffiliationPlugin: BclAffiliationPlugin,
     governancePlugin: GovernancePlugin,
     addressLinksPlugin: AddressLinksPlugin,
+    aex9TransferPlugin: Aex9TransferPlugin,
+    communityRoomStatePlugin: CommunityRoomStatePlugin,
   ) => {
     return [
       bclPlugin,
@@ -55,6 +63,8 @@ export const getPluginProvider = (): Provider => ({
       bclAffiliationPlugin,
       governancePlugin,
       addressLinksPlugin,
+      aex9TransferPlugin,
+      communityRoomStatePlugin,
     ];
   },
   inject: [
@@ -65,6 +75,8 @@ export const getPluginProvider = (): Provider => ({
     BclAffiliationPlugin,
     GovernancePlugin,
     AddressLinksPlugin,
+    Aex9TransferPlugin,
+    CommunityRoomStatePlugin,
   ],
 });
 

--- a/src/plugins/social/services/topic-management.service.ts
+++ b/src/plugins/social/services/topic-management.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, EntityManager } from 'typeorm';
 import { Topic } from '@/social/entities/topic.entity';
 import { Post } from '@/social/entities/post.entity';
+import { normalizeTopicName } from '@/social/utils/topic-name.util';
 
 @Injectable()
 export class TopicManagementService {
@@ -31,7 +32,7 @@ export class TopicManagementService {
         continue;
       }
 
-      const normalizedName = topicName.trim().toLowerCase();
+      const normalizedName = normalizeTopicName(topicName);
 
       // Try to find existing topic
       let topic = await this.topicRepository.findOne({

--- a/src/process-guards.ts
+++ b/src/process-guards.ts
@@ -1,0 +1,27 @@
+/**
+ * Global process-level guards shared by the main (`main.ts`) and worker
+ * (`worker.bootstrap.ts`) bootstraps.
+ *
+ * After logging we explicitly exit with code 1 so that the process manager
+ * (Docker, PM2, systemd, etc.) can restart the service. Continuing after these
+ * events is unsafe. Extracted (rather than duplicated) so both entrypoints share
+ * identical behavior and cannot diverge.
+ */
+export function registerProcessGuards(): void {
+  process.on('uncaughtException', (error: unknown) => {
+    // eslint-disable-next-line no-console
+    console.error('UNCAUGHT EXCEPTION, process will exit:', error);
+    process.exit(1);
+  });
+
+  process.on('unhandledRejection', (reason: unknown) => {
+    // eslint-disable-next-line no-console
+    console.error('UNHANDLED REJECTION, process will exit:', reason);
+    process.exit(1);
+  });
+
+  process.on('exit', (code: number) => {
+    // eslint-disable-next-line no-console
+    console.error('Process exiting with code', code);
+  });
+}

--- a/src/social/controllers/posts.controller.spec.ts
+++ b/src/social/controllers/posts.controller.spec.ts
@@ -117,4 +117,99 @@ describe('PostsController', () => {
       expect.any(Object),
     );
   });
+
+  describe('trend mention performance', () => {
+    const attachTrendMentions = (
+      items: Array<{ id: string; content: string }>,
+      tokens: Array<Record<string, any>>,
+    ) => {
+      const tokenQueryBuilder = {
+        leftJoinAndMapOne: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue(tokens),
+      };
+      const tokenRepository = {
+        createQueryBuilder: jest.fn().mockReturnValue(tokenQueryBuilder),
+      };
+      const trendController = new PostsController(
+        {} as any,
+        tokenRepository as any,
+        {} as any,
+        {} as any,
+        {} as any,
+      );
+
+      return {
+        tokenQueryBuilder,
+        run: () =>
+          (trendController as any).attachTrendMentionsPerformance(items),
+      };
+    };
+
+    it('resolves a hashtag naming a token from a non-Latin collection', async () => {
+      const items = [{ id: 'post-1', content: 'accumulating #汉字 早期' }];
+      const { tokenQueryBuilder, run } = attachTrendMentions(items, [
+        { symbol: '汉字', sale_address: 'ct_chinese', performance: { pct: 1 } },
+      ]);
+
+      await run();
+
+      expect(tokenQueryBuilder.andWhere).toHaveBeenCalledWith(
+        'UPPER(token.symbol) IN (:...names)',
+        { names: ['汉字'] },
+      );
+      expect((items[0] as any).trend_mentions).toEqual([
+        {
+          name: '汉字',
+          sale_address: 'ct_chinese',
+          performance: { pct: 1 },
+        },
+      ]);
+    });
+
+    it('resolves a lowercase Cyrillic hashtag onto the uppercase symbol', async () => {
+      const items = [{ id: 'post-2', content: 'держим #привет' }];
+      const { tokenQueryBuilder, run } = attachTrendMentions(items, [
+        { symbol: 'ПРИВЕТ', sale_address: 'ct_russian', performance: null },
+      ]);
+
+      await run();
+
+      expect(tokenQueryBuilder.andWhere).toHaveBeenCalledWith(
+        'UPPER(token.symbol) IN (:...names)',
+        { names: ['ПРИВЕТ'] },
+      );
+      expect((items[0] as any).trend_mentions).toEqual([
+        { name: 'ПРИВЕТ', sale_address: 'ct_russian', performance: null },
+      ]);
+    });
+
+    it('resolves Latin and non-Latin hashtags in the same post', async () => {
+      const items = [{ id: 'post-3', content: 'swapping #WORDS-1 for #汉字' }];
+      const { run } = attachTrendMentions(items, [
+        { symbol: 'WORDS-1', sale_address: 'ct_words', performance: null },
+        { symbol: '汉字', sale_address: 'ct_chinese', performance: null },
+      ]);
+
+      await run();
+
+      expect((items[0] as any).trend_mentions).toEqual([
+        { name: 'WORDS-1', sale_address: 'ct_words', performance: null },
+        { name: '汉字', sale_address: 'ct_chinese', performance: null },
+      ]);
+    });
+
+    it('reports a mention with no matching token as an unresolved trend', async () => {
+      const items = [{ id: 'post-4', content: 'hyping #汉字' }];
+      const { run } = attachTrendMentions(items, []);
+
+      await run();
+
+      expect((items[0] as any).trend_mentions).toEqual([
+        { name: '汉字', sale_address: null, performance: null },
+      ]);
+    });
+  });
 });

--- a/src/social/controllers/posts.controller.spec.ts
+++ b/src/social/controllers/posts.controller.spec.ts
@@ -56,6 +56,7 @@ describe('PostsController', () => {
       {} as any,
       {} as any,
       {} as any,
+      {} as any,
     );
   });
 
@@ -101,6 +102,10 @@ describe('PostsController', () => {
       {
         getProfilesByAddresses: jest.fn().mockResolvedValue([]),
       } as any,
+      {
+        getCurrentFactory: jest.fn().mockResolvedValue({ collections: {} }),
+        mapCollectionInfo: jest.fn().mockReturnValue(null),
+      } as any,
     );
 
     await popularController.popular({
@@ -122,6 +127,7 @@ describe('PostsController', () => {
     const attachTrendMentions = (
       items: Array<{ id: string; content: string }>,
       tokens: Array<Record<string, any>>,
+      collections: Record<string, any> = {},
     ) => {
       const tokenQueryBuilder = {
         leftJoinAndMapOne: jest.fn().mockReturnThis(),
@@ -133,12 +139,31 @@ describe('PostsController', () => {
       const tokenRepository = {
         createQueryBuilder: jest.fn().mockReturnValue(tokenQueryBuilder),
       };
+      // Faithful stand-in for CommunityFactoryService.mapCollectionInfo so the
+      // resolved collection badge reflects the real lookup behaviour.
+      const communityFactoryService = {
+        getCurrentFactory: jest.fn().mockResolvedValue({ collections }),
+        mapCollectionInfo: jest.fn((factory, collectionId) => {
+          const collection = collectionId
+            ? factory?.collections?.[collectionId]
+            : undefined;
+          return collection
+            ? {
+                id: collection.id,
+                name: collection.name,
+                description: collection.description,
+                allowed_name_length: collection.allowed_name_length,
+              }
+            : null;
+        }),
+      };
       const trendController = new PostsController(
         {} as any,
         tokenRepository as any,
         {} as any,
         {} as any,
         {} as any,
+        communityFactoryService as any,
       );
 
       return {
@@ -164,6 +189,7 @@ describe('PostsController', () => {
         {
           name: '汉字',
           sale_address: 'ct_chinese',
+          collection_info: null,
           performance: { pct: 1 },
         },
       ]);
@@ -182,7 +208,12 @@ describe('PostsController', () => {
         { names: ['ПРИВЕТ'] },
       );
       expect((items[0] as any).trend_mentions).toEqual([
-        { name: 'ПРИВЕТ', sale_address: 'ct_russian', performance: null },
+        {
+          name: 'ПРИВЕТ',
+          sale_address: 'ct_russian',
+          collection_info: null,
+          performance: null,
+        },
       ]);
     });
 
@@ -196,8 +227,18 @@ describe('PostsController', () => {
       await run();
 
       expect((items[0] as any).trend_mentions).toEqual([
-        { name: 'WORDS-1', sale_address: 'ct_words', performance: null },
-        { name: '汉字', sale_address: 'ct_chinese', performance: null },
+        {
+          name: 'WORDS-1',
+          sale_address: 'ct_words',
+          collection_info: null,
+          performance: null,
+        },
+        {
+          name: '汉字',
+          sale_address: 'ct_chinese',
+          collection_info: null,
+          performance: null,
+        },
       ]);
     });
 
@@ -208,7 +249,52 @@ describe('PostsController', () => {
       await run();
 
       expect((items[0] as any).trend_mentions).toEqual([
-        { name: '汉字', sale_address: null, performance: null },
+        {
+          name: '汉字',
+          sale_address: null,
+          collection_info: null,
+          performance: null,
+        },
+      ]);
+    });
+
+    it('attaches resolved collection metadata to a mentioned token', async () => {
+      const items = [{ id: 'post-5', content: 'buying #汉字' }];
+      const collectionId = '汉字-ak_deployer';
+      const { run } = attachTrendMentions(
+        items,
+        [
+          {
+            symbol: '汉字',
+            sale_address: 'ct_chinese',
+            collection: collectionId,
+            performance: null,
+          },
+        ],
+        {
+          [collectionId]: {
+            id: collectionId,
+            name: '汉字',
+            description: 'Chinese collection',
+            allowed_name_length: '20',
+          },
+        },
+      );
+
+      await run();
+
+      expect((items[0] as any).trend_mentions).toEqual([
+        {
+          name: '汉字',
+          sale_address: 'ct_chinese',
+          collection_info: {
+            id: collectionId,
+            name: '汉字',
+            description: 'Chinese collection',
+            allowed_name_length: '20',
+          },
+          performance: null,
+        },
       ]);
     });
   });

--- a/src/social/controllers/posts.controller.ts
+++ b/src/social/controllers/posts.controller.ts
@@ -29,6 +29,7 @@ import { TokenPerformanceView } from '@/tokens/entities/tokens-performance.view'
 import { PopularRankingContentItem } from '@/plugins/popular-ranking.interface';
 import { extractTrendMentions } from '../utils/content-parser.util';
 import { ProfileReadService } from '@/profile/services/profile-read.service';
+import { CommunityFactoryService } from '@/ae/community-factory.service';
 import {
   OpaqueIdPipe,
   OptionalAeAccountAddressPipe,
@@ -45,6 +46,7 @@ export class PostsController {
     private readonly popularRankingService: PopularRankingService,
     private readonly readsService: ReadsService,
     private readonly profileReadService: ProfileReadService,
+    private readonly communityFactoryService: CommunityFactoryService,
   ) {
     //
   }
@@ -106,6 +108,10 @@ export class PostsController {
       }
     }
 
+    // Loaded once so every mention resolves its collection badge from the same
+    // cached factory schema instead of awaiting per mention.
+    const factory = await this.communityFactoryService.getCurrentFactory();
+
     for (const item of items) {
       const names = mentionsByPost.get(item.id);
       if (!names) {
@@ -116,6 +122,10 @@ export class PostsController {
         return {
           name,
           sale_address: token?.sale_address ?? null,
+          collection_info: this.communityFactoryService.mapCollectionInfo(
+            factory,
+            token?.collection,
+          ),
           performance: token?.performance ?? null,
         };
       });

--- a/src/social/controllers/topics.controller.spec.ts
+++ b/src/social/controllers/topics.controller.spec.ts
@@ -37,4 +37,71 @@ describe('TopicsController', () => {
     );
     expect(paginate).toHaveBeenCalledWith(queryBuilder, { page: 1, limit: 50 });
   });
+
+  describe('lookup by name', () => {
+    // Topics are written lowercased, so a lookup has to fold the caller's input
+    // the same way or an uppercase Cyrillic tag never resolves.
+    const lookupController = (found: unknown) => {
+      const findOne = jest.fn().mockResolvedValue(found);
+      return {
+        findOne,
+        controller: new TopicsController({ findOne } as any),
+      };
+    };
+
+    it('folds an uppercase Cyrillic name onto the stored lowercase topic', async () => {
+      const stored = { id: 'uuid-1', name: 'привет' };
+      const { findOne, controller: c } = lookupController(stored);
+
+      await expect(c.getByName('ПРИВЕТ')).resolves.toBe(stored);
+      expect(findOne).toHaveBeenCalledWith({
+        where: { name: 'привет' },
+        relations: ['posts'],
+      });
+    });
+
+    it('folds case for Latin names too, and trims', async () => {
+      const stored = { id: 'uuid-2', name: 'governance' };
+      const { findOne, controller: c } = lookupController(stored);
+
+      await expect(c.getByName('  GoVeRnAnCe  ')).resolves.toBe(stored);
+      expect(findOne).toHaveBeenCalledWith({
+        where: { name: 'governance' },
+        relations: ['posts'],
+      });
+    });
+
+    it('passes caseless scripts through unchanged', async () => {
+      const stored = { id: 'uuid-3', name: '汉字' };
+      const { findOne, controller: c } = lookupController(stored);
+
+      await expect(c.getByName('汉字')).resolves.toBe(stored);
+      expect(findOne).toHaveBeenCalledWith({
+        where: { name: '汉字' },
+        relations: ['posts'],
+      });
+    });
+
+    it('folds case on the name branch of getById as well', async () => {
+      const stored = { id: 'uuid-4', name: 'привет' };
+      const { findOne, controller: c } = lookupController(stored);
+
+      await expect(c.getById('ПРИВЕТ')).resolves.toBe(stored);
+      expect(findOne).toHaveBeenCalledWith({
+        where: { name: 'привет' },
+        relations: ['posts'],
+      });
+    });
+
+    it('still treats a UUID as an id, not a name', async () => {
+      const stored = { id: '3f2504e0-4f89-11d3-9a0c-0305e82c3301' };
+      const { findOne, controller: c } = lookupController(stored);
+
+      await c.getById('3F2504E0-4F89-11D3-9A0C-0305E82C3301');
+      expect(findOne).toHaveBeenCalledWith({
+        where: { id: '3F2504E0-4F89-11D3-9A0C-0305E82C3301' },
+        relations: ['posts'],
+      });
+    });
+  });
 });

--- a/src/social/controllers/topics.controller.ts
+++ b/src/social/controllers/topics.controller.ts
@@ -21,6 +21,7 @@ import { Repository } from 'typeorm';
 import { Topic } from '../entities/topic.entity';
 import { ApiOkResponsePaginated } from '@/utils/api-type';
 import { TopicParamPipe } from '@/common/validation/request-validation';
+import { normalizeTopicName } from '../utils/topic-name.util';
 
 const ALLOWED_ORDER_BY = new Set(['name', 'post_count', 'created_at']);
 const ALLOWED_ORDER_DIRECTIONS = new Set(['ASC', 'DESC']);
@@ -120,7 +121,7 @@ export class TopicsController {
       );
 
     const topic = await this.topicRepository.findOne({
-      where: isUUID ? { id } : { name: id },
+      where: isUUID ? { id } : { name: normalizeTopicName(id) },
       relations: ['posts'],
     });
     if (!topic) {
@@ -144,7 +145,7 @@ export class TopicsController {
   @Get('name/:name')
   async getByName(@Param('name', TopicParamPipe) name: string) {
     const topic = await this.topicRepository.findOne({
-      where: { name },
+      where: { name: normalizeTopicName(name) },
       relations: ['posts'],
     });
     if (!topic) {

--- a/src/social/dto/post-trend-mention.dto.ts
+++ b/src/social/dto/post-trend-mention.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { PerformancePeriodDto } from '@/tokens/dto/performance-period.dto';
+import { CollectionInfoDto } from '@/tokens/dto/collection-info.dto';
 
 export class TrendPerformanceSummaryDto {
   @ApiProperty({ type: () => PerformancePeriodDto, nullable: true })
@@ -27,6 +28,15 @@ export class PostTrendMentionDto {
     nullable: true,
   })
   sale_address?: string | null;
+
+  @ApiProperty({
+    description:
+      "Collection metadata for the mentioned token's collection, or null " +
+      'when the token is unresolved / has no known collection.',
+    type: () => CollectionInfoDto,
+    nullable: true,
+  })
+  collection_info?: CollectionInfoDto | null;
 
   @ApiProperty({
     description: 'Performance summary for 24h and 7d windows',

--- a/src/social/entities/post.entity.ts
+++ b/src/social/entities/post.entity.ts
@@ -16,6 +16,9 @@ import { Topic } from './topic.entity';
 })
 @Index('IDX_POSTS_CREATED_AT', ['created_at'])
 @Index('IDX_POSTS_SENDER_ADDRESS_CREATED_AT', ['sender_address', 'created_at'])
+// Serves comment lookups and each level of the popular-ranking thread CTE;
+// Postgres does not index FK columns automatically.
+@Index('IDX_POSTS_POST_ID', ['post_id'])
 export class Post {
   @PrimaryColumn()
   id: string;

--- a/src/social/post.module.ts
+++ b/src/social/post.module.ts
@@ -20,11 +20,13 @@ import { GovernancePluginModule } from '@/plugins/governance/governance-plugin.m
 import { getPopularRankingContributorProvider } from '@/plugins';
 import { ProfileModule } from '@/profile/profile.module';
 import { TokensModule } from '@/tokens/tokens.module';
+import { AeModule } from '@/ae/ae.module';
 
 @Module({
   imports: [
     ProfileModule,
     TokensModule,
+    AeModule,
     TransactionsModule,
     GovernancePluginModule, // Import to access GovernancePopularRankingService
     TypeOrmModule.forFeature([

--- a/src/social/services/popular-ranking.service.spec.ts
+++ b/src/social/services/popular-ranking.service.spec.ts
@@ -1095,37 +1095,48 @@ describe('PopularRankingService', () => {
       const weights = (service as any).resolveWeights();
       const cap = POPULAR_RANKING_CONFIG.READS_PER_INTERACTION_CAP;
 
-      // Zero active interactions: a million reads score the same as the cap.
-      const inflated = (service as any).computeScore(
-        noTrending,
-        scoreInput(10, { reads: 1_000_000 }),
-        weights,
-        '24h',
-      );
-      const atCap = (service as any).computeScore(
-        noTrending,
-        scoreInput(10, { reads: cap }),
-        weights,
-        '24h',
-      );
-      expect(inflated).toBeCloseTo(atCap, 10);
+      // `computeScore` -> `computeFreshnessFactor`/`computeInteractionsPerHour`
+      // call `Date.now()` live on every invocation, so two calls a few
+      // microseconds apart get a genuinely different age-in-hours and thus a
+      // genuinely different (if tiny) score — flaking a `toBeCloseTo(..., 10)`
+      // assertion regardless of a shared `createdAt`. Freeze `Date.now()` for
+      // each paired comparison so both calls see identical elapsed time.
+      const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(Date.now());
+      try {
+        // Zero active interactions: a million reads score the same as the cap.
+        const inflated = (service as any).computeScore(
+          noTrending,
+          scoreInput(10, { reads: 1_000_000 }),
+          weights,
+          '24h',
+        );
+        const atCap = (service as any).computeScore(
+          noTrending,
+          scoreInput(10, { reads: cap }),
+          weights,
+          '24h',
+        );
+        expect(inflated).toBeCloseTo(atCap, 10);
 
-      // Active engagement raises the cap, so real interactions unlock more
-      // read credit.
-      const engaged = (service as any).computeScore(
-        noTrending,
-        scoreInput(10, { comments: 10, reads: 1_000_000 }),
-        weights,
-        '24h',
-      );
-      const engagedAtCap = (service as any).computeScore(
-        noTrending,
-        scoreInput(10, { comments: 10, reads: cap * 11 }),
-        weights,
-        '24h',
-      );
-      expect(engaged).toBeCloseTo(engagedAtCap, 10);
-      expect(engaged).toBeGreaterThan(inflated);
+        // Active engagement raises the cap, so real interactions unlock more
+        // read credit.
+        const engaged = (service as any).computeScore(
+          noTrending,
+          scoreInput(10, { comments: 10, reads: 1_000_000 }),
+          weights,
+          '24h',
+        );
+        const engagedAtCap = (service as any).computeScore(
+          noTrending,
+          scoreInput(10, { comments: 10, reads: cap * 11 }),
+          weights,
+          '24h',
+        );
+        expect(engaged).toBeCloseTo(engagedAtCap, 10);
+        expect(engaged).toBeGreaterThan(inflated);
+      } finally {
+        nowSpy.mockRestore();
+      }
     });
 
     it('applies bounded, deterministic tie rotation per post id', () => {

--- a/src/social/services/popular-ranking.service.spec.ts
+++ b/src/social/services/popular-ranking.service.spec.ts
@@ -23,6 +23,7 @@ jest.mock('ioredis', () => {
 });
 
 import { PopularRankingService } from './popular-ranking.service';
+import { POPULAR_RANKING_CONFIG } from '@/configs/constants';
 
 function createCandidateQueryBuilder(posts: Array<{ id: string }>) {
   return {
@@ -844,7 +845,9 @@ describe('PopularRankingService', () => {
       };
       const svc = buildScoredService([dayOldPost, olderPost, freshPost], {});
 
-      const result = await svc.getPopularPostsPage('all', 10, 0, undefined, {
+      // 7d window: the 'all' window now applies age gravity, so equal-score
+      // posts of different ages are only expected on time-bounded windows.
+      const result = await svc.getPopularPostsPage('7d', 10, 0, undefined, {
         comments: 'med',
       });
       const scores = new Map(
@@ -1016,6 +1019,118 @@ describe('PopularRankingService', () => {
 
       expect(explanation.map((item) => item.id)).toEqual(
         result.items.map((item) => item.id),
+      );
+    });
+  });
+
+  describe('scoring math (velocity, gravity, emoji)', () => {
+    const noTrending = new Map<string, number>();
+
+    function scoreInput(ageHours: number, overrides: Record<string, any> = {}) {
+      return {
+        content: 'a perfectly reasonable amount of content',
+        comments: 0,
+        tipsAmountAE: 0,
+        tipsCount: 0,
+        uniqueTippers: 0,
+        reads: 0,
+        topics: [],
+        createdAt: new Date(
+          Date.now() - ageHours * 60 * 60 * 1000,
+        ).toISOString(),
+        ...overrides,
+      };
+    }
+
+    it('seeds interactionsPerHour weight from config for the default feed', () => {
+      const weights = (service as any).resolveWeights();
+      expect(weights.interactionsPerHour).toBe(
+        POPULAR_RANKING_CONFIG.WEIGHTS.interactionsPerHour,
+      );
+      expect(weights.interactionsPerHour).toBeGreaterThan(0);
+    });
+
+    it('scales the interactionsPerHour override from the config default', () => {
+      const weights = (service as any).resolveWeights({
+        interactionsPerHour: 'high',
+      });
+      expect(weights.interactionsPerHour).toBeCloseTo(
+        POPULAR_RANKING_CONFIG.WEIGHTS.interactionsPerHour *
+          POPULAR_RANKING_CONFIG.CUSTOMIZATION.SCALE_MULTIPLIERS.high,
+      );
+    });
+
+    it('keeps a positive velocity contribution past the freshness window on default weights', () => {
+      // Both posts are past FRESHNESS_BOOST_HOURS with identical totals, so
+      // freshness-gated terms are zero for both and any score gap comes from
+      // the always-on interactionsPerHour term.
+      const weights = (service as any).resolveWeights();
+      const momentum = (service as any).computeScore(
+        noTrending,
+        scoreInput(POPULAR_RANKING_CONFIG.FRESHNESS_BOOST_HOURS + 10, {
+          comments: 48,
+        }),
+        weights,
+        '7d',
+      );
+      const slowBurn = (service as any).computeScore(
+        noTrending,
+        scoreInput(160, { comments: 48 }),
+        weights,
+        '7d',
+      );
+      expect(momentum).toBeGreaterThan(slowBurn);
+    });
+
+    it("decays older posts in the 'all' window given identical engagement", () => {
+      const weights = (service as any).resolveWeights();
+      const newer = (service as any).computeScore(
+        noTrending,
+        scoreInput(24, { comments: 20, reads: 100 }),
+        weights,
+        'all',
+      );
+      const older = (service as any).computeScore(
+        noTrending,
+        scoreInput(24 * 30, { comments: 20, reads: 100 }),
+        weights,
+        'all',
+      );
+      expect(newer).toBeGreaterThan(older);
+    });
+
+    it("does not decay time-bounded windows' scores by age gravity", () => {
+      // Same totals, same age: gravity applies only to 'all', so the '24h'
+      // score must be strictly higher than the gravity-divided 'all' score.
+      const weights = (service as any).resolveWeights();
+      const input = scoreInput(10, { comments: 20 });
+      const windowed = (service as any).computeScore(
+        noTrending,
+        input,
+        weights,
+        '24h',
+      );
+      const allWindow = (service as any).computeScore(
+        noTrending,
+        input,
+        weights,
+        'all',
+      );
+      expect(windowed).toBeGreaterThan(allWindow);
+    });
+
+    it('counts every emoji, not just the first match', () => {
+      const svc = service as any;
+      expect(svc.countEmojis('nice 😀 post 😀 with 😀 five 😀 emojis 😀')).toBe(
+        5,
+      );
+      expect(svc.countEmojis('plain text with 123 #hash and *star')).toBe(0);
+    });
+
+    it('penalizes short emoji-only posts in content quality', () => {
+      const svc = service as any;
+      expect(svc.computeContentQuality('😂😂😂😂😂')).toBeLessThan(
+        svc.computeContentQuality('hello'),
       );
     });
   });

--- a/src/social/services/popular-ranking.service.spec.ts
+++ b/src/social/services/popular-ranking.service.spec.ts
@@ -1261,22 +1261,22 @@ describe('PopularRankingService', () => {
     it('recomputes when the per-window lock is acquired', async () => {
       redisMock.set.mockResolvedValue('OK');
 
-      await service.refreshPopular24h();
+      await service.refreshPopularAll();
 
       expect(redisMock.set).toHaveBeenCalledWith(
-        'popular:refresh-lock:24h',
+        'popular:refresh-lock:all',
         '1',
         'EX',
         expect.any(Number),
         'NX',
       );
-      expect(recomputeSpy).toHaveBeenCalledWith('24h');
+      expect(recomputeSpy).toHaveBeenCalledWith('all');
     });
 
     it('skips the tick when another instance holds the lock', async () => {
       redisMock.set.mockResolvedValue(null);
 
-      await service.refreshPopular7d();
+      await service.refreshPopularAll();
 
       expect(recomputeSpy).not.toHaveBeenCalled();
     });
@@ -1289,17 +1289,22 @@ describe('PopularRankingService', () => {
       expect(recomputeSpy).not.toHaveBeenCalled();
     });
 
-    it('uses lock TTLs below each window refresh interval', async () => {
+    it('uses a lock TTL below the all-window refresh interval', async () => {
       redisMock.set.mockResolvedValue('OK');
 
-      await service.refreshPopular24h();
-      await service.refreshPopular7d();
       await service.refreshPopularAll();
 
-      const ttls = redisMock.set.mock.calls.map((call: any[]) => call[3]);
-      expect(ttls[0]).toBeLessThan(60);
-      expect(ttls[1]).toBeLessThan(300);
-      expect(ttls[2]).toBeLessThan(600);
+      const ttl = redisMock.set.mock.calls[0][3];
+      expect(ttl).toBeLessThan(600);
+    });
+
+    // Guards against re-introducing the wasted work: GET /posts/popular is
+    // all-time only, so nothing reads the 24h/7d caches and they must not be
+    // recomputed on a schedule.
+    it('does not schedule recomputes for the deprecated 24h/7d windows', () => {
+      const svc = service as unknown as Record<string, unknown>;
+      expect(svc.refreshPopular24h).toBeUndefined();
+      expect(svc.refreshPopular7d).toBeUndefined();
     });
   });
 

--- a/src/social/services/popular-ranking.service.spec.ts
+++ b/src/social/services/popular-ranking.service.spec.ts
@@ -11,6 +11,7 @@ const redisMock = {
   quit: jest.fn().mockResolvedValue('OK'),
   ping: jest.fn().mockResolvedValue('PONG'),
   del: jest.fn().mockResolvedValue(1),
+  set: jest.fn().mockResolvedValue('OK'),
   zcard: jest.fn().mockResolvedValue(1),
   pipeline: jest.fn().mockReturnValue(pipelineMock),
 };
@@ -61,15 +62,7 @@ describe('PopularRankingService', () => {
       addSelect: jest.fn().mockReturnThis(),
       where: jest.fn().mockReturnThis(),
       andWhere: jest.fn().mockReturnThis(),
-      groupBy: jest.fn().mockReturnThis(),
-      getRawMany: jest.fn().mockResolvedValue([]),
-    };
-    const commentQueryBuilder = {
-      innerJoin: jest.fn().mockReturnThis(),
-      select: jest.fn().mockReturnThis(),
-      addSelect: jest.fn().mockReturnThis(),
-      where: jest.fn().mockReturnThis(),
-      andWhere: jest.fn().mockReturnThis(),
+      setParameter: jest.fn().mockReturnThis(),
       groupBy: jest.fn().mockReturnThis(),
       getRawMany: jest.fn().mockResolvedValue([]),
     };
@@ -83,10 +76,8 @@ describe('PopularRankingService', () => {
     };
 
     postRepository = {
-      createQueryBuilder: jest
-        .fn()
-        .mockReturnValueOnce(candidateQueryBuilder)
-        .mockReturnValueOnce(commentQueryBuilder),
+      createQueryBuilder: jest.fn().mockReturnValue(candidateQueryBuilder),
+      query: jest.fn().mockResolvedValue([]),
       find: jest.fn().mockResolvedValue([defaultPost]),
       findBy: jest.fn().mockResolvedValue([defaultPost]),
     };
@@ -125,20 +116,17 @@ describe('PopularRankingService', () => {
     );
   });
 
-  it('excludes self-comments from ranking comment count', async () => {
+  it('counts whole threads while excluding the root author from comment count', async () => {
     await service.recompute('7d', 10);
 
-    const commentQueryBuilder =
-      postRepository.createQueryBuilder.mock.results[1].value;
+    const [sql, params] = postRepository.query.mock.calls[0];
 
-    expect(commentQueryBuilder.innerJoin).toHaveBeenCalledWith(
-      expect.any(Function),
-      'parent',
-      'parent.id = comment.post_id',
-    );
-    expect(commentQueryBuilder.andWhere).toHaveBeenCalledWith(
-      'comment.sender_address != parent.sender_address',
-    );
+    expect(sql).toContain('WITH RECURSIVE');
+    expect(sql).toContain('c.sender_address != t.root_sender');
+    expect(sql).toContain('c.is_hidden = false');
+    expect(sql).toContain('t.depth <');
+    expect(params[0]).toEqual(['post-1']);
+    expect(params[1]).toBeInstanceOf(Date);
   });
 
   it('falls back to window-filtered recent posts when Redis cache is empty', async () => {
@@ -205,6 +193,7 @@ describe('PopularRankingService', () => {
       addSelect: jest.fn().mockReturnThis(),
       where: jest.fn().mockReturnThis(),
       andWhere: jest.fn().mockReturnThis(),
+      setParameter: jest.fn().mockReturnThis(),
       groupBy: jest.fn().mockReturnThis(),
       getRawMany: jest.fn().mockResolvedValue([
         {
@@ -212,25 +201,15 @@ describe('PopularRankingService', () => {
           amount_sum: '0',
           count: '2',
           unique_tippers: '2',
+          recent_count: '2',
         },
         {
           post_id: 'post-fast',
           amount_sum: '0',
           count: '2',
           unique_tippers: '2',
+          recent_count: '2',
         },
-      ]),
-    };
-    const commentQueryBuilder = {
-      innerJoin: jest.fn().mockReturnThis(),
-      select: jest.fn().mockReturnThis(),
-      addSelect: jest.fn().mockReturnThis(),
-      where: jest.fn().mockReturnThis(),
-      andWhere: jest.fn().mockReturnThis(),
-      groupBy: jest.fn().mockReturnThis(),
-      getRawMany: jest.fn().mockResolvedValue([
-        { parent_id: 'post-old', count: '4' },
-        { parent_id: 'post-fast', count: '4' },
       ]),
     };
     const readsQueryBuilder = {
@@ -246,10 +225,11 @@ describe('PopularRankingService', () => {
     };
 
     postRepository = {
-      createQueryBuilder: jest
-        .fn()
-        .mockReturnValueOnce(candidateQueryBuilder)
-        .mockReturnValueOnce(commentQueryBuilder),
+      createQueryBuilder: jest.fn().mockReturnValue(candidateQueryBuilder),
+      query: jest.fn().mockResolvedValue([
+        { root_id: 'post-old', count: '4', recent_count: '4' },
+        { root_id: 'post-fast', count: '4', recent_count: '4' },
+      ]),
       find: jest.fn().mockResolvedValue([oldPost, fastPost]),
       findBy: jest.fn().mockResolvedValue([oldPost, fastPost]),
     };
@@ -386,23 +366,13 @@ describe('PopularRankingService', () => {
         topics: [],
       };
       const candidateQB = createCandidateQueryBuilder([post]);
-      const commentQB = {
-        innerJoin: jest.fn().mockReturnThis(),
-        select: jest.fn().mockReturnThis(),
-        addSelect: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        andWhere: jest.fn().mockReturnThis(),
-        groupBy: jest.fn().mockReturnThis(),
-        getRawMany: jest
-          .fn()
-          .mockResolvedValue([{ parent_id: 'post-w', count: '5' }]),
-      };
       const tipQB = {
         select: jest.fn().mockReturnThis(),
         innerJoin: jest.fn().mockReturnThis(),
         addSelect: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
         andWhere: jest.fn().mockReturnThis(),
+        setParameter: jest.fn().mockReturnThis(),
         groupBy: jest.fn().mockReturnThis(),
         getRawMany: jest.fn().mockResolvedValue([
           {
@@ -410,6 +380,7 @@ describe('PopularRankingService', () => {
             amount_sum: '100',
             count: '3',
             unique_tippers: '2',
+            recent_count: '3',
           },
         ]),
       };
@@ -425,10 +396,12 @@ describe('PopularRankingService', () => {
       };
 
       const repo = {
-        createQueryBuilder: jest
+        createQueryBuilder: jest.fn().mockReturnValue(candidateQB),
+        query: jest
           .fn()
-          .mockReturnValueOnce(candidateQB)
-          .mockReturnValueOnce(commentQB),
+          .mockResolvedValue([
+            { root_id: 'post-w', count: '5', recent_count: '5' },
+          ]),
         find: jest.fn().mockResolvedValue([post]),
         findBy: jest.fn().mockResolvedValue([post]),
       };
@@ -481,23 +454,13 @@ describe('PopularRankingService', () => {
   describe('computeInteractionsPerHour edge cases', () => {
     function buildServiceWith(post: any) {
       const candidateQB = createCandidateQueryBuilder([post]);
-      const commentQB = {
-        innerJoin: jest.fn().mockReturnThis(),
-        select: jest.fn().mockReturnThis(),
-        addSelect: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        andWhere: jest.fn().mockReturnThis(),
-        groupBy: jest.fn().mockReturnThis(),
-        getRawMany: jest
-          .fn()
-          .mockResolvedValue([{ parent_id: post.id, count: '3' }]),
-      };
       const tipQB = {
         select: jest.fn().mockReturnThis(),
         innerJoin: jest.fn().mockReturnThis(),
         addSelect: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
         andWhere: jest.fn().mockReturnThis(),
+        setParameter: jest.fn().mockReturnThis(),
         groupBy: jest.fn().mockReturnThis(),
         getRawMany: jest.fn().mockResolvedValue([
           {
@@ -505,6 +468,7 @@ describe('PopularRankingService', () => {
             amount_sum: '0',
             count: '1',
             unique_tippers: '1',
+            recent_count: '1',
           },
         ]),
       };
@@ -519,10 +483,12 @@ describe('PopularRankingService', () => {
 
       return new PopularRankingService(
         {
-          createQueryBuilder: jest
+          createQueryBuilder: jest.fn().mockReturnValue(candidateQB),
+          query: jest
             .fn()
-            .mockReturnValueOnce(candidateQB)
-            .mockReturnValueOnce(commentQB),
+            .mockResolvedValue([
+              { root_id: post.id, count: '3', recent_count: '3' },
+            ]),
           find: jest.fn().mockResolvedValue([post]),
           findBy: jest.fn().mockResolvedValue([post]),
         } as any,
@@ -567,13 +533,13 @@ describe('PopularRankingService', () => {
       expect(result.scoredItems![0].score).toBeGreaterThanOrEqual(0);
     });
 
-    it('caps effectiveHours to window size for 24h window', async () => {
+    it('caps velocity hours so equal recent activity favors the younger post', async () => {
       const now = Date.now();
       const very_old_post = {
         id: 'post-capped',
         sender_address: 'ak_capped',
-        created_at: new Date(now - 48 * 60 * 60 * 1000).toISOString(),
-        content: 'old post that should be capped at 24h',
+        created_at: new Date(now - 200 * 60 * 60 * 1000).toISOString(),
+        content: 'old post whose velocity divisor is capped',
         topics: [],
       };
       const recent_post = {
@@ -588,24 +554,13 @@ describe('PopularRankingService', () => {
         very_old_post,
         recent_post,
       ]);
-      const commentQB = {
-        innerJoin: jest.fn().mockReturnThis(),
-        select: jest.fn().mockReturnThis(),
-        addSelect: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        andWhere: jest.fn().mockReturnThis(),
-        groupBy: jest.fn().mockReturnThis(),
-        getRawMany: jest.fn().mockResolvedValue([
-          { parent_id: 'post-capped', count: '5' },
-          { parent_id: 'post-recent', count: '5' },
-        ]),
-      };
       const tipQB = {
         select: jest.fn().mockReturnThis(),
         innerJoin: jest.fn().mockReturnThis(),
         addSelect: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
         andWhere: jest.fn().mockReturnThis(),
+        setParameter: jest.fn().mockReturnThis(),
         groupBy: jest.fn().mockReturnThis(),
         getRawMany: jest.fn().mockResolvedValue([
           {
@@ -613,12 +568,14 @@ describe('PopularRankingService', () => {
             amount_sum: '0',
             count: '2',
             unique_tippers: '2',
+            recent_count: '2',
           },
           {
             post_id: 'post-recent',
             amount_sum: '0',
             count: '2',
             unique_tippers: '2',
+            recent_count: '2',
           },
         ]),
       };
@@ -636,10 +593,11 @@ describe('PopularRankingService', () => {
 
       const svc = new PopularRankingService(
         {
-          createQueryBuilder: jest
-            .fn()
-            .mockReturnValueOnce(candidateQB)
-            .mockReturnValueOnce(commentQB),
+          createQueryBuilder: jest.fn().mockReturnValue(candidateQB),
+          query: jest.fn().mockResolvedValue([
+            { root_id: 'post-capped', count: '5', recent_count: '5' },
+            { root_id: 'post-recent', count: '5', recent_count: '5' },
+          ]),
           find: jest.fn().mockResolvedValue([very_old_post, recent_post]),
           findBy: jest.fn().mockResolvedValue([very_old_post, recent_post]),
         } as any,
@@ -649,7 +607,7 @@ describe('PopularRankingService', () => {
         [],
       );
 
-      const result = await svc.getPopularPostsPage('24h', 10, 0, undefined, {
+      const result = await svc.getPopularPostsPage('all', 10, 0, undefined, {
         interactionsPerHour: 'high',
       });
 
@@ -685,26 +643,13 @@ describe('PopularRankingService', () => {
       comments: Record<string, string>,
     ) {
       const candidateQB = createCandidateQueryBuilder(posts);
-      const commentQB = {
-        innerJoin: jest.fn().mockReturnThis(),
-        select: jest.fn().mockReturnThis(),
-        addSelect: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        andWhere: jest.fn().mockReturnThis(),
-        groupBy: jest.fn().mockReturnThis(),
-        getRawMany: jest.fn().mockResolvedValue(
-          Object.entries(comments).map(([parent_id, count]) => ({
-            parent_id,
-            count,
-          })),
-        ),
-      };
       const tipQB = {
         select: jest.fn().mockReturnThis(),
         innerJoin: jest.fn().mockReturnThis(),
         addSelect: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
         andWhere: jest.fn().mockReturnThis(),
+        setParameter: jest.fn().mockReturnThis(),
         groupBy: jest.fn().mockReturnThis(),
         getRawMany: jest.fn().mockResolvedValue([]),
       };
@@ -719,10 +664,14 @@ describe('PopularRankingService', () => {
 
       return new PopularRankingService(
         {
-          createQueryBuilder: jest
-            .fn()
-            .mockReturnValueOnce(candidateQB)
-            .mockReturnValueOnce(commentQB),
+          createQueryBuilder: jest.fn().mockReturnValue(candidateQB),
+          query: jest.fn().mockResolvedValue(
+            Object.entries(comments).map(([root_id, count]) => ({
+              root_id,
+              count,
+              recent_count: count,
+            })),
+          ),
           find: jest.fn().mockResolvedValue(posts),
           findBy: jest.fn().mockResolvedValue(posts),
         } as any,
@@ -760,23 +709,13 @@ describe('PopularRankingService', () => {
           .fn()
           .mockResolvedValue([{ id: 'topic-heavy' }, { id: 'target-post' }]),
       };
-      const commentQB = {
-        innerJoin: jest.fn().mockReturnThis(),
-        select: jest.fn().mockReturnThis(),
-        addSelect: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        andWhere: jest.fn().mockReturnThis(),
-        groupBy: jest.fn().mockReturnThis(),
-        getRawMany: jest
-          .fn()
-          .mockResolvedValue([{ parent_id: 'target-post', count: '4' }]),
-      };
       const tipQB = {
         select: jest.fn().mockReturnThis(),
         innerJoin: jest.fn().mockReturnThis(),
         addSelect: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
         andWhere: jest.fn().mockReturnThis(),
+        setParameter: jest.fn().mockReturnThis(),
         groupBy: jest.fn().mockReturnThis(),
         getRawMany: jest.fn().mockResolvedValue([]),
       };
@@ -789,10 +728,12 @@ describe('PopularRankingService', () => {
         getRawMany: jest.fn().mockResolvedValue([]),
       };
       const repo = {
-        createQueryBuilder: jest
+        createQueryBuilder: jest.fn().mockReturnValue(candidateQB),
+        query: jest
           .fn()
-          .mockReturnValueOnce(candidateQB)
-          .mockReturnValueOnce(commentQB),
+          .mockResolvedValue([
+            { root_id: 'target-post', count: '4', recent_count: '4' },
+          ]),
         find: jest.fn().mockResolvedValue([targetPost, topicHeavyPost]),
         findBy: jest.fn().mockResolvedValue([targetPost, topicHeavyPost]),
       };
@@ -820,8 +761,9 @@ describe('PopularRankingService', () => {
       ]);
     });
 
-    it('boosts fresh posts and removes that boost after 24 hours', async () => {
+    it('boosts fresh posts and removes that boost after the freshness window', async () => {
       const now = Date.now();
+      const boostHours = POPULAR_RANKING_CONFIG.FRESHNESS_BOOST_HOURS;
       const freshPost = {
         id: 'post-fresh',
         sender_address: 'ak_fresh',
@@ -829,21 +771,28 @@ describe('PopularRankingService', () => {
         content: 'same quality content',
         topics: [],
       };
-      const dayOldPost = {
-        id: 'post-day-old',
-        sender_address: 'ak_day_old',
-        created_at: new Date(now - 25 * 60 * 60 * 1000).toISOString(),
+      const pastWindowPost = {
+        id: 'post-past-window',
+        sender_address: 'ak_past_window',
+        created_at: new Date(
+          now - (boostHours + 2) * 60 * 60 * 1000,
+        ).toISOString(),
         content: 'same quality content',
         topics: [],
       };
       const olderPost = {
         id: 'post-older',
         sender_address: 'ak_older',
-        created_at: new Date(now - 48 * 60 * 60 * 1000).toISOString(),
+        created_at: new Date(
+          now - (boostHours + 26) * 60 * 60 * 1000,
+        ).toISOString(),
         content: 'same quality content',
         topics: [],
       };
-      const svc = buildScoredService([dayOldPost, olderPost, freshPost], {});
+      const svc = buildScoredService(
+        [pastWindowPost, olderPost, freshPost],
+        {},
+      );
 
       // 7d window: the 'all' window now applies age gravity, so equal-score
       // posts of different ages are only expected on time-bounded windows.
@@ -855,9 +804,13 @@ describe('PopularRankingService', () => {
       );
 
       expect(scores.get('post-fresh')).toBeGreaterThan(
-        scores.get('post-day-old')!,
+        scores.get('post-past-window')!,
       );
-      expect(scores.get('post-day-old')).toBeCloseTo(scores.get('post-older')!);
+      // Past the window both posts carry no freshness or velocity — scores
+      // may differ only by the deterministic tie-rotation jitter.
+      expect(
+        Math.abs(scores.get('post-past-window')! - scores.get('post-older')!),
+      ).toBeLessThanOrEqual(POPULAR_RANKING_CONFIG.TIE_ROTATION_EPSILON);
     });
 
     it('avoids duplicate authors within a page when alternatives exist', async () => {
@@ -1119,12 +1072,132 @@ describe('PopularRankingService', () => {
       expect(windowed).toBeGreaterThan(allWindow);
     });
 
+    it('registers momentum for an old post catching fire via recent interactions', () => {
+      // Same lifetime totals, same age (so identical gravity); only the
+      // recent-interaction count differs.
+      const weights = (service as any).resolveWeights();
+      const catchingFire = (service as any).computeScore(
+        noTrending,
+        scoreInput(24 * 90, { comments: 100, recentInteractions: 50 }),
+        weights,
+        'all',
+      );
+      const dormant = (service as any).computeScore(
+        noTrending,
+        scoreInput(24 * 90, { comments: 100, recentInteractions: 0 }),
+        weights,
+        'all',
+      );
+      expect(catchingFire).toBeGreaterThan(dormant);
+    });
+
+    it('caps read contribution relative to active engagement', () => {
+      const weights = (service as any).resolveWeights();
+      const cap = POPULAR_RANKING_CONFIG.READS_PER_INTERACTION_CAP;
+
+      // Zero active interactions: a million reads score the same as the cap.
+      const inflated = (service as any).computeScore(
+        noTrending,
+        scoreInput(10, { reads: 1_000_000 }),
+        weights,
+        '24h',
+      );
+      const atCap = (service as any).computeScore(
+        noTrending,
+        scoreInput(10, { reads: cap }),
+        weights,
+        '24h',
+      );
+      expect(inflated).toBeCloseTo(atCap, 10);
+
+      // Active engagement raises the cap, so real interactions unlock more
+      // read credit.
+      const engaged = (service as any).computeScore(
+        noTrending,
+        scoreInput(10, { comments: 10, reads: 1_000_000 }),
+        weights,
+        '24h',
+      );
+      const engagedAtCap = (service as any).computeScore(
+        noTrending,
+        scoreInput(10, { comments: 10, reads: cap * 11 }),
+        weights,
+        '24h',
+      );
+      expect(engaged).toBeCloseTo(engagedAtCap, 10);
+      expect(engaged).toBeGreaterThan(inflated);
+    });
+
+    it('applies bounded, deterministic tie rotation per post id', () => {
+      const svc = service as any;
+      const first = svc.computeTieRotation('post-a');
+      const second = svc.computeTieRotation('post-a');
+      const other = svc.computeTieRotation('post-b');
+
+      expect(first).toBe(second);
+      expect(first).toBeGreaterThanOrEqual(0);
+      expect(first).toBeLessThan(POPULAR_RANKING_CONFIG.TIE_ROTATION_EPSILON);
+      expect(other).not.toBe(first);
+      expect(svc.computeTieRotation(undefined)).toBe(0);
+    });
+
     it('counts every emoji, not just the first match', () => {
       const svc = service as any;
       expect(svc.countEmojis('nice 😀 post 😀 with 😀 five 😀 emojis 😀')).toBe(
         5,
       );
       expect(svc.countEmojis('plain text with 123 #hash and *star')).toBe(0);
+      // ZWJ sequences count per pictographic component, variation-selector
+      // emoji count once — both nonzero so the ratio penalty can trigger.
+      expect(svc.countEmojis('👨‍👩‍👧')).toBe(3);
+      expect(svc.countEmojis('❤️')).toBe(1);
+    });
+
+    it('computes velocity from recent interactions capped at the velocity window', () => {
+      const svc = service as any;
+      const window = POPULAR_RANKING_CONFIG.VELOCITY_WINDOW_HOURS;
+
+      // Old post: divisor is the velocity window, not the post age.
+      expect(
+        svc.computeInteractionsPerHour(
+          scoreInput(200, { recentInteractions: window * 2 }),
+          'all',
+        ),
+      ).toBeCloseTo(2);
+
+      // Very young post: divisor clamps to 1 hour so a burst in the first
+      // minutes is not multiplied into an absurd hourly rate.
+      expect(
+        svc.computeInteractionsPerHour(
+          scoreInput(0.1, { recentInteractions: 5 }),
+          '24h',
+        ),
+      ).toBeCloseTo(5);
+
+      // No recent data (plugin items): lifetime-average fallback.
+      expect(
+        svc.computeInteractionsPerHour(scoreInput(2, { comments: 4 }), '24h'),
+      ).toBeCloseTo(2);
+    });
+
+    it('scores the all window safely when createdAt is missing or invalid', () => {
+      const weights = (service as any).resolveWeights();
+      for (const createdAt of [undefined, 'not-a-date']) {
+        const score = (service as any).computeScore(
+          noTrending,
+          { ...scoreInput(1, { comments: 5 }), createdAt },
+          weights,
+          'all',
+        );
+        expect(Number.isFinite(score)).toBe(true);
+        expect(score).toBeGreaterThanOrEqual(0);
+      }
+    });
+
+    it('returns zero tie rotation for missing or empty ids', () => {
+      const svc = service as any;
+      expect(svc.computeTieRotation(undefined)).toBe(0);
+      expect(svc.computeTieRotation('')).toBe(0);
     });
 
     it('penalizes short emoji-only posts in content quality', () => {
@@ -1132,6 +1205,66 @@ describe('PopularRankingService', () => {
       expect(svc.computeContentQuality('😂😂😂😂😂')).toBeLessThan(
         svc.computeContentQuality('hello'),
       );
+    });
+  });
+
+  describe('scheduled refresh locking', () => {
+    let recomputeSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      redisMock.set.mockReset();
+      recomputeSpy = jest
+        .spyOn(service as any, 'awaitOrTriggerRecompute')
+        .mockResolvedValue(undefined);
+    });
+
+    afterEach(() => {
+      recomputeSpy.mockRestore();
+      redisMock.set.mockResolvedValue('OK');
+    });
+
+    it('recomputes when the per-window lock is acquired', async () => {
+      redisMock.set.mockResolvedValue('OK');
+
+      await service.refreshPopular24h();
+
+      expect(redisMock.set).toHaveBeenCalledWith(
+        'popular:refresh-lock:24h',
+        '1',
+        'EX',
+        expect.any(Number),
+        'NX',
+      );
+      expect(recomputeSpy).toHaveBeenCalledWith('24h');
+    });
+
+    it('skips the tick when another instance holds the lock', async () => {
+      redisMock.set.mockResolvedValue(null);
+
+      await service.refreshPopular7d();
+
+      expect(recomputeSpy).not.toHaveBeenCalled();
+    });
+
+    it('skips the tick when Redis is unreachable', async () => {
+      redisMock.set.mockRejectedValue(new Error('redis down'));
+
+      await service.refreshPopularAll();
+
+      expect(recomputeSpy).not.toHaveBeenCalled();
+    });
+
+    it('uses lock TTLs below each window refresh interval', async () => {
+      redisMock.set.mockResolvedValue('OK');
+
+      await service.refreshPopular24h();
+      await service.refreshPopular7d();
+      await service.refreshPopularAll();
+
+      const ttls = redisMock.set.mock.calls.map((call: any[]) => call[3]);
+      expect(ttls[0]).toBeLessThan(60);
+      expect(ttls[1]).toBeLessThan(300);
+      expect(ttls[2]).toBeLessThan(600);
     });
   });
 
@@ -1172,21 +1305,13 @@ describe('PopularRankingService', () => {
         topics: [],
       };
       const candidateQB = createCandidateQueryBuilder([post]);
-      const commentQB = {
-        innerJoin: jest.fn().mockReturnThis(),
-        select: jest.fn().mockReturnThis(),
-        addSelect: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        andWhere: jest.fn().mockReturnThis(),
-        groupBy: jest.fn().mockReturnThis(),
-        getRawMany: jest.fn().mockResolvedValue([]),
-      };
       const tipQB = {
         select: jest.fn().mockReturnThis(),
         innerJoin: jest.fn().mockReturnThis(),
         addSelect: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
         andWhere: jest.fn().mockReturnThis(),
+        setParameter: jest.fn().mockReturnThis(),
         groupBy: jest.fn().mockReturnThis(),
         getRawMany: jest.fn().mockResolvedValue([]),
       };
@@ -1201,10 +1326,8 @@ describe('PopularRankingService', () => {
 
       const svc = new PopularRankingService(
         {
-          createQueryBuilder: jest
-            .fn()
-            .mockReturnValueOnce(candidateQB)
-            .mockReturnValueOnce(commentQB),
+          createQueryBuilder: jest.fn().mockReturnValue(candidateQB),
+          query: jest.fn().mockResolvedValue([]),
           find: jest.fn().mockResolvedValue([post]),
           findBy: jest.fn().mockResolvedValue([post]),
         } as any,

--- a/src/social/services/popular-ranking.service.spec.ts
+++ b/src/social/services/popular-ranking.service.spec.ts
@@ -1206,6 +1206,30 @@ describe('PopularRankingService', () => {
         svc.computeContentQuality('hello'),
       );
     });
+
+    it('scores non-Latin posts on par with Latin ones of the same length', () => {
+      // The alphanumeric ratio used an ASCII-only class, so a wholly Chinese,
+      // Arabic or Cyrillic post scored 0 on that term and ranked below an
+      // otherwise identical Latin post.
+      const svc = service as any;
+      const latin = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+      const baseline = svc.computeContentQuality(latin);
+
+      for (const content of [
+        '汉'.repeat(latin.length),
+        'م'.repeat(latin.length),
+        'п'.repeat(latin.length),
+      ]) {
+        expect(svc.computeContentQuality(content)).toBeCloseTo(baseline, 10);
+      }
+    });
+
+    it('still discounts a post of pure punctuation', () => {
+      const svc = service as any;
+      expect(svc.computeContentQuality('!'.repeat(30))).toBeLessThan(
+        svc.computeContentQuality('a'.repeat(30)),
+      );
+    });
   });
 
   describe('scheduled refresh locking', () => {

--- a/src/social/services/popular-ranking.service.ts
+++ b/src/social/services/popular-ranking.service.ts
@@ -46,15 +46,10 @@ export type PopularRankingWeightOverrides = Partial<
   Record<PopularCustomizableWeightKey, PopularRankingWeightScale | undefined>
 >;
 
-type Mutable<T> = {
-  -readonly [K in keyof T]: T[K];
-};
-
-type PopularRankingResolvedWeights = Mutable<
-  typeof POPULAR_RANKING_CONFIG.WEIGHTS
-> & {
-  interactionsPerHour: number;
-};
+type PopularRankingResolvedWeights = Record<
+  keyof typeof POPULAR_RANKING_CONFIG.WEIGHTS,
+  number
+>;
 
 interface PopularScoreInput {
   content: string;
@@ -129,7 +124,6 @@ export class PopularRankingService implements OnModuleDestroy {
   ): PopularRankingResolvedWeights {
     const resolved: PopularRankingResolvedWeights = {
       ...POPULAR_RANKING_CONFIG.WEIGHTS,
-      interactionsPerHour: 0,
     };
 
     if (!this.hasWeightOverrides(overrides)) {
@@ -143,11 +137,7 @@ export class PopularRankingService implements OnModuleDestroy {
       }
 
       const multiplier = multipliers[value];
-      if (key === 'interactionsPerHour') {
-        resolved.interactionsPerHour =
-          POPULAR_RANKING_CONFIG.CUSTOMIZATION.ADDITIONAL_SIGNAL_WEIGHTS
-            .interactionsPerHour * multiplier;
-      } else if (key in resolved) {
+      if (key in resolved) {
         (resolved as Record<string, number>)[key] *= multiplier;
       }
     }
@@ -963,7 +953,7 @@ export class PopularRankingService implements OnModuleDestroy {
     const interactionsPerHour = this.computeInteractionsPerHour(input, window);
     const freshnessFactor = this.computeFreshnessFactor(input);
 
-    return (
+    const baseScore =
       weights.comments * Math.log(1 + comments) +
       weights.tipsAmountAE * Math.log(1 + tipsAmountAE) +
       weights.tipsCount * Math.log(1 + tipsCount) +
@@ -975,7 +965,19 @@ export class PopularRankingService implements OnModuleDestroy {
       weights.velocityBoost *
         Math.log(1 + interactionsPerHour) *
         freshnessFactor +
-      weights.interactionsPerHour * Math.log(1 + interactionsPerHour)
+      weights.interactionsPerHour * Math.log(1 + interactionsPerHour);
+
+    if (window !== 'all') {
+      return baseScore;
+    }
+
+    // Log-dampened engagement never decays on its own, so without gravity old
+    // high-total posts pin the 'all' feed forever. +2 keeps brand-new posts
+    // from being divided by ~0.
+    const ageHours = this.computeAgeHours(input.createdAt, 1) ?? 1;
+    return (
+      baseScore /
+      Math.pow(ageHours + 2, POPULAR_RANKING_CONFIG.ALL_WINDOW_GRAVITY)
     );
   }
 
@@ -1040,21 +1042,28 @@ export class PopularRankingService implements OnModuleDestroy {
     }));
   }
 
+  private countEmojis(content: string): number {
+    try {
+      // Extended_Pictographic instead of Emoji: \p{Emoji} also matches digits,
+      // '#' and '*'. Global flag so every occurrence counts, not just the first.
+      return (content.match(/\p{Extended_Pictographic}/gu) || []).length;
+    } catch {
+      return 0;
+    }
+  }
+
   private computeContentQuality(content: string): number {
     if (!content) return 0;
     const cfg = POPULAR_RANKING_CONFIG.CONTENT;
-    const len = content.length;
+    // Code-point length, not UTF-16 length: emoji are surrogate pairs, so an
+    // emoji-only post would otherwise cap emojiRatio at 0.5 and dodge the
+    // short-and-emoji-heavy penalty.
+    const len = [...content].length;
     const lengthScore = Math.max(
       0,
       Math.min(1, (len - cfg.minLengthForNoPenalty) / cfg.maxReferenceLength),
     );
-    let emojis = 0;
-    try {
-      const emojiRegex = /[\p{Emoji_Presentation}\p{Emoji}\u200d]+/u;
-      emojis = (content.match(emojiRegex) || []).length;
-    } catch {
-      emojis = 0;
-    }
+    const emojis = this.countEmojis(content);
     const emojiRatio = Math.min(1, emojis / Math.max(1, len));
     const alnumMatches = content.match(/[A-Za-z0-9]/g) || [];
     const alnumRatio = Math.min(1, alnumMatches.length / Math.max(1, len));

--- a/src/social/services/popular-ranking.service.ts
+++ b/src/social/services/popular-ranking.service.ts
@@ -1214,7 +1214,10 @@ export class PopularRankingService implements OnModuleDestroy {
     );
     const emojis = this.countEmojis(content);
     const emojiRatio = Math.min(1, emojis / Math.max(1, len));
-    const alnumMatches = content.match(/[A-Za-z0-9]/g) || [];
+    // Letters/numbers in any script: an ASCII-only class scores a wholly Chinese,
+    // Arabic or Cyrillic post at a 0 ratio, permanently forfeiting this term and
+    // ranking non-Latin posts below identical Latin ones.
+    const alnumMatches = content.match(/[\p{L}\p{N}]/gu) || [];
     const alnumRatio = Math.min(1, alnumMatches.length / Math.max(1, len));
 
     let quality = 0.6 * lengthScore + 0.2 * alnumRatio + 0.2 * (1 - emojiRatio);

--- a/src/social/services/popular-ranking.service.ts
+++ b/src/social/services/popular-ranking.service.ts
@@ -415,20 +415,16 @@ export class PopularRankingService implements OnModuleDestroy {
   /**
    * Scheduled refresh so user requests almost never pay recompute latency —
    * on a low-traffic instance the lazy path would otherwise find a cold cache
-   * on nearly every request. Cadence is staggered by how fast each feed
-   * actually changes ('all' scores 10k candidates; no point doing that every
-   * minute), and the lazy recompute stays as cold-start fallback.
+   * on nearly every request; the lazy recompute stays as cold-start fallback.
+   *
+   * Only the 'all' window is refreshed on a schedule. GET /posts/popular is
+   * all-time — the `window` query param is deprecated and ignored — so nothing
+   * reads the '24h'/'7d' caches. Scheduling those recomputes only burned DB
+   * (candidate scan, tips/reads aggregation, recursive thread CTE) every
+   * minute/5 minutes to populate caches no request serves. The windowed code
+   * paths remain for the lazy/on-demand fallback should a consumer request
+   * them again.
    */
-  @Cron(CronExpression.EVERY_MINUTE)
-  refreshPopular24h(): Promise<void> {
-    return this.refreshWindowLocked('24h', 55);
-  }
-
-  @Cron(CronExpression.EVERY_5_MINUTES)
-  refreshPopular7d(): Promise<void> {
-    return this.refreshWindowLocked('7d', 295);
-  }
-
   @Cron(CronExpression.EVERY_10_MINUTES)
   refreshPopularAll(): Promise<void> {
     return this.refreshWindowLocked('all', 595);

--- a/src/social/services/popular-ranking.service.ts
+++ b/src/social/services/popular-ranking.service.ts
@@ -5,6 +5,7 @@ import {
   OnModuleDestroy,
   Optional,
 } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
 import { InjectRepository } from '@nestjs/typeorm';
 import { In, Repository } from 'typeorm';
 import { Post } from '../entities/post.entity';
@@ -52,12 +53,19 @@ type PopularRankingResolvedWeights = Record<
 >;
 
 interface PopularScoreInput {
+  id?: string;
   content: string;
   comments: number;
   tipsAmountAE: number;
   tipsCount: number;
   uniqueTippers: number;
   reads: number;
+  /**
+   * Interactions within VELOCITY_WINDOW_HOURS. When absent (sources without
+   * interaction timestamps, e.g. plugin items) velocity falls back to the
+   * lifetime average.
+   */
+  recentInteractions?: number;
   topics?: Array<{ name?: string }>;
   createdAt?: Date | string;
 }
@@ -404,6 +412,56 @@ export class PopularRankingService implements OnModuleDestroy {
     await task;
   }
 
+  /**
+   * Scheduled refresh so user requests almost never pay recompute latency —
+   * on a low-traffic instance the lazy path would otherwise find a cold cache
+   * on nearly every request. Cadence is staggered by how fast each feed
+   * actually changes ('all' scores 10k candidates; no point doing that every
+   * minute), and the lazy recompute stays as cold-start fallback.
+   */
+  @Cron(CronExpression.EVERY_MINUTE)
+  refreshPopular24h(): Promise<void> {
+    return this.refreshWindowLocked('24h', 55);
+  }
+
+  @Cron(CronExpression.EVERY_5_MINUTES)
+  refreshPopular7d(): Promise<void> {
+    return this.refreshWindowLocked('7d', 295);
+  }
+
+  @Cron(CronExpression.EVERY_10_MINUTES)
+  refreshPopularAll(): Promise<void> {
+    return this.refreshWindowLocked('all', 595);
+  }
+
+  /**
+   * A short-lived Redis lock (TTL just under the window's cron interval)
+   * keeps multiple app instances from recomputing the same window in
+   * parallel — whoever grabs the lock does the work, the rest skip the tick.
+   */
+  private async refreshWindowLocked(
+    window: PopularWindow,
+    lockTtlSeconds: number,
+  ): Promise<void> {
+    try {
+      const acquired = await this.redis.set(
+        `popular:refresh-lock:${window}`,
+        '1',
+        'EX',
+        lockTtlSeconds,
+        'NX',
+      );
+      if (acquired === null) {
+        return;
+      }
+    } catch {
+      // Redis unreachable — recompute could not cache its result anyway.
+      return;
+    }
+
+    await this.awaitOrTriggerRecompute(window);
+  }
+
   private async hydrateRankedItems(
     window: PopularWindow,
     ids: string[],
@@ -649,8 +707,11 @@ export class PopularRankingService implements OnModuleDestroy {
 
     const ids = candidates.map((c) => c.id);
     let tipsByPost = new Map<string, any>();
-    let commentsByPost = new Map<string, number>();
+    let commentsByPost = new Map<string, { count: number; recent: number }>();
     let readsByPost = new Map<string, number>();
+    const recentSince = new Date(
+      Date.now() - POPULAR_RANKING_CONFIG.VELOCITY_WINDOW_HOURS * 3600 * 1000,
+    );
 
     if (ids.length > 0) {
       const tipsRaw = await this.tipRepository
@@ -663,30 +724,65 @@ export class PopularRankingService implements OnModuleDestroy {
         )
         .addSelect('COUNT(*)', 'count')
         .addSelect('COUNT(DISTINCT tip.sender_address)', 'unique_tippers')
+        .addSelect(
+          'COUNT(*) FILTER (WHERE tip.created_at >= :recentSince)',
+          'recent_count',
+        )
         .where('tip.post_id IN (:...ids)', { ids })
         .andWhere('tip.sender_address != post.sender_address')
+        .setParameter('recentSince', recentSince)
         .groupBy('tip.post_id')
         .getRawMany<{
           post_id: string;
           amount_sum: string;
           count: string;
           unique_tippers: string;
+          recent_count: string;
         }>();
       tipsByPost = new Map(tipsRaw.map((t) => [t.post_id, t] as const));
 
-      const commentsRaw = await this.postRepository
-        .createQueryBuilder('comment')
-        .innerJoin(Post, 'parent', 'parent.id = comment.post_id')
-        .select('comment.post_id', 'parent_id')
-        .addSelect('COUNT(*)', 'count')
-        .where('comment.post_id IN (:...ids)', { ids })
-        .andWhere('comment.is_hidden = false')
-        .andWhere('comment.sender_address != parent.sender_address')
-        .groupBy('comment.post_id')
-        .getRawMany<{ parent_id: string; count: string }>();
+      // Whole-thread comment count: replies to comments attach to the
+      // comment's id, so counting direct children only would score a deep
+      // 30-message discussion as its handful of top-level comments. Replies
+      // authored by the root post's author are excluded (same anti-self-boost
+      // rule as before), and hidden comments prune their entire subtree.
+      const commentsRaw: Array<{
+        root_id: string;
+        count: string;
+        recent_count: string;
+      }> = await this.postRepository.query(
+        `WITH RECURSIVE thread AS (
+           SELECT p.id, p.id AS root_id, p.sender_address AS root_sender,
+                  0 AS depth
+           FROM posts p
+           WHERE p.id = ANY($1)
+           UNION ALL
+           SELECT c.id, t.root_id, t.root_sender, t.depth + 1
+           FROM posts c
+           INNER JOIN thread t ON c.post_id = t.id
+           WHERE c.is_hidden = false
+             AND t.depth < ${POPULAR_RANKING_CONFIG.THREAD_COUNT_MAX_DEPTH}
+         )
+         SELECT t.root_id AS root_id,
+                COUNT(*) AS count,
+                COUNT(*) FILTER (WHERE c.created_at >= $2) AS recent_count
+         FROM thread t
+         INNER JOIN posts c ON c.id = t.id
+         WHERE t.id != t.root_id
+           AND c.sender_address != t.root_sender
+         GROUP BY t.root_id`,
+        [ids, recentSince],
+      );
       commentsByPost = new Map(
         commentsRaw.map(
-          (r) => [r.parent_id, parseInt(r.count || '0', 10)] as const,
+          (r) =>
+            [
+              r.root_id,
+              {
+                count: parseInt(r.count || '0', 10),
+                recent: parseInt(r.recent_count || '0', 10),
+              },
+            ] as const,
         ),
       );
 
@@ -717,19 +813,25 @@ export class PopularRankingService implements OnModuleDestroy {
 
     const scoredPosts: PopularScoreItem[] = candidates.map((post) => {
       const tipsAgg = tipsByPost.get(post.id);
+      const commentsAgg = commentsByPost.get(post.id);
+      const recentInteractions =
+        (commentsAgg?.recent || 0) +
+        (tipsAgg ? parseInt(tipsAgg.recent_count || '0', 10) : 0);
       return {
         postId: post.id,
         score: this.computeScore(
           trendingByTag,
           {
+            id: post.id,
             content: post.content,
-            comments: commentsByPost.get(post.id) || 0,
+            comments: commentsAgg?.count || 0,
             tipsAmountAE: tipsAgg ? parseFloat(tipsAgg.amount_sum || '0') : 0,
             tipsCount: tipsAgg ? parseInt(tipsAgg.count || '0', 10) : 0,
             uniqueTippers: tipsAgg
               ? parseInt(tipsAgg.unique_tippers || '0', 10)
               : 0,
             reads: readsByPost.get(post.id) || 0,
+            recentInteractions,
             topics: post.topics,
             createdAt: post.created_at,
           },
@@ -746,6 +848,7 @@ export class PopularRankingService implements OnModuleDestroy {
         score: this.computeScore(
           trendingByTag,
           {
+            id: item.id,
             content: item.content,
             comments: item.total_comments || 0,
             tipsAmountAE: 0,
@@ -880,6 +983,17 @@ export class PopularRankingService implements OnModuleDestroy {
       return 0;
     }
 
+    // Recent interactions over the velocity window (or the post's age when
+    // younger): an old post catching fire today registers full velocity
+    // instead of having new activity averaged over its lifetime.
+    if (input.recentInteractions !== undefined) {
+      const velocityHours = Math.min(
+        ageHours,
+        POPULAR_RANKING_CONFIG.VELOCITY_WINDOW_HOURS,
+      );
+      return input.recentInteractions / Math.max(1, velocityHours);
+    }
+
     const effectiveHours =
       window === 'all'
         ? ageHours
@@ -909,6 +1023,30 @@ export class PopularRankingService implements OnModuleDestroy {
     return Math.max(
       minimumHours,
       (Date.now() - date.getTime()) / (60 * 60 * 1000),
+    );
+  }
+
+  /**
+   * Deterministic per-hour jitter in [0, TIE_ROTATION_EPSILON) that rotates
+   * near-tied posts (mostly the zero-engagement tail) so their relative order
+   * changes every hour instead of being frozen between recomputes. Added
+   * before gravity, so it scales down with everything else on 'all'.
+   */
+  private computeTieRotation(id?: string): number {
+    if (!id) {
+      return 0;
+    }
+
+    const hourBucket = Math.floor(Date.now() / (60 * 60 * 1000));
+    const seed = `${id}:${hourBucket}`;
+    let hash = 0x811c9dc5; // FNV-1a
+    for (let i = 0; i < seed.length; i++) {
+      hash ^= seed.charCodeAt(i);
+      hash = Math.imul(hash, 0x01000193);
+    }
+
+    return (
+      ((hash >>> 0) / 0x100000000) * POPULAR_RANKING_CONFIG.TIE_ROTATION_EPSILON
     );
   }
 
@@ -953,19 +1091,30 @@ export class PopularRankingService implements OnModuleDestroy {
     const interactionsPerHour = this.computeInteractionsPerHour(input, window);
     const freshnessFactor = this.computeFreshnessFactor(input);
 
+    // Reads are the easiest signal to inflate (a request with a browser UA is
+    // enough), so their counted volume is capped relative to active
+    // engagement — passive signal alone cannot outvote real interactions.
+    const activeInteractions = comments + tipsCount + uniqueTippers;
+    const effectiveReads = Math.min(
+      reads,
+      POPULAR_RANKING_CONFIG.READS_PER_INTERACTION_CAP *
+        (1 + activeInteractions),
+    );
+
     const baseScore =
       weights.comments * Math.log(1 + comments) +
       weights.tipsAmountAE * Math.log(1 + tipsAmountAE) +
       weights.tipsCount * Math.log(1 + tipsCount) +
       weights.uniqueTippers * Math.log(1 + uniqueTippers) +
-      weights.reads * Math.log(1 + reads) +
+      weights.reads * Math.log(1 + effectiveReads) +
       weights.trendingBoost * trendingBoost +
       weights.contentQuality * contentQuality +
       weights.freshnessBoost * freshnessFactor +
       weights.velocityBoost *
         Math.log(1 + interactionsPerHour) *
         freshnessFactor +
-      weights.interactionsPerHour * Math.log(1 + interactionsPerHour);
+      weights.interactionsPerHour * Math.log(1 + interactionsPerHour) +
+      this.computeTieRotation(input.id);
 
     if (window !== 'all') {
       return baseScore;

--- a/src/social/services/post.service.ts
+++ b/src/social/services/post.service.ts
@@ -29,6 +29,7 @@ import {
 } from '../interfaces/post.interfaces';
 import { parsePostContent } from '../utils/content-parser.util';
 import { refreshTrendingScoresForPostSafely } from '../utils/token-mentions.util';
+import { normalizeTopicName } from '../utils/topic-name.util';
 import { TokensService } from '@/tokens/tokens.service';
 
 @Injectable()
@@ -962,7 +963,7 @@ export class PostService {
         continue;
       }
 
-      const normalizedName = topicName.trim().toLowerCase();
+      const normalizedName = normalizeTopicName(topicName);
 
       // Try to find existing topic
       let topic = await this.topicRepository.findOne({

--- a/src/social/services/reads.service.spec.ts
+++ b/src/social/services/reads.service.spec.ts
@@ -1,0 +1,115 @@
+const redisSetMock = jest.fn();
+const redisMock = {
+  on: jest.fn().mockReturnThis(),
+  quit: jest.fn().mockResolvedValue('OK'),
+  set: redisSetMock,
+};
+
+jest.mock('ioredis', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => redisMock),
+}));
+
+import { ReadsService } from './reads.service';
+
+describe('ReadsService', () => {
+  let repo: any;
+  let service: ReadsService;
+
+  const buildReq = (ua = 'Mozilla/5.0', ip = '1.2.3.4') =>
+    ({
+      headers: { 'user-agent': ua },
+      ip,
+      socket: { remoteAddress: ip },
+    }) as any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    repo = { query: jest.fn().mockResolvedValue(undefined) };
+    service = new ReadsService(repo);
+  });
+
+  it('counts the first read of a viewer per post per day', async () => {
+    redisSetMock.mockResolvedValue('OK');
+
+    await service.recordRead('post-1', buildReq());
+
+    expect(redisSetMock).toHaveBeenCalledWith(
+      expect.stringContaining('reads:seen:'),
+      '1',
+      'EX',
+      expect.any(Number),
+      'NX',
+    );
+    expect(repo.query).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips repeat reads from the same viewer on the same day', async () => {
+    redisSetMock.mockResolvedValue(null);
+
+    await service.recordRead('post-1', buildReq());
+
+    expect(repo.query).not.toHaveBeenCalled();
+  });
+
+  it('fails open and counts the read when Redis is unavailable', async () => {
+    redisSetMock.mockRejectedValue(new Error('redis down'));
+
+    await service.recordRead('post-1', buildReq());
+
+    expect(repo.query).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores bot user agents entirely', async () => {
+    await service.recordRead('post-1', buildReq('curl/8.0.1'));
+
+    expect(redisSetMock).not.toHaveBeenCalled();
+    expect(repo.query).not.toHaveBeenCalled();
+  });
+
+  it('treats a missing user agent as a bot', async () => {
+    await service.recordRead('post-1', { headers: {} } as any);
+
+    expect(redisSetMock).not.toHaveBeenCalled();
+    expect(repo.query).not.toHaveBeenCalled();
+  });
+
+  it('fails open when the viewer IP cannot be determined', async () => {
+    const req = {
+      headers: { 'user-agent': 'Mozilla/5.0' },
+      socket: {},
+    } as any;
+
+    await service.recordRead('post-1', req);
+
+    expect(redisSetMock).not.toHaveBeenCalled();
+    expect(repo.query).toHaveBeenCalledTimes(1);
+  });
+
+  it('identifies the viewer by the first x-forwarded-for hop only', async () => {
+    redisSetMock.mockResolvedValue('OK');
+    const reqWithXff = (xff: string) =>
+      ({
+        headers: { 'user-agent': 'Mozilla/5.0', 'x-forwarded-for': xff },
+        ip: '10.0.0.1',
+        socket: { remoteAddress: '10.0.0.1' },
+      }) as any;
+
+    await service.recordRead('post-1', reqWithXff('1.1.1.1, 2.2.2.2'));
+    await service.recordRead('post-1', reqWithXff('1.1.1.1, 9.9.9.9'));
+    await service.recordRead('post-1', reqWithXff('3.3.3.3, 2.2.2.2'));
+
+    const keys = redisSetMock.mock.calls.map((call) => call[0]);
+    expect(keys[0]).toBe(keys[1]);
+    expect(keys[2]).not.toBe(keys[0]);
+  });
+
+  it('never throws when the reads upsert fails', async () => {
+    redisSetMock.mockResolvedValue('OK');
+    repo.query.mockRejectedValue(new Error('db down'));
+
+    await expect(
+      service.recordRead('post-1', buildReq()),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/social/services/reads.service.ts
+++ b/src/social/services/reads.service.ts
@@ -1,18 +1,32 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import { createHash } from 'crypto';
+import Redis from 'ioredis';
 import { PostReadsDaily } from '../entities/post-reads.entity';
 import type { Request } from 'express';
 import { POPULAR_RANKING_CONFIG } from '@/configs/constants';
+import { REDIS_CONFIG } from '@/configs/redis';
 
 @Injectable()
-export class ReadsService {
+export class ReadsService implements OnModuleDestroy {
   private readonly logger = new Logger(ReadsService.name);
+  private readonly redis = new Redis(REDIS_CONFIG);
+  // Keys embed the UTC date, so a fixed TTL just past a full day is enough.
+  private static readonly DEDUP_TTL_SECONDS = 25 * 60 * 60;
 
   constructor(
     @InjectRepository(PostReadsDaily)
     private readonly postReadsRepository: Repository<PostReadsDaily>,
-  ) {}
+  ) {
+    this.redis.on('error', (error) => {
+      this.logger.error('Reads dedup Redis connection error', error);
+    });
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await this.redis.quit();
+  }
 
   async recordRead(postId: string, req: Request): Promise<void> {
     try {
@@ -25,6 +39,14 @@ export class ReadsService {
       const dd = String(today.getUTCDate()).padStart(2, '0');
       const dateOnly = `${yyyy}-${mm}-${dd}`;
 
+      const isFirstReadToday = await this.isFirstReadToday(
+        postId,
+        dateOnly,
+        req,
+        ua,
+      );
+      if (!isFirstReadToday) return;
+
       // upsert reads += 1 for (post_id, date) using raw SQL for increment
       await this.postReadsRepository.query(
         `INSERT INTO post_reads_daily (post_id, date, reads)
@@ -35,6 +57,46 @@ export class ReadsService {
       );
     } catch (e) {
       this.logger.debug('recordRead skipped', e as any);
+    }
+  }
+
+  /**
+   * One counted read per viewer, post, and UTC day. Viewer identity is an
+   * IP+UA hash — coarse, but it stops a single client from inflating reads
+   * with a request loop. Fails open (counts the read) when the viewer cannot
+   * be identified or Redis is unavailable.
+   */
+  private async isFirstReadToday(
+    postId: string,
+    dateOnly: string,
+    req: Request,
+    ua: string,
+  ): Promise<boolean> {
+    const forwarded = (req?.headers?.['x-forwarded-for'] as string) || '';
+    const ip =
+      forwarded.split(',')[0]?.trim() ||
+      req?.ip ||
+      req?.socket?.remoteAddress ||
+      '';
+    if (!ip) return true;
+
+    const viewer = createHash('sha256')
+      .update(`${ip}:${ua}`)
+      .digest('hex')
+      .slice(0, 16);
+    const key = `reads:seen:${dateOnly}:${postId}:${viewer}`;
+
+    try {
+      const created = await this.redis.set(
+        key,
+        '1',
+        'EX',
+        ReadsService.DEDUP_TTL_SECONDS,
+        'NX',
+      );
+      return created !== null;
+    } catch {
+      return true;
     }
   }
 

--- a/src/social/utils/content-parser.util.spec.ts
+++ b/src/social/utils/content-parser.util.spec.ts
@@ -99,6 +99,56 @@ describe('Content Parser Utilities', () => {
 
       expect(topics).toEqual(['VALID']);
     });
+
+    it('finds a hashtag with no whitespace before it, as CJK is written', () => {
+      // Chinese has no inter-word spaces, so a split-on-whitespace scan sees one
+      // long "word" that does not start with '#' and yields nothing.
+      expect(extractTopics('我喜欢#汉字')).toEqual(['汉字']);
+      expect(extractTopics('看看#汉字，很好')).toEqual(['汉字']);
+    });
+
+    it('ends an undelimited hashtag greedily, exactly as it does in ASCII', () => {
+      // With no space or punctuation after it there is no boundary to find, so
+      // the trailing character is absorbed. This is the same semantics ASCII has
+      // always had ('#WORDSfoo' -> 'WORDSFOO'), not a CJK-specific regression.
+      expect(extractTopics('看看#汉字和吧')).toEqual(['汉字和吧']);
+      expect(extractTopics('buy #WORDSfoo now')).toEqual(['WORDSFOO']);
+    });
+
+    it('agrees with extractTrendMentions on which hashtags exist', () => {
+      // The two extractors used to disagree for CJK: mentions used a regex scan,
+      // topics split on whitespace. They must find the same set.
+      for (const content of [
+        '我喜欢#汉字',
+        '看看#汉字，很好',
+        '看看#汉字和吧',
+      ]) {
+        expect(extractTopics(content)).toEqual(
+          extractTrendMentions(content).map((m) => m.toUpperCase()),
+        );
+      }
+    });
+
+    it('drops trailing punctuation so the topic stays addressable', () => {
+      // `#汉字。` used to be stored as `汉字。`, which TopicParamPipe rejects with a
+      // 400 — the topic existed but its own page was unreachable.
+      expect(extractTopics('i like #汉字。 a lot')).toEqual(['汉字']);
+      expect(extractTopics('i like #مرحبا؟ a lot')).toEqual(['مرحبا']);
+      expect(extractTopics('wow #hello! there')).toEqual(['HELLO']);
+    });
+
+    it('produces topic names the topic param validator accepts', () => {
+      const TOPIC_PATTERN = /^[\p{L}\p{N}][\p{L}\p{N} _.-]{0,127}$/u;
+      const content =
+        '#汉字。 #مرحبا؟ #ПРИВЕТ! #hello! #CamelCase #valid_tag #123 #-lead #_lead';
+
+      const topics = extractTopics(content, 20);
+
+      expect(topics.length).toBeGreaterThan(0);
+      for (const topic of topics) {
+        expect(TOPIC_PATTERN.test(topic)).toBe(true);
+      }
+    });
   });
 
   describe('extractTrendMentions', () => {

--- a/src/social/utils/content-parser.util.spec.ts
+++ b/src/social/utils/content-parser.util.spec.ts
@@ -124,6 +124,29 @@ describe('Content Parser Utilities', () => {
         'CAMELCASE',
       ]);
     });
+
+    it('extracts mentions of tokens from the non-Latin collections', () => {
+      expect(extractTrendMentions('buying #汉字 today')).toEqual(['汉字']);
+      expect(extractTrendMentions('buying #مرحبا today')).toEqual(['مرحبا']);
+      expect(extractTrendMentions('buying #ПРИВЕТ today')).toEqual(['ПРИВЕТ']);
+    });
+
+    it('uppercases a Cyrillic mention to the symbol the token is stored under', () => {
+      // The RUSSIAN collection only permits А-Я, so the on-chain symbol is
+      // uppercase; a lowercase hashtag has to fold onto it to resolve.
+      expect(extractTrendMentions('держим #привет крепко')).toEqual(['ПРИВЕТ']);
+      expect(extractTrendMentions('и #ёлка тоже')).toEqual(['ЁЛКА']);
+    });
+
+    it('extracts Latin and non-Latin mentions from the same post', () => {
+      expect(
+        extractTrendMentions('swapping #WORDS-1 for #汉字 and #привет'),
+      ).toEqual(['WORDS-1', '汉字', 'ПРИВЕТ']);
+    });
+
+    it('deduplicates a non-Latin mention repeated in one post', () => {
+      expect(extractTrendMentions('#汉字 then #汉字 again')).toEqual(['汉字']);
+    });
   });
 
   describe('extractMedia', () => {

--- a/src/social/utils/content-parser.util.ts
+++ b/src/social/utils/content-parser.util.ts
@@ -50,11 +50,25 @@ export function parsePostContent(
 }
 
 /**
+ * A hashtag, scanned rather than split on whitespace: Chinese is written without
+ * spaces, so `我喜欢#汉字` has no whitespace-delimited word starting with `#` and a
+ * split-based scan finds nothing — while `extractTrendMentions` (a real regex
+ * scan) does find the token. The two extractors have to agree.
+ *
+ * The body is exactly what `TOPIC_PATTERN` in the request validation accepts, so
+ * a topic we store is always addressable at `/topics/name/:name`.
+ */
+const TOPIC_HASHTAG_PATTERN = /#([\p{L}\p{N}][\p{L}\p{N}_.-]*)/gu;
+
+/** Characters `TOPIC_PATTERN` would reject, e.g. `。`, `؟`, `!`, emoji. */
+const TOPIC_DISALLOWED_CHARS = /[^\p{L}\p{N}_.-]+/gu;
+
+/**
  * Normalize topic name according to business rules:
  * - Convert camelCase to kebab-case
  * - Convert to uppercase
- * - Keep all characters (no removal)
- * - Clean up multiple hyphens and leading/trailing hyphens
+ * - Drop characters a topic name may not contain
+ * - Clean up hyphens, and ensure it starts with a letter or number
  */
 function normalizeTopic(topic: string): string {
   // Remove the # prefix if present
@@ -63,11 +77,17 @@ function normalizeTopic(topic: string): string {
   // First, convert camelCase to kebab-case
   const kebabCase = withoutHash.replace(/([a-z])([A-Z])/g, '$1-$2');
 
-  // Convert to uppercase (but keep all characters)
-  const normalized = kebabCase.toUpperCase();
-
-  // Clean up multiple hyphens and leading/trailing hyphens
-  return normalized.replace(/-+/g, '-').replace(/^-|-$/g, '');
+  return (
+    kebabCase
+      .toUpperCase()
+      // CJK/Arabic terminal punctuation clings to a hashtag (there is no
+      // separating space), so `#汉字。` would otherwise be stored as `汉字。` — a
+      // name TopicParamPipe rejects, making the topic's own page 400.
+      .replace(TOPIC_DISALLOWED_CHARS, '')
+      .replace(/-+/g, '-')
+      .replace(/^[_.-]+/, '')
+      .replace(/-$/, '')
+  );
 }
 
 /**
@@ -81,9 +101,7 @@ export function extractTopics(
     return [];
   }
 
-  const topics = content
-    .split(/\s+/)
-    .filter((word) => word.startsWith('#') && word.length > 1)
+  const topics = (content.match(TOPIC_HASHTAG_PATTERN) ?? [])
     .map((topic) => normalizeTopic(topic))
     .filter((topic) => topic.length > 0 && topic.length <= 50) // Reasonable length limits
     .slice(0, maxTopics);

--- a/src/social/utils/content-parser.util.ts
+++ b/src/social/utils/content-parser.util.ts
@@ -74,8 +74,9 @@ function normalizeTopic(topic: string): string {
   // Remove the # prefix if present
   const withoutHash = topic.startsWith('#') ? topic.slice(1) : topic;
 
-  // First, convert camelCase to kebab-case
-  const kebabCase = withoutHash.replace(/([a-z])([A-Z])/g, '$1-$2');
+  // camelCase -> kebab-case, in any script that has letter case. Must stay in
+  // step with `normalizeTagName`, or a trending tag never matches its topic.
+  const kebabCase = withoutHash.replace(/(\p{Ll})(\p{Lu})/gu, '$1-$2');
 
   return (
     kebabCase

--- a/src/social/utils/token-mentions-sql.util.spec.ts
+++ b/src/social/utils/token-mentions-sql.util.spec.ts
@@ -1,0 +1,138 @@
+import { BCL_FACTORY } from '@/configs/contracts';
+import {
+  TOKEN_HASHTAG_REGEX_SOURCE,
+  buildNormalizedTokenMentionSelectSql,
+  buildTokenMentionExistsSql,
+} from './token-mentions-sql.util';
+
+const HYPHEN = 0x2d;
+
+const matchAll = (content: string): string[] => {
+  const matches = content.match(new RegExp(TOKEN_HASHTAG_REGEX_SOURCE, 'g'));
+  return (matches ?? []).map((match) => match.slice(1));
+};
+
+/** Every codepoint a collection permits, as a flat list. */
+const allowedCodepoints = (collection: {
+  allowed_name_chars: { [key: string]: number[] }[];
+}): number[] => {
+  const codepoints: number[] = [];
+
+  for (const entry of collection.allowed_name_chars) {
+    if (Array.isArray(entry.SingleChar)) {
+      codepoints.push(entry.SingleChar[0]);
+    }
+    if (Array.isArray(entry.CharRangeFromTo)) {
+      codepoints.push(entry.CharRangeFromTo[0], entry.CharRangeFromTo[1]);
+    }
+  }
+
+  return codepoints;
+};
+
+describe('token-mentions-sql util', () => {
+  describe('TOKEN_HASHTAG_REGEX_SOURCE', () => {
+    it('matches hashtags naming tokens from every non-Latin collection', () => {
+      expect(matchAll('look at #汉字 rising')).toEqual(['汉字']);
+      expect(matchAll('look at #مرحبا rising')).toEqual(['مرحبا']);
+      expect(matchAll('look at #ПРИВЕТ rising')).toEqual(['ПРИВЕТ']);
+      expect(matchAll('look at #ЁЛКА rising')).toEqual(['ЁЛКА']);
+    });
+
+    it('still matches the Latin hashtags it always did', () => {
+      expect(matchAll('buy #WORDS-1 and #beta_2 now')).toEqual([
+        'WORDS-1',
+        'beta_2',
+      ]);
+    });
+
+    it('picks up several scripts out of one post', () => {
+      expect(matchAll('#汉字 vs #WORDS vs #привет vs #مرحبا')).toEqual([
+        '汉字',
+        'WORDS',
+        'привет',
+        'مرحبا',
+      ]);
+    });
+
+    it('accepts a hyphen inside a symbol but not as its first character', () => {
+      expect(matchAll('#WORDS-1')).toEqual(['WORDS-1']);
+      expect(matchAll('#-nope')).toEqual([]);
+    });
+
+    it('caps a symbol at 50 characters', () => {
+      expect(matchAll('#' + 'A'.repeat(50))).toEqual(['A'.repeat(50)]);
+      expect(matchAll('#' + 'A'.repeat(60))).toEqual(['A'.repeat(50)]);
+      expect(matchAll('#' + '汉'.repeat(60))).toEqual(['汉'.repeat(50)]);
+    });
+
+    it('ignores a bare hash', () => {
+      expect(matchAll('# not a tag #')).toEqual([]);
+    });
+
+    /**
+     * The guard that keeps this honest: the class is derived from the factory
+     * config, so a collection added later is covered without editing this file —
+     * and if its charset somehow is not matched, this fails.
+     */
+    it('matches a symbol built from any collection the factory allows', () => {
+      const collections = Object.values(BCL_FACTORY).flatMap((factory) =>
+        Object.values(factory.collections),
+      );
+
+      expect(collections.length).toBeGreaterThan(0);
+
+      for (const collection of collections) {
+        const symbol = allowedCodepoints(collection)
+          .filter((codepoint) => codepoint !== HYPHEN)
+          .map((codepoint) => String.fromCodePoint(codepoint))
+          .join('');
+
+        expect(matchAll(`mentioning #${symbol} here`)).toEqual([symbol]);
+
+        // People type the symbol in whichever case is convenient; both the JS
+        // parser and Postgres UPPER() fold it back to the stored symbol.
+        const lowercased = symbol.toLowerCase();
+        expect(matchAll(`mentioning #${lowercased} here`)).toEqual([
+          lowercased,
+        ]);
+      }
+    });
+
+    /**
+     * This exact string is interpolated into Postgres `regexp_matches(...)` as
+     * well as passed to `new RegExp(...)`. `\uXXXX` is the only escape both
+     * engines read the same way — a JS-only construct (`\p{L}`, `\u{...}`) would
+     * still pass the JS tests here while silently matching nothing in SQL.
+     */
+    it('uses only escape syntax that Postgres and JS both understand', () => {
+      expect(TOKEN_HASHTAG_REGEX_SOURCE).toMatch(
+        /^#\(\[(?:\\u[0-9A-F]{4}|-)+\]\[(?:\\u[0-9A-F]{4}|-)+\]\{0,49\}\)$/,
+      );
+      expect(TOKEN_HASHTAG_REGEX_SOURCE).not.toContain('\\p{');
+      expect(TOKEN_HASHTAG_REGEX_SOURCE).not.toContain('\\u{');
+    });
+
+    it('does not leak an unescaped quote into the SQL string literal', () => {
+      expect(TOKEN_HASHTAG_REGEX_SOURCE).not.toContain("'");
+    });
+  });
+
+  describe('SQL builders', () => {
+    it('embeds the shared pattern in the content fallback', () => {
+      const sql = buildNormalizedTokenMentionSelectSql('post');
+
+      expect(sql).toContain(`'${TOKEN_HASHTAG_REGEX_SOURCE}'`);
+      expect(sql).toContain('UPPER(mention.symbol)');
+      expect(sql).toContain('post.token_mentions');
+    });
+
+    it('scopes the exists check to the given alias and symbol', () => {
+      const sql = buildTokenMentionExistsSql('post', '$2');
+
+      expect(sql).toContain('EXISTS (');
+      expect(sql).toContain('normalized_mentions.symbol = $2');
+      expect(sql).toContain(`'${TOKEN_HASHTAG_REGEX_SOURCE}'`);
+    });
+  });
+});

--- a/src/social/utils/token-mentions-sql.util.ts
+++ b/src/social/utils/token-mentions-sql.util.ts
@@ -1,4 +1,196 @@
-export const TOKEN_HASHTAG_REGEX_SOURCE = '#([A-Za-z0-9_][A-Za-z0-9_-]{0,49})';
+import { Logger } from '@nestjs/common';
+import { BCL_FACTORY } from '@/configs/contracts';
+
+const logger = new Logger('TokenMentionsSqlUtil');
+
+/**
+ * A BCL token's symbol is its on-chain community name verbatim, and each factory
+ * collection declares exactly which characters such a name may contain
+ * (`allowed_name_chars`). The hashtag character class is therefore derived from
+ * that config instead of being hardcoded: adding a collection (CHINESE, ARABIC,
+ * RUSSIAN, ...) makes its tokens mentionable without touching this file.
+ *
+ * The source string below is consumed verbatim by two regex engines — JS
+ * `RegExp` and Postgres ARE (`regexp_matches`) — so every codepoint is emitted
+ * as a `\uXXXX` escape. That is the one form both engines read identically, and
+ * it keeps regex-special characters (`-`, `]`, `^`) from ever landing in the
+ * bracket expression raw.
+ */
+
+/** Inclusive `[start, end]` codepoint interval. */
+type CodepointRange = [number, number];
+
+/** Accepted long before collections existed; kept so old mentions still parse. */
+const UNDERSCORE = 0x5f;
+
+/** Legal inside a symbol, never as its first character. */
+const HYPHEN = 0x2d;
+
+/** Total symbol length cap (first character + tail). */
+const MAX_SYMBOL_LENGTH = 50;
+
+/** A `\uXXXX` escape is exactly 4 hex digits in both engines. */
+const BMP_MAX = 0xffff;
+
+/**
+ * Every codepoint any collection permits, across every network.
+ */
+function collectionRanges(): CodepointRange[] {
+  const ranges: CodepointRange[] = [[UNDERSCORE, UNDERSCORE]];
+
+  for (const factory of Object.values(BCL_FACTORY)) {
+    for (const collection of Object.values(factory.collections ?? {})) {
+      for (const entry of collection.allowed_name_chars ?? []) {
+        const single = entry.SingleChar;
+        if (Array.isArray(single) && single.length > 0) {
+          ranges.push([single[0], single[0]]);
+        }
+
+        const range = entry.CharRangeFromTo;
+        if (Array.isArray(range) && range.length > 1) {
+          ranges.push([range[0], range[1]]);
+        }
+      }
+    }
+  }
+
+  return ranges;
+}
+
+/**
+ * Collections declare the *stored* casing (WORDS allows `A-Z`, RUSSIAN `А-Я`),
+ * but people type `#words` and `#привет`. Both the JS parser and Postgres
+ * `UPPER()` fold a mention up to the stored symbol, so the class has to admit
+ * either case on the way in.
+ */
+function withCaseCounterparts(ranges: CodepointRange[]): CodepointRange[] {
+  const expanded: CodepointRange[] = [...ranges];
+
+  for (const [start, end] of ranges) {
+    for (let codepoint = start; codepoint <= end; codepoint++) {
+      const character = String.fromCodePoint(codepoint);
+
+      for (const variant of [
+        character.toLowerCase(),
+        character.toUpperCase(),
+      ]) {
+        // Some characters case-fold to multiple characters (ß -> SS); such a
+        // fold has no single codepoint to add to the class.
+        if (variant.length === 1 && variant !== character) {
+          const variantCodepoint = variant.codePointAt(0) as number;
+          expanded.push([variantCodepoint, variantCodepoint]);
+        }
+      }
+    }
+  }
+
+  return expanded;
+}
+
+/** Sorts and coalesces overlapping or adjacent intervals. */
+function mergeRanges(ranges: CodepointRange[]): CodepointRange[] {
+  const sorted = [...ranges].sort((a, b) => a[0] - b[0] || a[1] - b[1]);
+  const merged: CodepointRange[] = [];
+
+  for (const [start, end] of sorted) {
+    const previous = merged[merged.length - 1];
+
+    if (previous && start <= previous[1] + 1) {
+      previous[1] = Math.max(previous[1], end);
+      continue;
+    }
+
+    merged.push([start, end]);
+  }
+
+  return merged;
+}
+
+/**
+ * Astral codepoints would need `\u{...}` in JS but `\Uxxxxxxxx` in Postgres, so
+ * there is no shared escape for them. No collection uses any today; warn loudly
+ * rather than silently failing to match if one ever does.
+ */
+function toBasicMultilingualPlane(ranges: CodepointRange[]): CodepointRange[] {
+  const kept: CodepointRange[] = [];
+  let dropped = false;
+
+  for (const [start, end] of ranges) {
+    if (start > BMP_MAX) {
+      dropped = true;
+      continue;
+    }
+
+    if (end > BMP_MAX) {
+      dropped = true;
+      kept.push([start, BMP_MAX]);
+      continue;
+    }
+
+    kept.push([start, end]);
+  }
+
+  if (dropped) {
+    logger.warn(
+      'A BCL collection allows codepoints above U+FFFF. Hashtags using them will not be indexed: ' +
+        'JS and Postgres have no common escape syntax for astral codepoints.',
+    );
+  }
+
+  return kept;
+}
+
+/** Removes a single codepoint from a set of intervals, splitting where needed. */
+function withoutCodepoint(
+  ranges: CodepointRange[],
+  codepoint: number,
+): CodepointRange[] {
+  const remaining: CodepointRange[] = [];
+
+  for (const [start, end] of ranges) {
+    if (codepoint < start || codepoint > end) {
+      remaining.push([start, end]);
+      continue;
+    }
+
+    if (start <= codepoint - 1) {
+      remaining.push([start, codepoint - 1]);
+    }
+
+    if (codepoint + 1 <= end) {
+      remaining.push([codepoint + 1, end]);
+    }
+  }
+
+  return remaining;
+}
+
+const escapeCodepoint = (codepoint: number): string =>
+  `\\u${codepoint.toString(16).toUpperCase().padStart(4, '0')}`;
+
+/** Renders intervals as the inside of a bracket expression, fully escaped. */
+function toCharClass(ranges: CodepointRange[]): string {
+  return ranges
+    .map(([start, end]) =>
+      start === end
+        ? escapeCodepoint(start)
+        : `${escapeCodepoint(start)}-${escapeCodepoint(end)}`,
+    )
+    .join('');
+}
+
+const ALLOWED_RANGES = mergeRanges(
+  toBasicMultilingualPlane(
+    withCaseCounterparts(mergeRanges(collectionRanges())),
+  ),
+);
+
+const TAIL_CLASS = toCharClass(ALLOWED_RANGES);
+const FIRST_CLASS = toCharClass(withoutCodepoint(ALLOWED_RANGES, HYPHEN));
+
+export const TOKEN_HASHTAG_REGEX_SOURCE = `#([${FIRST_CLASS}][${TAIL_CLASS}]{0,${
+  MAX_SYMBOL_LENGTH - 1
+}})`;
 
 export function buildNormalizedTokenMentionSelectSql(
   postAlias: string,

--- a/src/social/utils/topic-name.util.ts
+++ b/src/social/utils/topic-name.util.ts
@@ -1,0 +1,11 @@
+/**
+ * Topic rows are stored under a lowercased name, so every lookup has to fold the
+ * caller's input the same way the writer did — otherwise `/topics/name/ПРИВЕТ`
+ * misses the row stored as `привет`.
+ *
+ * `toLowerCase()` is Unicode-aware, so this covers Cyrillic as well as Latin.
+ * Chinese and Arabic are caseless and pass through unchanged.
+ */
+export function normalizeTopicName(name: string): string {
+  return name.trim().toLowerCase();
+}

--- a/src/token-gated-rooms/__tests__/aex9-transfer.plugin.spec.ts
+++ b/src/token-gated-rooms/__tests__/aex9-transfer.plugin.spec.ts
@@ -1,0 +1,79 @@
+import { Aex9TransferPlugin } from '../plugins/aex9-transfer.plugin';
+import { BalanceIndexerService } from '../services/balance-indexer.service';
+import {
+  AEX9_TRANSFER_PLUGIN_NAME,
+  AEX9_TRANSFER_PLUGIN_VERSION,
+} from '../plugins/aex9-transfer-sync.service';
+import type { Tx } from '@/mdw-sync/entities/tx.entity';
+
+/**
+ * Unit coverage for the AEX9-transfer plugin shell (Task 03). The single
+ * predicate filter must: accept an in-allowlist `ContractCallTx`, reject an
+ * out-of-allowlist contract id, reject non-`ContractCallTx`, and reject a missing
+ * `contract_id`. Mirrors `BclPlugin`'s predicate gating.
+ */
+describe('Aex9TransferPlugin', () => {
+  const TOKEN = 'ct_in_allowlist';
+
+  const makeIndexer = (allow: Set<string>): BalanceIndexerService =>
+    ({
+      isCommunityToken: (addr?: string | null) => !!addr && allow.has(addr),
+    }) as unknown as BalanceIndexerService;
+
+  const makePlugin = (allow: Set<string>): Aex9TransferPlugin =>
+    new Aex9TransferPlugin(
+      {} as any, // txRepository (unused by filters())
+      {} as any, // pluginSyncStateRepository
+      makeIndexer(allow),
+      {} as any, // syncService
+      { bufferAllPendingEvictions: jest.fn().mockResolvedValue(0) } as any, // reorgEviction
+    );
+
+  const predicate = (plugin: Aex9TransferPlugin) => {
+    const filters = plugin.filters();
+    expect(filters).toHaveLength(1);
+    expect(typeof filters[0].predicate).toBe('function');
+    return filters[0].predicate!;
+  };
+
+  it('exposes the canonical name + version', () => {
+    const plugin = makePlugin(new Set());
+    expect(plugin.name).toBe(AEX9_TRANSFER_PLUGIN_NAME);
+    expect(plugin.version).toBe(AEX9_TRANSFER_PLUGIN_VERSION);
+  });
+
+  it('accepts an in-allowlist ContractCallTx', () => {
+    const plugin = makePlugin(new Set([TOKEN]));
+    const ok = predicate(plugin)({
+      type: 'ContractCallTx',
+      contract_id: TOKEN,
+    } as Partial<Tx>);
+    expect(ok).toBe(true);
+  });
+
+  it('rejects an out-of-allowlist contract id', () => {
+    const plugin = makePlugin(new Set([TOKEN]));
+    const ok = predicate(plugin)({
+      type: 'ContractCallTx',
+      contract_id: 'ct_not_in_allowlist',
+    } as Partial<Tx>);
+    expect(ok).toBe(false);
+  });
+
+  it('rejects a non-ContractCallTx (e.g. SpendTx) even if contract_id matches', () => {
+    const plugin = makePlugin(new Set([TOKEN]));
+    const ok = predicate(plugin)({
+      type: 'SpendTx',
+      contract_id: TOKEN,
+    } as Partial<Tx>);
+    expect(ok).toBe(false);
+  });
+
+  it('rejects a tx with no contract_id', () => {
+    const plugin = makePlugin(new Set([TOKEN]));
+    const ok = predicate(plugin)({
+      type: 'ContractCallTx',
+    } as Partial<Tx>);
+    expect(ok).toBe(false);
+  });
+});

--- a/src/token-gated-rooms/__tests__/balance-apply.spec.ts
+++ b/src/token-gated-rooms/__tests__/balance-apply.spec.ts
@@ -1,0 +1,151 @@
+import { BigNumber } from 'bignumber.js';
+import { Aex9TransferSyncService } from '../plugins/aex9-transfer-sync.service';
+import { BalanceIndexerService } from '../services/balance-indexer.service';
+import { AEX9_TRANSFER_PLUGIN_NAME } from '../plugins/aex9-transfer-sync.service';
+import { SyncDirectionEnum } from '@/plugins/plugin.interface';
+import type { Tx } from '@/mdw-sync/entities/tx.entity';
+
+const TOKEN = 'ct_token';
+const FROM = 'ak_from';
+const TO = 'ak_to';
+
+/** Build a Tx carrying pre-decoded plugin logs (the BasePlugin-persisted shape). */
+function txWithTransfers(
+  transfers: Array<{ name: string; args: unknown[] }>,
+  overrides: Partial<Tx> = {},
+): Tx {
+  return {
+    hash: 'th_test',
+    type: 'ContractCallTx',
+    contract_id: TOKEN,
+    block_height: 100,
+    raw: { log: [] },
+    logs: {
+      [AEX9_TRANSFER_PLUGIN_NAME]: { _version: 1, data: transfers },
+    },
+    data: undefined,
+    ...overrides,
+  } as unknown as Tx;
+}
+
+describe('Aex9TransferSyncService.processTransaction (balance apply)', () => {
+  let indexer: jest.Mocked<
+    Pick<
+      BalanceIndexerService,
+      'isCommunityToken' | 'applyDelta' | 'emitBalanceChanged'
+    >
+  >;
+  let txRepository: { update: jest.Mock };
+  let service: Aex9TransferSyncService;
+
+  beforeEach(() => {
+    indexer = {
+      isCommunityToken: jest.fn().mockReturnValue(true),
+      applyDelta: jest.fn(),
+      emitBalanceChanged: jest.fn(),
+    } as any;
+    txRepository = { update: jest.fn().mockResolvedValue(undefined) };
+    service = new Aex9TransferSyncService(
+      {} as any, // aeSdkService
+      indexer as unknown as BalanceIndexerService,
+      txRepository as any,
+    );
+  });
+
+  it('applies both legs of a single transfer (from decrement, to increment)', async () => {
+    indexer.applyDelta
+      .mockResolvedValueOnce(new BigNumber('500')) // from
+      .mockResolvedValueOnce(new BigNumber('1500')); // to
+
+    const tx = txWithTransfers([
+      { name: 'Transfer', args: [FROM, TO, '1000'] },
+    ]);
+    await service.processTransaction(tx, SyncDirectionEnum.Live);
+
+    expect(indexer.applyDelta).toHaveBeenCalledTimes(2);
+    // from leg: negated value
+    expect(indexer.applyDelta).toHaveBeenNthCalledWith(
+      1,
+      TOKEN,
+      FROM,
+      expect.objectContaining({}),
+      100,
+    );
+    expect(indexer.applyDelta.mock.calls[0][2].toFixed()).toBe('-1000');
+    // to leg: positive value
+    expect(indexer.applyDelta.mock.calls[1][1]).toBe(TO);
+    expect(indexer.applyDelta.mock.calls[1][2].toFixed()).toBe('1000');
+
+    // both holders changed → both emitted
+    expect(indexer.emitBalanceChanged).toHaveBeenCalledWith(TOKEN, FROM);
+    expect(indexer.emitBalanceChanged).toHaveBeenCalledWith(TOKEN, TO);
+  });
+
+  it('ignores non-Transfer (Allowance) events — no balance moves', async () => {
+    const tx = txWithTransfers([
+      { name: 'Allowance', args: [FROM, TO, '1000'] },
+    ]);
+    await service.processTransaction(tx, SyncDirectionEnum.Live);
+    expect(indexer.applyDelta).not.toHaveBeenCalled();
+    expect(indexer.emitBalanceChanged).not.toHaveBeenCalled();
+  });
+
+  it('does not emit for a leg whose balance did not change (applyDelta → null)', async () => {
+    indexer.applyDelta
+      .mockResolvedValueOnce(null) // from unchanged (e.g. clamp no-op)
+      .mockResolvedValueOnce(new BigNumber('1000')); // to changed
+
+    const tx = txWithTransfers([
+      { name: 'Transfer', args: [FROM, TO, '1000'] },
+    ]);
+    await service.processTransaction(tx, SyncDirectionEnum.Live);
+
+    expect(indexer.emitBalanceChanged).toHaveBeenCalledTimes(1);
+    expect(indexer.emitBalanceChanged).toHaveBeenCalledWith(TOKEN, TO);
+  });
+
+  it('is idempotent: a tx already marked _applied is a no-op', async () => {
+    const tx = txWithTransfers(
+      [{ name: 'Transfer', args: [FROM, TO, '1000'] }],
+      {
+        data: {
+          [AEX9_TRANSFER_PLUGIN_NAME]: {
+            _version: 1,
+            data: { _applied: true },
+          },
+        },
+      },
+    );
+    await service.processTransaction(tx, SyncDirectionEnum.Live);
+    expect(indexer.applyDelta).not.toHaveBeenCalled();
+    expect(indexer.emitBalanceChanged).not.toHaveBeenCalled();
+  });
+
+  it('marks the tx _applied after a successful apply (persisted via repo)', async () => {
+    indexer.applyDelta.mockResolvedValue(new BigNumber('1'));
+    const tx = txWithTransfers([
+      { name: 'Transfer', args: [FROM, TO, '1000'] },
+    ]);
+    await service.processTransaction(tx, SyncDirectionEnum.Live);
+    expect(tx.data?.[AEX9_TRANSFER_PLUGIN_NAME]?.data?._applied).toBe(true);
+    expect(txRepository.update).toHaveBeenCalledWith(
+      { hash: 'th_test' },
+      { data: tx.data },
+    );
+  });
+
+  it('skips a tx whose contract is no longer in the allowlist', async () => {
+    indexer.isCommunityToken.mockReturnValue(false);
+    const tx = txWithTransfers([
+      { name: 'Transfer', args: [FROM, TO, '1000'] },
+    ]);
+    await service.processTransaction(tx, SyncDirectionEnum.Live);
+    expect(indexer.applyDelta).not.toHaveBeenCalled();
+  });
+
+  it('ignores zero / non-positive transfer values', async () => {
+    const tx = txWithTransfers([{ name: 'Transfer', args: [FROM, TO, '0'] }]);
+    await service.processTransaction(tx, SyncDirectionEnum.Live);
+    expect(indexer.applyDelta).not.toHaveBeenCalled();
+  });
+});

--- a/src/token-gated-rooms/__tests__/balance-indexer.integration.spec.ts
+++ b/src/token-gated-rooms/__tests__/balance-indexer.integration.spec.ts
@@ -1,0 +1,233 @@
+import 'dotenv/config';
+import { BigNumber } from 'bignumber.js';
+import { DataSource, Repository } from 'typeorm';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { DATABASE_CONFIG } from '@/configs/database';
+import { Token } from '@/tokens/entities/token.entity';
+import { Tx } from '@/mdw-sync/entities/tx.entity';
+import { TokenBalance } from '../entities/token-balance.entity';
+import { BalanceIndexerService } from '../services/balance-indexer.service';
+import { BalanceReconciliationService } from '../services/balance-reconciliation.service';
+import { Aex9TransferSyncService } from '../plugins/aex9-transfer-sync.service';
+import { AEX9_TRANSFER_PLUGIN_NAME } from '../plugins/aex9-transfer-sync.service';
+import { TGR_BALANCE_CHANGED } from '../events';
+import { TGR_COMMUNITY_UPSERTED } from '../events';
+import { SyncDirectionEnum } from '@/plugins/plugin.interface';
+
+/**
+ * DB integration (Task 03, Task 02 harness style). Drives the real
+ * `BalanceIndexerService` / `Aex9TransferSyncService` / `BalanceReconciliationService`
+ * against a live Postgres `token_balance` table. Requires `DB_HOST` (repo `.env`);
+ * skipped automatically otherwise so unit-only runs stay green.
+ *
+ * The `token_balance` table is ensured via raw DDL (idempotent) so the test does
+ * not depend on the app having run its migrations, and rows are scoped to a unique
+ * test token id then cleaned up.
+ */
+const HAS_DB = !!process.env.DB_HOST;
+const d = HAS_DB ? describe : describe.skip;
+
+const TEST_TOKEN = 'ct_tgr03_int_token';
+const TEST_SALE = 'ct_tgr03_int_sale';
+const FROM = 'ak_tgr03_from';
+const TO = 'ak_tgr03_to';
+const config: any = {
+  communityTokenRefreshSec: 300,
+  reconcileBatchSize: 500,
+  reconcileIntervalSec: 600,
+};
+
+d('AEX9 balance indexer (integration)', () => {
+  let ds: DataSource;
+  let tokenBalanceRepo: Repository<TokenBalance>;
+  let tokenRepo: Repository<Token>;
+  let txRepo: Repository<Tx>;
+  let emitter: EventEmitter2;
+
+  beforeAll(async () => {
+    ds = new DataSource({
+      ...(DATABASE_CONFIG as any),
+      synchronize: false,
+      entities: [Token, Tx, TokenBalance],
+    });
+    await ds.initialize();
+    // Ensure the table exists (idempotent) so the test is self-contained.
+    await ds.query(`
+      CREATE TABLE IF NOT EXISTS "token_balance" (
+        "token_address" character varying NOT NULL,
+        "holder_address" character varying NOT NULL,
+        "balance" numeric NOT NULL DEFAULT 0,
+        "updated_height" integer NOT NULL DEFAULT 0,
+        "last_reconciled_at" timestamptz,
+        CONSTRAINT "PK_token_balance" PRIMARY KEY ("token_address", "holder_address")
+      )
+    `);
+    tokenBalanceRepo = ds.getRepository(TokenBalance);
+    tokenRepo = ds.getRepository(Token);
+    txRepo = ds.getRepository(Tx);
+    emitter = new EventEmitter2();
+  }, 60_000);
+
+  afterEach(async () => {
+    await tokenBalanceRepo.delete({ token_address: TEST_TOKEN });
+    await tokenRepo.delete({ sale_address: TEST_SALE }).catch(() => undefined);
+  });
+
+  afterAll(async () => {
+    if (ds?.isInitialized) {
+      await ds.destroy();
+    }
+  });
+
+  const makeIndexer = () =>
+    new BalanceIndexerService(tokenRepo, tokenBalanceRepo, emitter, config);
+
+  it('indexes a Transfer into token_balance rows in raw base units, sets height, emits', async () => {
+    const indexer = makeIndexer();
+    indexer.addToAllowlist(TEST_TOKEN);
+
+    const sync = new Aex9TransferSyncService({} as any, indexer, txRepo);
+
+    const changed: Array<{ tokenAddress: string; holderAddress: string }> = [];
+    emitter.on(TGR_BALANCE_CHANGED, (p: any) => changed.push(p));
+
+    // Seed sender with a starting balance so the from-leg has something to debit.
+    await tokenBalanceRepo.save(
+      tokenBalanceRepo.create({
+        token_address: TEST_TOKEN,
+        holder_address: FROM,
+        balance: new BigNumber('5000000000000000000'), // 5 @ 18 decimals
+        updated_height: 1,
+      }),
+    );
+
+    // A real-shaped pre-decoded Transfer of 2 @ 18 decimals (raw base units).
+    const tx = {
+      hash: 'th_tgr03_transfer',
+      type: 'ContractCallTx',
+      contract_id: TEST_TOKEN,
+      block_height: 4242,
+      raw: { log: [] },
+      logs: {
+        [AEX9_TRANSFER_PLUGIN_NAME]: {
+          _version: 1,
+          data: [
+            {
+              name: 'Transfer',
+              args: [FROM, TO, '2000000000000000000'],
+            },
+          ],
+        },
+      },
+    } as unknown as Tx;
+    // Persist the tx so the _applied marker update has a row to touch.
+    await txRepo.save({
+      ...tx,
+      block_hash: 'mh_tgr03',
+      micro_index: '0',
+      micro_time: '0',
+      signatures: [],
+    } as any);
+
+    await sync.processTransaction(tx, SyncDirectionEnum.Live);
+
+    const fromRow = await tokenBalanceRepo.findOneByOrFail({
+      token_address: TEST_TOKEN,
+      holder_address: FROM,
+    });
+    const toRow = await tokenBalanceRepo.findOneByOrFail({
+      token_address: TEST_TOKEN,
+      holder_address: TO,
+    });
+
+    expect(fromRow.balance.toFixed()).toBe('3000000000000000000'); // 5 - 2
+    expect(toRow.balance.toFixed()).toBe('2000000000000000000'); // 0 + 2
+    expect(toRow.updated_height).toBe(4242);
+
+    const holders = changed.map((c) => c.holderAddress).sort();
+    expect(holders).toEqual([FROM, TO].sort());
+    for (const c of changed) {
+      expect(c.tokenAddress).toBe(TEST_TOKEN);
+    }
+
+    await txRepo.delete({ hash: 'th_tgr03_transfer' }).catch(() => undefined);
+  }, 60_000);
+
+  it('reconciliation corrects a drifted balance, advances last_reconciled_at, emits', async () => {
+    const indexer = makeIndexer();
+
+    // Seed a drifted row.
+    await tokenBalanceRepo.save(
+      tokenBalanceRepo.create({
+        token_address: TEST_TOKEN,
+        holder_address: TO,
+        balance: new BigNumber('111'), // wrong
+        updated_height: 1,
+        last_reconciled_at: new Date('2000-01-01T00:00:00Z'),
+      }),
+    );
+
+    const aeSdkService = {
+      sdk: { getHeight: jest.fn().mockResolvedValue(99999) },
+    } as any;
+    const reconciler = new BalanceReconciliationService(
+      tokenBalanceRepo,
+      { add: jest.fn() } as any,
+      indexer,
+      aeSdkService,
+      config,
+    );
+    // Stub the chain read to the TRUE value.
+    jest
+      .spyOn(reconciler, 'readAuthoritativeBalance')
+      .mockResolvedValue(new BigNumber('1000'));
+
+    const changed: any[] = [];
+    emitter.on(TGR_BALANCE_CHANGED, (p) => changed.push(p));
+
+    const corrected = await reconciler.runOnce();
+    expect(corrected).toBeGreaterThanOrEqual(1);
+
+    const row = await tokenBalanceRepo.findOneByOrFail({
+      token_address: TEST_TOKEN,
+      holder_address: TO,
+    });
+    expect(row.balance.toFixed()).toBe('1000');
+    expect(row.updated_height).toBe(99999);
+    expect(row.last_reconciled_at.getTime()).toBeGreaterThan(
+      new Date('2000-01-02T00:00:00Z').getTime(),
+    );
+    expect(
+      changed.some(
+        (c) => c.tokenAddress === TEST_TOKEN && c.holderAddress === TO,
+      ),
+    ).toBe(true);
+  }, 60_000);
+
+  it('allowlist refresh: tgr.community.upserted makes a new token indexable', async () => {
+    const indexer = makeIndexer();
+    await indexer.refreshAllowlist();
+    expect(indexer.isCommunityToken(TEST_TOKEN)).toBe(false);
+
+    // Insert a minimal Token row via raw SQL so the test does not depend on the
+    // Task-00 TGR columns being migrated into the live `token` table (the
+    // allowlist only reads `address`; a full entity save would SELECT all cols).
+    await ds.query(
+      `INSERT INTO "token" ("sale_address","address","name","symbol")
+       VALUES ($1,$2,$3,$4)
+       ON CONFLICT ("sale_address") DO UPDATE SET "address" = EXCLUDED."address"`,
+      [TEST_SALE, TEST_TOKEN, 'TGR03', 'TGR03'],
+    );
+
+    await indexer.onCommunityUpserted({ saleAddress: TEST_SALE });
+    expect(indexer.isCommunityToken(TEST_TOKEN)).toBe(true);
+
+    // And a full refresh from DB also picks it up.
+    const indexer2 = makeIndexer();
+    await indexer2.refreshAllowlist();
+    expect(indexer2.isCommunityToken(TEST_TOKEN)).toBe(true);
+
+    // sanity: TGR_COMMUNITY_UPSERTED is the canonical name we listen on
+    expect(TGR_COMMUNITY_UPSERTED).toBe('tgr.community.upserted');
+  }, 60_000);
+});

--- a/src/token-gated-rooms/__tests__/balance-indexer.service.spec.ts
+++ b/src/token-gated-rooms/__tests__/balance-indexer.service.spec.ts
@@ -1,0 +1,199 @@
+import { BigNumber } from 'bignumber.js';
+import { BalanceIndexerService } from '../services/balance-indexer.service';
+import type { TokenBalance } from '../entities/token-balance.entity';
+
+const TOKEN = 'ct_token';
+const HOLDER = 'ak_holder';
+
+/**
+ * Unit coverage for the allowlist cache + `applyDelta` clamp logic (Task 03).
+ * Repositories + emitter are stubbed; the focus is the negative-clamp guard
+ * (mirrors `TokenHolderService.calculateNewBalance`) and the change-detection
+ * that drives `tgr.balance.changed`.
+ */
+describe('BalanceIndexerService', () => {
+  const makeService = (opts: {
+    tokenRows?: Array<{ address: string }>;
+    existingBalance?: TokenBalance | null;
+    refreshSec?: number;
+  }) => {
+    const tokenBalanceStore = {
+      value: opts.existingBalance ?? null,
+    };
+    const tokenRepository = {
+      find: jest.fn().mockResolvedValue(opts.tokenRows ?? []),
+      findOne: jest.fn(),
+    };
+    const tokenBalanceRepository = {
+      findOne: jest
+        .fn()
+        .mockImplementation(async () => tokenBalanceStore.value),
+      create: jest.fn().mockImplementation((x) => x),
+      save: jest.fn().mockImplementation(async (x) => {
+        tokenBalanceStore.value = x as TokenBalance;
+        return x;
+      }),
+      update: jest.fn().mockResolvedValue(undefined),
+    };
+    const eventEmitter = { emit: jest.fn() };
+    const config = {
+      communityTokenRefreshSec: opts.refreshSec ?? 300,
+    };
+    const service = new BalanceIndexerService(
+      tokenRepository as any,
+      tokenBalanceRepository as any,
+      eventEmitter as any,
+      config as any,
+    );
+    return {
+      service,
+      tokenRepository,
+      tokenBalanceRepository,
+      eventEmitter,
+      tokenBalanceStore,
+    };
+  };
+
+  describe('applyDelta', () => {
+    it('increments a new holder from zero (to leg)', async () => {
+      const { service } = makeService({ existingBalance: null });
+      const next = await service.applyDelta(
+        TOKEN,
+        HOLDER,
+        new BigNumber('1000'),
+        50,
+      );
+      expect(next?.toFixed()).toBe('1000');
+    });
+
+    it('decrements an existing balance (from leg)', async () => {
+      const { service } = makeService({
+        existingBalance: {
+          token_address: TOKEN,
+          holder_address: HOLDER,
+          balance: new BigNumber('1000'),
+          updated_height: 10,
+          last_reconciled_at: null as any,
+        },
+      });
+      const next = await service.applyDelta(
+        TOKEN,
+        HOLDER,
+        new BigNumber('-400'),
+        60,
+      );
+      expect(next?.toFixed()).toBe('600');
+    });
+
+    it('clamps at 0 — never persists a negative balance', async () => {
+      const { service } = makeService({
+        existingBalance: {
+          token_address: TOKEN,
+          holder_address: HOLDER,
+          balance: new BigNumber('100'),
+          updated_height: 10,
+          last_reconciled_at: null as any,
+        },
+      });
+      const next = await service.applyDelta(
+        TOKEN,
+        HOLDER,
+        new BigNumber('-999999'),
+        60,
+      );
+      expect(next?.toFixed()).toBe('0');
+    });
+
+    it('returns null when the balance does not actually change', async () => {
+      const { service, tokenBalanceRepository } = makeService({
+        existingBalance: {
+          token_address: TOKEN,
+          holder_address: HOLDER,
+          balance: new BigNumber('0'),
+          updated_height: 10,
+          last_reconciled_at: null as any,
+        },
+      });
+      // already 0, clamp keeps it 0 → no change
+      const next = await service.applyDelta(
+        TOKEN,
+        HOLDER,
+        new BigNumber('-5'),
+        60,
+      );
+      expect(next).toBeNull();
+      // height was newer → only an updated_height bump, not a balance save
+      expect(tokenBalanceRepository.update).toHaveBeenCalled();
+    });
+  });
+
+  describe('allowlist', () => {
+    it('loads community-token addresses from Token where address is set', async () => {
+      const { service } = makeService({
+        tokenRows: [{ address: 'ct_a' }, { address: 'ct_b' }],
+      });
+      await service.refreshAllowlist();
+      expect(service.isCommunityToken('ct_a')).toBe(true);
+      expect(service.isCommunityToken('ct_b')).toBe(true);
+      expect(service.isCommunityToken('ct_c')).toBe(false);
+    });
+
+    it('addToAllowlist makes a new token indexable immediately', async () => {
+      const { service } = makeService({ tokenRows: [] });
+      await service.refreshAllowlist();
+      expect(service.isCommunityToken('ct_new')).toBe(false);
+      service.addToAllowlist('ct_new');
+      expect(service.isCommunityToken('ct_new')).toBe(true);
+    });
+
+    it('isCommunityToken(undefined/null) is false', async () => {
+      const { service } = makeService({ tokenRows: [] });
+      await service.refreshAllowlist();
+      expect(service.isCommunityToken(undefined)).toBe(false);
+      expect(service.isCommunityToken(null)).toBe(false);
+    });
+
+    it('onCommunityUpserted adds the token AEX9 address', async () => {
+      const { service, tokenRepository } = makeService({ tokenRows: [] });
+      await service.refreshAllowlist();
+      tokenRepository.findOne.mockResolvedValue({ address: 'ct_upserted' });
+      await service.onCommunityUpserted({ saleAddress: 'ct_sale' });
+      expect(service.isCommunityToken('ct_upserted')).toBe(true);
+    });
+
+    it('onLiveTx refreshes the allowlist on a create_community tx', async () => {
+      const { service, tokenRepository } = makeService({ tokenRows: [] });
+      await service.refreshAllowlist();
+      tokenRepository.find.mockResolvedValue([{ address: 'ct_fresh' }]);
+      await service.onLiveTx({
+        hash: 'th_x',
+        type: 'ContractCallTx',
+        function: 'create_community',
+      } as any);
+      expect(service.isCommunityToken('ct_fresh')).toBe(true);
+    });
+
+    it('onLiveTx ignores non-create_community txs', async () => {
+      const { service, tokenRepository } = makeService({ tokenRows: [] });
+      await service.refreshAllowlist();
+      tokenRepository.find.mockClear();
+      await service.onLiveTx({
+        hash: 'th_y',
+        type: 'ContractCallTx',
+        function: 'buy',
+      } as any);
+      expect(tokenRepository.find).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('emitBalanceChanged', () => {
+    it('emits the thin canonical payload', () => {
+      const { service, eventEmitter } = makeService({});
+      service.emitBalanceChanged(TOKEN, HOLDER);
+      expect(eventEmitter.emit).toHaveBeenCalledWith('tgr.balance.changed', {
+        tokenAddress: TOKEN,
+        holderAddress: HOLDER,
+      });
+    });
+  });
+});

--- a/src/token-gated-rooms/__tests__/balance-indexer.service.spec.ts
+++ b/src/token-gated-rooms/__tests__/balance-indexer.service.spec.ts
@@ -125,6 +125,36 @@ describe('BalanceIndexerService', () => {
       // height was newer → only an updated_height bump, not a balance save
       expect(tokenBalanceRepository.update).toHaveBeenCalled();
     });
+
+    it('routes read+write through the passed transactional manager (joins the outer tx), not the default repo', async () => {
+      const { service, tokenBalanceRepository } = makeService({
+        existingBalance: null,
+      });
+      // A manager whose repository records the writes, so we can prove the
+      // default (auto-committing) repo was NOT touched under a transaction.
+      const txRepo = {
+        findOne: jest.fn().mockResolvedValue(null),
+        create: jest.fn().mockImplementation((x) => x),
+        save: jest.fn().mockImplementation(async (x) => x),
+        update: jest.fn().mockResolvedValue(undefined),
+      };
+      const manager = { getRepository: jest.fn().mockReturnValue(txRepo) };
+
+      const next = await service.applyDelta(
+        TOKEN,
+        HOLDER,
+        new BigNumber('1000'),
+        50,
+        manager as any,
+      );
+
+      expect(next?.toFixed()).toBe('1000');
+      // The write went to the transactional repo…
+      expect(txRepo.save).toHaveBeenCalledTimes(1);
+      // …and the default connection repo was never used (would survive rollback).
+      expect(tokenBalanceRepository.findOne).not.toHaveBeenCalled();
+      expect(tokenBalanceRepository.save).not.toHaveBeenCalled();
+    });
   });
 
   describe('allowlist', () => {

--- a/src/token-gated-rooms/__tests__/balance-reconciliation.service.spec.ts
+++ b/src/token-gated-rooms/__tests__/balance-reconciliation.service.spec.ts
@@ -1,0 +1,155 @@
+import { BigNumber } from 'bignumber.js';
+import { BalanceReconciliationService } from '../services/balance-reconciliation.service';
+import { BalanceIndexerService } from '../services/balance-indexer.service';
+
+const TOKEN = 'ct_token';
+const HOLDER = 'ak_holder';
+
+/**
+ * Unit coverage for the reconciliation sweep (Task 03). Repos/queue/SDK are
+ * stubbed; the focus is the rotating-cursor batch + drift correction + emit.
+ */
+describe('BalanceReconciliationService.runOnce', () => {
+  const makeService = (opts: {
+    rows: Array<{
+      token_address: string;
+      holder_address: string;
+      balance: BigNumber;
+      updated_height: number;
+    }>;
+    authoritative: BigNumber | null;
+    batchSize?: number;
+  }) => {
+    const qb = {
+      orderBy: jest.fn().mockReturnThis(),
+      take: jest.fn().mockReturnThis(),
+      getMany: jest.fn().mockResolvedValue(opts.rows),
+    };
+    const tokenBalanceRepository = {
+      createQueryBuilder: jest.fn().mockReturnValue(qb),
+      update: jest.fn().mockResolvedValue(undefined),
+    };
+    const reconcileQueue = { add: jest.fn().mockResolvedValue(undefined) };
+    const setAuthoritativeBalance = jest.fn();
+    const emitBalanceChanged = jest.fn();
+    const balanceIndexer = {
+      setAuthoritativeBalance,
+      emitBalanceChanged,
+    } as unknown as BalanceIndexerService;
+    const aeSdkService = {
+      sdk: { getHeight: jest.fn().mockResolvedValue(12345) },
+    };
+    const config = {
+      reconcileBatchSize: opts.batchSize ?? 500,
+      reconcileIntervalSec: 600,
+    };
+    const service = new BalanceReconciliationService(
+      tokenBalanceRepository as any,
+      reconcileQueue as any,
+      balanceIndexer,
+      aeSdkService as any,
+      config as any,
+    );
+    // stub the chain read directly (no real SDK)
+    jest
+      .spyOn(service, 'readAuthoritativeBalance')
+      .mockResolvedValue(opts.authoritative);
+    return {
+      service,
+      tokenBalanceRepository,
+      setAuthoritativeBalance,
+      emitBalanceChanged,
+      qb,
+    };
+  };
+
+  it('orders the batch by oldest last_reconciled_at and limits to batch size', async () => {
+    const { service, qb } = makeService({
+      rows: [],
+      authoritative: new BigNumber('1'),
+      batchSize: 250,
+    });
+    await service.runOnce();
+    expect(qb.orderBy).toHaveBeenCalledWith(
+      'tb.last_reconciled_at',
+      'ASC',
+      'NULLS FIRST',
+    );
+    expect(qb.take).toHaveBeenCalledWith(250);
+  });
+
+  it('corrects a drifted row, sets the authoritative value, and emits', async () => {
+    const { service, setAuthoritativeBalance, emitBalanceChanged } =
+      makeService({
+        rows: [
+          {
+            token_address: TOKEN,
+            holder_address: HOLDER,
+            balance: new BigNumber('999'), // stored (drifted)
+            updated_height: 10,
+          },
+        ],
+        authoritative: new BigNumber('1000'), // true value on chain
+      });
+    setAuthoritativeBalance.mockResolvedValue(new BigNumber('1000')); // changed
+
+    const corrected = await service.runOnce();
+
+    expect(corrected).toBe(1);
+    expect(setAuthoritativeBalance).toHaveBeenCalledWith(
+      TOKEN,
+      HOLDER,
+      expect.any(BigNumber),
+      12345, // tip height
+    );
+    expect(setAuthoritativeBalance.mock.calls[0][2].toFixed()).toBe('1000');
+    expect(emitBalanceChanged).toHaveBeenCalledWith(TOKEN, HOLDER);
+  });
+
+  it('does not emit when the stored balance already matches chain (no drift)', async () => {
+    const { service, setAuthoritativeBalance, emitBalanceChanged } =
+      makeService({
+        rows: [
+          {
+            token_address: TOKEN,
+            holder_address: HOLDER,
+            balance: new BigNumber('1000'),
+            updated_height: 10,
+          },
+        ],
+        authoritative: new BigNumber('1000'),
+      });
+    setAuthoritativeBalance.mockResolvedValue(null); // unchanged
+
+    const corrected = await service.runOnce();
+
+    expect(corrected).toBe(0);
+    expect(emitBalanceChanged).not.toHaveBeenCalled();
+  });
+
+  it('skips overwrite (advances cursor only) when the chain read fails', async () => {
+    const { service, tokenBalanceRepository, setAuthoritativeBalance } =
+      makeService({
+        rows: [
+          {
+            token_address: TOKEN,
+            holder_address: HOLDER,
+            balance: new BigNumber('1000'),
+            updated_height: 10,
+          },
+        ],
+        authoritative: null, // read failed
+      });
+    await service.runOnce();
+    expect(setAuthoritativeBalance).not.toHaveBeenCalled();
+    expect(tokenBalanceRepository.update).toHaveBeenCalledWith(
+      { token_address: TOKEN, holder_address: HOLDER },
+      expect.objectContaining({ last_reconciled_at: expect.any(Date) }),
+    );
+  });
+
+  it('returns 0 with no rows', async () => {
+    const { service } = makeService({ rows: [], authoritative: null });
+    expect(await service.runOnce()).toBe(0);
+  });
+});

--- a/src/token-gated-rooms/__tests__/decimals.spec.ts
+++ b/src/token-gated-rooms/__tests__/decimals.spec.ts
@@ -1,0 +1,102 @@
+import { BigNumber } from 'bignumber.js';
+import { toShiftedBigNumber, humanToRaw, hasAtLeast } from '../utils/decimals';
+
+/**
+ * Unit coverage for the decimals util (Task 03). The indexed `token_balance` is
+ * already raw on-chain; this util only converts human-entered thresholds to raw
+ * and compares raw-vs-raw. `Token.decimals` is a STRING — the coercion must work.
+ */
+describe('decimals util', () => {
+  describe('toShiftedBigNumber', () => {
+    it('shifts by 0 decimals (no-op)', () => {
+      expect(toShiftedBigNumber('7', 0).toFixed()).toBe('7');
+    });
+
+    it('shifts by 6 decimals', () => {
+      expect(toShiftedBigNumber('1', 6).toFixed()).toBe('1000000');
+    });
+
+    it('shifts by 18 decimals', () => {
+      expect(toShiftedBigNumber('1', 18).toFixed()).toBe('1000000000000000000');
+    });
+
+    it('coerces a STRING precision (Token.decimals is a string)', () => {
+      const decimalsAsString: string = '18';
+      expect(toShiftedBigNumber('2', decimalsAsString).toFixed()).toBe(
+        '2000000000000000000',
+      );
+    });
+
+    it('coerces a bigint precision', () => {
+      expect(toShiftedBigNumber('3', 6n).toFixed()).toBe('3000000');
+    });
+
+    it('accepts a BigNumber value', () => {
+      expect(toShiftedBigNumber(new BigNumber('5'), 6).toFixed()).toBe(
+        '5000000',
+      );
+    });
+  });
+
+  describe('humanToRaw', () => {
+    it('decimals 0 → raw equals input integer', () => {
+      expect(humanToRaw('42', 0).toFixed()).toBe('42');
+    });
+
+    it('decimals 6 → 1.5 tokens = 1_500000 base units', () => {
+      expect(humanToRaw('1.5', 6).toFixed()).toBe('1500000');
+    });
+
+    it('decimals 18 → 1 token = 10^18 base units', () => {
+      expect(humanToRaw('1', 18).toFixed()).toBe('1000000000000000000');
+    });
+
+    it('coerces a STRING decimals value', () => {
+      const decimals: string = '6';
+      expect(humanToRaw('2.5', decimals).toFixed()).toBe('2500000');
+    });
+
+    it('floors sub-base-unit precision (base units are integers)', () => {
+      // 0.0000001 at 6 decimals would be 0.1 base units → floored to 0
+      expect(humanToRaw('0.0000001', 6).toFixed()).toBe('0');
+      // 1.9999999 at 6 decimals → 1999999.9 → floored to 1999999
+      expect(humanToRaw('1.9999999', 6).toFixed()).toBe('1999999');
+    });
+  });
+
+  describe('hasAtLeast (raw-vs-raw, no float scaling)', () => {
+    it('equal → true (boundary, inclusive)', () => {
+      const v = new BigNumber('1000000000000000000');
+      expect(hasAtLeast(v, v)).toBe(true);
+    });
+
+    it('just-below → false', () => {
+      expect(
+        hasAtLeast(
+          new BigNumber('999999999999999999'),
+          new BigNumber('1000000000000000000'),
+        ),
+      ).toBe(false);
+    });
+
+    it('just-above → true', () => {
+      expect(
+        hasAtLeast(
+          new BigNumber('1000000000000000001'),
+          new BigNumber('1000000000000000000'),
+        ),
+      ).toBe(true);
+    });
+
+    it('zero balance vs zero threshold → true', () => {
+      expect(hasAtLeast(new BigNumber(0), new BigNumber(0))).toBe(true);
+    });
+
+    it('compares values beyond Number.MAX_SAFE_INTEGER without precision loss', () => {
+      const balance = new BigNumber('9007199254740993000000000000000000');
+      const threshold = new BigNumber('9007199254740992000000000000000000');
+      expect(hasAtLeast(balance, threshold)).toBe(true);
+      expect(hasAtLeast(threshold, balance)).toBe(false);
+    });
+  });
+});

--- a/src/token-gated-rooms/__tests__/harness-db.integration.spec.ts
+++ b/src/token-gated-rooms/__tests__/harness-db.integration.spec.ts
@@ -1,0 +1,96 @@
+import 'dotenv/config';
+import { DataSource } from 'typeorm';
+import { DATABASE_CONFIG } from '@/configs/database';
+import {
+  createIsolatedDatabase,
+  dropDatabase,
+  MINIMAL_TOKEN_TABLE_SQL,
+} from '@/test/harness/db';
+import { Token } from '@/tokens/entities/token.entity';
+import { CommunityRoom } from '@/token-gated-rooms/entities/community-room.entity';
+import { RoomMembership } from '@/token-gated-rooms/entities/room-membership.entity';
+import { RoomNotificationPreference } from '@/token-gated-rooms/entities/room-notification-preference.entity';
+import { RoomMessageSeen } from '@/token-gated-rooms/entities/room-message-seen.entity';
+import { TokenBalance } from '@/token-gated-rooms/entities/token-balance.entity';
+import { RoomBackfillState } from '@/token-gated-rooms/entities/room-backfill-state.entity';
+
+/**
+ * Task 02 harness self-test (DB isolation). Proves `createIsolatedDatabase`:
+ *   - provisions a brand-new throwaway database,
+ *   - applies the real TGR migrations into it (no `synchronize`),
+ *   - a `token` row written through the migrated schema reads back with the new
+ *     TGR columns present (`nostr_room_state` defaulting to `'none'`),
+ *   - `drop()` removes the database (asserted gone via `pg_database`),
+ *   - and the whole thing never touches the shared application database.
+ *
+ * Auto-skips when `DB_HOST` is unset so unit-only runs stay green.
+ */
+const HAS_DB = !!process.env.DB_HOST;
+const d = HAS_DB ? describe : describe.skip;
+
+async function databaseExists(name: string): Promise<boolean> {
+  const admin = new DataSource({
+    ...(DATABASE_CONFIG as any),
+    synchronize: false,
+    entities: [],
+    migrations: [],
+  });
+  await admin.initialize();
+  try {
+    const rows = await admin.query(
+      `SELECT 1 FROM pg_database WHERE datname = $1`,
+      [name],
+    );
+    return rows.length > 0;
+  } finally {
+    await admin.destroy();
+  }
+}
+
+d('harness/db: isolated throwaway database (self-test)', () => {
+  it('creates a DB, runs migrations, round-trips a token, then drops it', async () => {
+    const db = await createIsolatedDatabase({
+      entities: [
+        Token,
+        CommunityRoom,
+        RoomMembership,
+        RoomNotificationPreference,
+        RoomMessageSeen,
+        TokenBalance,
+        RoomBackfillState,
+      ],
+      seedSql: [MINIMAL_TOKEN_TABLE_SQL],
+    });
+
+    try {
+      // The throwaway DB exists and is isolated from the shared app DB.
+      expect(await databaseExists(db.name)).toBe(true);
+      expect(db.name).not.toBe((DATABASE_CONFIG as any).database);
+
+      await db.dataSource.runMigrations();
+
+      // Insert a token directly and read the new TGR columns back.
+      await db.dataSource.query(`INSERT INTO "token" ("address") VALUES ($1)`, [
+        'ct_harness_selftest',
+      ]);
+      const rows = await db.dataSource.query(
+        `SELECT "address", "has_nostr_room", "nostr_room_state" FROM "token" WHERE "address" = $1`,
+        ['ct_harness_selftest'],
+      );
+      expect(rows).toHaveLength(1);
+      expect(rows[0].has_nostr_room).toBe(false);
+      expect(rows[0].nostr_room_state).toBe('none');
+    } finally {
+      // Drop via the handle; belt-and-braces drop by name in case it threw mid-way.
+      await db.drop().catch(() => dropDatabase(db.name).catch(() => undefined));
+    }
+
+    // The database is gone after teardown.
+    expect(await databaseExists(db.name)).toBe(false);
+  }, 60_000);
+
+  it('refuses to drop the shared application database', async () => {
+    const appDb = (DATABASE_CONFIG as any).database as string;
+    await expect(dropDatabase(appDb)).rejects.toThrow(/refusing to drop/i);
+  });
+});

--- a/src/token-gated-rooms/__tests__/harness-relay.spec.ts
+++ b/src/token-gated-rooms/__tests__/harness-relay.spec.ts
@@ -1,0 +1,41 @@
+import {
+  RELAY_ADMIN_NSEC,
+  RELAY_URL,
+  relayReachable,
+} from '@/test/harness/relay';
+
+/**
+ * Task 02 harness self-test (relay fixture). Proves the centralized
+ * `relayReachable` probe + relay-admin defaults behave for relay-backed specs:
+ *   - an unreachable URL resolves `false` (within the bounded timeout) so specs
+ *     can `describe.skip` deterministically — this runs with no relay present;
+ *   - the configured local relay (when one is up at `RELAY_URL`) resolves `true`.
+ *
+ * Kept in the unit project (no DB) so it always runs; the live-relay assertion is
+ * gated on reachability so it never flakes the no-container path.
+ */
+describe('harness/relay: reachability probe (self-test)', () => {
+  it('exposes the local relay URL + relay-admin nsec defaults', () => {
+    expect(typeof RELAY_URL).toBe('string');
+    expect(RELAY_URL).toMatch(/^wss?:\/\//);
+    expect(RELAY_ADMIN_NSEC).toMatch(/^nsec1[0-9a-z]+$/);
+  });
+
+  it('returns false for an unreachable relay (bounded, no throw)', async () => {
+    // A port nothing listens on — must resolve false within the timeout.
+    const reachable = await relayReachable('ws://127.0.0.1:1', 1500);
+    expect(reachable).toBe(false);
+  }, 5000);
+
+  it('detects the local relay when one is running (auto-skip otherwise)', async () => {
+    const up = await relayReachable(RELAY_URL, 3000);
+    if (!up) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[harness/relay self-test] no relay at ${RELAY_URL} — skipping live check`,
+      );
+      return;
+    }
+    expect(up).toBe(true);
+  }, 8000);
+});

--- a/src/token-gated-rooms/client-room-api.module.spec.ts
+++ b/src/token-gated-rooms/client-room-api.module.spec.ts
@@ -1,0 +1,48 @@
+import 'reflect-metadata';
+import { MODULE_METADATA } from '@nestjs/common/constants';
+import { ClientRoomApiModule } from './client-room-api.module';
+import { RoomsController } from './controllers/rooms.controller';
+import { RoomsQueryService } from './services/rooms-query.service';
+import { RoomMuteService } from './services/room-mute.service';
+import { DeviceChallengeService } from '@/notifications/services/device-challenge.service';
+
+/**
+ * Static wiring smoke for the Task 13 self-contained client room API module.
+ *
+ * Worker mode was removed (see `deworker-plan.md` DW1): HTTP always runs in the
+ * single always-on process, so `ClientRoomApiModule` is now a plain `@Module`
+ * that ALWAYS mounts its controller + read/mute services + the locally-provided
+ * `DeviceChallengeService`. There is no per-mode distinction left to assert — the
+ * old "main wires X / a dedicated worker wires nothing" split collapses to "the
+ * controller + providers are always present".
+ *
+ * This reads the static `@Module` metadata via `Reflect.getMetadata` instead of a
+ * full `app.init()` boot, so it asserts the unified wiring with no Postgres/Redis
+ * dependency (the actual provider instantiation is exercised by the AppModule boot).
+ */
+function controllers(): unknown[] {
+  return (
+    Reflect.getMetadata(MODULE_METADATA.CONTROLLERS, ClientRoomApiModule) ?? []
+  );
+}
+
+function providers(): unknown[] {
+  return (
+    Reflect.getMetadata(MODULE_METADATA.PROVIDERS, ClientRoomApiModule) ?? []
+  );
+}
+
+describe('ClientRoomApiModule wiring', () => {
+  it('always registers the RoomsController (HTTP runs in the single process)', () => {
+    expect(controllers()).toContain(RoomsController);
+  });
+
+  it('always provides the read service, mute service and the local DeviceChallengeService', () => {
+    const declared = providers();
+    expect(declared).toContain(RoomsQueryService);
+    expect(declared).toContain(RoomMuteService);
+    // Re-provided locally because NotificationsModule does not export it (see
+    // the module doc-comment) — must always be present, not gated by any mode.
+    expect(declared).toContain(DeviceChallengeService);
+  });
+});

--- a/src/token-gated-rooms/client-room-api.module.ts
+++ b/src/token-gated-rooms/client-room-api.module.ts
@@ -1,0 +1,51 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { NotificationsModule } from '@/notifications/notifications.module';
+import notificationsConfig from '@/notifications/notifications.config';
+import { DeviceChallenge } from '@/notifications/entities/device-challenge.entity';
+import { DeviceChallengeService } from '@/notifications/services/device-challenge.service';
+import tgrConfig from './config/tgr.config';
+import { CommunityRoom } from './entities/community-room.entity';
+import { RoomMembership } from './entities/room-membership.entity';
+import { RoomNotificationsModule } from './room-notifications.module';
+import { RoomsController } from './controllers/rooms.controller';
+import { RoomsQueryService } from './services/rooms-query.service';
+import { RoomMuteService } from './services/room-mute.service';
+
+/**
+ * Client room API — the HTTP surface for token-gated rooms.
+ *
+ * Plain self-contained `@Module` (worker mode removed — see `deworker-plan.md`).
+ * HTTP always runs in the single process, so the controller always mounts.
+ *
+ * ## Why it provides DeviceChallengeService locally
+ * `NotificationsModule` exports `NotificationPreferencesService` but NOT
+ * `DeviceChallengeService`. To reuse the exact signed-challenge flow without
+ * editing the notifications wiring, this module re-provides `DeviceChallengeService`
+ * (its only deps are the `DeviceChallenge` repo + `notificationsConfig`, both
+ * imported here). Its `@Cron cleanupExpired` sweep is multi-instance safe — it
+ * takes a `pg_try_advisory_xact_lock` so only one instance deletes per tick.
+ *
+ * Reuse, not re-provide, for the rest:
+ *   - `NotificationPreferencesService` ← `NotificationsModule` export (mute-all);
+ *   - `RoomPreferencesService` ← `RoomNotificationsModule` export (per-room mute).
+ *
+ * `RoomNotificationsModule` is a plain `@Module` (NestJS singleton), so nesting it
+ * here as well as in `TokenGatedRoomsModule` registers its `worker:room-notify`
+ * queue + processors exactly once — no double-registration.
+ *
+ * Boot-safe: nothing schedules work or opens a socket in `onModuleInit`.
+ */
+@Module({
+  imports: [
+    ConfigModule.forFeature(tgrConfig),
+    ConfigModule.forFeature(notificationsConfig),
+    TypeOrmModule.forFeature([CommunityRoom, RoomMembership, DeviceChallenge]),
+    NotificationsModule,
+    RoomNotificationsModule,
+  ],
+  controllers: [RoomsController],
+  providers: [RoomsQueryService, RoomMuteService, DeviceChallengeService],
+})
+export class ClientRoomApiModule {}

--- a/src/token-gated-rooms/config/env-validation.spec.ts
+++ b/src/token-gated-rooms/config/env-validation.spec.ts
@@ -1,0 +1,26 @@
+import { isRelayConfigured, RELAY_ENV } from './env-validation';
+
+// Worker mode removed (deworker-plan.md): there is no longer a throwing
+// `validateTgrEnv`. The relay-actuator duties self-enable iff a relay is
+// configured; `env-validation` now just re-exports the `isRelayConfigured`
+// predicate + the list of relay-enabling env vars.
+describe('relay-config env', () => {
+  it('RELAY_ENV lists the two relay-enabling vars', () => {
+    expect(RELAY_ENV).toEqual(['TG_RELAY_URL', 'TG_BOT_NSEC']);
+  });
+
+  it('isRelayConfigured is true only when both vars are present (non-blank)', () => {
+    expect(
+      isRelayConfigured({
+        TG_RELAY_URL: 'ws://relay',
+        TG_BOT_NSEC: 'nsec1abc',
+      }),
+    ).toBe(true);
+    expect(isRelayConfigured({ TG_RELAY_URL: 'ws://relay' })).toBe(false);
+    expect(isRelayConfigured({ TG_BOT_NSEC: 'nsec1abc' })).toBe(false);
+    expect(isRelayConfigured({ TG_RELAY_URL: '  ', TG_BOT_NSEC: '' })).toBe(
+      false,
+    );
+    expect(isRelayConfigured({})).toBe(false);
+  });
+});

--- a/src/token-gated-rooms/config/env-validation.ts
+++ b/src/token-gated-rooms/config/env-validation.ts
@@ -1,0 +1,16 @@
+/**
+ * Relay-enable predicate for the token-gated-rooms feature.
+ *
+ * Worker mode is gone (see `deworker-plan.md` DW2): TGR runs in ONE always-on
+ * process and the relay-actuator duties self-enable iff a relay is configured.
+ * There is no longer a fail-fast on missing OR invalid relay vars — a missing var,
+ * or a `TG_BOT_NSEC` that isn't a valid bech32 `nsec1…`, simply leaves the relay
+ * duties dormant (the public API + indexer still boot; the actuators decode the
+ * nsec defensively and log loudly on failure rather than crashing). This module
+ * re-exports the canonical predicate from `tgr.config` so existing import sites
+ * keep working.
+ */
+export { isRelayConfigured } from './tgr.config';
+
+/** Env vars that enable the relay-actuator duties when both are present. */
+export const RELAY_ENV = ['TG_RELAY_URL', 'TG_BOT_NSEC'] as const;

--- a/src/token-gated-rooms/config/queue-prefix.spec.ts
+++ b/src/token-gated-rooms/config/queue-prefix.spec.ts
@@ -1,0 +1,39 @@
+import { prefixQueue, TGR_QUEUE_NAMES, TGR_QUEUE_OWNER } from './queue-prefix';
+
+describe('prefixQueue', () => {
+  const bases = [
+    'publish-nip29',
+    'room-backfill',
+    'reconcile-balance',
+    'reconcile-membership',
+    'room-notify',
+  ];
+
+  it('exposes the five canonical base names verbatim', () => {
+    expect(Object.values(TGR_QUEUE_NAMES).sort()).toEqual([...bases].sort());
+  });
+
+  it.each(bases)('prefixes "%s" with main:', (base) => {
+    expect(prefixQueue(base, 'main')).toBe(`main:${base}`);
+  });
+
+  it.each(bases)('prefixes "%s" with worker:', (base) => {
+    expect(prefixQueue(base, 'worker')).toBe(`worker:${base}`);
+  });
+
+  it('matches the §9 owner mapping (worker-consumed vs indexer-side)', () => {
+    // Per plan §9: relay/publish/notify run in the worker; the AEX9 balance
+    // sweep (reconcile-balance) is driven by the indexer (main).
+    expect(TGR_QUEUE_OWNER['publish-nip29']).toBe('worker');
+    expect(TGR_QUEUE_OWNER['room-backfill']).toBe('worker');
+    expect(TGR_QUEUE_OWNER['reconcile-balance']).toBe('main');
+    expect(TGR_QUEUE_OWNER['reconcile-membership']).toBe('worker');
+    expect(TGR_QUEUE_OWNER['room-notify']).toBe('worker');
+  });
+
+  it('prefixes each queue using its §9 owner', () => {
+    for (const [base, owner] of Object.entries(TGR_QUEUE_OWNER)) {
+      expect(prefixQueue(base, owner)).toBe(`${owner}:${base}`);
+    }
+  });
+});

--- a/src/token-gated-rooms/config/queue-prefix.ts
+++ b/src/token-gated-rooms/config/queue-prefix.ts
@@ -1,0 +1,59 @@
+/**
+ * Bull queue-name prefixing for the token-gated-rooms feature.
+ *
+ * TGR runs in ONE always-on process (worker mode removed — see `deworker-plan.md`),
+ * but the queue NAMES keep their historical `main:`/`worker:` prefixes so a cutover
+ * never orphans in-flight Redis jobs (DW5). The prefix is now purely a stable name
+ * component; this helper remains the single source of that mapping.
+ */
+
+/**
+ * The set of queue-ownership prefixes — a stable name component now that there is a
+ * single process consuming every queue. Retained as `'main' | 'worker'` so the
+ * existing registered queue names (`worker:publish-nip29`, `main:reconcile-balance`)
+ * stay byte-for-byte identical across the cutover.
+ */
+export type QueueOwner = 'main' | 'worker';
+
+/** Constant queue-name prefixes (not user-tunable env, plan §18). */
+export const QUEUE_PREFIX = {
+  main: 'main',
+  worker: 'worker',
+} as const;
+
+/**
+ * The five canonical base queue names (Shared contracts / plan §18). The map's
+ * value is the process that **consumes** the queue and therefore the prefix it
+ * must be registered under.
+ */
+export const TGR_QUEUE_NAMES = {
+  PUBLISH_NIP29: 'publish-nip29',
+  ROOM_BACKFILL: 'room-backfill',
+  RECONCILE_BALANCE: 'reconcile-balance',
+  RECONCILE_MEMBERSHIP: 'reconcile-membership',
+  ROOM_NOTIFY: 'room-notify',
+} as const;
+
+/**
+ * Canonical consumer for each base queue (plan §9): all relay/publish/notify
+ * work runs in the **worker**; the `reconcile-balance` AEX9 sweep is driven by
+ * the indexer (main). The owning tasks register their queue with the matching
+ * prefix; this table documents the intended split.
+ */
+export const TGR_QUEUE_OWNER: Record<string, QueueOwner> = {
+  [TGR_QUEUE_NAMES.PUBLISH_NIP29]: 'worker',
+  [TGR_QUEUE_NAMES.ROOM_BACKFILL]: 'worker',
+  [TGR_QUEUE_NAMES.RECONCILE_BALANCE]: 'main',
+  [TGR_QUEUE_NAMES.RECONCILE_MEMBERSHIP]: 'worker',
+  [TGR_QUEUE_NAMES.ROOM_NOTIFY]: 'worker',
+};
+
+/**
+ * Returns the prefixed queue name: `` `${mode}:${baseName}` ``.
+ *
+ * @example prefixQueue('publish-nip29', 'worker') // 'worker:publish-nip29'
+ * @example prefixQueue('reconcile-balance', 'main') // 'main:reconcile-balance'
+ */
+export function prefixQueue(baseName: string, owner: QueueOwner): string {
+  return `${QUEUE_PREFIX[owner]}:${baseName}`;
+}

--- a/src/token-gated-rooms/config/tgr.config.spec.ts
+++ b/src/token-gated-rooms/config/tgr.config.spec.ts
@@ -1,0 +1,182 @@
+import tgrConfig, { isRelayConfigured } from './tgr.config';
+
+describe('isRelayConfigured', () => {
+  // Worker mode removed (deworker-plan.md): the relay-actuator duties self-enable
+  // iff BOTH TG_RELAY_URL and TG_BOT_NSEC are present (non-blank).
+  it('true when both relay url + bot nsec are present (env map form)', () => {
+    expect(
+      isRelayConfigured({
+        TG_RELAY_URL: 'ws://relay',
+        TG_BOT_NSEC: 'nsec1abc',
+      }),
+    ).toBe(true);
+  });
+
+  it('true when both are present (typed config form)', () => {
+    expect(
+      isRelayConfigured({
+        nostrRelayUrl: 'ws://relay',
+        nostrBotNsec: 'nsec1abc',
+      }),
+    ).toBe(true);
+  });
+
+  it('false when the relay url is missing', () => {
+    expect(isRelayConfigured({ TG_BOT_NSEC: 'nsec1abc' })).toBe(false);
+    expect(
+      isRelayConfigured({ nostrRelayUrl: '', nostrBotNsec: 'nsec1abc' }),
+    ).toBe(false);
+  });
+
+  it('false when the bot nsec is missing', () => {
+    expect(isRelayConfigured({ TG_RELAY_URL: 'ws://relay' })).toBe(false);
+    expect(
+      isRelayConfigured({ nostrRelayUrl: 'ws://relay', nostrBotNsec: '   ' }),
+    ).toBe(false);
+  });
+
+  it('false when both are blank/absent', () => {
+    expect(isRelayConfigured({})).toBe(false);
+    expect(isRelayConfigured({ TG_RELAY_URL: '  ', TG_BOT_NSEC: '' })).toBe(
+      false,
+    );
+  });
+});
+
+describe('tgrConfig defaults', () => {
+  const TGR_KEYS = [
+    'TG_RELAY_URL',
+    'TG_BOT_NSEC',
+    'TG_ROOM_ADMINS',
+    'NOSTR_LINK_PROVIDER',
+    'TG_GROUP_ID_PREFIX',
+    'TG_BACKFILL_BATCH_SIZE',
+    'TG_ROOM_PROVISION_BATCH',
+    'TG_PUBLISH_CONCURRENCY',
+    'TG_PUBLISH_RATE_PER_SEC',
+    'TG_PUBLISH_ACK_TIMEOUT_MS',
+    'TG_PUBLISH_MAX_RETRIES',
+    'TG_PUBLISH_BACKOFF_CAP',
+    'TG_RELAY_HEALTH_PAUSE_SEC',
+    'TG_REORG_CONFIRMATION_DEPTH_BLOCKS',
+    'TG_RECONCILE_BATCH_SIZE',
+    'TG_RECONCILE_INTERVAL',
+    'TG_COMMUNITY_TOKEN_REFRESH',
+    'TG_MSG_COALESCE_WINDOW_SEC',
+    'TG_MSG_RATE_CAP',
+    'TG_ROOM_NOTIFY_DEPTH_BREAK',
+    'TG_SUBSCRIBER_SHARDS',
+  ];
+
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of TGR_KEYS) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of TGR_KEYS) {
+      if (saved[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = saved[key];
+      }
+    }
+  });
+
+  it('resolves every §18 var to its documented default when env is unset', () => {
+    const cfg = tgrConfig();
+    expect(cfg.nostrRelayUrl).toBeUndefined();
+    expect(cfg.nostrBotNsec).toBeUndefined();
+    expect(cfg.nostrRoomAdmins).toEqual([]);
+    expect(cfg.nostrLinkProvider).toBe('nostr');
+    expect(cfg.nostrGroupIdPrefix).toBe('sh');
+    expect(cfg.backfillBatchSize).toBe(100);
+    expect(cfg.backfillPageDelayMs).toBe(1000);
+    expect(cfg.roomProvisionBatchSize).toBe(100);
+    expect(cfg.publishConcurrency).toBe(2);
+    expect(cfg.publishRatePerSec).toBe(100);
+    expect(cfg.publishAckTimeoutMs).toBe(5000);
+    expect(cfg.publishMaxRetries).toBe(5);
+    expect(cfg.publishBackoffCapMs).toBe(5 * 60 * 1000);
+    expect(cfg.relayHealthPauseSec).toBe(5);
+    expect(cfg.reorgConfirmationDepthBlocks).toBe(10);
+    expect(cfg.reconcileBatchSize).toBe(500);
+    expect(cfg.reconcileIntervalSec).toBe(10 * 60);
+    expect(cfg.communityTokenRefreshSec).toBe(5 * 60);
+    expect(cfg.msgCoalesceWindowSec).toBe(60);
+    expect(cfg.roomNotifyDepthBreak).toBe(10000);
+    expect(cfg.subscriberShards).toBe(1);
+    expect(cfg.queuePrefixes).toEqual({ main: 'main', worker: 'worker' });
+  });
+
+  it('rejects garbage numeric knobs and falls back to default', () => {
+    process.env.TG_BACKFILL_BATCH_SIZE = 'not-a-number';
+    process.env.TG_PUBLISH_CONCURRENCY = '';
+    process.env.TG_PUBLISH_ACK_TIMEOUT_MS = 'abc';
+    process.env.TG_SUBSCRIBER_SHARDS = '-3'; // below min
+    const cfg = tgrConfig();
+    expect(cfg.backfillBatchSize).toBe(100);
+    expect(cfg.publishConcurrency).toBe(2);
+    expect(cfg.publishAckTimeoutMs).toBe(5000);
+    expect(cfg.subscriberShards).toBe(1);
+  });
+
+  it('parses valid numeric overrides', () => {
+    process.env.TG_BACKFILL_BATCH_SIZE = '50';
+    process.env.TG_PUBLISH_RATE_PER_SEC = '250';
+    process.env.TG_ROOM_PROVISION_BATCH = '80';
+    const cfg = tgrConfig();
+    expect(cfg.backfillBatchSize).toBe(50);
+    expect(cfg.publishRatePerSec).toBe(250);
+    expect(cfg.roomProvisionBatchSize).toBe(80);
+  });
+
+  it('hard-caps room-batch knobs at 100 → an over-cap override falls back to default', () => {
+    process.env.TG_BACKFILL_BATCH_SIZE = '500'; // above max 100 → default
+    expect(tgrConfig().backfillBatchSize).toBe(100);
+    process.env.TG_ROOM_PROVISION_BATCH = '5000'; // above max 100 → default
+    expect(tgrConfig().roomProvisionBatchSize).toBe(100);
+    process.env.TG_ROOM_PROVISION_BATCH = '0'; // below min → default
+    expect(tgrConfig().roomProvisionBatchSize).toBe(100);
+    process.env.TG_ROOM_PROVISION_BATCH = 'garbage';
+    expect(tgrConfig().roomProvisionBatchSize).toBe(100);
+  });
+
+  it('parses TG_ROOM_ADMINS comma-separated into a trimmed array', () => {
+    process.env.TG_ROOM_ADMINS = ' npub1aaa , npub1bbb ,, npub1ccc ';
+    const cfg = tgrConfig();
+    expect(cfg.nostrRoomAdmins).toEqual(['npub1aaa', 'npub1bbb', 'npub1ccc']);
+  });
+
+  it('parses an empty TG_ROOM_ADMINS into []', () => {
+    process.env.TG_ROOM_ADMINS = '';
+    expect(tgrConfig().nostrRoomAdmins).toEqual([]);
+  });
+
+  it('parses duration knobs (5m / 10m) into the documented units', () => {
+    process.env.TG_RECONCILE_INTERVAL = '15m';
+    process.env.TG_COMMUNITY_TOKEN_REFRESH = '90s';
+    process.env.TG_PUBLISH_BACKOFF_CAP = '2m';
+    const cfg = tgrConfig();
+    expect(cfg.reconcileIntervalSec).toBe(15 * 60);
+    expect(cfg.communityTokenRefreshSec).toBe(90);
+    expect(cfg.publishBackoffCapMs).toBe(2 * 60 * 1000);
+  });
+
+  it('falls back on garbage duration values', () => {
+    process.env.TG_RECONCILE_INTERVAL = 'soon';
+    expect(tgrConfig().reconcileIntervalSec).toBe(10 * 60);
+  });
+
+  it('isRelayConfigured reads the resolved typed config', () => {
+    process.env.TG_RELAY_URL = 'ws://relay';
+    process.env.TG_BOT_NSEC = 'nsec1abc';
+    expect(isRelayConfigured(tgrConfig())).toBe(true);
+    delete process.env.TG_BOT_NSEC;
+    expect(isRelayConfigured(tgrConfig())).toBe(false);
+  });
+});

--- a/src/token-gated-rooms/config/tgr.config.ts
+++ b/src/token-gated-rooms/config/tgr.config.ts
@@ -1,0 +1,293 @@
+import { Logger } from '@nestjs/common';
+import { registerAs } from '@nestjs/config';
+import { QUEUE_PREFIX } from './queue-prefix';
+
+export const TGR_CONFIG = 'tokenGatedRooms';
+
+const configLogger = new Logger('TgrConfig');
+
+/**
+ * The relay-enable switch (replaces the old `main`/`worker`/`combined` process
+ * modes — see `deworker-plan.md` DW2). TGR now runs in ONE always-on process; the
+ * relay-actuator duties (writer/subscriber + their Bull consumers + the
+ * backfill/reconcile/membership-sync crons) self-enable iff a relay is configured
+ * (`TG_RELAY_URL` + `TG_BOT_NSEC` both non-blank). When unconfigured the process
+ * still indexes room-state/balances/eligibility and serves the read API — it just
+ * publishes nothing — so a missing relay var can never crash the public API. A var
+ * that is present but INVALID (e.g. a malformed `TG_BOT_NSEC`) is likewise
+ * non-fatal: the relay actuators decode the nsec defensively and stay dormant (with
+ * a loud error log) instead of throwing at boot.
+ *
+ * Accepts either the typed config (`ConfigType<typeof tgrConfig>`, what services
+ * inject) or a raw env-like map (`{ TG_RELAY_URL, TG_BOT_NSEC }`) so it is callable
+ * from both runtime providers and pure unit tests.
+ */
+export function isRelayConfigured(
+  source:
+    | { nostrRelayUrl?: string | null; nostrBotNsec?: string | null }
+    | Record<string, string | undefined>,
+): boolean {
+  const url =
+    (source as { nostrRelayUrl?: string | null }).nostrRelayUrl ??
+    (source as Record<string, string | undefined>).TG_RELAY_URL;
+  const nsec =
+    (source as { nostrBotNsec?: string | null }).nostrBotNsec ??
+    (source as Record<string, string | undefined>).TG_BOT_NSEC;
+  return (
+    typeof url === 'string' &&
+    url.trim() !== '' &&
+    typeof nsec === 'string' &&
+    nsec.trim() !== ''
+  );
+}
+
+/**
+ * Numeric env parser mirroring `configs/database.ts#parseNumber`: blank/garbage
+ * or out-of-range values fall back to the default instead of poisoning a knob.
+ */
+function parseNumber(
+  value: string | undefined,
+  defaultValue: number,
+  options: { min?: number; max?: number; integer?: boolean } = {},
+): number {
+  if (value === undefined || value.trim() === '') {
+    return defaultValue;
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    return defaultValue;
+  }
+  if (options.integer && !Number.isInteger(parsed)) {
+    return defaultValue;
+  }
+  if (options.min !== undefined && parsed < options.min) {
+    return defaultValue;
+  }
+  if (options.max !== undefined && parsed > options.max) {
+    return defaultValue;
+  }
+  return parsed;
+}
+
+/**
+ * Parse a duration like `5m`, `10m`, `30s`, or a bare number (seconds) into
+ * **seconds**. Garbage falls back to the default (also in seconds). Used for the
+ * `*_INTERVAL` / `*_REFRESH` / backoff-cap knobs expressed as `5m` in §18.
+ */
+function parseDurationSeconds(
+  value: string | undefined,
+  defaultSeconds: number,
+): number {
+  if (value === undefined || value.trim() === '') {
+    return defaultSeconds;
+  }
+  const match = value.trim().match(/^(\d+(?:\.\d+)?)\s*(ms|s|m|h)?$/i);
+  if (!match) {
+    configLogger.warn(
+      `Duration "${value}" is not parseable; falling back to ${defaultSeconds}s`,
+    );
+    return defaultSeconds;
+  }
+  const amount = Number(match[1]);
+  const unit = (match[2] || 's').toLowerCase();
+  const factor =
+    unit === 'h' ? 3600 : unit === 'm' ? 60 : unit === 'ms' ? 0.001 : 1;
+  const seconds = amount * factor;
+  if (!Number.isFinite(seconds) || seconds < 0) {
+    return defaultSeconds;
+  }
+  return seconds;
+}
+
+/** Parse a comma-separated list into a trimmed, non-empty array. */
+function parseList(value: string | undefined): string[] {
+  if (value === undefined || value.trim() === '') {
+    return [];
+  }
+  return value
+    .split(',')
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+}
+
+function parseBool(value: string | undefined, defaultValue: boolean): boolean {
+  if (value === undefined || value.trim() === '') {
+    return defaultValue;
+  }
+  return value.trim().toLowerCase() === 'true';
+}
+
+/**
+ * Env-backed config for the token-gated-rooms feature (plan §18). Consumed via
+ * `@Inject(tgrConfig.KEY)` with `ConfigType<typeof tgrConfig>`. Defaults are
+ * verbatim from §18; numeric knobs reject garbage and fall back to default.
+ *
+ * Duration-shaped knobs (`*Sec`, `reconcileIntervalSec`, `communityTokenRefreshSec`,
+ * `publishBackoffCapMs`) are normalized to a numeric unit so consumers don't
+ * re-parse `5m`/`10m` strings.
+ */
+export default registerAs(TGR_CONFIG, () => ({
+  /** groups_relay ws:// — enables the relay duties when set (D7/DW2). */
+  nostrRelayUrl: process.env.TG_RELAY_URL,
+
+  /** Secret. Enables the relay duties when set. Must be the relay admin (D7). */
+  nostrBotNsec: process.env.TG_BOT_NSEC,
+
+  /** Comma-separated nostr pubkeys (npub/hex) seeded as admins in every room (D9). */
+  nostrRoomAdmins: parseList(process.env.TG_ROOM_ADMINS),
+
+  /** `Account.links` provider key resolved to a Nostr pubkey (§6.6). */
+  nostrLinkProvider: process.env.NOSTR_LINK_PROVIDER || 'nostr',
+
+  /** Group-id prefix (only used if a derived id is chosen; D3 default uses sale_address). */
+  nostrGroupIdPrefix: process.env.TG_GROUP_ID_PREFIX || 'sh',
+
+  /**
+   * Rooms per backfill batch (eager sweep + the to-completion `run()` /
+   * stale-pending sweep). HARD-CAPPED at 100 so a single iteration can never open
+   * a large burst of DB work and starve the shared Postgres pool — an override
+   * above 100 falls back to the default rather than being honored.
+   */
+  backfillBatchSize: parseNumber(process.env.TG_BACKFILL_BATCH_SIZE, 100, {
+    integer: true,
+    min: 1,
+    max: 100,
+  }),
+
+  /**
+   * Delay (ms) the eager backfill waits between pages before enqueueing the next
+   * one (`RoomBackfillProcessor` chains pages via a delayed job). Paces the sweep
+   * so back-to-back pages don't sustain pressure on the DB pool / relay; `0`
+   * chains immediately (legacy behaviour). Default 1s.
+   */
+  backfillPageDelayMs: parseNumber(
+    process.env.TG_BACKFILL_PAGE_DELAY_MS,
+    1000,
+    {
+      integer: true,
+      min: 0,
+    },
+  ),
+
+  /**
+   * Tokens provisioned per tick of the 5-minute roomless-token cron
+   * (`CommunityRoomBackfillService.provisionRoomlessTokens`). Selects up to this
+   * many tokens with `room_id IS NULL AND sale_address IS NOT NULL` and re-fires
+   * the relay-room create + member seed for each. HARD-CAPPED at 100 (each token
+   * is a sequential on-chain `get_state()` read + DB upsert): a smaller tick keeps
+   * the recurring cron from saturating the pool; the working set is re-derived
+   * every tick, so a backlog simply drains over more ticks.
+   */
+  roomProvisionBatchSize: parseNumber(
+    process.env.TG_ROOM_PROVISION_BATCH,
+    100,
+    {
+      integer: true,
+      min: 1,
+      max: 100,
+    },
+  ),
+
+  /**
+   * Schedule the eager room backfill (Task 09) on worker boot. Default `false`
+   * (boot-safe): with this off, the worker never auto-enqueues the ~54k-token
+   * sweep on module init — the kickoff must be triggered explicitly. Only honored
+   * in the worker process. The `RoomBackfillService` boot gate reads
+   * `process.env.TG_BACKFILL_ON_BOOT` directly; this knob mirrors it for consumers
+   * that prefer the typed config.
+   */
+  backfillOnBoot: parseBool(process.env.TG_BACKFILL_ON_BOOT, false),
+
+  /** publish-nip29 workers (conservative; avoid indexer starve). */
+  publishConcurrency: parseNumber(process.env.TG_PUBLISH_CONCURRENCY, 2, {
+    integer: true,
+    min: 1,
+  }),
+
+  /** Token-bucket publish rate. */
+  publishRatePerSec: parseNumber(process.env.TG_PUBLISH_RATE_PER_SEC, 100, {
+    min: 1,
+  }),
+
+  /** Per-publish relay ACK timeout (ms). */
+  publishAckTimeoutMs: parseNumber(
+    process.env.TG_PUBLISH_ACK_TIMEOUT_MS,
+    5000,
+    {
+      integer: true,
+      min: 1,
+    },
+  ),
+
+  /** Capped exponential backoff: max retries + backoff cap (ms, default 5m). */
+  publishMaxRetries: parseNumber(process.env.TG_PUBLISH_MAX_RETRIES, 5, {
+    integer: true,
+    min: 0,
+  }),
+  publishBackoffCapMs:
+    parseDurationSeconds(process.env.TG_PUBLISH_BACKOFF_CAP, 5 * 60) * 1000,
+
+  /** Pause publishes on relay outage (seconds). */
+  relayHealthPauseSec: parseNumber(process.env.TG_RELAY_HEALTH_PAUSE_SEC, 5, {
+    min: 0,
+  }),
+
+  /** Reorg eviction buffer (blocks, §6.5). */
+  reorgConfirmationDepthBlocks: parseNumber(
+    process.env.TG_REORG_CONFIRMATION_DEPTH_BLOCKS,
+    10,
+    { integer: true, min: 0 },
+  ),
+
+  /** Reconciliation batch size + interval (default 500 / 10m). */
+  reconcileBatchSize: parseNumber(process.env.TG_RECONCILE_BATCH_SIZE, 500, {
+    integer: true,
+    min: 1,
+  }),
+  reconcileIntervalSec: parseDurationSeconds(
+    process.env.TG_RECONCILE_INTERVAL,
+    10 * 60,
+  ),
+
+  /** Refresh the AEX9 filter allowlist (default 5m). */
+  communityTokenRefreshSec: parseDurationSeconds(
+    process.env.TG_COMMUNITY_TOKEN_REFRESH,
+    5 * 60,
+  ),
+
+  /** New-message throttling: coalesce window (s) + per-recipient rate cap. */
+  msgCoalesceWindowSec: parseNumber(
+    process.env.TG_MSG_COALESCE_WINDOW_SEC,
+    60,
+    {
+      integer: true,
+      min: 0,
+    },
+  ),
+  msgRateCap: parseNumber(process.env.TG_MSG_RATE_CAP, 0, {
+    integer: true,
+    min: 0,
+  }),
+
+  /** room-notify queue depth that trips the §7.1 circuit-breaker. */
+  roomNotifyDepthBreak: parseNumber(
+    process.env.TG_ROOM_NOTIFY_DEPTH_BREAK,
+    10000,
+    {
+      integer: true,
+      min: 1,
+    },
+  ),
+
+  /** Number of relay-subscriber shards (§7.1). */
+  subscriberShards: parseNumber(process.env.TG_SUBSCRIBER_SHARDS, 1, {
+    integer: true,
+    min: 1,
+  }),
+
+  /** Constant Redis-isolation queue prefixes (not user-tunable, §9). */
+  queuePrefixes: {
+    main: QUEUE_PREFIX.main,
+    worker: QUEUE_PREFIX.worker,
+  },
+}));

--- a/src/token-gated-rooms/config/tgr.config.ts
+++ b/src/token-gated-rooms/config/tgr.config.ts
@@ -269,6 +269,18 @@ export default registerAs(TGR_CONFIG, () => ({
     min: 0,
   }),
 
+  /**
+   * Access-revoke debounce (access-ledger plan §4). When a member's room access is
+   * lost (`relay_state → removed`), the "you no longer have access" push is held
+   * this many seconds; if access is regained within the window (a transient
+   * eligibility flap) NEITHER push fires. Default 180s. `0` disables the debounce
+   * (revoke immediately) — not recommended while balances can flap.
+   */
+  accessRevokeGraceSec: parseDurationSeconds(
+    process.env.TG_ACCESS_REVOKE_GRACE_SEC,
+    180,
+  ),
+
   /** room-notify queue depth that trips the §7.1 circuit-breaker. */
   roomNotifyDepthBreak: parseNumber(
     process.env.TG_ROOM_NOTIFY_DEPTH_BREAK,

--- a/src/token-gated-rooms/controllers/room-recheck.controller.ts
+++ b/src/token-gated-rooms/controllers/room-recheck.controller.ts
@@ -1,0 +1,54 @@
+import {
+  Body,
+  Controller,
+  HttpCode,
+  Param,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+  ApiTags,
+} from '@nestjs/swagger';
+import { RateLimitGuard } from '@/api-core/guards/rate-limit.guard';
+import { RoomViewDto } from '../dto/room.view.dto';
+import { RecheckRoomDto } from '../dto/recheck-room.dto';
+import { RoomRecheckService } from '../services/room-recheck.service';
+
+/**
+ * On-demand room-access recheck (`POST /rooms/:saleAddress/recheck`).
+ *
+ * The client calls this when a holder is stuck on "Setting up your access…": unlike
+ * the passive, cached `GET /rooms` read, this ACTIVELY recomputes eligibility,
+ * reads the relay's authoritative member set, and heals/provisions the caller's
+ * membership ({@link RoomRecheckService}). Returns the refreshed caller view so the
+ * composer can unlock immediately. Rate-limited (idempotent + safe to repeat).
+ *
+ * Lives in `TokenGatedRoomsModule` (not `ClientRoomApiModule`) because the heal path
+ * needs the relay writer + eligibility + room-backfill providers; co-locating it
+ * there keeps the wiring acyclic.
+ */
+@ApiTags('Rooms')
+@Controller('rooms')
+@UseGuards(RateLimitGuard)
+export class RoomRecheckController {
+  constructor(private readonly recheck: RoomRecheckService) {}
+
+  @Post(':saleAddress/recheck')
+  @HttpCode(200)
+  @ApiOperation({ operationId: 'recheckRoomAccess' })
+  @ApiParam({ name: 'saleAddress', type: 'string' })
+  @ApiOkResponse({
+    type: RoomViewDto,
+    description:
+      'Refreshed caller view after the recheck. 200 with an empty body when the caller is not eligible / the sale address is not a gated room.',
+  })
+  async recheckRoomAccess(
+    @Param('saleAddress') saleAddress: string,
+    @Body() dto: RecheckRoomDto,
+  ): Promise<RoomViewDto | null> {
+    return this.recheck.recheck(dto.address, saleAddress);
+  }
+}

--- a/src/token-gated-rooms/controllers/rooms.controller.spec.ts
+++ b/src/token-gated-rooms/controllers/rooms.controller.spec.ts
@@ -1,0 +1,155 @@
+import { BadRequestException } from '@nestjs/common';
+import { RoomsController } from './rooms.controller';
+import { RoomsQueryService } from '../services/rooms-query.service';
+import { RoomMuteService } from '../services/room-mute.service';
+import { DeviceChallengeService } from '@/notifications/services/device-challenge.service';
+
+const ADDR = 'ak_member';
+const SALE = 'ct_sale';
+
+describe('RoomsController', () => {
+  let rooms: jest.Mocked<
+    Pick<
+      RoomsQueryService,
+      'listEligibleRooms' | 'listRoomMembers' | 'getRoomConfig'
+    >
+  >;
+  let mute: jest.Mocked<Pick<RoomMuteService, 'getMute' | 'setMute'>>;
+  let challenges: jest.Mocked<
+    Pick<DeviceChallengeService, 'issue' | 'verifyAndConsumeForRoomMute'>
+  >;
+  let controller: RoomsController;
+
+  beforeEach(() => {
+    rooms = {
+      listEligibleRooms: jest.fn(),
+      listRoomMembers: jest.fn(),
+      getRoomConfig: jest.fn(),
+    } as any;
+    mute = { getMute: jest.fn(), setMute: jest.fn() } as any;
+    challenges = {
+      issue: jest.fn(),
+      verifyAndConsumeForRoomMute: jest.fn(),
+    } as any;
+    controller = new RoomsController(
+      rooms as any,
+      mute as any,
+      challenges as any,
+    );
+  });
+
+  describe('validatePagination (via listEligibleRooms)', () => {
+    it('rejects page < 1', async () => {
+      await expect(
+        controller.listEligibleRooms(ADDR, 0, 100),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('rejects limit < 1', async () => {
+      await expect(
+        controller.listEligibleRooms(ADDR, 1, 0),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('rejects limit > 100', async () => {
+      await expect(
+        controller.listEligibleRooms(ADDR, 1, 101),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('accepts default page=1 limit=100 and delegates', async () => {
+      rooms.listEligibleRooms.mockResolvedValue({ items: [], meta: {} } as any);
+      await controller.listEligibleRooms(ADDR, 1, 100);
+      expect(rooms.listEligibleRooms).toHaveBeenCalledWith(ADDR, 1, 100);
+    });
+  });
+
+  describe('listRoomMembers', () => {
+    it('passes include_pending through and validates pagination', async () => {
+      rooms.listRoomMembers.mockResolvedValue({ items: [], meta: {} } as any);
+      await controller.listRoomMembers(SALE, 1, 50, true);
+      expect(rooms.listRoomMembers).toHaveBeenCalledWith(SALE, 1, 50, true);
+    });
+
+    it('rejects bad pagination', async () => {
+      await expect(
+        controller.listRoomMembers(SALE, 1, 999, false),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+  });
+
+  describe('getRoomConfig', () => {
+    it('delegates to the query service', () => {
+      rooms.getRoomConfig.mockReturnValue({
+        relay_url: 'ws://r',
+        admin_pubkey: 'a'.repeat(64),
+      });
+      expect(controller.getRoomConfig()).toEqual({
+        relay_url: 'ws://r',
+        admin_pubkey: 'a'.repeat(64),
+      });
+    });
+  });
+
+  describe('requestRoomMuteChallenge', () => {
+    it('delegates to the shared challenge service', async () => {
+      challenges.issue.mockResolvedValue({
+        nonce: 'n',
+        expiresAt: new Date(),
+      });
+      await controller.requestRoomMuteChallenge({ address: ADDR });
+      expect(challenges.issue).toHaveBeenCalledWith(ADDR);
+    });
+  });
+
+  describe('getRoomMute', () => {
+    it('delegates to the mute service', async () => {
+      mute.getMute.mockResolvedValue({ muted: true, mute_all: false });
+      expect(await controller.getRoomMute(SALE, ADDR)).toEqual({
+        muted: true,
+        mute_all: false,
+      });
+      expect(mute.getMute).toHaveBeenCalledWith(ADDR, SALE);
+    });
+  });
+
+  describe('setRoomMute', () => {
+    it('verifies the signed challenge BEFORE writing, then sets the mute', async () => {
+      mute.setMute.mockResolvedValue({ muted: true, mute_all: true });
+      const dto = {
+        address: ADDR,
+        nonce: 'n',
+        signature: 'sg_x',
+        muted: true,
+        mute_all: true,
+      };
+      const result = await controller.setRoomMute(SALE, dto as any);
+      expect(challenges.verifyAndConsumeForRoomMute).toHaveBeenCalledWith(
+        'n',
+        ADDR,
+        SALE,
+        true,
+        true,
+        'sg_x',
+      );
+      expect(mute.setMute).toHaveBeenCalledWith(ADDR, SALE, true, true);
+      expect(result).toEqual({ muted: true, mute_all: true });
+    });
+
+    it('does not write when verification throws', async () => {
+      challenges.verifyAndConsumeForRoomMute.mockRejectedValue(
+        new BadRequestException('Challenge already used'),
+      );
+      const dto = {
+        address: ADDR,
+        nonce: 'n',
+        signature: 'sg_x',
+        muted: true,
+      };
+      await expect(
+        controller.setRoomMute(SALE, dto as any),
+      ).rejects.toBeInstanceOf(BadRequestException);
+      expect(mute.setMute).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/token-gated-rooms/controllers/rooms.controller.ts
+++ b/src/token-gated-rooms/controllers/rooms.controller.ts
@@ -1,0 +1,184 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  DefaultValuePipe,
+  Get,
+  HttpCode,
+  Param,
+  ParseBoolPipe,
+  ParseIntPipe,
+  Post,
+  Query,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
+import {
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiTags,
+} from '@nestjs/swagger';
+import { CacheInterceptor, CacheTTL } from '@nestjs/cache-manager';
+import { Pagination } from 'nestjs-typeorm-paginate';
+import { RateLimitGuard } from '@/api-core/guards/rate-limit.guard';
+import { AeAccountAddressPipe } from '@/common/validation/request-validation';
+import { ApiOkResponsePaginated } from '@/utils/api-type';
+import { DeviceChallengeService } from '@/notifications/services/device-challenge.service';
+import { RequestChallengeDto } from '@/notifications/dto/request-challenge.dto';
+import { RoomsQueryService } from '../services/rooms-query.service';
+import { RoomMuteService } from '../services/room-mute.service';
+import { RoomViewDto } from '../dto/room.view.dto';
+import { RoomMemberViewDto } from '../dto/room-member.view.dto';
+import { RoomConfigViewDto } from '../dto/room-config.view.dto';
+import { RoomMuteViewDto } from '../dto/room-mute.view.dto';
+import { UpdateRoomMuteDto } from '../dto/update-room-mute.dto';
+
+const MAX_PAGE_LIMIT = 100;
+const ROOMS_LIST_CACHE_TTL_MS = 10_000;
+const MEMBERS_LIST_CACHE_TTL_MS = 10_000;
+const CONFIG_CACHE_TTL_MS = 60_000;
+
+/**
+ * Client room API (Task 13). MAIN MODE — served by the API (HTTP) process.
+ *
+ * Read surface (public, by validated address): the rooms a holder is eligible
+ * for, a room's members, the NIP-42 relay handshake config. Write surface: the
+ * per-room mute preference, behind the SAME signed-challenge flow as notification
+ * preferences (reuses {@link DeviceChallengeService} with a distinct, body-bound
+ * room-mute message). No relay I/O, no queue enqueue, no notification dispatch —
+ * the only writes are `room_notification_preference` + the type-level switch via
+ * the existing prefs service.
+ */
+@ApiTags('Rooms')
+@Controller('rooms')
+@UseGuards(RateLimitGuard)
+export class RoomsController {
+  constructor(
+    private readonly rooms: RoomsQueryService,
+    private readonly mute: RoomMuteService,
+    private readonly challenges: DeviceChallengeService,
+  ) {}
+
+  private validatePagination(page: number, limit: number): void {
+    if (page < 1) {
+      throw new BadRequestException('Page must be greater than or equal to 1');
+    }
+    if (limit < 1 || limit > MAX_PAGE_LIMIT) {
+      throw new BadRequestException(
+        `Limit must be between 1 and ${MAX_PAGE_LIMIT}`,
+      );
+    }
+  }
+
+  /** Rooms the address is eligible for (paginated). */
+  @Get()
+  @UseInterceptors(CacheInterceptor)
+  @CacheTTL(ROOMS_LIST_CACHE_TTL_MS)
+  @ApiOperation({ operationId: 'listEligibleRooms' })
+  @ApiQuery({ name: 'address', type: 'string', required: true })
+  @ApiQuery({ name: 'page', type: 'number', required: false })
+  @ApiQuery({ name: 'limit', type: 'number', required: false })
+  @ApiOkResponsePaginated(RoomViewDto)
+  async listEligibleRooms(
+    @Query('address', AeAccountAddressPipe) address: string,
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page = 1,
+    @Query('limit', new DefaultValuePipe(100), ParseIntPipe) limit = 100,
+  ): Promise<Pagination<RoomViewDto>> {
+    this.validatePagination(page, limit);
+    return this.rooms.listEligibleRooms(address, page, limit);
+  }
+
+  /**
+   * Relay handshake info for the app's NIP-42 AUTH (§16). Declared BEFORE the
+   * `:saleAddress`-scoped routes so `/rooms/config` is never captured as a sale
+   * address. No `address` param.
+   */
+  @Get('config')
+  @UseInterceptors(CacheInterceptor)
+  @CacheTTL(CONFIG_CACHE_TTL_MS)
+  @ApiOperation({ operationId: 'getRoomConfig' })
+  @ApiOkResponse({ type: RoomConfigViewDto })
+  getRoomConfig(): RoomConfigViewDto {
+    return this.rooms.getRoomConfig();
+  }
+
+  /** Members of a room (paginated). 404 if the room is unknown. */
+  @Get(':saleAddress/members')
+  @UseInterceptors(CacheInterceptor)
+  @CacheTTL(MEMBERS_LIST_CACHE_TTL_MS)
+  @ApiOperation({ operationId: 'listRoomMembers' })
+  @ApiParam({ name: 'saleAddress', type: 'string' })
+  @ApiQuery({ name: 'page', type: 'number', required: false })
+  @ApiQuery({ name: 'limit', type: 'number', required: false })
+  @ApiQuery({
+    name: 'include_pending',
+    type: 'boolean',
+    required: false,
+    description:
+      'When true, also include eligible-but-not-yet-added members (relay_state != added). Default false = readable (added) members only.',
+  })
+  @ApiOkResponsePaginated(RoomMemberViewDto)
+  async listRoomMembers(
+    @Param('saleAddress') saleAddress: string,
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page = 1,
+    @Query('limit', new DefaultValuePipe(100), ParseIntPipe) limit = 100,
+    @Query('include_pending', new DefaultValuePipe(false), ParseBoolPipe)
+    includePending = false,
+  ): Promise<Pagination<RoomMemberViewDto>> {
+    this.validatePagination(page, limit);
+    return this.rooms.listRoomMembers(saleAddress, page, limit, includePending);
+  }
+
+  /** Current room-mute state for `(address, saleAddress)`. Public read. */
+  @Get(':saleAddress/mute')
+  @ApiOperation({ operationId: 'getRoomMute' })
+  @ApiParam({ name: 'saleAddress', type: 'string' })
+  @ApiQuery({ name: 'address', type: 'string', required: true })
+  @ApiOkResponse({ type: RoomMuteViewDto })
+  async getRoomMute(
+    @Param('saleAddress') saleAddress: string,
+    @Query('address', AeAccountAddressPipe) address: string,
+  ): Promise<RoomMuteViewDto> {
+    return this.mute.getMute(address, saleAddress);
+  }
+
+  /**
+   * Issue a single-use nonce for the room-mute signed write. Reuses the shared
+   * challenge table (per-address pending cap applies); intent is distinguished by
+   * the message the client rebuilds and signs (see `room-mute.message.ts`).
+   */
+  @Post(':saleAddress/mute/challenge')
+  @ApiOperation({ operationId: 'requestRoomMuteChallenge' })
+  @ApiParam({ name: 'saleAddress', type: 'string' })
+  async requestRoomMuteChallenge(@Body() dto: RequestChallengeDto) {
+    return this.challenges.issue(dto.address);
+  }
+
+  /**
+   * Set the per-room mute (and, optionally, mute-all) for `address`, signed. The
+   * signature binds to the body-hashed room-mute message, so a captured nonce+sig
+   * — or a swapped `muted`/`mute_all`/room — is rejected. Address is carried in
+   * the body (the route varies only by `:saleAddress`).
+   */
+  @Post(':saleAddress/mute')
+  @HttpCode(200)
+  @ApiOperation({ operationId: 'setRoomMute' })
+  @ApiParam({ name: 'saleAddress', type: 'string' })
+  @ApiOkResponse({ type: RoomMuteViewDto })
+  async setRoomMute(
+    @Param('saleAddress') saleAddress: string,
+    @Body() dto: UpdateRoomMuteDto,
+  ): Promise<RoomMuteViewDto> {
+    await this.challenges.verifyAndConsumeForRoomMute(
+      dto.nonce,
+      dto.address,
+      saleAddress,
+      dto.muted,
+      dto.mute_all,
+      dto.signature,
+    );
+    return this.mute.setMute(dto.address, saleAddress, dto.muted, dto.mute_all);
+  }
+}

--- a/src/token-gated-rooms/controllers/rooms.integration.spec.ts
+++ b/src/token-gated-rooms/controllers/rooms.integration.spec.ts
@@ -1,0 +1,326 @@
+import 'dotenv/config';
+import { DataSource, Repository } from 'typeorm';
+import { MemoryAccount, verifyMessageSignature } from '@aeternity/aepp-sdk';
+import { DATABASE_CONFIG } from '@/configs/database';
+import { Token } from '@/tokens/entities/token.entity';
+import { NotificationPreference } from '@/notifications/entities/notification-preference.entity';
+import { DeviceChallenge } from '@/notifications/entities/device-challenge.entity';
+import { NotificationPreferencesService } from '@/notifications/services/notification-preferences.service';
+import { DeviceChallengeService } from '@/notifications/services/device-challenge.service';
+import { CommunityRoom } from '../entities/community-room.entity';
+import { RoomMembership } from '../entities/room-membership.entity';
+import { RoomNotificationPreference } from '../entities/room-notification-preference.entity';
+import { RoomsQueryService } from '../services/rooms-query.service';
+import { RoomPreferencesService } from '../services/room-preferences.service';
+import { RoomMuteService } from '../services/room-mute.service';
+import { buildRoomMuteMessage } from '../notifications/room-mute.message';
+
+/**
+ * Task 13 client room API — DB integration (harness mirrors Task 04's isolated
+ * `tgrNN_test` schema). Drives the read services + the signed mute roundtrip
+ * against a real Postgres; the relay/queue are never touched (out of scope).
+ *
+ * Auto-skips when `DB_HOST` is unset so unit-only runs stay green.
+ */
+const HAS_DB = !!process.env.DB_HOST;
+const d = HAS_DB ? describe : describe.skip;
+
+const SCHEMA = 'tgr13_test';
+const SALE_ELIGIBLE = 'ct_tgr13_eligible';
+const SALE_UNLINKED = 'ct_tgr13_unlinked';
+const SALE_INELIGIBLE = 'ct_tgr13_ineligible';
+
+// a valid nsec (secret = 32 bytes of 0x01); derived pubkey is deterministic.
+const NSEC = 'nsec1qyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqstywftw';
+const EXPECTED_PUB =
+  '1b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f';
+
+const tgrConfigStub = {
+  nostrRelayUrl: 'ws://relay.tgr13.local',
+  nostrBotNsec: NSEC,
+} as any;
+
+const challengeConfig = {
+  challengeTtlMs: 300_000,
+  challengeMaxPendingPerAddress: 5,
+} as any;
+
+d('Client room API (integration)', () => {
+  let ds: DataSource;
+  let roomRepo: Repository<CommunityRoom>;
+  let membershipRepo: Repository<RoomMembership>;
+  let roomPrefRepo: Repository<RoomNotificationPreference>;
+  let notifPrefRepo: Repository<NotificationPreference>;
+  let challengeRepo: Repository<DeviceChallenge>;
+
+  let query: RoomsQueryService;
+  let muteService: RoomMuteService;
+  let roomPrefs: RoomPreferencesService;
+  let challenges: DeviceChallengeService;
+
+  let account: any;
+  let address: string;
+
+  beforeAll(async () => {
+    const boot = new DataSource({
+      ...(DATABASE_CONFIG as any),
+      synchronize: false,
+      entities: [],
+    });
+    await boot.initialize();
+    await boot.query(`DROP SCHEMA IF EXISTS "${SCHEMA}" CASCADE`);
+    await boot.query(`CREATE SCHEMA "${SCHEMA}"`);
+    await boot.destroy();
+
+    ds = new DataSource({
+      ...(DATABASE_CONFIG as any),
+      schema: SCHEMA,
+      synchronize: true,
+      entities: [
+        Token,
+        CommunityRoom,
+        RoomMembership,
+        RoomNotificationPreference,
+        NotificationPreference,
+        DeviceChallenge,
+      ],
+    });
+    await ds.initialize();
+
+    roomRepo = ds.getRepository(CommunityRoom);
+    membershipRepo = ds.getRepository(RoomMembership);
+    roomPrefRepo = ds.getRepository(RoomNotificationPreference);
+    notifPrefRepo = ds.getRepository(NotificationPreference);
+    challengeRepo = ds.getRepository(DeviceChallenge);
+
+    const notifPrefs = new NotificationPreferencesService(notifPrefRepo);
+    roomPrefs = new RoomPreferencesService(roomPrefRepo, notifPrefs);
+    muteService = new RoomMuteService(roomPrefs, notifPrefs);
+    query = new RoomsQueryService(roomRepo, membershipRepo, tgrConfigStub);
+    challenges = new DeviceChallengeService(challengeRepo, challengeConfig);
+
+    account = MemoryAccount.generate();
+    address = account.address;
+  }, 60_000);
+
+  beforeEach(async () => {
+    await membershipRepo.clear();
+    await roomRepo.clear();
+    await roomPrefRepo.clear();
+    await notifPrefRepo.clear();
+    await challengeRepo.clear();
+
+    await roomRepo.save([
+      roomRepo.create({
+        sale_address: SALE_ELIGIBLE,
+        token_address: 'ct_token_e',
+        symbol: 'ELIG',
+        owner_address: 'ak_owner',
+        is_private: true,
+        is_community: false,
+        deleted: false,
+        created_height: 200,
+      }),
+      roomRepo.create({
+        sale_address: SALE_UNLINKED,
+        token_address: 'ct_token_u',
+        symbol: 'UNLK',
+        owner_address: 'ak_owner',
+        is_private: true,
+        is_community: false,
+        deleted: false,
+        created_height: 100,
+      }),
+      roomRepo.create({
+        sale_address: SALE_INELIGIBLE,
+        token_address: 'ct_token_i',
+        symbol: 'INEL',
+        owner_address: 'ak_owner',
+        is_private: false,
+        is_community: false,
+        deleted: false,
+        created_height: 50,
+      }),
+    ]);
+
+    await membershipRepo.save([
+      // eligible + added + linked → readable
+      membershipRepo.create({
+        sale_address: SALE_ELIGIBLE,
+        member_address: address,
+        member_pubkey: 'a'.repeat(64),
+        role: 'member',
+        eligible: true,
+        relay_state: 'added',
+      }),
+      // eligible but unlinked (§6.6): no pubkey, pending_add → readable=false
+      membershipRepo.create({
+        sale_address: SALE_UNLINKED,
+        member_address: address,
+        member_pubkey: null,
+        role: 'member',
+        eligible: true,
+        relay_state: 'pending_add',
+      }),
+      // ineligible → must NOT appear in the eligible list
+      membershipRepo.create({
+        sale_address: SALE_INELIGIBLE,
+        member_address: address,
+        member_pubkey: 'c'.repeat(64),
+        role: 'member',
+        eligible: false,
+        relay_state: 'added',
+      }),
+      // another member of the eligible room (for the members list)
+      membershipRepo.create({
+        sale_address: SALE_ELIGIBLE,
+        member_address: 'ak_other_member',
+        member_pubkey: 'd'.repeat(64),
+        role: 'admin',
+        eligible: true,
+        relay_state: 'added',
+      }),
+    ]);
+  });
+
+  afterAll(async () => {
+    if (ds?.isInitialized) {
+      await ds.query(`DROP SCHEMA IF EXISTS "${SCHEMA}" CASCADE`);
+      await ds.destroy();
+    }
+  });
+
+  it('listEligibleRooms returns only eligible + non-deleted rooms with correct readable', async () => {
+    const res = await query.listEligibleRooms(address, 1, 100);
+    const bySale = new Map(res.items.map((r) => [r.sale_address, r]));
+    expect(res.meta.totalItems).toBe(2); // eligible + unlinked, NOT ineligible
+    expect(bySale.has(SALE_INELIGIBLE)).toBe(false);
+
+    expect(bySale.get(SALE_ELIGIBLE)).toMatchObject({
+      symbol: 'ELIG',
+      relay_state: 'added',
+      readable: true,
+    });
+    expect(bySale.get(SALE_UNLINKED)).toMatchObject({
+      symbol: 'UNLK',
+      relay_state: 'pending_add',
+      member_pubkey: null,
+      readable: false,
+    });
+    // newest (created_height DESC) first
+    expect(res.items[0].sale_address).toBe(SALE_ELIGIBLE);
+  });
+
+  it('listEligibleRooms paginates deterministically', async () => {
+    const p1 = await query.listEligibleRooms(address, 1, 1);
+    const p2 = await query.listEligibleRooms(address, 2, 1);
+    expect(p1.items).toHaveLength(1);
+    expect(p2.items).toHaveLength(1);
+    expect(p1.items[0].sale_address).not.toBe(p2.items[0].sale_address);
+    expect(p1.meta.totalItems).toBe(2);
+  });
+
+  it('listRoomMembers returns the added members; unknown room → 404', async () => {
+    const res = await query.listRoomMembers(SALE_ELIGIBLE, 1, 100);
+    expect(res.items.length).toBe(2);
+    expect(res.items[0]).not.toHaveProperty('balance');
+    await expect(
+      query.listRoomMembers('ct_does_not_exist', 1, 100),
+    ).rejects.toThrow(/not found/i);
+  });
+
+  it('getRoomConfig returns the relay url + derived hex admin pubkey (never the nsec)', () => {
+    const cfg = query.getRoomConfig();
+    expect(cfg.relay_url).toBe('ws://relay.tgr13.local');
+    expect(cfg.admin_pubkey).toBe(EXPECTED_PUB);
+    expect(JSON.stringify(cfg)).not.toContain(NSEC);
+  });
+
+  it('mute roundtrip: challenge → sign → verify+set persists; replay rejected; Task 12 isRoomEnabled honors it', async () => {
+    // 1. issue challenge
+    const { nonce } = await challenges.issue(address);
+
+    // 2. sign the body-bound room-mute message
+    const message = buildRoomMuteMessage(
+      address,
+      nonce,
+      SALE_ELIGIBLE,
+      true,
+      true,
+    );
+    const sigBytes = await account.signMessage(message);
+    expect(
+      verifyMessageSignature(message, sigBytes, address as `ak_${string}`),
+    ).toBe(true);
+    const signature = Buffer.from(sigBytes).toString('hex');
+
+    // 3. verify + apply (the controller's two steps)
+    await challenges.verifyAndConsumeForRoomMute(
+      nonce,
+      address,
+      SALE_ELIGIBLE,
+      true,
+      true,
+      signature,
+    );
+    const state = await muteService.setMute(address, SALE_ELIGIBLE, true, true);
+    expect(state).toEqual({ muted: true, mute_all: true });
+
+    // per-room row persisted
+    const row = await roomPrefRepo.findOne({
+      where: { address, sale_address: SALE_ELIGIBLE },
+    });
+    expect(row?.muted).toBe(true);
+
+    // 4. replay the SAME nonce → rejected
+    await expect(
+      challenges.verifyAndConsumeForRoomMute(
+        nonce,
+        address,
+        SALE_ELIGIBLE,
+        true,
+        true,
+        signature,
+      ),
+    ).rejects.toThrow(/already used/i);
+
+    // 5. cross-task enforcement: the pref this task wrote is the one Task 12 reads.
+    expect(
+      await roomPrefs.isRoomEnabled(address, 'room-messages', SALE_ELIGIBLE),
+    ).toBe(false);
+  });
+
+  it('mute write with only per-room muted leaves the type-level switch untouched', async () => {
+    const { nonce } = await challenges.issue(address);
+    const message = buildRoomMuteMessage(
+      address,
+      nonce,
+      SALE_ELIGIBLE,
+      true,
+      undefined,
+    );
+    const sigBytes = await account.signMessage(message);
+    const signature = Buffer.from(sigBytes).toString('hex');
+
+    await challenges.verifyAndConsumeForRoomMute(
+      nonce,
+      address,
+      SALE_ELIGIBLE,
+      true,
+      undefined,
+      signature,
+    );
+    const state = await muteService.setMute(
+      address,
+      SALE_ELIGIBLE,
+      true,
+      undefined,
+    );
+    // mute_all stays false (no room-messages override written)
+    expect(state).toEqual({ muted: true, mute_all: false });
+    const typeRow = await notifPrefRepo.findOne({
+      where: { address, type: 'room-messages' },
+    });
+    expect(typeRow).toBeNull();
+  });
+});

--- a/src/token-gated-rooms/dto/recheck-room.dto.ts
+++ b/src/token-gated-rooms/dto/recheck-room.dto.ts
@@ -1,0 +1,12 @@
+import { IsAeAccountAddress } from '@/common/validation/request-validation';
+import { ApiProperty } from '@nestjs/swagger';
+
+/**
+ * Body for `POST /rooms/:saleAddress/recheck` — the caller's AE address. The room
+ * is the route param; the recheck heals/provisions that address's membership.
+ */
+export class RecheckRoomDto {
+  @ApiProperty({ example: 'ak_2sZ...' })
+  @IsAeAccountAddress()
+  address: string;
+}

--- a/src/token-gated-rooms/dto/room-config.view.dto.ts
+++ b/src/token-gated-rooms/dto/room-config.view.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+/**
+ * Relay handshake info the app needs for its NIP-42 AUTH flow (Task 13 Req 3,
+ * plan §16). NEVER carries the bot nsec — only the public relay URL and the bot's
+ * **hex** pubkey (derived from `TG_BOT_NSEC`).
+ */
+export class RoomConfigViewDto {
+  @ApiProperty({
+    example: 'wss://relay.superhero.com',
+    description: 'groups_relay websocket URL (= TG_RELAY_URL).',
+  })
+  relay_url: string;
+
+  @ApiProperty({
+    example: 'a1b2c3...',
+    description:
+      'Relay-admin (bot) public key in hex, derived from TG_BOT_NSEC. The nsec is never exposed.',
+  })
+  admin_pubkey: string;
+}

--- a/src/token-gated-rooms/dto/room-member.view.dto.ts
+++ b/src/token-gated-rooms/dto/room-member.view.dto.ts
@@ -1,0 +1,36 @@
+import { ApiProperty } from '@nestjs/swagger';
+import type {
+  RoomMembershipRelayState,
+  RoomMembershipRole,
+} from '../entities/room-membership.entity';
+
+/**
+ * One member of a room (Task 13 Req 2). Deliberately carries NO balance — holder
+ * balances/holder lists are `tokens.controller.ts :address/holders`. snake_case
+ * to match the rest of the public surface.
+ */
+export class RoomMemberViewDto {
+  @ApiProperty({ example: 'ak_2sZ...' })
+  member_address: string;
+
+  @ApiProperty({
+    type: String,
+    nullable: true,
+    example: 'a1b2...',
+    description:
+      'Resolved hex Nostr pubkey, or null until the holder links one.',
+  })
+  member_pubkey: string | null;
+
+  @ApiProperty({ enum: ['member', 'admin'], example: 'member' })
+  role: RoomMembershipRole;
+
+  @ApiProperty({
+    enum: ['pending_add', 'added', 'pending_remove', 'removed'],
+    example: 'added',
+  })
+  relay_state: RoomMembershipRelayState;
+
+  @ApiProperty({ example: true })
+  eligible: boolean;
+}

--- a/src/token-gated-rooms/dto/room-mute.view.dto.ts
+++ b/src/token-gated-rooms/dto/room-mute.view.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+/**
+ * Current room-mute state for an `(address, sale_address)` pair (Task 13 Req 5/6).
+ * Two layers: per-room `muted` and the type-level `mute_all` (the `room-messages`
+ * switch). Both default to `false` (opt-out model — silent only when explicitly set).
+ */
+export class RoomMuteViewDto {
+  @ApiProperty({
+    example: false,
+    description:
+      'Per-room mute for this (address, sale_address). Default false (no row = not muted).',
+  })
+  muted: boolean;
+
+  @ApiProperty({
+    example: false,
+    description:
+      "Mute-all for room messages (the type-level `room-messages` switch). True iff that type is disabled. Suppresses EVERY room's message pushes.",
+  })
+  mute_all: boolean;
+}

--- a/src/token-gated-rooms/dto/room.view.dto.ts
+++ b/src/token-gated-rooms/dto/room.view.dto.ts
@@ -1,0 +1,68 @@
+import { ApiProperty } from '@nestjs/swagger';
+import type {
+  RoomMembershipRelayState,
+  RoomMembershipRole,
+} from '../entities/room-membership.entity';
+
+/**
+ * One token-gated room the caller is eligible for (Task 13 Req 1). Joins
+ * `community_room` metadata with the caller's own `room_membership` row so the
+ * client knows both the room shape AND whether it can actually read it.
+ *
+ * Field style is **snake_case** (mirrors `TokenDto` / `PreferenceView`, repo
+ * CLAUDE.md). `min_token_threshold` is raw integer base units as a string
+ * (`Token.decimals` is a string; never lose precision through a JS number).
+ */
+export class RoomViewDto {
+  @ApiProperty({
+    example: 'ct_2sZ...',
+    description: 'NIP-29 group id = the token sale address (verbatim, D3).',
+  })
+  sale_address: string;
+
+  @ApiProperty({
+    example: 'ct_...',
+    description: 'AEX9 token contract address.',
+  })
+  token_address: string;
+
+  @ApiProperty({ example: 'WORDS' })
+  symbol: string;
+
+  @ApiProperty({ example: true })
+  is_private: boolean;
+
+  @ApiProperty({
+    example: '1000000000000000000',
+    description: 'Minimum balance to be eligible, raw integer base units.',
+  })
+  min_token_threshold: string;
+
+  @ApiProperty({ example: false })
+  is_community: boolean;
+
+  @ApiProperty({ enum: ['member', 'admin'], example: 'member' })
+  role: RoomMembershipRole;
+
+  @ApiProperty({
+    enum: ['pending_add', 'added', 'pending_remove', 'removed'],
+    example: 'added',
+  })
+  relay_state: RoomMembershipRelayState;
+
+  @ApiProperty({
+    type: String,
+    nullable: true,
+    example: 'a1b2...',
+    description:
+      'Resolved hex Nostr pubkey, or null until the holder links one.',
+  })
+  member_pubkey: string | null;
+
+  @ApiProperty({
+    example: true,
+    description:
+      "True iff the member is actually published on the relay (relay_state='added' AND member_pubkey set). When false, show the §16 'link your Nostr key' fallback.",
+  })
+  readable: boolean;
+}

--- a/src/token-gated-rooms/dto/update-room-mute.dto.ts
+++ b/src/token-gated-rooms/dto/update-room-mute.dto.ts
@@ -1,0 +1,41 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean, IsOptional, IsString } from 'class-validator';
+import { IsAeAccountAddress } from '@/common/validation/request-validation';
+
+/**
+ * Signed body for `POST /api/rooms/:saleAddress/mute` (Task 13 Req 5). Mirrors
+ * `UpdatePreferencesDto` but carries `address` IN THE BODY (the route varies only
+ * by `:saleAddress`), validated as an `ak_…`. The signature binds to the
+ * intent-specific, body-hashed room-mute message (see `room-mute.message.ts`), so
+ * a captured prefs/device signature — or a swapped `muted`/`mute_all` — is rejected.
+ */
+export class UpdateRoomMuteDto {
+  @ApiProperty({ example: 'ak_2sZ...' })
+  @IsAeAccountAddress()
+  address: string;
+
+  @ApiProperty({
+    description: 'Nonce returned by POST /rooms/:saleAddress/mute/challenge',
+  })
+  @IsString()
+  nonce: string;
+
+  @ApiProperty({
+    description: 'Signature of the room-mute message (sg_... or hex)',
+  })
+  @IsString()
+  signature: string;
+
+  @ApiProperty({ description: 'Mute this specific room for this address.' })
+  @IsBoolean()
+  muted: boolean;
+
+  @ApiProperty({
+    required: false,
+    description:
+      'Optional: also toggle mute-all for room messages (the type-level `room-messages` switch). Omit to leave the type-level switch untouched.',
+  })
+  @IsOptional()
+  @IsBoolean()
+  mute_all?: boolean;
+}

--- a/src/token-gated-rooms/entities/community-room.entity.ts
+++ b/src/token-gated-rooms/entities/community-room.entity.ts
@@ -1,0 +1,79 @@
+import { BigNumberTransformer } from '@/utils/BigNumberTransformer';
+import { BigNumber } from 'bignumber.js';
+import { Column, Entity, Index, PrimaryColumn } from 'typeorm';
+
+/**
+ * Indexed RoomManagement state for a token-gated room (plan §4.2).
+ *
+ * PK is `sale_address` (= the NIP-29 group id, D3). Communities take policy from
+ * `CommunityManagement`; plain token-gated rooms use defaults. Written by the
+ * community-room-state indexer (Task 04); this entity is schema only.
+ */
+@Entity({ name: 'community_room' })
+@Index('idx_community_room_state_synced_at', ['state_synced_at'])
+@Index('idx_community_room_moderators', { synchronize: false })
+@Index('idx_community_room_muted', { synchronize: false })
+export class CommunityRoom {
+  @PrimaryColumn()
+  sale_address: string;
+
+  @Column()
+  token_address: string;
+
+  @Column()
+  symbol: string;
+
+  @Column()
+  owner_address: string;
+
+  @Index('idx_community_room_is_private')
+  @Column({
+    default: false,
+  })
+  is_private: boolean;
+
+  /**
+   * Minimum balance to be eligible, stored as **raw integer base units** (plan
+   * §5.4; compare raw-vs-raw). Round-trips through `BigNumberTransformer`.
+   */
+  @Column({
+    default: 0n,
+    type: 'numeric',
+    transformer: BigNumberTransformer,
+  })
+  min_token_threshold: BigNumber;
+
+  @Column({
+    type: 'jsonb',
+    nullable: true,
+  })
+  moderators: string[];
+
+  @Column({
+    type: 'jsonb',
+    nullable: true,
+  })
+  muted: string[];
+
+  @Column({
+    default: false,
+  })
+  is_community: boolean;
+
+  @Column({
+    type: 'timestamptz',
+    nullable: true,
+  })
+  state_synced_at: Date;
+
+  @Column({
+    type: 'int',
+    nullable: true,
+  })
+  created_height: number;
+
+  @Column({
+    default: false,
+  })
+  deleted: boolean;
+}

--- a/src/token-gated-rooms/entities/migrations.integration.spec.ts
+++ b/src/token-gated-rooms/entities/migrations.integration.spec.ts
@@ -15,9 +15,9 @@ import { TokenBalance } from './token-balance.entity';
 import { RoomBackfillState } from './room-backfill-state.entity';
 
 /**
- * DB integration (Task 00): apply the 7 ordered migrations on a real Postgres and
- * assert the 6 TGR tables + 4 Token columns + named indexes + enum types exist,
- * then revert and assert they are gone.
+ * DB integration (Task 00): apply the ordered TGR migrations on a real Postgres and
+ * assert the TGR tables + 4 Token columns + named indexes + enum types exist, then
+ * revert every migration and assert they are gone.
  *
  * Hermetic isolation (Task 02 harness): the migrations hard-code the `"public"`
  * schema and `ALTER TABLE "token"`, so a *dedicated schema* on the shared DB is
@@ -99,10 +99,11 @@ d('TGR migrations (integration)', () => {
     return rows.length > 0;
   };
 
-  it('creates all 6 TGR tables', async () => {
+  it('creates all TGR tables', async () => {
     for (const t of [
       'community_room',
       'room_membership',
+      'room_membership_event',
       'room_notification_preference',
       'room_message_seen',
       'token_balance',
@@ -167,11 +168,13 @@ d('TGR migrations (integration)', () => {
     }
   });
 
-  it('creates the 3 Postgres enum types', async () => {
+  it('creates the Postgres enum types', async () => {
     for (const e of [
       'token_nostr_room_state_enum',
       'room_membership_role_enum',
       'room_membership_relay_state_enum',
+      'room_membership_access_state_enum',
+      'room_membership_event_event_enum',
     ]) {
       expect(await enumExists(e)).toBe(true);
     }
@@ -199,14 +202,22 @@ d('TGR migrations (integration)', () => {
     });
   });
 
-  it('reverting all 7 removes the tables, Token columns and enum types', async () => {
-    for (let i = 0; i < 7; i++) {
-      await ds.undoLastMigration();
+  it('reverting every migration removes the tables, Token columns and enum types', async () => {
+    // Drain ALL applied migrations (count-independent, so adding a migration never
+    // silently leaves a hardcoded loop under-reverting). `undoLastMigration` throws
+    // once there is nothing left to revert.
+    for (let i = 0; i < 100; i++) {
+      try {
+        await ds.undoLastMigration();
+      } catch {
+        break;
+      }
     }
 
     for (const t of [
       'community_room',
       'room_membership',
+      'room_membership_event',
       'room_notification_preference',
       'room_message_seen',
       'token_balance',
@@ -226,6 +237,8 @@ d('TGR migrations (integration)', () => {
       'token_nostr_room_state_enum',
       'room_membership_role_enum',
       'room_membership_relay_state_enum',
+      'room_membership_access_state_enum',
+      'room_membership_event_event_enum',
     ]) {
       expect(await enumExists(e)).toBe(false);
     }

--- a/src/token-gated-rooms/entities/migrations.integration.spec.ts
+++ b/src/token-gated-rooms/entities/migrations.integration.spec.ts
@@ -1,0 +1,233 @@
+import 'dotenv/config';
+import { BigNumber } from 'bignumber.js';
+import { DataSource } from 'typeorm';
+import {
+  createIsolatedDatabase,
+  IsolatedDb,
+  MINIMAL_TOKEN_TABLE_SQL,
+} from '@/test/harness/db';
+import { Token } from '@/tokens/entities/token.entity';
+import { CommunityRoom } from './community-room.entity';
+import { RoomMembership } from './room-membership.entity';
+import { RoomNotificationPreference } from './room-notification-preference.entity';
+import { RoomMessageSeen } from './room-message-seen.entity';
+import { TokenBalance } from './token-balance.entity';
+import { RoomBackfillState } from './room-backfill-state.entity';
+
+/**
+ * DB integration (Task 00): apply the 7 ordered migrations on a real Postgres and
+ * assert the 6 TGR tables + 4 Token columns + named indexes + enum types exist,
+ * then revert and assert they are gone.
+ *
+ * Hermetic isolation (Task 02 harness): the migrations hard-code the `"public"`
+ * schema and `ALTER TABLE "token"`, so a *dedicated schema* on the shared DB is
+ * not enough — the enum types and `"public".*` references would still collide
+ * with the shared `public` schema (left dirty by another integration spec or a
+ * prior `npm run migration:run`). Instead we provision a brand-new **throwaway
+ * database** per run (`createIsolatedDatabase`): its private `public` schema means
+ * every migration object is scoped to this run, so up()/revert() are deterministic
+ * regardless of the shared DB's state, and `afterAll` drops the whole database.
+ *
+ * Requires the local Postgres (DB_* env / repo .env). Skipped automatically when
+ * no DB host is configured so unit-only runs stay green.
+ */
+const HAS_DB = !!process.env.DB_HOST;
+const d = HAS_DB ? describe : describe.skip;
+
+d('TGR migrations (integration)', () => {
+  let db: IsolatedDb;
+  let ds: DataSource;
+
+  beforeAll(async () => {
+    // A brand-new database with a minimal `token` table (migration #1 alters it).
+    // The throwaway DB's `public` schema is private to this run, so the real
+    // up()/down() path runs against a guaranteed-clean slate.
+    db = await createIsolatedDatabase({
+      entities: [
+        Token,
+        CommunityRoom,
+        RoomMembership,
+        RoomNotificationPreference,
+        RoomMessageSeen,
+        TokenBalance,
+        RoomBackfillState,
+      ],
+      migrations: [__dirname + '/../../migrations/*{.ts,.js}'],
+      seedSql: [MINIMAL_TOKEN_TABLE_SQL],
+    });
+    ds = db.dataSource;
+    await ds.runMigrations();
+  }, 60_000);
+
+  afterAll(async () => {
+    // Drop the entire throwaway database — no shared state to clean up.
+    if (db) await db.drop();
+  }, 60_000);
+
+  const tableExists = async (name: string): Promise<boolean> => {
+    const rows = await ds.query(
+      `SELECT 1 FROM information_schema.tables WHERE table_schema='public' AND table_name=$1`,
+      [name],
+    );
+    return rows.length > 0;
+  };
+
+  const columnExists = async (
+    table: string,
+    column: string,
+  ): Promise<boolean> => {
+    const rows = await ds.query(
+      `SELECT 1 FROM information_schema.columns WHERE table_name=$1 AND column_name=$2`,
+      [table, column],
+    );
+    return rows.length > 0;
+  };
+
+  const indexExists = async (name: string): Promise<boolean> => {
+    const rows = await ds.query(
+      `SELECT 1 FROM pg_indexes WHERE schemaname='public' AND indexname=$1`,
+      [name],
+    );
+    return rows.length > 0;
+  };
+
+  const enumExists = async (name: string): Promise<boolean> => {
+    const rows = await ds.query(
+      `SELECT 1 FROM pg_type WHERE typtype='e' AND typname=$1`,
+      [name],
+    );
+    return rows.length > 0;
+  };
+
+  it('creates all 6 TGR tables', async () => {
+    for (const t of [
+      'community_room',
+      'room_membership',
+      'room_notification_preference',
+      'room_message_seen',
+      'token_balance',
+      'room_backfill_state',
+    ]) {
+      expect(await tableExists(t)).toBe(true);
+    }
+  });
+
+  it('adds the 4 Token columns', async () => {
+    for (const c of [
+      'nostr_group_id',
+      'has_nostr_room',
+      'nostr_room_created_at',
+      'nostr_room_state',
+    ]) {
+      expect(await columnExists('token', c)).toBe(true);
+    }
+  });
+
+  it('creates the named partial / compound / unique indexes', async () => {
+    for (const idx of [
+      'idx_token_nostr_room_state_pending',
+      'uq_room_membership_sale_member',
+      'idx_room_membership_sale_relay_state',
+      'idx_room_membership_member_address',
+      'idx_room_membership_eligible',
+      'idx_community_room_is_private',
+      'idx_community_room_state_synced_at',
+      'idx_community_room_moderators',
+      'idx_community_room_muted',
+      'idx_room_message_seen_sale_address',
+    ]) {
+      expect(await indexExists(idx)).toBe(true);
+    }
+  });
+
+  it('partial indexes carry their WHERE predicate', async () => {
+    const rows = await ds.query(
+      `SELECT indexname, indexdef FROM pg_indexes WHERE schemaname='public' AND indexname IN ($1,$2)`,
+      ['idx_token_nostr_room_state_pending', 'idx_room_membership_eligible'],
+    );
+    const byName = Object.fromEntries(
+      rows.map((r: any) => [r.indexname, r.indexdef]),
+    );
+    expect(byName['idx_token_nostr_room_state_pending']).toMatch(
+      /WHERE .*nostr_room_state <> 'created'/i,
+    );
+    expect(byName['idx_room_membership_eligible']).toMatch(
+      /WHERE .*eligible = true/i,
+    );
+  });
+
+  it('GIN-indexes the jsonb moderators/muted columns', async () => {
+    const rows = await ds.query(
+      `SELECT indexname, indexdef FROM pg_indexes WHERE schemaname='public' AND indexname IN ($1,$2)`,
+      ['idx_community_room_moderators', 'idx_community_room_muted'],
+    );
+    expect(rows).toHaveLength(2);
+    for (const r of rows) {
+      expect(r.indexdef).toMatch(/USING gin/i);
+    }
+  });
+
+  it('creates the 3 Postgres enum types', async () => {
+    for (const e of [
+      'token_nostr_room_state_enum',
+      'room_membership_role_enum',
+      'room_membership_relay_state_enum',
+    ]) {
+      expect(await enumExists(e)).toBe(true);
+    }
+  });
+
+  it('round-trips raw base units through numeric columns (no precision loss)', async () => {
+    const repo = ds.getRepository(TokenBalance);
+    const raw = '123456789012345678901234'; // > Number.MAX_SAFE_INTEGER
+    await repo.save(
+      repo.create({
+        token_address: 'ct_integration_test_token',
+        holder_address: 'ak_integration_test_holder',
+        balance: new BigNumber(raw),
+        updated_height: 1,
+      }),
+    );
+    const found = await repo.findOneByOrFail({
+      token_address: 'ct_integration_test_token',
+      holder_address: 'ak_integration_test_holder',
+    });
+    expect(found.balance.toFixed()).toBe(raw);
+    await repo.delete({
+      token_address: 'ct_integration_test_token',
+      holder_address: 'ak_integration_test_holder',
+    });
+  });
+
+  it('reverting all 7 removes the tables, Token columns and enum types', async () => {
+    for (let i = 0; i < 7; i++) {
+      await ds.undoLastMigration();
+    }
+
+    for (const t of [
+      'community_room',
+      'room_membership',
+      'room_notification_preference',
+      'room_message_seen',
+      'token_balance',
+      'room_backfill_state',
+    ]) {
+      expect(await tableExists(t)).toBe(false);
+    }
+    for (const c of [
+      'nostr_group_id',
+      'has_nostr_room',
+      'nostr_room_created_at',
+      'nostr_room_state',
+    ]) {
+      expect(await columnExists('token', c)).toBe(false);
+    }
+    for (const e of [
+      'token_nostr_room_state_enum',
+      'room_membership_role_enum',
+      'room_membership_relay_state_enum',
+    ]) {
+      expect(await enumExists(e)).toBe(false);
+    }
+  });
+});

--- a/src/token-gated-rooms/entities/raw-base-units.spec.ts
+++ b/src/token-gated-rooms/entities/raw-base-units.spec.ts
@@ -1,0 +1,40 @@
+import { BigNumber } from 'bignumber.js';
+import { BigNumberTransformer } from '@/utils/BigNumberTransformer';
+
+/**
+ * `community_room.min_token_threshold` and `token_balance.balance` are stored as
+ * raw integer base units via `BigNumberTransformer` (the same column transformer
+ * the entities declare). This asserts large 18-decimals values round-trip with no
+ * precision loss — the gating compares raw-vs-raw (plan §5.4), so a silent float
+ * truncation would corrupt eligibility.
+ */
+describe('raw base-unit columns round-trip via BigNumberTransformer', () => {
+  const cases: Array<[string, string]> = [
+    ['zero', '0'],
+    ['1 token @18 decimals', '1000000000000000000'],
+    ['fractional-ish large @18 decimals', '123456789012345678901234'],
+    [
+      'beyond Number.MAX_SAFE_INTEGER',
+      '9007199254740993000000000000000000', // not representable as a JS number
+    ],
+  ];
+
+  it.each(cases)('%s', (_label, raw) => {
+    // DB → entity
+    const fromDb = BigNumberTransformer.from(raw) as BigNumber;
+    expect(fromDb).toBeInstanceOf(BigNumber);
+    expect(fromDb.toFixed()).toBe(raw);
+
+    // entity → DB (no exponential notation, no precision loss)
+    const toDb = BigNumberTransformer.to(fromDb);
+    expect(toDb).toBe(raw);
+    expect(toDb).not.toContain('e');
+  });
+
+  it('passes through null/undefined unchanged (nullable columns)', () => {
+    expect(BigNumberTransformer.from(null)).toBeNull();
+    expect(BigNumberTransformer.from(undefined)).toBeUndefined();
+    expect(BigNumberTransformer.to(null)).toBeNull();
+    expect(BigNumberTransformer.to(undefined)).toBeUndefined();
+  });
+});

--- a/src/token-gated-rooms/entities/room-backfill-state.entity.ts
+++ b/src/token-gated-rooms/entities/room-backfill-state.entity.ts
@@ -1,0 +1,31 @@
+import { Column, Entity, PrimaryColumn, UpdateDateColumn } from 'typeorm';
+
+/**
+ * Single-row resume cursor for the eager room backfill (plan §4.6 / §6.2),
+ * mirroring the `SyncState`/indexer cursor pattern: a fixed PK `id='global'`,
+ * the last height reached, and the in-batch offset. Written by the backfill
+ * queue (Task 09); schema only here.
+ */
+@Entity({ name: 'room_backfill_state' })
+export class RoomBackfillState {
+  @PrimaryColumn({ default: 'global' })
+  id: string;
+
+  @Column({
+    type: 'int',
+    nullable: true,
+  })
+  last_height: number;
+
+  @Column({
+    type: 'int',
+    default: 0,
+  })
+  batch_offset: number;
+
+  @UpdateDateColumn({
+    type: 'timestamptz',
+    default: () => 'CURRENT_TIMESTAMP(6)',
+  })
+  updated_at: Date;
+}

--- a/src/token-gated-rooms/entities/room-membership-event.entity.ts
+++ b/src/token-gated-rooms/entities/room-membership-event.entity.ts
@@ -1,0 +1,85 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+/** Access transition recorded in the ledger (access-ledger plan §3.3). */
+export type RoomMembershipEventType = 'access_granted' | 'access_revoked';
+
+export const ROOM_MEMBERSHIP_EVENT_TYPES: readonly RoomMembershipEventType[] = [
+  'access_granted',
+  'access_revoked',
+] as const;
+
+/**
+ * Append-only **access-transition ledger** (access-ledger plan §3.3). One row per
+ * *genuine* access change of a `(sale_address, member_address)` — the durable,
+ * restart-safe source for BOTH the "you're in" and "you lost access" pushes, and
+ * the audit trail used to see whether/why eligibility still flaps.
+ *
+ * Why a table (vs a Redis dedup key / a single column):
+ *  - durable dedup — survives process restarts (a Redis TTL does not);
+ *  - one uniform source drives grant + revoke pushes;
+ *  - `is_first_grant` distinguishes a genuine first join ("Welcome") from a
+ *    re-grant after a real lapse ("You're back");
+ *  - row-by-row history is exactly what's needed to diagnose flapping (each flap
+ *    = a granted/revoked pair, with reasons).
+ *
+ * Rows are written ONLY by {@link MembershipAccessService} on a real effective-access
+ * transition (grant immediately; revoke after the debounce grace). The push is
+ * enqueued off inserting a row; `notified_at` is stamped by the room-notify
+ * processor on successful dispatch (belt-and-suspenders dedup: never re-push a
+ * stamped event on a Bull retry).
+ */
+@Entity({ name: 'room_membership_event' })
+@Index('idx_room_membership_event_sale_member', [
+  'sale_address',
+  'member_address',
+  'created_at',
+])
+@Index('idx_room_membership_event_unnotified', ['notified_at'], {
+  where: 'notified_at IS NULL',
+})
+export class RoomMembershipEvent {
+  @PrimaryGeneratedColumn({ type: 'bigint' })
+  id: string;
+
+  @Column()
+  sale_address: string;
+
+  @Column()
+  member_address: string;
+
+  @Column({
+    type: 'enum',
+    enum: ROOM_MEMBERSHIP_EVENT_TYPES,
+  })
+  event: RoomMembershipEventType;
+
+  /**
+   * Why access changed — audit/telemetry. e.g. `join`, `regained` (grants);
+   * `eligibility_lost`, `room_deleted`, `reorg_evicted`, `access_lost` (revokes).
+   */
+  @Column({ type: 'varchar' })
+  reason: string;
+
+  /** True iff no prior `access_granted` exists for `(sale, member)` (copy). */
+  @Column({ default: false })
+  is_first_grant: boolean;
+
+  @CreateDateColumn({
+    type: 'timestamptz',
+    default: () => 'CURRENT_TIMESTAMP(6)',
+  })
+  created_at: Date;
+
+  /** Stamped when the push is dispatched; NULL = not yet pushed. */
+  @Column({
+    type: 'timestamptz',
+    nullable: true,
+  })
+  notified_at: Date;
+}

--- a/src/token-gated-rooms/entities/room-membership.entity.ts
+++ b/src/token-gated-rooms/entities/room-membership.entity.ts
@@ -1,0 +1,101 @@
+import {
+  Column,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+/** On-relay membership lifecycle for a desired-state row (plan §4.3). */
+export type RoomMembershipRelayState =
+  | 'pending_add'
+  | 'added'
+  | 'pending_remove'
+  | 'removed';
+
+/** NIP-29 role of a member within a room (plan §4.3). */
+export type RoomMembershipRole = 'member' | 'admin';
+
+export const ROOM_MEMBERSHIP_ROLES: readonly RoomMembershipRole[] = [
+  'member',
+  'admin',
+] as const;
+
+export const ROOM_MEMBERSHIP_RELAY_STATES: readonly RoomMembershipRelayState[] =
+  ['pending_add', 'added', 'pending_remove', 'removed'] as const;
+
+/**
+ * Desired-state membership ledger (plan §4.3). Relay `39002` is the source of
+ * truth; this is the desired-state + cache used by membership-sync (Task 10) and
+ * reconciliation (Task 11). Schema only here.
+ */
+@Entity({ name: 'room_membership' })
+@Index('uq_room_membership_sale_member', ['sale_address', 'member_address'], {
+  unique: true,
+})
+@Index('idx_room_membership_sale_relay_state', ['sale_address', 'relay_state'])
+@Index('idx_room_membership_member_address', ['member_address'])
+@Index('idx_room_membership_eligible', ['sale_address'], {
+  where: 'eligible = true',
+})
+export class RoomMembership {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  sale_address: string;
+
+  @Column()
+  member_address: string;
+
+  /** Resolved hex Nostr pubkey (npub→hex normalized); null until linked (§6.6). */
+  @Column({
+    type: 'varchar',
+    nullable: true,
+  })
+  member_pubkey: string;
+
+  @Column({
+    type: 'enum',
+    enum: ROOM_MEMBERSHIP_ROLES,
+    default: 'member',
+  })
+  role: RoomMembershipRole;
+
+  @Column({
+    default: false,
+  })
+  eligible: boolean;
+
+  @Column({
+    type: 'enum',
+    enum: ROOM_MEMBERSHIP_RELAY_STATES,
+    default: 'pending_add',
+  })
+  relay_state: RoomMembershipRelayState;
+
+  /** Reorg eviction buffer: hold removal until this height passes (§6.5). */
+  @Column({
+    type: 'int',
+    nullable: true,
+  })
+  held_until_height: number;
+
+  @Column({
+    type: 'timestamptz',
+    nullable: true,
+  })
+  last_published_at: Date;
+
+  @Column({
+    type: 'timestamptz',
+    nullable: true,
+  })
+  last_reconciled_at: Date;
+
+  @UpdateDateColumn({
+    type: 'timestamptz',
+    default: () => 'CURRENT_TIMESTAMP(6)',
+  })
+  updated_at: Date;
+}

--- a/src/token-gated-rooms/entities/room-membership.entity.ts
+++ b/src/token-gated-rooms/entities/room-membership.entity.ts
@@ -16,6 +16,18 @@ export type RoomMembershipRelayState =
 /** NIP-29 role of a member within a room (plan §4.3). */
 export type RoomMembershipRole = 'member' | 'admin';
 
+/**
+ * Last **notified** effective-access state (access-ledger plan). Decoupled from
+ * `relay_state` (a sync signal that churns): notifications are driven off
+ * transitions of THIS field, so reconcile re-adds / `39002` regeneration / a
+ * transient flap absorbed within the grace window never re-notify.
+ * `granted` ⇔ the member currently has room access (was `relay_state='added'`).
+ */
+export type RoomMembershipAccessState = 'none' | 'granted';
+
+export const ROOM_MEMBERSHIP_ACCESS_STATES: readonly RoomMembershipAccessState[] =
+  ['none', 'granted'] as const;
+
 export const ROOM_MEMBERSHIP_ROLES: readonly RoomMembershipRole[] = [
   'member',
   'admin',
@@ -73,6 +85,45 @@ export class RoomMembership {
     default: 'pending_add',
   })
   relay_state: RoomMembershipRelayState;
+
+  /**
+   * Last **notified** effective-access state (access-ledger plan). Drives the
+   * membership push instead of the raw `relay_state` ACK, so relay-sync churn
+   * (reconcile re-adds, `39002` regeneration, flaps absorbed within the grace
+   * window) never re-notifies. Written only by `MembershipAccessService`.
+   */
+  @Column({
+    type: 'enum',
+    enum: ROOM_MEMBERSHIP_ACCESS_STATES,
+    default: 'none',
+  })
+  access_state: RoomMembershipAccessState;
+
+  /** When `access_state` last flipped (audit/observability). */
+  @Column({
+    type: 'timestamptz',
+    nullable: true,
+  })
+  access_changed_at: Date;
+
+  /**
+   * Debounce timer: set when access is lost (`relay_state → removed`); if still
+   * set + still-removed after `TG_ACCESS_REVOKE_GRACE_SEC`, the finalizer emits a
+   * single `access_revoked`. Cleared if access is regained first (flap absorbed —
+   * no push either way). NULL = no pending revoke.
+   */
+  @Column({
+    type: 'timestamptz',
+    nullable: true,
+  })
+  pending_revoke_since: Date;
+
+  /** Reason carried through the revoke debounce for the finalizer's event row. */
+  @Column({
+    type: 'varchar',
+    nullable: true,
+  })
+  pending_revoke_reason: string;
 
   /** Reorg eviction buffer: hold removal until this height passes (§6.5). */
   @Column({

--- a/src/token-gated-rooms/entities/room-message-seen.entity.ts
+++ b/src/token-gated-rooms/entities/room-message-seen.entity.ts
@@ -1,0 +1,22 @@
+import { Column, Entity, Index, PrimaryColumn } from 'typeorm';
+
+/**
+ * Dedup key for new-message notifications (plan §7.1). PK is the Nostr `event_id`,
+ * so a re-delivered relay event is only notified once. Written by the relay
+ * subscriber (Task 14); schema only here.
+ */
+@Entity({ name: 'room_message_seen' })
+@Index('idx_room_message_seen_sale_address', ['sale_address'])
+export class RoomMessageSeen {
+  @PrimaryColumn()
+  event_id: string;
+
+  @Column()
+  sale_address: string;
+
+  @Column({
+    type: 'timestamptz',
+    default: () => 'now()',
+  })
+  seen_at: Date;
+}

--- a/src/token-gated-rooms/entities/room-notification-preference.entity.ts
+++ b/src/token-gated-rooms/entities/room-notification-preference.entity.ts
@@ -1,0 +1,26 @@
+import { Column, Entity, PrimaryColumn, UpdateDateColumn } from 'typeorm';
+
+/**
+ * Per-room mute preference (plan §4.4). Composite PK `(address, sale_address)`.
+ * Mute-all is the type-level `room-messages` switch; this is the per-room override.
+ * Behavior owned by Task 12; schema only here.
+ */
+@Entity({ name: 'room_notification_preference' })
+export class RoomNotificationPreference {
+  @PrimaryColumn()
+  address: string;
+
+  @PrimaryColumn()
+  sale_address: string;
+
+  @Column({
+    default: false,
+  })
+  muted: boolean;
+
+  @UpdateDateColumn({
+    type: 'timestamptz',
+    default: () => 'CURRENT_TIMESTAMP(6)',
+  })
+  updated_at: Date;
+}

--- a/src/token-gated-rooms/entities/token-balance.entity.ts
+++ b/src/token-gated-rooms/entities/token-balance.entity.ts
@@ -1,0 +1,37 @@
+import { BigNumberTransformer } from '@/utils/BigNumberTransformer';
+import { BigNumber } from 'bignumber.js';
+import { Column, Entity, PrimaryColumn } from 'typeorm';
+
+/**
+ * Authoritative AEX9 balance per holder (plan §4.5). Composite PK
+ * `(token_address, holder_address)`. `balance` is stored as **raw integer base
+ * units** (plan §5.4; compare raw-vs-raw). `last_reconciled_at` is the cursor for
+ * the rotating reconciliation sweep (Task 03). Schema only here.
+ */
+@Entity({ name: 'token_balance' })
+export class TokenBalance {
+  @PrimaryColumn()
+  token_address: string;
+
+  @PrimaryColumn()
+  holder_address: string;
+
+  @Column({
+    default: 0n,
+    type: 'numeric',
+    transformer: BigNumberTransformer,
+  })
+  balance: BigNumber;
+
+  @Column({
+    type: 'int',
+    default: 0,
+  })
+  updated_height: number;
+
+  @Column({
+    type: 'timestamptz',
+    nullable: true,
+  })
+  last_reconciled_at: Date;
+}

--- a/src/token-gated-rooms/enums/nostr-room-state.enum.spec.ts
+++ b/src/token-gated-rooms/enums/nostr-room-state.enum.spec.ts
@@ -1,0 +1,65 @@
+import {
+  NostrRoomState,
+  NOSTR_ROOM_STATES,
+  NOSTR_ROOM_STATE_DEFAULT,
+  NOSTR_ROOM_STATE_TRANSITIONS,
+  isLegalNostrRoomStateTransition,
+} from './nostr-room-state.enum';
+
+describe('nostr-room-state transition table (plan §4.7)', () => {
+  it('declares the five canonical states with `none` as default', () => {
+    expect([...NOSTR_ROOM_STATES]).toEqual([
+      'none',
+      'pending',
+      'created',
+      'failed',
+      'deleted',
+    ]);
+    expect(NOSTR_ROOM_STATE_DEFAULT).toBe('none');
+  });
+
+  it('encodes exactly the §4.7 adjacency', () => {
+    expect(NOSTR_ROOM_STATE_TRANSITIONS).toEqual({
+      none: ['pending'],
+      pending: ['created', 'failed', 'deleted'],
+      created: ['deleted'],
+      failed: ['pending'],
+      deleted: [],
+    });
+  });
+
+  describe('legal transitions', () => {
+    const legal: Array<[NostrRoomState, NostrRoomState]> = [
+      ['none', 'pending'],
+      ['pending', 'created'], // relay ACK / "Group already exists"
+      ['pending', 'failed'],
+      ['failed', 'pending'], // retry, capped backoff
+      ['created', 'deleted'],
+      ['pending', 'deleted'],
+    ];
+    it.each(legal)('allows %s → %s', (from, to) => {
+      expect(isLegalNostrRoomStateTransition(from, to)).toBe(true);
+    });
+  });
+
+  describe('illegal transitions', () => {
+    const illegal: Array<[NostrRoomState, NostrRoomState]> = [
+      ['created', 'pending'], // cannot un-create
+      ['created', 'failed'],
+      ['none', 'created'], // must go through pending
+      ['none', 'failed'],
+      ['failed', 'created'],
+      ['pending', 'none'],
+    ];
+    it.each(illegal)('rejects %s → %s', (from, to) => {
+      expect(isLegalNostrRoomStateTransition(from, to)).toBe(false);
+    });
+  });
+
+  it('treats `deleted` as terminal (no outgoing transitions)', () => {
+    expect([...NOSTR_ROOM_STATE_TRANSITIONS.deleted]).toEqual([]);
+    for (const to of NOSTR_ROOM_STATES) {
+      expect(isLegalNostrRoomStateTransition('deleted', to)).toBe(false);
+    }
+  });
+});

--- a/src/token-gated-rooms/enums/nostr-room-state.enum.ts
+++ b/src/token-gated-rooms/enums/nostr-room-state.enum.ts
@@ -1,0 +1,71 @@
+/**
+ * `Token.nostr_room_state` machine (plan §4.7).
+ *
+ * States:
+ *   - `none`    — no room requested yet (initial / default).
+ *   - `pending` — `9007` create-group (and `9002` edit-metadata) enqueued/published,
+ *                 awaiting relay ACK. A `pending` row stale > 24h without an ACK is
+ *                 re-published (stays `pending`).
+ *   - `created` — relay ACKed the group exists (`has_nostr_room=true`). Also reached
+ *                 when the relay replies `"Group already exists"` for a `pending` create.
+ *   - `failed`  — publish failed; retried with capped backoff back to `pending`.
+ *   - `deleted` — community deleted → `9008` delete-group. **Terminal**: groups_relay
+ *                 blocks recreate of a `9008`-deleted id, so no transitions leave here.
+ *
+ * Legal transitions (see {@link NOSTR_ROOM_STATE_TRANSITIONS}):
+ *   none    → pending
+ *   pending → created            (relay ACK, or `"Group already exists"`)
+ *   pending → failed             (publish error)
+ *   pending → deleted            (community deleted before ACK)
+ *   failed  → pending            (retry, capped backoff)
+ *   created → deleted            (community deleted)
+ *   deleted → ∅                  (terminal)
+ *
+ * NOTE: a `pending` create that the relay answers with `"Group already exists"` is
+ * treated as a successful `pending → created`. Re-publish of a stale `pending` row
+ * (>24h, no ACK) is NOT a state change — it stays `pending`.
+ *
+ * Transition **enforcement** (only legal transitions allowed) is Task 09 — this file
+ * is the schema/doc source of truth only and is exported for the unit tests.
+ */
+export type NostrRoomState =
+  | 'none'
+  | 'pending'
+  | 'created'
+  | 'failed'
+  | 'deleted';
+
+/** All values of {@link NostrRoomState}, in canonical order (used by the migration enum). */
+export const NOSTR_ROOM_STATES: readonly NostrRoomState[] = [
+  'none',
+  'pending',
+  'created',
+  'failed',
+  'deleted',
+] as const;
+
+/** Initial / default state for a freshly indexed token. */
+export const NOSTR_ROOM_STATE_DEFAULT: NostrRoomState = 'none';
+
+/**
+ * Adjacency map of legal `nostr_room_state` transitions (plan §4.7).
+ * `deleted` is terminal → empty outgoing set.
+ */
+export const NOSTR_ROOM_STATE_TRANSITIONS: Readonly<
+  Record<NostrRoomState, readonly NostrRoomState[]>
+> = {
+  none: ['pending'],
+  pending: ['created', 'failed', 'deleted'],
+  created: ['deleted'],
+  failed: ['pending'],
+  deleted: [],
+} as const;
+
+/**
+ * Pure predicate: is `from → to` a legal transition? (No side effects, no DB.)
+ * Enforcement lives in Task 09; this exists for the unit tests + later guards.
+ */
+export const isLegalNostrRoomStateTransition = (
+  from: NostrRoomState,
+  to: NostrRoomState,
+): boolean => NOSTR_ROOM_STATE_TRANSITIONS[from]?.includes(to) ?? false;

--- a/src/token-gated-rooms/events.ts
+++ b/src/token-gated-rooms/events.ts
@@ -1,0 +1,81 @@
+/**
+ * Canonical in-process event names + payloads for token-gated rooms (plan §5/§7,
+ * Shared contracts in tasks/README.md). Emitted/consumed via the global
+ * `@nestjs/event-emitter` EventEmitter2 (registered by `mdw-sync` —
+ * `EventEmitterModule.forRoot()`), the same mechanism as `LIVE_TX_EVENT`.
+ *
+ * Payloads are intentionally THIN: they carry the identifying keys only and
+ * handlers re-query the desired-state tables. This mirrors `LIVE_TX_EVENT` and
+ * keeps emitters cheap + avoids stale snapshots travelling through the bus.
+ *
+ * This file is the single source of truth for these names — every TGR task
+ * imports from here so producers and consumers stay in sync. Do not redefine
+ * these strings elsewhere.
+ */
+
+/** A BCL community-room desired-state row was created/updated (Task 04). */
+export const TGR_COMMUNITY_UPSERTED = 'tgr.community.upserted';
+export interface TgrCommunityUpsertedPayload {
+  /** `Token.sale_address` — PK of `community_room` and the NIP-29 group id. */
+  saleAddress: string;
+}
+
+/** An AEX9 balance row changed (Task 03). */
+export const TGR_BALANCE_CHANGED = 'tgr.balance.changed';
+export interface TgrBalanceChangedPayload {
+  tokenAddress: string;
+  holderAddress: string;
+}
+
+/** A member's eligibility for a room flipped (Task 06). */
+export const TGR_ELIGIBILITY_CHANGED = 'tgr.eligibility.changed';
+export interface TgrEligibilityChangedPayload {
+  saleAddress: string;
+  memberAddress: string;
+  eligible: boolean;
+}
+
+/** A NIP-29 group was created on the relay and ACKed (Task 07/09). */
+export const TGR_ROOM_CREATED = 'tgr.room.created';
+export interface TgrRoomCreatedPayload {
+  saleAddress: string;
+}
+
+/**
+ * A relay publish for a group reported `"Group not found"` — the relay has no such
+ * group though the DB marks the room created (DB↔relay desync, e.g. the relay was
+ * reset). The owner re-creates the group (queued `9007`), after which the deferred
+ * member adds resume. Emitted by the publish processor; consumed by
+ * `RoomBackfillService.onGroupMissing`.
+ */
+export const TGR_GROUP_MISSING = 'tgr.group.missing';
+export interface TgrGroupMissingPayload {
+  saleAddress: string;
+}
+
+/** A room membership desired-state row changed `relay_state` (Task 10). */
+export const TGR_MEMBERSHIP_CHANGED = 'tgr.membership.changed';
+export interface TgrMembershipChangedPayload {
+  saleAddress: string;
+  memberAddress: string;
+  /** New `room_membership.relay_state`. */
+  relayState: 'pending_add' | 'added' | 'pending_remove' | 'removed';
+}
+
+/** An address↔nostr identity link changed (Task 05; from address-links). */
+export const TGR_LINK_CHANGED = 'tgr.link.changed';
+export interface TgrLinkChangedPayload {
+  /** æternity account address whose nostr link was added/removed/changed. */
+  address: string;
+}
+
+/** A relay publish was ACKed/failed (Task 07 → consumed by 10/15). */
+export const TGR_PUBLISH_ACK = 'tgr.publish.ack';
+export interface TgrPublishAckPayload {
+  saleAddress: string;
+  /** member pubkey for membership publishes; omitted for group-level events. */
+  pubkey?: string;
+  /** NIP-29 kind that was published (9007/9002/9000/9001/...). */
+  kind: number;
+  ok: boolean;
+}

--- a/src/token-gated-rooms/events.ts
+++ b/src/token-gated-rooms/events.ts
@@ -60,6 +60,17 @@ export interface TgrMembershipChangedPayload {
   memberAddress: string;
   /** New `room_membership.relay_state`. */
   relayState: 'pending_add' | 'added' | 'pending_remove' | 'removed';
+  /**
+   * Access-ledger event id (access-ledger plan). Set ONLY for genuine
+   * effective-access transitions emitted by `MembershipAccessService` (grant /
+   * debounced revoke); the room-notify processor stamps this event's `notified_at`
+   * on dispatch (durable dedup). Absent for thin role transitions.
+   */
+  accessEventId?: string;
+  /** True iff the member's first-ever access grant (drives "Welcome" copy). */
+  isFirstGrant?: boolean;
+  /** Why access changed (audit/telemetry) — e.g. `join`, `eligibility_lost`. */
+  reason?: string;
 }
 
 /** An address↔nostr identity link changed (Task 05; from address-links). */

--- a/src/token-gated-rooms/listeners/room-event.listener.spec.ts
+++ b/src/token-gated-rooms/listeners/room-event.listener.spec.ts
@@ -1,0 +1,138 @@
+import { RoomEventListener } from './room-event.listener';
+import type { TgrMembershipChangedPayload } from '../events';
+
+describe('RoomEventListener', () => {
+  const SALE = 'ct_sale';
+  const MEMBER = 'ak_member';
+
+  let queue: { add: jest.Mock; getJobCounts: jest.Mock };
+  let redis: { tryAcquire: jest.Mock; incrementWithCap: jest.Mock };
+  let tgr: any;
+  let notifications: any;
+  let listener: RoomEventListener;
+
+  const added: TgrMembershipChangedPayload = {
+    saleAddress: SALE,
+    memberAddress: MEMBER,
+    relayState: 'added',
+  };
+
+  beforeEach(() => {
+    queue = {
+      add: jest.fn().mockResolvedValue({ id: 'j1' }),
+      getJobCounts: jest.fn().mockResolvedValue({ waiting: 0, delayed: 0 }),
+    };
+    redis = {
+      tryAcquire: jest.fn().mockResolvedValue(true),
+      incrementWithCap: jest
+        .fn()
+        .mockResolvedValue({ count: 1, capped: false }),
+    };
+    tgr = {
+      roomNotifyDepthBreak: 10000,
+      msgCoalesceWindowSec: 60,
+      msgRateCap: 0,
+    };
+    notifications = { enabled: true };
+    listener = new RoomEventListener(
+      queue as any,
+      redis as any,
+      tgr,
+      notifications,
+    );
+  });
+
+  it('enqueues an "added" room-notify job on a relay_state=added event', async () => {
+    await listener.onMembershipChanged(added);
+    expect(queue.add).toHaveBeenCalledTimes(1);
+    expect(queue.add.mock.calls[0][0]).toEqual({
+      saleAddress: SALE,
+      memberAddress: MEMBER,
+      change: 'added',
+    });
+  });
+
+  it('maps relay_state=removed and pending_remove to a "removed" job', async () => {
+    await listener.onMembershipChanged({
+      saleAddress: SALE,
+      memberAddress: MEMBER,
+      relayState: 'removed',
+    });
+    expect(queue.add.mock.calls[0][0].change).toBe('removed');
+
+    queue.add.mockClear();
+    redis.tryAcquire.mockResolvedValue(true);
+    await listener.onMembershipChanged({
+      saleAddress: SALE,
+      memberAddress: MEMBER,
+      relayState: 'pending_remove',
+    });
+    expect(queue.add.mock.calls[0][0].change).toBe('removed');
+  });
+
+  it('ignores non-membership relay states (pending_add — role/in-flight)', async () => {
+    await listener.onMembershipChanged({
+      saleAddress: SALE,
+      memberAddress: MEMBER,
+      relayState: 'pending_add',
+    });
+    expect(queue.add).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when notifications are disabled', async () => {
+    notifications.enabled = false;
+    await listener.onMembershipChanged(added);
+    expect(queue.add).not.toHaveBeenCalled();
+  });
+
+  it('ignores payloads missing sale/member', async () => {
+    await listener.onMembershipChanged({ relayState: 'added' } as any);
+    expect(queue.add).not.toHaveBeenCalled();
+  });
+
+  it('drops the push when the room-notify queue is over the depth break', async () => {
+    queue.getJobCounts.mockResolvedValue({ waiting: 9999, delayed: 1 });
+    await listener.onMembershipChanged(added);
+    expect(queue.add).not.toHaveBeenCalled();
+  });
+
+  it('coalesces repeated (sale, member, change) within the window', async () => {
+    // Second tryAcquire returns false → coalesced (no enqueue).
+    redis.tryAcquire.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+    await listener.onMembershipChanged(added);
+    await listener.onMembershipChanged(added);
+    expect(queue.add).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips coalescing entirely when the window is 0', async () => {
+    tgr.msgCoalesceWindowSec = 0;
+    await listener.onMembershipChanged(added);
+    expect(redis.tryAcquire).not.toHaveBeenCalled();
+    expect(queue.add).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops when the per-recipient rate cap is hit (when configured)', async () => {
+    tgr.msgRateCap = 5;
+    redis.incrementWithCap.mockResolvedValue({ count: 6, capped: true });
+    await listener.onMembershipChanged(added);
+    expect(queue.add).not.toHaveBeenCalled();
+  });
+
+  it('does not apply the rate cap when msgRateCap=0 (default off)', async () => {
+    tgr.msgRateCap = 0;
+    await listener.onMembershipChanged(added);
+    expect(redis.incrementWithCap).not.toHaveBeenCalled();
+    expect(queue.add).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails open on a coalesce Redis error (still enqueues)', async () => {
+    redis.tryAcquire.mockRejectedValue(new Error('redis down'));
+    await listener.onMembershipChanged(added);
+    expect(queue.add).toHaveBeenCalledTimes(1);
+  });
+
+  it('never throws back into the emitter (swallows enqueue errors)', async () => {
+    queue.add.mockRejectedValue(new Error('bull down'));
+    await expect(listener.onMembershipChanged(added)).resolves.toBeUndefined();
+  });
+});

--- a/src/token-gated-rooms/listeners/room-event.listener.ts
+++ b/src/token-gated-rooms/listeners/room-event.listener.ts
@@ -104,7 +104,13 @@ export class RoomEventListener {
       }
 
       await this.roomNotifyQueue.add(
-        { saleAddress, memberAddress, change },
+        {
+          saleAddress,
+          memberAddress,
+          change,
+          accessEventId: payload?.accessEventId,
+          isFirstGrant: payload?.isFirstGrant,
+        },
         roomNotifyJobOptions(),
       );
     } catch (error) {

--- a/src/token-gated-rooms/listeners/room-event.listener.ts
+++ b/src/token-gated-rooms/listeners/room-event.listener.ts
@@ -1,0 +1,207 @@
+import { InjectQueue } from '@nestjs/bull';
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { ConfigType } from '@nestjs/config';
+import { OnEvent } from '@nestjs/event-emitter';
+import { Queue } from 'bull';
+import notificationsConfig from '@/notifications/notifications.config';
+import { NotificationRedisService } from '@/notifications/services/notification-redis.service';
+import tgrConfig from '../config/tgr.config';
+import {
+  TGR_MEMBERSHIP_CHANGED,
+  type TgrMembershipChangedPayload,
+} from '../events';
+import type { RoomMembershipChange } from '../notifications/room-membership.notification';
+import {
+  ROOM_NOTIFY_QUEUE,
+  roomNotifyJobOptions,
+  type RoomNotifyJob,
+} from '../queues/room-notify.types';
+
+/**
+ * Bridges the in-process `tgr.membership.changed` event into the membership-push
+ * pipeline — **WORKER PROCESS ONLY** (Task 12, plan §7).
+ *
+ * ## Why worker-only
+ * `tgr.membership.changed` is emitted by `MembershipSyncService` in the WORKER
+ * process on the relay-ACK seam. `@nestjs/event-emitter` (EventEmitter2) is
+ * **in-process only** — a listener in the main API container would NEVER fire.
+ * So this listener is registered as a worker-mode provider (see
+ * `RoomNotificationsModule`).
+ *
+ * ## Pipeline
+ * The listener is the cheap front of a two-stage path: it gates + throttles, then
+ * ENQUEUES onto `worker:room-notify`. The `RoomNotifyProcessor` (also worker) does
+ * the heavy lifting — device resolution + per-room/type mute checks + dispatch via
+ * `NotificationService`. Keeping the device + mute checks in the processor means a
+ * burst of membership flips never blocks the emitter on N DB round-trips.
+ *
+ * Gates applied here (in order, all best-effort / fail-open):
+ *   1. notifications master kill-switch (`notificationsConfig.enabled`);
+ *   2. **circuit-breaker** — if the `worker:room-notify` depth is past
+ *      `roomNotifyDepthBreak` (§7.1), drop the event rather than pile on;
+ *   3. **coalescing** — collapse repeated `(sale, member, change)` events within
+ *      `msgCoalesceWindowSec` to one enqueue (SET NX marker);
+ *   4. **per-recipient rate cap** — `msgRateCap`/`msgCoalesceWindowSec` fixed
+ *      window (only when `msgRateCap > 0`; default 0 = off).
+ *
+ * The member's device + mute state are NOT checked here — that is the processor's
+ * job (so the listener stays a thin, non-blocking front). It NEVER throws back into
+ * the emitter.
+ */
+@Injectable()
+export class RoomEventListener {
+  private readonly logger = new Logger(RoomEventListener.name);
+
+  constructor(
+    @InjectQueue(ROOM_NOTIFY_QUEUE)
+    private readonly roomNotifyQueue: Queue<RoomNotifyJob>,
+    private readonly redis: NotificationRedisService,
+    @Inject(tgrConfig.KEY)
+    private readonly tgr: ConfigType<typeof tgrConfig>,
+    @Inject(notificationsConfig.KEY)
+    private readonly notifications: ConfigType<typeof notificationsConfig>,
+  ) {}
+
+  @OnEvent(TGR_MEMBERSHIP_CHANGED, { async: true, promisify: true })
+  async onMembershipChanged(
+    payload: TgrMembershipChangedPayload,
+  ): Promise<void> {
+    try {
+      if (!this.notifications.enabled) {
+        return;
+      }
+      const saleAddress = payload?.saleAddress;
+      const memberAddress = payload?.memberAddress;
+      const change = this.changeFor(payload?.relayState);
+      if (!saleAddress || !memberAddress || !change) {
+        // role transitions (relay_state still 'added'/'pending_*') and partial
+        // payloads are not membership-add/remove pushes — ignore.
+        return;
+      }
+
+      // (2) Circuit-breaker: shed load when the notify queue is backed up (§7.1).
+      if (await this.isQueueOverDepth()) {
+        this.logger.warn(
+          `room-notify depth past ${this.tgr.roomNotifyDepthBreak}; dropping membership push for ${memberAddress} in ${saleAddress}`,
+        );
+        return;
+      }
+
+      // (3) Coalesce repeated (sale, member, change) within the window.
+      if (
+        !(await this.shouldEnqueueAfterCoalesce(
+          saleAddress,
+          memberAddress,
+          change,
+        ))
+      ) {
+        return;
+      }
+
+      // (4) Per-recipient rate cap (only when configured > 0).
+      if (await this.isRateCapped(memberAddress)) {
+        return;
+      }
+
+      await this.roomNotifyQueue.add(
+        { saleAddress, memberAddress, change },
+        roomNotifyJobOptions(),
+      );
+    } catch (error) {
+      // Notifications must never break the emitter (membership-sync worker loop).
+      this.logger.error(
+        'Failed to process tgr.membership.changed for notification',
+        error as Error,
+      );
+    }
+  }
+
+  /**
+   * Map the thin event's `relay_state` to an add/remove membership change.
+   * `'added'` → added; `'removed'`/`'pending_remove'` → removed; anything else
+   * (e.g. a role transition that leaves the row `'added'`/`'pending_add'`) is not
+   * a membership push.
+   */
+  private changeFor(
+    relayState: TgrMembershipChangedPayload['relayState'] | undefined,
+  ): RoomMembershipChange | null {
+    if (relayState === 'added') {
+      return 'added';
+    }
+    if (relayState === 'removed' || relayState === 'pending_remove') {
+      return 'removed';
+    }
+    return null;
+  }
+
+  /** True iff the room-notify queue depth is past the circuit-breaker threshold. */
+  private async isQueueOverDepth(): Promise<boolean> {
+    try {
+      const counts = await this.roomNotifyQueue.getJobCounts();
+      const depth = (counts.waiting ?? 0) + (counts.delayed ?? 0);
+      return depth >= this.tgr.roomNotifyDepthBreak;
+    } catch (error) {
+      // Fail open: a depth-probe failure must not silently drop every push.
+      this.logger.warn(
+        `room-notify depth probe failed — failing open: ${(error as Error).message}`,
+      );
+      return false;
+    }
+  }
+
+  /**
+   * Coalesce window (§7): the first event for `(sale, member, change)` acquires a
+   * SET NX marker (TTL = `msgCoalesceWindowSec`) and proceeds; repeats within the
+   * window are dropped. A window of 0 disables coalescing (always enqueue).
+   */
+  private async shouldEnqueueAfterCoalesce(
+    saleAddress: string,
+    memberAddress: string,
+    change: RoomMembershipChange,
+  ): Promise<boolean> {
+    const windowSec = this.tgr.msgCoalesceWindowSec;
+    if (windowSec <= 0) {
+      return true;
+    }
+    try {
+      const key = `tgr:notify:coalesce:${saleAddress}:${memberAddress}:${change}`;
+      return await this.redis.tryAcquire(key, windowSec * 1000);
+    } catch (error) {
+      // Fail open: a Redis blip should not silently swallow the notification.
+      this.logger.warn(
+        `coalesce check failed — failing open: ${(error as Error).message}`,
+      );
+      return true;
+    }
+  }
+
+  /**
+   * Per-recipient fixed-window rate cap (§7, `msgRateCap`). Off by default
+   * (`msgRateCap=0`). Fail-open on Redis trouble (mirror the post-comment listener).
+   */
+  private async isRateCapped(memberAddress: string): Promise<boolean> {
+    const cap = this.tgr.msgRateCap;
+    if (cap <= 0) {
+      return false;
+    }
+    const windowSec = Math.max(1, this.tgr.msgCoalesceWindowSec || 60);
+    try {
+      const { capped } = await this.redis.incrementWithCap(
+        `tgr:notify:rate:${memberAddress}`,
+        windowSec,
+        cap,
+      );
+      if (capped) {
+        this.logger.warn(
+          `room-notify rate cap hit for ${memberAddress} (${cap}/${windowSec}s) — dropping until window resets`,
+        );
+      }
+      return capped;
+    } catch (error) {
+      this.logger.warn(
+        `room-notify rate-cap check failed for ${memberAddress} — failing open: ${(error as Error).message}`,
+      );
+      return false;
+    }
+  }
+}

--- a/src/token-gated-rooms/nostr/__tests__/group-id.spec.ts
+++ b/src/token-gated-rooms/nostr/__tests__/group-id.spec.ts
@@ -1,0 +1,37 @@
+import { groupIdFor } from '../group-id';
+
+describe('groupIdFor', () => {
+  it('returns sale_address verbatim when nostr_group_id is absent', () => {
+    expect(groupIdFor({ sale_address: 'ct_abc123' })).toBe('ct_abc123');
+  });
+
+  it('prefers nostr_group_id when present', () => {
+    expect(
+      groupIdFor({ sale_address: 'ct_abc', nostr_group_id: 'ct_persisted' }),
+    ).toBe('ct_persisted');
+  });
+
+  it('falls back to sale_address when nostr_group_id is null/undefined', () => {
+    expect(groupIdFor({ sale_address: 'ct_x', nostr_group_id: null })).toBe(
+      'ct_x',
+    );
+    expect(
+      groupIdFor({ sale_address: 'ct_y', nostr_group_id: undefined }),
+    ).toBe('ct_y');
+  });
+
+  it('preserves mixed case (no lowercasing)', () => {
+    const mixed = 'ct_MiXeDCaSe_2vK7QpAaBbCc';
+    expect(groupIdFor({ sale_address: mixed })).toBe(mixed);
+    expect(groupIdFor({ sale_address: mixed })).not.toBe(mixed.toLowerCase());
+  });
+
+  it('does not hash, slugify, or prefix the id', () => {
+    const addr = 'ct_2aBc!weird.chars_keep';
+    const out = groupIdFor({ sale_address: addr });
+    expect(out).toBe(addr);
+    expect(out).not.toMatch(/^sh:/);
+    // not a 64-char sha256 hex
+    expect(out).not.toMatch(/^[0-9a-f]{64}$/);
+  });
+});

--- a/src/token-gated-rooms/nostr/__tests__/nip29.spec.ts
+++ b/src/token-gated-rooms/nostr/__tests__/nip29.spec.ts
@@ -1,0 +1,134 @@
+import {
+  createGroup,
+  deleteGroup,
+  editMetadata,
+  NIP29_KIND,
+  putUser,
+  removeUser,
+  setRoles,
+} from '../nip29';
+
+const GID = 'ct_MixedCaseGroupId123';
+
+describe('nip29 builders', () => {
+  describe('createGroup (9007)', () => {
+    it('emits kind 9007 with only the h tag (group id first, verbatim)', () => {
+      const t = createGroup(GID);
+      expect(t.kind).toBe(NIP29_KIND.CREATE_GROUP);
+      expect(t.kind).toBe(9007);
+      expect(t.tags).toEqual([['h', GID]]);
+      expect(t.content).toBe('');
+    });
+  });
+
+  describe('editMetadata (9002)', () => {
+    it('public room: h first, name/about, public, closed', () => {
+      const t = editMetadata(GID, {
+        name: '$FOO',
+        about: 'a foo room',
+        isPrivate: false,
+      });
+      expect(t.kind).toBe(9002);
+      expect(t.tags).toEqual([
+        ['h', GID],
+        ['name', '$FOO'],
+        ['about', 'a foo room'],
+        ['public'],
+        ['closed'],
+      ]);
+    });
+
+    it('private room: emits ["private"] instead of ["public"], always closed', () => {
+      const t = editMetadata(GID, {
+        name: '$FOO',
+        about: 'a foo room',
+        isPrivate: true,
+      });
+      expect(t.tags).toContainEqual(['private']);
+      expect(t.tags).not.toContainEqual(['public']);
+      expect(t.tags).toContainEqual(['closed']);
+      // h tag is always first.
+      expect(t.tags[0]).toEqual(['h', GID]);
+    });
+
+    it('defaults to public + closed and omits name/about when absent', () => {
+      const t = editMetadata(GID);
+      expect(t.tags).toEqual([['h', GID], ['public'], ['closed']]);
+    });
+
+    it('never emits a previous tag', () => {
+      const t = editMetadata(GID, { name: 'x', about: 'y', isPrivate: true });
+      expect(t.tags.some((tag) => tag[0] === 'previous')).toBe(false);
+    });
+  });
+
+  describe('putUser (9000)', () => {
+    const PK = 'a'.repeat(64);
+
+    it('plain member add: ["p", pubkey] (no role element)', () => {
+      const t = putUser(GID, PK);
+      expect(t.kind).toBe(9000);
+      expect(t.tags).toEqual([
+        ['h', GID],
+        ['p', PK],
+      ]);
+    });
+
+    it('add with role: ["p", pubkey, role]', () => {
+      const t = putUser(GID, PK, 'admin');
+      expect(t.tags).toEqual([
+        ['h', GID],
+        ['p', PK, 'admin'],
+      ]);
+    });
+  });
+
+  describe('removeUser (9001)', () => {
+    const PK = 'b'.repeat(64);
+    it('emits kind 9001 with h first then p', () => {
+      const t = removeUser(GID, PK);
+      expect(t.kind).toBe(9001);
+      expect(t.tags).toEqual([
+        ['h', GID],
+        ['p', PK],
+      ]);
+    });
+  });
+
+  describe('setRoles (9006)', () => {
+    const PK = 'c'.repeat(64);
+    it('emits kind 9006 with p tag carrying pubkey then roles', () => {
+      const t = setRoles(GID, PK, ['admin', 'moderator']);
+      expect(t.kind).toBe(9006);
+      expect(t.tags).toEqual([
+        ['h', GID],
+        ['p', PK, 'admin', 'moderator'],
+      ]);
+    });
+  });
+
+  describe('deleteGroup (9008)', () => {
+    it('emits kind 9008 with only the h tag', () => {
+      const t = deleteGroup(GID);
+      expect(t.kind).toBe(9008);
+      expect(t.tags).toEqual([['h', GID]]);
+    });
+  });
+
+  it('no builder emits a previous tag', () => {
+    const PK = 'd'.repeat(64);
+    const templates = [
+      createGroup(GID),
+      editMetadata(GID, { name: 'n', about: 'a', isPrivate: false }),
+      putUser(GID, PK),
+      putUser(GID, PK, 'admin'),
+      removeUser(GID, PK),
+      setRoles(GID, PK, ['admin']),
+      deleteGroup(GID),
+    ];
+    for (const t of templates) {
+      expect(t.tags.some((tag) => tag[0] === 'previous')).toBe(false);
+      expect(t.tags[0][0]).toBe('h'); // h-tag always first
+    }
+  });
+});

--- a/src/token-gated-rooms/nostr/__tests__/relay-subscriber.integration.spec.ts
+++ b/src/token-gated-rooms/nostr/__tests__/relay-subscriber.integration.spec.ts
@@ -1,0 +1,310 @@
+import 'dotenv/config';
+import { DataSource, Repository } from 'typeorm';
+import { getPublicKey, nip19, Relay } from 'nostr-tools';
+import WebSocket from 'ws';
+import { DATABASE_CONFIG } from '@/configs/database';
+import { Token } from '@/tokens/entities/token.entity';
+import { NotificationPreference } from '@/notifications/entities/notification-preference.entity';
+import { NotificationPreferencesService } from '@/notifications/services/notification-preferences.service';
+import { CommunityRoom } from '../../entities/community-room.entity';
+import { RoomMembership } from '../../entities/room-membership.entity';
+import { RoomNotificationPreference } from '../../entities/room-notification-preference.entity';
+import { RoomMessageSeen } from '../../entities/room-message-seen.entity';
+import { TokenBalance } from '../../entities/token-balance.entity';
+import { RoomBackfillState } from '../../entities/room-backfill-state.entity';
+import { RoomPreferencesService } from '../../services/room-preferences.service';
+import { RelaySubscriberService } from '../relay-subscriber.service';
+
+if (typeof (globalThis as { WebSocket?: unknown }).WebSocket === 'undefined') {
+  (globalThis as { WebSocket?: unknown }).WebSocket = WebSocket;
+}
+
+/**
+ * DB (+ optional relay) integration for the Task-14 relay subscriber. Mirrors the
+ * Task-12 harness: a real Postgres backs the room/membership/seen tables in a
+ * DEDICATED `tgr14_test` schema (`synchronize: true`). The enqueue sink + redis +
+ * NotificationService dependencies are mocked, so the test asserts the
+ * dedup/fan-out/recipient SQL over REAL Postgres.
+ *
+ * The relay-backed cases additionally require a reachable `groups_relay`; they are
+ * auto-skipped when unreachable, so unit-only CI stays green without the container.
+ *
+ * Requires the local Postgres (`DB_HOST`); auto-skips otherwise.
+ */
+const HAS_DB = !!process.env.DB_HOST;
+const d = HAS_DB ? describe : describe.skip;
+
+const SCHEMA = 'tgr14_test';
+const GID = 'ct_tgr14_sale';
+const TOKEN_ADDR = 'ct_tgr14_token';
+
+const RELAY_ADMIN_NSEC =
+  process.env.TG_BOT_NSEC ||
+  'nsec1dwg3l5mumawgr4xq4kc6klagytkj2w4s4kd2rrthy47g3v5mwx8qwrh7sx';
+const RELAY_URL = process.env.TG_RELAY_URL || 'ws://localhost:7777';
+
+async function relayReachable(url: string): Promise<boolean> {
+  try {
+    const relay = await Relay.connect(url);
+    relay.close();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function makeConfig(): any {
+  return {
+    nostrBotNsec: RELAY_ADMIN_NSEC,
+    nostrRelayUrl: RELAY_URL,
+    msgCoalesceWindowSec: 0, // immediate flush — deterministic assertions
+    msgRateCap: 0,
+    roomNotifyDepthBreak: 10000,
+    subscriberShards: 1,
+    communityTokenRefreshSec: 300,
+    relayHealthPauseSec: 1,
+  };
+}
+
+d('RelaySubscriberService (integration)', () => {
+  let ds: DataSource;
+  let tokenRepo: Repository<Token>;
+  let roomRepo: Repository<CommunityRoom>;
+  let membershipRepo: Repository<RoomMembership>;
+  let seenRepo: Repository<RoomMessageSeen>;
+  let roomPrefRepo: Repository<RoomNotificationPreference>;
+  let notifPrefRepo: Repository<NotificationPreference>;
+  let roomPreferences: RoomPreferencesService;
+  let add: jest.Mock;
+  let svc: RelaySubscriberService;
+
+  const adminPubkey = (): string => {
+    const decoded = nip19.decode(RELAY_ADMIN_NSEC);
+    return getPublicKey(decoded.data as Uint8Array);
+  };
+
+  beforeAll(async () => {
+    const boot = new DataSource({
+      ...(DATABASE_CONFIG as any),
+      synchronize: false,
+      entities: [],
+    });
+    await boot.initialize();
+    await boot.query(`DROP SCHEMA IF EXISTS "${SCHEMA}" CASCADE`);
+    await boot.query(`CREATE SCHEMA "${SCHEMA}"`);
+    await boot.destroy();
+
+    ds = new DataSource({
+      ...(DATABASE_CONFIG as any),
+      schema: SCHEMA,
+      synchronize: true,
+      entities: [
+        Token,
+        CommunityRoom,
+        RoomMembership,
+        RoomNotificationPreference,
+        RoomMessageSeen,
+        TokenBalance,
+        RoomBackfillState,
+        NotificationPreference,
+      ],
+    });
+    await ds.initialize();
+
+    tokenRepo = ds.getRepository(Token);
+    roomRepo = ds.getRepository(CommunityRoom);
+    membershipRepo = ds.getRepository(RoomMembership);
+    seenRepo = ds.getRepository(RoomMessageSeen);
+    roomPrefRepo = ds.getRepository(RoomNotificationPreference);
+    notifPrefRepo = ds.getRepository(NotificationPreference);
+  }, 60_000);
+
+  beforeEach(async () => {
+    await seenRepo.clear();
+    await membershipRepo.clear();
+    await roomPrefRepo.clear();
+    await notifPrefRepo.clear();
+    await roomRepo.clear();
+    await tokenRepo.clear();
+
+    await tokenRepo.save(
+      tokenRepo.create({
+        sale_address: GID,
+        address: TOKEN_ADDR,
+        name: 'TGR14',
+        symbol: 'TGR',
+        owner_address: 'ak_owner',
+        nostr_room_state: 'created',
+      } as Partial<Token>),
+    );
+    await roomRepo.save(
+      roomRepo.create({
+        sale_address: GID,
+        token_address: TOKEN_ADDR,
+        symbol: 'TGR',
+        owner_address: 'ak_owner',
+      } as Partial<CommunityRoom>),
+    );
+    // 3 added members: alice (author), bob, carol.
+    await membershipRepo.save([
+      membershipRepo.create({
+        sale_address: GID,
+        member_address: 'ak_alice',
+        member_pubkey: 'pk_alice',
+        relay_state: 'added',
+      }),
+      membershipRepo.create({
+        sale_address: GID,
+        member_address: 'ak_bob',
+        member_pubkey: 'pk_bob',
+        relay_state: 'added',
+      }),
+      membershipRepo.create({
+        sale_address: GID,
+        member_address: 'ak_carol',
+        member_pubkey: 'pk_carol',
+        relay_state: 'added',
+      }),
+      // A pending member must NOT be a recipient.
+      membershipRepo.create({
+        sale_address: GID,
+        member_address: 'ak_dave',
+        member_pubkey: 'pk_dave',
+        relay_state: 'pending_add',
+      }),
+    ]);
+
+    const notifPrefs = new NotificationPreferencesService(notifPrefRepo);
+    roomPreferences = new RoomPreferencesService(roomPrefRepo, notifPrefs);
+
+    add = jest.fn().mockResolvedValue({ id: 'job' });
+    const notifyQueue = {
+      add,
+      getJobCounts: jest.fn().mockResolvedValue({ waiting: 0, delayed: 0 }),
+    } as any;
+    const redis = {
+      incrementWithCap: jest
+        .fn()
+        .mockResolvedValue({ count: 1, capped: false }),
+    } as any;
+
+    svc = new RelaySubscriberService(
+      tokenRepo,
+      roomRepo,
+      membershipRepo,
+      seenRepo,
+      roomPreferences,
+      redis,
+      notifyQueue,
+      makeConfig(),
+    );
+  });
+
+  afterAll(async () => {
+    if (ds?.isInitialized) {
+      await ds.destroy();
+    }
+    const cleanup = new DataSource({
+      ...(DATABASE_CONFIG as any),
+      synchronize: false,
+      entities: [],
+    });
+    await cleanup.initialize();
+    await cleanup.query(`DROP SCHEMA IF EXISTS "${SCHEMA}" CASCADE`);
+    await cleanup.destroy();
+  }, 60_000);
+
+  const chat = (id: string, authorPubkey: string): any => ({
+    id,
+    pubkey: authorPubkey,
+    kind: 9,
+    created_at: Math.floor(Date.now() / 1000),
+    content: 'gm',
+    tags: [['h', GID]],
+    sig: 'x',
+  });
+
+  it('member posts → one job per OTHER added member, none for the author', async () => {
+    await svc.onEvent(chat('e1', 'pk_alice'));
+    const recipients = add.mock.calls.map((c) => c[1].recipient).sort();
+    expect(recipients).toEqual(['ak_bob', 'ak_carol']); // not alice, not dave
+    const seen = await seenRepo.findOne({ where: { event_id: 'e1' } });
+    expect(seen).not.toBeNull();
+    expect(seen!.sale_address).toBe(GID);
+  });
+
+  it('muted member is excluded while others get a job', async () => {
+    await roomPrefRepo.save(
+      roomPrefRepo.create({
+        address: 'ak_bob',
+        sale_address: GID,
+        muted: true,
+      }),
+    );
+    await svc.onEvent(chat('e2', 'pk_alice'));
+    const recipients = add.mock.calls.map((c) => c[1].recipient).sort();
+    expect(recipients).toEqual(['ak_carol']);
+  });
+
+  it('redelivery of the same event id → no duplicate jobs (dedup holds)', async () => {
+    await svc.onEvent(chat('e3', 'pk_alice'));
+    expect(add).toHaveBeenCalledTimes(2);
+    add.mockClear();
+    await svc.onEvent(chat('e3', 'pk_alice'));
+    expect(add).not.toHaveBeenCalled();
+  });
+
+  it('refreshSubscription loads only this shard from Token nostr_room_state=created', async () => {
+    // A non-created room must NOT enter the subscription set.
+    await tokenRepo.save(
+      tokenRepo.create({
+        sale_address: 'ct_pending',
+        address: 'ct_pending_t',
+        name: 'P',
+        symbol: 'P',
+        owner_address: 'ak_o',
+        nostr_room_state: 'pending',
+      } as Partial<Token>),
+    );
+    // refreshSubscription needs a live socket; skip the actual subscribe when no
+    // relay, just assert loadShardGroupIds via the private accessor through the
+    // documented behavior (the created room is present, the pending one is not).
+    const ids = await (svc as any).loadShardGroupIds();
+    expect(ids.has(GID)).toBe(true);
+    expect(ids.has('ct_pending')).toBe(false);
+  });
+
+  // ── relay-backed (auto-skip when unreachable) ────────────────────────────────
+  describe('against a live groups_relay', () => {
+    let available = false;
+    beforeAll(async () => {
+      available =
+        !!process.env.TG_RELAY_URL || (await relayReachable(RELAY_URL));
+      if (!available) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[relay-subscriber.integration] skipping relay cases — no relay at ${RELAY_URL}`,
+        );
+      }
+    }, 30_000);
+
+    const itRelay = (name: string, fn: () => Promise<void>, timeout = 20_000) =>
+      it(
+        name,
+        async () => {
+          if (!available) {
+            return;
+          }
+          await fn();
+        },
+        timeout,
+      );
+
+    itRelay('connects + completes NIP-42 AUTH as relay admin', async () => {
+      await (svc as any).ensureConnected();
+      expect(svc.isHealthy()).toBe(true);
+      expect(svc.pubkey).toBe(adminPubkey());
+      svc.onApplicationShutdown();
+    });
+  });
+});

--- a/src/token-gated-rooms/nostr/__tests__/relay-subscriber.service.spec.ts
+++ b/src/token-gated-rooms/nostr/__tests__/relay-subscriber.service.spec.ts
@@ -1,0 +1,359 @@
+import { firstHTag, RelaySubscriberService } from '../relay-subscriber.service';
+import { shardForGroupId } from '../shard';
+
+/**
+ * Unit coverage for the relay subscriber's ROUTER + dedup + coalescing + fan-out +
+ * rate-cap + circuit-breaker (Task 14, plan §7.1). No real socket: we drive
+ * `onEvent` directly and assert the resulting enqueues over mocked repos/queue/redis.
+ *
+ * A valid relay-admin nsec is required only so the constructor can decode it; the
+ * connection lifecycle is never invoked here (no `onModuleInit`).
+ */
+const RELAY_ADMIN_NSEC =
+  'nsec1dwg3l5mumawgr4xq4kc6klagytkj2w4s4kd2rrthy47g3v5mwx8qwrh7sx';
+
+const GID = 'ct_room_sale';
+const SYMBOL = 'ROOM';
+
+type Mock = jest.Mock;
+
+interface Harness {
+  svc: RelaySubscriberService;
+  add: Mock;
+  getJobCounts: Mock;
+  isRoomEnabled: Mock;
+  incrementWithCap: Mock;
+  recordSeen: Mock;
+  findRoom: Mock;
+  findMembers: Mock;
+}
+
+function makeHarness(
+  config: Partial<{
+    msgCoalesceWindowSec: number;
+    msgRateCap: number;
+    roomNotifyDepthBreak: number;
+    subscriberShards: number;
+    communityTokenRefreshSec: number;
+    relayHealthPauseSec: number;
+  }> = {},
+): Harness {
+  const add: Mock = jest.fn().mockResolvedValue({ id: 'job1' });
+  const getJobCounts: Mock = jest
+    .fn()
+    .mockResolvedValue({ waiting: 0, delayed: 0 });
+  const isRoomEnabled: Mock = jest.fn().mockResolvedValue(true);
+  const incrementWithCap: Mock = jest
+    .fn()
+    .mockResolvedValue({ count: 1, capped: false });
+
+  // room_message_seen INSERT ... ON CONFLICT DO NOTHING → returns inserted ids.
+  const recordSeen: Mock = jest.fn().mockResolvedValue({
+    identifiers: [{ event_id: 'e1' }],
+    raw: [{ event_id: 'e1' }],
+  });
+  const insertChain = {
+    insert: () => insertChain,
+    into: () => insertChain,
+    values: () => insertChain,
+    orIgnore: () => insertChain,
+    returning: () => insertChain,
+    execute: () => recordSeen(),
+  };
+
+  const findRoom: Mock = jest.fn().mockResolvedValue({
+    sale_address: GID,
+    symbol: SYMBOL,
+    deleted: false,
+  });
+  const findMembers: Mock = jest.fn().mockResolvedValue([
+    { member_address: 'ak_alice', member_pubkey: 'pk_alice' },
+    { member_address: 'ak_bob', member_pubkey: 'pk_bob' },
+  ]);
+
+  const tokenRepo = { find: jest.fn().mockResolvedValue([]) } as any;
+  const roomRepo = { findOne: findRoom } as any;
+  const membershipRepo = { find: findMembers } as any;
+  const seenRepo = {
+    createQueryBuilder: () => insertChain,
+  } as any;
+  const roomPreferences = { isRoomEnabled } as any;
+  const redis = { incrementWithCap } as any;
+  const notifyQueue = { add, getJobCounts } as any;
+  const cfg = {
+    nostrBotNsec: RELAY_ADMIN_NSEC,
+    nostrRelayUrl: 'ws://localhost:7777',
+    msgCoalesceWindowSec: config.msgCoalesceWindowSec ?? 0,
+    msgRateCap: config.msgRateCap ?? 0,
+    roomNotifyDepthBreak: config.roomNotifyDepthBreak ?? 10000,
+    subscriberShards: config.subscriberShards ?? 1,
+    communityTokenRefreshSec: config.communityTokenRefreshSec ?? 300,
+    relayHealthPauseSec: config.relayHealthPauseSec ?? 5,
+  } as any;
+
+  const svc = new RelaySubscriberService(
+    tokenRepo,
+    roomRepo,
+    membershipRepo,
+    seenRepo,
+    roomPreferences,
+    redis,
+    notifyQueue,
+    cfg,
+  );
+
+  return {
+    svc,
+    add,
+    getJobCounts,
+    isRoomEnabled,
+    incrementWithCap,
+    recordSeen,
+    findRoom,
+    findMembers,
+  };
+}
+
+function chatEvent(
+  over: Partial<{
+    id: string;
+    pubkey: string;
+    kind: number;
+    tags: string[][];
+  }> = {},
+): any {
+  return {
+    id: over.id ?? 'e1',
+    pubkey: over.pubkey ?? 'pk_sender',
+    kind: over.kind ?? 9,
+    created_at: 1700000000,
+    content: 'hi',
+    tags: over.tags ?? [['h', GID]],
+    sig: 'x',
+  };
+}
+
+describe('firstHTag', () => {
+  it('returns the first h-tag value', () => {
+    expect(firstHTag({ tags: [['h', GID]] })).toBe(GID);
+  });
+  it('first h-tag wins when multiple', () => {
+    expect(
+      firstHTag({
+        tags: [
+          ['h', 'ct_a'],
+          ['h', 'ct_b'],
+        ],
+      }),
+    ).toBe('ct_a');
+  });
+  it('ignores non-h tags before the h-tag', () => {
+    expect(
+      firstHTag({
+        tags: [
+          ['e', 'x'],
+          ['h', GID],
+        ],
+      }),
+    ).toBe(GID);
+  });
+  it('undefined when no h-tag', () => {
+    expect(firstHTag({ tags: [['e', 'x']] })).toBeUndefined();
+    expect(firstHTag({ tags: [] })).toBeUndefined();
+    expect(firstHTag({})).toBeUndefined();
+  });
+  it('undefined when h-tag has empty value', () => {
+    expect(firstHTag({ tags: [['h', '']] })).toBeUndefined();
+  });
+});
+
+describe('RelaySubscriberService.onEvent (window=0, immediate flush)', () => {
+  it('h-routing: enqueues one job per added member except the author', async () => {
+    const h = makeHarness();
+    // Author is bob (member_pubkey pk_bob); alice should get a job, bob excluded.
+    await h.svc.onEvent(chatEvent({ pubkey: 'pk_bob' }));
+    expect(h.add).toHaveBeenCalledTimes(1);
+    const [name, payload] = h.add.mock.calls[0];
+    expect(name).toBe('room-message');
+    expect(payload).toMatchObject({
+      sale_address: GID,
+      recipient: 'ak_alice',
+      symbol: SYMBOL,
+      message_count: 1,
+      sample_event_id: 'e1',
+    });
+  });
+
+  it('fan-out to all members when the author is not a member', async () => {
+    const h = makeHarness();
+    await h.svc.onEvent(chatEvent({ pubkey: 'pk_outsider' }));
+    expect(h.add).toHaveBeenCalledTimes(2);
+    const recipients = h.add.mock.calls.map((c) => c[1].recipient).sort();
+    expect(recipients).toEqual(['ak_alice', 'ak_bob']);
+  });
+
+  it('missing h-tag → dropped (no dedup, no fan-out)', async () => {
+    const h = makeHarness();
+    await h.svc.onEvent(chatEvent({ tags: [['e', 'x']] }));
+    expect(h.recordSeen).not.toHaveBeenCalled();
+    expect(h.add).not.toHaveBeenCalled();
+  });
+
+  it('unknown room → dropped after dedup record', async () => {
+    const h = makeHarness();
+    h.findRoom.mockResolvedValueOnce(null);
+    await h.svc.onEvent(chatEvent());
+    expect(h.recordSeen).toHaveBeenCalledTimes(1); // still deduped
+    expect(h.add).not.toHaveBeenCalled();
+  });
+
+  it('deleted room → dropped after dedup record', async () => {
+    const h = makeHarness();
+    h.findRoom.mockResolvedValueOnce({
+      sale_address: GID,
+      symbol: SYMBOL,
+      deleted: true,
+    });
+    await h.svc.onEvent(chatEvent());
+    expect(h.recordSeen).toHaveBeenCalledTimes(1);
+    expect(h.add).not.toHaveBeenCalled();
+  });
+
+  it('dedup: a re-delivered event.id is skipped (no fan-out)', async () => {
+    const h = makeHarness();
+    // First sight inserts; second sight: orIgnore returns no identifiers.
+    h.recordSeen
+      .mockResolvedValueOnce({ identifiers: [{ event_id: 'e1' }], raw: [{}] })
+      .mockResolvedValueOnce({ identifiers: [], raw: [] });
+
+    await h.svc.onEvent(chatEvent({ pubkey: 'pk_outsider' }));
+    expect(h.add).toHaveBeenCalledTimes(2);
+    h.add.mockClear();
+
+    await h.svc.onEvent(chatEvent({ pubkey: 'pk_outsider' }));
+    expect(h.findRoom).toHaveBeenCalledTimes(1); // not re-resolved
+    expect(h.add).not.toHaveBeenCalled();
+  });
+
+  it('mute: per-room/type-level muted recipient is excluded', async () => {
+    const h = makeHarness();
+    // alice enabled, bob muted.
+    h.isRoomEnabled.mockImplementation(
+      async (addr: string) => addr === 'ak_alice',
+    );
+    await h.svc.onEvent(chatEvent({ pubkey: 'pk_outsider' }));
+    const recipients = h.add.mock.calls.map((c) => c[1].recipient);
+    expect(recipients).toEqual(['ak_alice']);
+  });
+
+  it('only relay_state=added members are queried as recipients', async () => {
+    const h = makeHarness();
+    await h.svc.onEvent(chatEvent({ pubkey: 'pk_outsider' }));
+    expect(h.findMembers).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { sale_address: GID, relay_state: 'added' },
+      }),
+    );
+  });
+
+  it('rate cap: a recipient over the cap is dropped (and counted via redis)', async () => {
+    const h = makeHarness({ msgRateCap: 1 });
+    // alice under cap, bob over cap.
+    h.incrementWithCap.mockImplementation(async (key: string) => ({
+      count: key.includes('ak_bob') ? 2 : 1,
+      capped: key.includes('ak_bob'),
+    }));
+    await h.svc.onEvent(chatEvent({ pubkey: 'pk_outsider' }));
+    const recipients = h.add.mock.calls.map((c) => c[1].recipient);
+    expect(recipients).toEqual(['ak_alice']);
+    expect(h.incrementWithCap).toHaveBeenCalledTimes(2);
+  });
+
+  it('circuit breaker: depth over threshold pauses enqueue but still dedups', async () => {
+    const h = makeHarness({ roomNotifyDepthBreak: 10 });
+    h.getJobCounts.mockResolvedValue({ waiting: 20, delayed: 0 });
+    await h.svc.onEvent(chatEvent({ pubkey: 'pk_outsider' }));
+    expect(h.recordSeen).toHaveBeenCalledTimes(1); // dedup recorded while paused
+    expect(h.add).not.toHaveBeenCalled();
+  });
+
+  it('circuit breaker resumes once depth drops below the low-water mark', async () => {
+    const h = makeHarness({ roomNotifyDepthBreak: 10 });
+    // Trip: depth 20 ≥ 10.
+    h.getJobCounts.mockResolvedValueOnce({ waiting: 20, delayed: 0 });
+    await h.svc.onEvent(chatEvent({ id: 'e1', pubkey: 'pk_outsider' }));
+    expect(h.add).not.toHaveBeenCalled();
+
+    // Resume: depth 4 ≤ 5 (half of 10).
+    h.getJobCounts.mockResolvedValue({ waiting: 4, delayed: 0 });
+    await h.svc.onEvent(chatEvent({ id: 'e2', pubkey: 'pk_outsider' }));
+    expect(h.add).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('RelaySubscriberService coalescing (window>0)', () => {
+  // Real timers with a tiny window — the flush is async (DB + queue), which fake
+  // timers + microtask flushing make brittle; a short real window is deterministic.
+  const WINDOW_MS = 1;
+  const waitForFlush = async (): Promise<void> => {
+    await new Promise((r) => setTimeout(r, WINDOW_MS + 25));
+  };
+
+  it('5 messages in one room within the window → one job per recipient, count=5', async () => {
+    const h = makeHarness({ msgCoalesceWindowSec: WINDOW_MS / 1000 });
+    // Open the window, then immediately bump it before the (tiny) timer fires.
+    await h.svc.onEvent(chatEvent({ id: 'e0', pubkey: 'pk_outsider' }));
+    // Reach into the buffer to add 4 more without racing the timer.
+    const entry = (h.svc as any).coalescing.get(GID);
+    entry.count = 5;
+    expect(h.add).not.toHaveBeenCalled();
+
+    await waitForFlush();
+
+    // 2 added members (alice + bob), one job each, message_count = 5.
+    expect(h.add).toHaveBeenCalledTimes(2);
+    for (const call of h.add.mock.calls) {
+      expect(call[1].message_count).toBe(5);
+    }
+  });
+
+  it('a single message in the window flushes with count=1', async () => {
+    const h = makeHarness({ msgCoalesceWindowSec: WINDOW_MS / 1000 });
+    await h.svc.onEvent(chatEvent({ id: 'solo', pubkey: 'pk_outsider' }));
+    await waitForFlush();
+    expect(h.add).toHaveBeenCalledTimes(2);
+    expect(h.add.mock.calls[0][1].message_count).toBe(1);
+  });
+
+  it('dedup holds across the window (same id within window counted once)', async () => {
+    const h = makeHarness({ msgCoalesceWindowSec: WINDOW_MS / 1000 });
+    h.recordSeen
+      .mockResolvedValueOnce({ identifiers: [{}], raw: [{}] })
+      .mockResolvedValue({ identifiers: [], raw: [] });
+    await h.svc.onEvent(chatEvent({ id: 'dup', pubkey: 'pk_outsider' }));
+    await h.svc.onEvent(chatEvent({ id: 'dup', pubkey: 'pk_outsider' }));
+    await waitForFlush();
+    // Only the first sight counted → count=1.
+    expect(h.add).toHaveBeenCalledTimes(2);
+    expect(h.add.mock.calls[0][1].message_count).toBe(1);
+  });
+});
+
+describe('RelaySubscriberService sharding (onEvent)', () => {
+  it('drops events for groups outside this shard', async () => {
+    const h = makeHarness({ subscriberShards: 4 });
+    // Find a gid that does NOT belong to shard 0.
+    let foreignGid = '';
+    for (let i = 0; i < 1000; i++) {
+      const g = `ct_foreign_${i}`;
+      if (shardForGroupId(g, 4) !== 0) {
+        foreignGid = g;
+        break;
+      }
+    }
+    expect(foreignGid).not.toBe('');
+    await h.svc.onEvent(chatEvent({ tags: [['h', foreignGid]] }));
+    expect(h.recordSeen).not.toHaveBeenCalled();
+    expect(h.add).not.toHaveBeenCalled();
+  });
+});

--- a/src/token-gated-rooms/nostr/__tests__/relay-writer.integration.spec.ts
+++ b/src/token-gated-rooms/nostr/__tests__/relay-writer.integration.spec.ts
@@ -1,0 +1,207 @@
+import 'dotenv/config';
+import { Relay } from 'nostr-tools';
+import WebSocket from 'ws';
+import { RelayWriterService } from '../relay-writer.service';
+import { createGroup, editMetadata, putUser, removeUser } from '../nip29';
+
+if (typeof (globalThis as { WebSocket?: unknown }).WebSocket === 'undefined') {
+  (globalThis as { WebSocket?: unknown }).WebSocket = WebSocket;
+}
+
+/**
+ * Relay-write integration (Task 07). Runs against a local `groups_relay`
+ * (Task 02 harness: `ws://localhost:8080`, relay-admin keypair from
+ * `settings.test.yml`). The bot nsec under test MUST be the relay admin (D7) so
+ * managed-group creation is allowed.
+ *
+ * Skipped automatically when `TG_RELAY_URL` is unset OR the relay is not
+ * reachable, so unit-only CI stays green without the relay container.
+ */
+
+// Relay-admin nsec derived from settings.test.yml secret
+// 6b911fd37cdf5c81d4c0adb1ab7fa822ed253ab0ad9aa18d77257c88b29b718e
+// → pubkey 385c3a6ec0b9d57a4330dbd6284989be5bd00e41c535f9ca39b6ae7c521b81cd
+const RELAY_ADMIN_NSEC =
+  process.env.TG_BOT_NSEC ||
+  'nsec1dwg3l5mumawgr4xq4kc6klagytkj2w4s4kd2rrthy47g3v5mwx8qwrh7sx';
+
+const RELAY_URL = process.env.TG_RELAY_URL || 'ws://localhost:8080';
+
+function makeConfig(url: string): any {
+  return {
+    nostrRelayUrl: url,
+    nostrBotNsec: RELAY_ADMIN_NSEC,
+    publishAckTimeoutMs: 5000,
+    publishRatePerSec: 100,
+    publishMaxRetries: 5,
+    relayHealthPauseSec: 1,
+  };
+}
+
+async function relayReachable(url: string): Promise<boolean> {
+  try {
+    const relay = await Relay.connect(url);
+    relay.close();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Read the relay-served `39000` group state (its `d` tag is the group id). */
+async function read39000(url: string, groupId: string): Promise<boolean> {
+  const relay = await Relay.connect(url);
+  return await new Promise<boolean>((resolve) => {
+    let found = false;
+    const sub = relay.subscribe([{ kinds: [39000], '#d': [groupId] }], {
+      onevent: () => {
+        found = true;
+      },
+      oneose: () => {
+        sub.close();
+        relay.close();
+        resolve(found);
+      },
+    });
+    setTimeout(() => {
+      try {
+        sub.close();
+        relay.close();
+      } catch {
+        // ignore
+      }
+      resolve(found);
+    }, 4000);
+  });
+}
+
+const uniqueGid = (): string =>
+  `ct_TgrWriterIT_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+const memberPk = (n = 0): string =>
+  (n.toString(16).padStart(2, '0') + 'a'.repeat(62)).slice(0, 64);
+
+describe('RelayWriterService (integration)', () => {
+  let available = false;
+
+  beforeAll(async () => {
+    available = !!process.env.TG_RELAY_URL || (await relayReachable(RELAY_URL));
+    if (!available) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[relay-writer.integration] skipping — no reachable relay at ${RELAY_URL}`,
+      );
+    }
+  }, 30000);
+
+  const itRelay = (name: string, fn: () => Promise<void>, timeout = 20000) =>
+    it(
+      name,
+      async () => {
+        if (!available) {
+          return;
+        }
+        await fn();
+      },
+      timeout,
+    );
+
+  itRelay(
+    'publishes 9007 + 9002 (closed) and the relay serves a 39000',
+    async () => {
+      const writer = new RelayWriterService(makeConfig(RELAY_URL));
+      await writer.onModuleInit();
+      const gid = uniqueGid();
+
+      const created = await writer.publish(createGroup(gid));
+      expect(created.ok).toBe(true);
+
+      const meta = await writer.publish(
+        editMetadata(gid, {
+          name: '$IT',
+          about: 'integration room',
+          isPrivate: false,
+        }),
+      );
+      expect(meta.ok).toBe(true);
+
+      // Relay generates the addressable 39000 state for the group.
+      await new Promise((r) => setTimeout(r, 500));
+      expect(await read39000(RELAY_URL, gid)).toBe(true);
+
+      writer.onApplicationShutdown();
+    },
+  );
+
+  itRelay(
+    '9000 put-user adds to 39002, 9001 removes; fetchGroupMembers reflects both',
+    async () => {
+      const writer = new RelayWriterService(makeConfig(RELAY_URL));
+      await writer.onModuleInit();
+      const gid = uniqueGid();
+      const pk = memberPk(1);
+
+      await writer.publish(createGroup(gid));
+      await writer.publish(
+        editMetadata(gid, { name: '$IT2', isPrivate: false }),
+      );
+
+      const add = await writer.publish(putUser(gid, pk));
+      expect(add.ok).toBe(true);
+      await new Promise((r) => setTimeout(r, 500));
+
+      const afterAdd = await writer.fetchGroupMembers(gid);
+      expect(afterAdd.has(pk)).toBe(true);
+
+      const remove = await writer.publish(removeUser(gid, pk));
+      expect(remove.ok).toBe(true);
+      await new Promise((r) => setTimeout(r, 500));
+
+      const afterRemove = await writer.fetchGroupMembers(gid);
+      expect(afterRemove.has(pk)).toBe(false);
+
+      writer.onApplicationShutdown();
+    },
+  );
+
+  itRelay(
+    'duplicate 9007 for an existing group resolves (already-exists no-op)',
+    async () => {
+      const writer = new RelayWriterService(makeConfig(RELAY_URL));
+      await writer.onModuleInit();
+      const gid = uniqueGid();
+
+      const first = await writer.publish(createGroup(gid));
+      expect(first.ok).toBe(true);
+
+      // A second create either ok-acks or rejects with "Group already exists";
+      // the writer surfaces the reason and the PROCESSOR treats it as success.
+      const second = await writer.publish(createGroup(gid));
+      if (!second.ok) {
+        expect(second.reason.toLowerCase()).toContain('already exists');
+      }
+
+      // 39000 still served (group unchanged).
+      expect(await read39000(RELAY_URL, gid)).toBe(true);
+
+      writer.onApplicationShutdown();
+    },
+  );
+
+  itRelay(
+    'unreachable relay: publish reports failure and the writer is unhealthy (queue would pause)',
+    async () => {
+      // Point at a closed port — connect fails, publish must not hang forever.
+      const writer = new RelayWriterService(makeConfig('ws://127.0.0.1:1'));
+      // onModuleInit schedules a reconnect on failure instead of throwing.
+      await writer.onModuleInit();
+      expect(writer.isHealthy()).toBe(false);
+
+      await expect(
+        writer.publish(createGroup(uniqueGid())),
+      ).rejects.toBeDefined();
+      expect(writer.isHealthy()).toBe(false);
+
+      writer.onApplicationShutdown();
+    },
+  );
+});

--- a/src/token-gated-rooms/nostr/__tests__/room-admins.integration.spec.ts
+++ b/src/token-gated-rooms/nostr/__tests__/room-admins.integration.spec.ts
@@ -1,0 +1,242 @@
+import 'dotenv/config';
+import { generateSecretKey, getPublicKey, nip19, Relay } from 'nostr-tools';
+import WebSocket from 'ws';
+import { createGroup, editMetadata, putUser, setRoles } from '../nip29';
+import { RelayWriterService } from '../relay-writer.service';
+import { RelayAdminHealthService } from '../relay-admin-health';
+import { diffRoomAdmins } from '../room-admins';
+
+if (typeof (globalThis as { WebSocket?: unknown }).WebSocket === 'undefined') {
+  (globalThis as { WebSocket?: unknown }).WebSocket = WebSocket;
+}
+
+/**
+ * Relay integration for Task 08 (relay-admin + configured room admins). Runs
+ * against the local `groups_relay` (Task 02 harness, `ws://localhost:8080`,
+ * relay-admin keypair from `settings.test.yml`). The bot nsec under test MUST be
+ * the relay admin (D7).
+ *
+ * Skipped automatically when `TG_RELAY_URL` is unset AND no relay is reachable
+ * at the default URL, so unit-only CI stays green without the relay container.
+ *
+ * The publish path (the queue) is exercised by unit tests; here we publish the
+ * admin `9000`s straight through the writer (what the queue's processor does) and
+ * assert the relay's `39001` (admins) / `39002` (members) reflect them.
+ */
+
+// Relay-admin nsec derived from settings.test.yml secret (same as Task 07 IT).
+const RELAY_ADMIN_NSEC =
+  process.env.TG_BOT_NSEC ||
+  'nsec1dwg3l5mumawgr4xq4kc6klagytkj2w4s4kd2rrthy47g3v5mwx8qwrh7sx';
+const RELAY_URL = process.env.TG_RELAY_URL || 'ws://localhost:8080';
+
+function makeConfig(url: string, nsec: string): any {
+  return {
+    nostrRelayUrl: url,
+    nostrBotNsec: nsec,
+    publishAckTimeoutMs: 5000,
+    publishRatePerSec: 100,
+    publishMaxRetries: 5,
+    relayHealthPauseSec: 1,
+  };
+}
+
+async function relayReachable(url: string): Promise<boolean> {
+  try {
+    const relay = await Relay.connect(url);
+    relay.close();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Read the relay-served `39001` admins list (`d` tag = group id) → hex set. */
+async function read39001Admins(url: string, gid: string): Promise<Set<string>> {
+  const relay = await Relay.connect(url);
+  const admins = new Set<string>();
+  return await new Promise<Set<string>>((resolve) => {
+    const done = (): void => {
+      try {
+        relay.close();
+      } catch {
+        // ignore
+      }
+      resolve(admins);
+    };
+    const sub = relay.subscribe([{ kinds: [39001], '#d': [gid] }], {
+      onevent: (event) => {
+        for (const tag of event.tags) {
+          if (tag[0] === 'p' && typeof tag[1] === 'string') {
+            admins.add(tag[1]);
+          }
+        }
+      },
+      oneose: () => {
+        sub.close();
+        done();
+      },
+    });
+    setTimeout(done, 4000);
+  });
+}
+
+const uniqueGid = (): string =>
+  `ct_TgrAdminsIT_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+
+/** A random valid relay member keypair (so the relay accepts the `p` tag). */
+function randomPubkey(): string {
+  return getPublicKey(generateSecretKey());
+}
+
+describe('Task 08 relay admins (integration)', () => {
+  let available = false;
+
+  beforeAll(async () => {
+    available = !!process.env.TG_RELAY_URL || (await relayReachable(RELAY_URL));
+    if (!available) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[room-admins.integration] skipping — no reachable relay at ${RELAY_URL}`,
+      );
+    }
+  }, 30000);
+
+  const itRelay = (name: string, fn: () => Promise<void>, timeout = 20000) =>
+    it(
+      name,
+      async () => {
+        if (!available) {
+          return;
+        }
+        await fn();
+      },
+      timeout,
+    );
+
+  itRelay(
+    'seeding admins puts each configured admin into 39001 (admins) and 39002 (members)',
+    async () => {
+      const writer = new RelayWriterService(
+        makeConfig(RELAY_URL, RELAY_ADMIN_NSEC),
+      );
+      await writer.onModuleInit();
+      const gid = uniqueGid();
+      const adminA = randomPubkey();
+      const adminB = randomPubkey();
+
+      await writer.publish(createGroup(gid));
+      await writer.publish(
+        editMetadata(gid, { name: '$ADM', isPrivate: false }),
+      );
+
+      expect((await writer.publish(putUser(gid, adminA, 'admin'))).ok).toBe(
+        true,
+      );
+      expect((await writer.publish(putUser(gid, adminB, 'admin'))).ok).toBe(
+        true,
+      );
+      await new Promise((r) => setTimeout(r, 600));
+
+      const admins = await read39001Admins(RELAY_URL, gid);
+      expect(admins.has(adminA)).toBe(true);
+      expect(admins.has(adminB)).toBe(true);
+
+      const members = await writer.fetchGroupMembers(gid);
+      expect(members.has(adminA)).toBe(true);
+      expect(members.has(adminB)).toBe(true);
+
+      writer.onApplicationShutdown();
+    },
+  );
+
+  itRelay(
+    'idempotency: re-seeding the same admin produces no duplicate in 39001',
+    async () => {
+      const writer = new RelayWriterService(
+        makeConfig(RELAY_URL, RELAY_ADMIN_NSEC),
+      );
+      await writer.onModuleInit();
+      const gid = uniqueGid();
+      const admin = randomPubkey();
+
+      await writer.publish(createGroup(gid));
+      await writer.publish(putUser(gid, admin, 'admin'));
+      await writer.publish(putUser(gid, admin, 'admin')); // re-seed
+      await new Promise((r) => setTimeout(r, 600));
+
+      const admins = await read39001Admins(RELAY_URL, gid);
+      const occurrences = [...admins].filter((p) => p === admin).length;
+      expect(occurrences).toBe(1);
+
+      writer.onApplicationShutdown();
+    },
+  );
+
+  itRelay(
+    'converge: a 9006 set-roles=member demotes an admin no longer configured',
+    async () => {
+      const writer = new RelayWriterService(
+        makeConfig(RELAY_URL, RELAY_ADMIN_NSEC),
+      );
+      await writer.onModuleInit();
+      const gid = uniqueGid();
+      const keep = randomPubkey();
+      const drop = randomPubkey();
+
+      await writer.publish(createGroup(gid));
+      await writer.publish(putUser(gid, keep, 'admin'));
+      await writer.publish(putUser(gid, drop, 'admin'));
+      await new Promise((r) => setTimeout(r, 600));
+
+      const before = await read39001Admins(RELAY_URL, gid);
+      expect(before.has(drop)).toBe(true);
+
+      // diffRoomAdmins(configured=[keep], current=before, bot) → demote `drop`.
+      const { toDemote } = diffRoomAdmins([keep], [...before], writer.pubkey);
+      expect(toDemote).toContain(drop);
+      for (const hex of toDemote) {
+        await writer.publish(setRoles(gid, hex, ['member']));
+      }
+      await new Promise((r) => setTimeout(r, 600));
+
+      const after = await read39001Admins(RELAY_URL, gid);
+      expect(after.has(keep)).toBe(true);
+      expect(after.has(drop)).toBe(false);
+
+      writer.onApplicationShutdown();
+    },
+  );
+
+  itRelay(
+    'health-check: the correct relay-admin key passes; a non-admin key fails fast',
+    async () => {
+      // Correct admin key passes.
+      const okWriter = new RelayWriterService(
+        makeConfig(RELAY_URL, RELAY_ADMIN_NSEC),
+      );
+      await okWriter.onModuleInit();
+      const okHealth = new RelayAdminHealthService(
+        makeConfig(RELAY_URL, RELAY_ADMIN_NSEC),
+        okWriter,
+      );
+      await expect(okHealth.verify()).resolves.toBeUndefined();
+      okWriter.onApplicationShutdown();
+
+      // A freshly-generated non-admin key must fail fast (mismatch and/or the
+      // relay rejects its managed-create over a pre-existing h-tag).
+      const strangerNsec = nip19.nsecEncode(generateSecretKey());
+      const badWriter = new RelayWriterService(
+        makeConfig(RELAY_URL, strangerNsec),
+      );
+      await badWriter.onModuleInit();
+      const badHealth = new RelayAdminHealthService(
+        makeConfig(RELAY_URL, strangerNsec),
+        badWriter,
+      );
+      await expect(badHealth.verify()).rejects.toThrow();
+      badWriter.onApplicationShutdown();
+    },
+    40000,
+  );
+});

--- a/src/token-gated-rooms/nostr/__tests__/shard.spec.ts
+++ b/src/token-gated-rooms/nostr/__tests__/shard.spec.ts
@@ -1,0 +1,96 @@
+import { ownsGroupId, resolveShardIndex, shardForGroupId } from '../shard';
+
+describe('shardForGroupId', () => {
+  const SAMPLE_GIDS = Array.from(
+    { length: 500 },
+    (_, i) => `ct_${(i * 2654435761) >>> 0}sale${i}`,
+  );
+
+  it('returns 0 for shardCount <= 1', () => {
+    for (const gid of ['ct_a', 'ct_b', '']) {
+      expect(shardForGroupId(gid, 1)).toBe(0);
+      expect(shardForGroupId(gid, 0)).toBe(0);
+      expect(shardForGroupId(gid, -3)).toBe(0);
+    }
+  });
+
+  it('is deterministic — the same gid always maps to the same shard', () => {
+    for (const gid of SAMPLE_GIDS.slice(0, 50)) {
+      const a = shardForGroupId(gid, 8);
+      const b = shardForGroupId(gid, 8);
+      expect(a).toBe(b);
+    }
+  });
+
+  it('always returns an index in [0, shardCount)', () => {
+    for (const count of [2, 3, 8, 16]) {
+      for (const gid of SAMPLE_GIDS) {
+        const idx = shardForGroupId(gid, count);
+        expect(idx).toBeGreaterThanOrEqual(0);
+        expect(idx).toBeLessThan(count);
+        expect(Number.isInteger(idx)).toBe(true);
+      }
+    }
+  });
+
+  it('floors a fractional shardCount', () => {
+    const idx = shardForGroupId('ct_xyz', 4.9);
+    expect(idx).toBeGreaterThanOrEqual(0);
+    expect(idx).toBeLessThan(4);
+  });
+
+  it('is reasonably balanced across sample gids', () => {
+    const COUNT = 8;
+    const buckets = new Array<number>(COUNT).fill(0);
+    for (const gid of SAMPLE_GIDS) {
+      buckets[shardForGroupId(gid, COUNT)] += 1;
+    }
+    const ideal = SAMPLE_GIDS.length / COUNT;
+    // Every bucket within 50% of the ideal share (loose — just rule out a
+    // degenerate "everything lands on one shard" hash).
+    for (const n of buckets) {
+      expect(n).toBeGreaterThan(ideal * 0.5);
+      expect(n).toBeLessThan(ideal * 1.5);
+    }
+  });
+
+  it('different gids can map to different shards (not a constant)', () => {
+    const distinct = new Set(SAMPLE_GIDS.map((g) => shardForGroupId(g, 8)));
+    expect(distinct.size).toBeGreaterThan(1);
+  });
+});
+
+describe('ownsGroupId', () => {
+  it('agrees with shardForGroupId', () => {
+    const gid = 'ct_owner_test';
+    const idx = shardForGroupId(gid, 4);
+    expect(ownsGroupId(gid, idx, 4)).toBe(true);
+    expect(ownsGroupId(gid, (idx + 1) % 4, 4)).toBe(false);
+  });
+
+  it('single-shard owns everything', () => {
+    for (const gid of ['ct_a', 'ct_b', 'ct_c']) {
+      expect(ownsGroupId(gid, 0, 1)).toBe(true);
+    }
+  });
+});
+
+describe('resolveShardIndex', () => {
+  it('defaults to 0 when unset/blank', () => {
+    expect(resolveShardIndex({}, 4)).toBe(0);
+    expect(resolveShardIndex({ TG_SUBSCRIBER_SHARD_INDEX: '' }, 4)).toBe(0);
+    expect(resolveShardIndex({ TG_SUBSCRIBER_SHARD_INDEX: '   ' }, 4)).toBe(0);
+  });
+
+  it('parses a valid 0-based ordinal in range', () => {
+    expect(resolveShardIndex({ TG_SUBSCRIBER_SHARD_INDEX: '0' }, 4)).toBe(0);
+    expect(resolveShardIndex({ TG_SUBSCRIBER_SHARD_INDEX: '3' }, 4)).toBe(3);
+  });
+
+  it('falls back to 0 for out-of-range / non-integer / negative', () => {
+    expect(resolveShardIndex({ TG_SUBSCRIBER_SHARD_INDEX: '4' }, 4)).toBe(0);
+    expect(resolveShardIndex({ TG_SUBSCRIBER_SHARD_INDEX: '-1' }, 4)).toBe(0);
+    expect(resolveShardIndex({ TG_SUBSCRIBER_SHARD_INDEX: '1.5' }, 4)).toBe(0);
+    expect(resolveShardIndex({ TG_SUBSCRIBER_SHARD_INDEX: 'abc' }, 4)).toBe(0);
+  });
+});

--- a/src/token-gated-rooms/nostr/group-id.ts
+++ b/src/token-gated-rooms/nostr/group-id.ts
@@ -1,0 +1,28 @@
+/**
+ * NIP-29 group-id resolution for token-gated rooms.
+ *
+ * D3 (plan §6.4): the group id is `Token.sale_address` taken **verbatim** and
+ * persisted once in `Token.nostr_group_id`. The `groups_relay` accepts the id
+ * straight off the `h` tag with NO charset check and NO lowercasing
+ * (`extract_group_id`, `group.rs:1370`), so we must NOT derive, slugify, hash,
+ * or lowercase it here. This is the deliberate divergence from the bot's
+ * `groupId.ts` (which sha256-derives an id) — see Task 07.
+ *
+ * `TG_GROUP_ID_PREFIX` is therefore unused on the default path; it is legacy
+ * and only relevant if a derived-id scheme is ever reintroduced.
+ */
+export interface TokenLikeForGroupId {
+  /** æternity sale contract address — the canonical group id (`ct_…`). */
+  sale_address: string;
+  /** Persisted group id (set once = `sale_address`); preferred when present. */
+  nostr_group_id?: string | null;
+}
+
+/**
+ * Returns the NIP-29 group id for a token: the already-persisted
+ * `nostr_group_id` when set, otherwise the `sale_address` — **verbatim**. No
+ * normalization of any kind (mixed-case `ct_…` is preserved exactly).
+ */
+export function groupIdFor(token: TokenLikeForGroupId): string {
+  return token.nostr_group_id ?? token.sale_address;
+}

--- a/src/token-gated-rooms/nostr/nip29.ts
+++ b/src/token-gated-rooms/nostr/nip29.ts
@@ -1,0 +1,132 @@
+/**
+ * Pure NIP-29 management-event TEMPLATE builders for `groups_relay` (Task 07).
+ *
+ * Each builder is side-effect free: it returns `{ kind, tags, content }` ready to
+ * be finalized+signed by the relay writer. The `["h", groupId]` tag is ALWAYS
+ * first (the relay reads the group id off it verbatim — `extract_group_id`,
+ * `group.rs:1370`), and the group id is passed in already-resolved
+ * (`group-id.ts#groupIdFor`) — these builders never derive or normalize it.
+ *
+ * We deliberately do NOT emit a NIP-29 `previous` tag: `groups_relay`
+ * `validate_event` (`validation_middleware.rs:23`) requires only the `h` tag and
+ * does not enforce `previous`. Mirrors the bot's `NostrRoomManagement` builders.
+ *
+ * Kind reference (NIP-29 / `groups_relay`):
+ *   9007 create-group · 9002 edit-metadata · 9000 put-user · 9001 remove-user ·
+ *   9006 set-roles · 9008 delete-group.
+ */
+
+/** A finalize-ready event template (no `created_at`/`pubkey`/`sig` yet). */
+export interface Nip29Template {
+  kind: number;
+  tags: string[][];
+  content?: string;
+}
+
+/** NIP-29 management kinds (groups_relay constants). */
+export const NIP29_KIND = {
+  CREATE_GROUP: 9007,
+  EDIT_METADATA: 9002,
+  PUT_USER: 9000,
+  REMOVE_USER: 9001,
+  SET_ROLES: 9006,
+  DELETE_GROUP: 9008,
+} as const;
+
+export interface EditMetadataOptions {
+  name?: string;
+  about?: string;
+  /** Private groups gate reads (require NIP-42 AUTH); public are world-readable. */
+  isPrivate?: boolean;
+}
+
+/**
+ * kind 9007 — create the group. A fresh create makes the signer admin; over a
+ * pre-existing managed group the relay returns `"Group already exists"` (benign
+ * no-op) and over a pre-existing unmanaged `h` only the relay admin may create.
+ */
+export function createGroup(groupId: string): Nip29Template {
+  return {
+    kind: NIP29_KIND.CREATE_GROUP,
+    tags: [['h', groupId]],
+    content: '',
+  };
+}
+
+/**
+ * kind 9002 — edit group metadata (replaceable). Token-gated rooms are ALWAYS
+ * `closed`; `private`/`public` is driven by the token's privacy. Mirrors the
+ * reference builder's tag order: name, about, private|public, closed.
+ */
+export function editMetadata(
+  groupId: string,
+  { name, about, isPrivate }: EditMetadataOptions = {},
+): Nip29Template {
+  const tags: string[][] = [['h', groupId]];
+  if (name !== undefined) {
+    tags.push(['name', name]);
+  }
+  if (about !== undefined) {
+    tags.push(['about', about]);
+  }
+  tags.push(isPrivate ? ['private'] : ['public']);
+  tags.push(['closed']);
+  return { kind: NIP29_KIND.EDIT_METADATA, tags, content: '' };
+}
+
+/**
+ * kind 9000 — put (add/upgrade) a user. With a `role` the `p` tag carries it
+ * (`["p", pubkey, role]`), otherwise a plain member add (`["p", pubkey]`).
+ */
+export function putUser(
+  groupId: string,
+  pubkey: string,
+  role?: string,
+): Nip29Template {
+  const pTag = role ? ['p', pubkey, role] : ['p', pubkey];
+  return {
+    kind: NIP29_KIND.PUT_USER,
+    tags: [['h', groupId], pTag],
+    content: '',
+  };
+}
+
+/** kind 9001 — remove a user (revokes post, and read in private groups). */
+export function removeUser(groupId: string, pubkey: string): Nip29Template {
+  return {
+    kind: NIP29_KIND.REMOVE_USER,
+    tags: [
+      ['h', groupId],
+      ['p', pubkey],
+    ],
+    content: '',
+  };
+}
+
+/**
+ * kind 9006 — set a user's roles. One `p` tag carrying the pubkey followed by
+ * each role: `["p", pubkey, role1, role2, …]`.
+ */
+export function setRoles(
+  groupId: string,
+  pubkey: string,
+  roles: string[],
+): Nip29Template {
+  return {
+    kind: NIP29_KIND.SET_ROLES,
+    tags: [
+      ['h', groupId],
+      ['p', pubkey, ...roles],
+    ],
+    content: '',
+  };
+}
+
+/** kind 9008 — delete the group (terminal; the relay refuses to re-create it). */
+export function deleteGroup(groupId: string): Nip29Template {
+  return {
+    kind: NIP29_KIND.DELETE_GROUP,
+    tags: [['h', groupId]],
+    content: '',
+  };
+}

--- a/src/token-gated-rooms/nostr/pubkey.spec.ts
+++ b/src/token-gated-rooms/nostr/pubkey.spec.ts
@@ -1,0 +1,92 @@
+import { HEX64, normalizePubkey, npubToHex } from './pubkey';
+
+// nostr-tools/nip19 is mocked: the real module transitively pulls in @noble/*
+// (ESM-only), which ts-jest can't transform (same reason matrix-defi-bot's
+// NostrVerifiedAccounts.test.ts mocks it). The resolver only needs npub→hex, so
+// a fixture mapping known npubs ↔ hex is enough to exercise normalizePubkey.
+const HEX = 'a'.repeat(64);
+const NPUB = 'npub1valid';
+const NOTE = 'note1valid';
+
+jest.mock('nostr-tools/nip19', () => ({
+  decode: (value: string) => {
+    if (value === NPUB || value === NPUB.toLowerCase()) {
+      return { type: 'npub', data: HEX };
+    }
+    if (value === NOTE) {
+      return { type: 'note', data: HEX };
+    }
+    throw new Error('invalid bech32');
+  },
+}));
+
+describe('pubkey normalization (Task 05)', () => {
+  describe('HEX64', () => {
+    it('matches 64 lowercase hex chars only', () => {
+      expect(HEX64.test('0'.repeat(64))).toBe(true);
+      expect(HEX64.test('A'.repeat(64))).toBe(false); // uppercase
+      expect(HEX64.test('a'.repeat(63))).toBe(false); // too short
+      expect(HEX64.test('a'.repeat(65))).toBe(false); // too long
+      expect(HEX64.test('g'.repeat(64))).toBe(false); // non-hex
+    });
+  });
+
+  describe('normalizePubkey', () => {
+    it('returns lowercased hex for a valid 64-hex input', () => {
+      expect(normalizePubkey(HEX)).toBe(HEX);
+    });
+
+    it('lowercases an uppercase hex input', () => {
+      expect(normalizePubkey('A'.repeat(64))).toBe('a'.repeat(64));
+    });
+
+    it('trims surrounding whitespace before matching hex', () => {
+      expect(normalizePubkey(`  ${HEX}  `)).toBe(HEX);
+    });
+
+    it('decodes a valid npub to hex', () => {
+      expect(normalizePubkey(NPUB)).toBe(HEX);
+    });
+
+    it('decodes an uppercase npub (lowercased first) to hex', () => {
+      expect(normalizePubkey(NPUB.toUpperCase())).toBe(HEX);
+    });
+
+    it('returns undefined for garbage', () => {
+      expect(normalizePubkey('not-a-pubkey')).toBeUndefined();
+    });
+
+    it('returns undefined for wrong-length hex', () => {
+      expect(normalizePubkey('abc123')).toBeUndefined();
+      expect(normalizePubkey('a'.repeat(63))).toBeUndefined();
+      expect(normalizePubkey('a'.repeat(65))).toBeUndefined();
+    });
+
+    it('returns undefined for non-npub bech32 (e.g. note)', () => {
+      expect(normalizePubkey(NOTE)).toBeUndefined();
+    });
+
+    it('returns undefined for empty / nullish input', () => {
+      expect(normalizePubkey('')).toBeUndefined();
+      expect(normalizePubkey('   ')).toBeUndefined();
+      expect(normalizePubkey(null)).toBeUndefined();
+      expect(normalizePubkey(undefined)).toBeUndefined();
+    });
+
+    it('never returns a value that fails HEX64', () => {
+      for (const v of [HEX, NPUB, 'A'.repeat(64)]) {
+        const out = normalizePubkey(v);
+        expect(out).toBeDefined();
+        expect(HEX64.test(out as string)).toBe(true);
+      }
+    });
+  });
+
+  describe('npubToHex (alias)', () => {
+    it('behaves identically to normalizePubkey', () => {
+      expect(npubToHex(NPUB)).toBe(normalizePubkey(NPUB));
+      expect(npubToHex(HEX)).toBe(normalizePubkey(HEX));
+      expect(npubToHex('garbage')).toBeUndefined();
+    });
+  });
+});

--- a/src/token-gated-rooms/nostr/pubkey.ts
+++ b/src/token-gated-rooms/nostr/pubkey.ts
@@ -1,0 +1,75 @@
+// Load only the nip19 submodule via the package "exports" subpath. Importing the
+// `nostr-tools` entry pulls in @noble/curves (ESM-only), which ts-jest cannot
+// transform; the subpath is pure bech32. `require()` (not `import`) because
+// moduleResolution:node does not type-resolve the subpath, though Node + ts-jest
+// resolve it fine at runtime. Same pattern as matrix-defi-bot's
+// NostrVerifiedAccounts.
+const nip19: {
+  decode: (value: string) => { type: string; data: unknown };
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+} = require('nostr-tools/nip19');
+
+/**
+ * Pure npub→hex normalization helpers for token-gated rooms (Task 05).
+ *
+ * Kept Nest-free so they are unit-testable in isolation and reusable on the hot
+ * path. Mirrors `matrix-defi-bot`'s `NostrVerifiedAccounts.nostrValueToHex`
+ * exactly: accept a 64-char lowercase hex pubkey **or** a NIP-19 `npub`, reject
+ * everything else. Every value that leaves these helpers is guaranteed to match
+ * {@link HEX64} — we never emit a non-hex pubkey downstream (Task 10 puts it in a
+ * `9000` `p`-tag, so a malformed value would corrupt relay state).
+ */
+
+/** A normalized nostr pubkey: 64 lowercase hex chars. */
+export const HEX64 = /^[0-9a-f]{64}$/;
+
+/**
+ * Normalize a raw nostr link value (as stored verbatim in
+ * `Account.links[<provider>]` by the reactive link sync — may be hex or npub)
+ * into a lowercase 64-char hex pubkey.
+ *
+ * @returns the normalized hex pubkey, or `undefined` if the input is neither a
+ *   valid 64-hex string nor a valid `npub`. The result is always `HEX64`-valid.
+ */
+export function normalizePubkey(
+  value: string | null | undefined,
+): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const trimmed = value.trim().toLowerCase();
+  if (trimmed === '') {
+    return undefined;
+  }
+
+  // Already a hex pubkey.
+  if (HEX64.test(trimmed)) {
+    return trimmed;
+  }
+
+  // Otherwise try to decode it as a NIP-19 npub; reject any other bech32 type
+  // (nsec/note/nprofile/…) or garbage. nip19.decode throws on invalid input.
+  try {
+    const decoded = nip19.decode(trimmed);
+    if (decoded.type === 'npub' && typeof decoded.data === 'string') {
+      const hex = decoded.data.toLowerCase();
+      // Defensive: never trust the decoder to hand back exactly 64 hex chars.
+      return HEX64.test(hex) ? hex : undefined;
+    }
+  } catch {
+    // not a valid npub / not bech32 — fall through to undefined.
+  }
+
+  return undefined;
+}
+
+/**
+ * Strict alias used at call sites that semantically expect an npub but tolerate
+ * hex. Identical behavior to {@link normalizePubkey}; kept as a named export so
+ * the intent (decode-an-npub) reads clearly where it is used.
+ */
+export function npubToHex(
+  value: string | null | undefined,
+): string | undefined {
+  return normalizePubkey(value);
+}

--- a/src/token-gated-rooms/nostr/relay-admin-health.spec.ts
+++ b/src/token-gated-rooms/nostr/relay-admin-health.spec.ts
@@ -1,0 +1,148 @@
+import type { RelayWriter } from './relay-writer.contract';
+import {
+  ABUSE_VECTOR_NOTE,
+  RELAY_ADMIN_PUBKEY_ENV,
+  RelayAdminHealthService,
+  wsUrlToHttp,
+} from './relay-admin-health';
+
+const hex = (n: number): string =>
+  (n.toString(16).padStart(2, '0') + 'a'.repeat(62)).slice(0, 64);
+
+const BOT = hex(0);
+const OTHER = hex(9);
+
+function makeConfig(): any {
+  return { nostrRelayUrl: 'ws://localhost:8080' };
+}
+
+function makeRelay(
+  pubkey = BOT,
+  publishOk = true,
+): jest.Mocked<Pick<RelayWriter, 'pubkey' | 'publish'>> {
+  return {
+    pubkey,
+    publish: jest
+      .fn()
+      .mockResolvedValue({ ok: publishOk, id: 'evt', reason: 'rejected' }),
+  } as any;
+}
+
+function build(
+  relay = makeRelay(),
+  config = makeConfig(),
+): RelayAdminHealthService {
+  return new RelayAdminHealthService(config, relay as unknown as RelayWriter);
+}
+
+/** Stub global fetch to return a NIP-11 doc with the given admin pubkey. */
+function stubNip11(pubkey: string | undefined, ok = true): void {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok,
+    status: ok ? 200 : 500,
+    json: async () => ({ pubkey, supported_nips: [1, 11, 29, 42] }),
+  }) as any;
+}
+
+describe('wsUrlToHttp', () => {
+  it('ws→http, wss→https, http(s) passthrough', () => {
+    expect(wsUrlToHttp('ws://r:8080')).toBe('http://r:8080');
+    expect(wsUrlToHttp('wss://r')).toBe('https://r');
+    expect(wsUrlToHttp('http://r')).toBe('http://r');
+    expect(wsUrlToHttp('https://r')).toBe('https://r');
+  });
+  it('blank/garbage → undefined', () => {
+    expect(wsUrlToHttp('')).toBeUndefined();
+    expect(wsUrlToHttp(undefined)).toBeUndefined();
+    expect(wsUrlToHttp('not-a-url')).toBeUndefined();
+  });
+});
+
+describe('RelayAdminHealthService.verify', () => {
+  const originalFetch = global.fetch;
+  let savedEnv: string | undefined;
+
+  beforeEach(() => {
+    savedEnv = process.env[RELAY_ADMIN_PUBKEY_ENV];
+    delete process.env[RELAY_ADMIN_PUBKEY_ENV];
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    if (savedEnv === undefined) {
+      delete process.env[RELAY_ADMIN_PUBKEY_ENV];
+    } else {
+      process.env[RELAY_ADMIN_PUBKEY_ENV] = savedEnv;
+    }
+    jest.restoreAllMocks();
+  });
+
+  it('passes when the bot pubkey == the NIP-11 relay admin pubkey and publish OKs', async () => {
+    stubNip11(BOT);
+    const relay = makeRelay(BOT, true);
+    await expect(build(relay).verify()).resolves.toBeUndefined();
+    // publish probe (create) ran.
+    expect(relay.publish).toHaveBeenCalled();
+  });
+
+  it('FAILS FAST when the bot key is NOT the relay admin (mismatch)', async () => {
+    stubNip11(OTHER);
+    await expect(build(makeRelay(BOT, true)).verify()).rejects.toThrow(
+      /NOT the relay admin/i,
+    );
+  });
+
+  it('the failure log names the abuse vector', async () => {
+    stubNip11(OTHER);
+    await expect(build(makeRelay(BOT, true)).verify()).rejects.toThrow(
+      ABUSE_VECTOR_NOTE,
+    );
+  });
+
+  it('falls back to TG_RELAY_ADMIN_PUBKEY when NIP-11 omits pubkey', async () => {
+    stubNip11(undefined); // NIP-11 served no pubkey
+    process.env[RELAY_ADMIN_PUBKEY_ENV] = BOT;
+    await expect(build(makeRelay(BOT, true)).verify()).resolves.toBeUndefined();
+  });
+
+  it('fails when neither NIP-11 nor the env fallback yields an admin pubkey', async () => {
+    stubNip11(undefined);
+    await expect(build(makeRelay(BOT, true)).verify()).rejects.toThrow(
+      /could not determine the relay admin pubkey/i,
+    );
+  });
+
+  it('fails when the publish probe is rejected (not already-exists)', async () => {
+    stubNip11(BOT);
+    const relay = makeRelay(BOT, false);
+    relay.publish.mockResolvedValue({
+      ok: false,
+      id: 'evt',
+      reason: 'some relay reject',
+    });
+    await expect(build(relay).verify()).rejects.toThrow(
+      /publish probe failed/i,
+    );
+  });
+
+  it('treats an "already exists" publish reject as a benign success', async () => {
+    stubNip11(BOT);
+    const relay = makeRelay(BOT, false);
+    relay.publish.mockResolvedValueOnce({
+      ok: false,
+      id: 'evt',
+      reason: 'Group already exists',
+    });
+    // cleanup 9008 publish (second call) — any resolution is fine.
+    relay.publish.mockResolvedValueOnce({ ok: true, id: 'evt2' });
+    await expect(build(relay).verify()).resolves.toBeUndefined();
+  });
+
+  it('tolerates a NIP-11 fetch failure and uses the env fallback', async () => {
+    global.fetch = jest
+      .fn()
+      .mockRejectedValue(new Error('ECONNREFUSED')) as any;
+    process.env[RELAY_ADMIN_PUBKEY_ENV] = BOT;
+    await expect(build(makeRelay(BOT, true)).verify()).resolves.toBeUndefined();
+  });
+});

--- a/src/token-gated-rooms/nostr/relay-admin-health.ts
+++ b/src/token-gated-rooms/nostr/relay-admin-health.ts
@@ -1,0 +1,260 @@
+import {
+  Inject,
+  Injectable,
+  Logger,
+  OnApplicationBootstrap,
+} from '@nestjs/common';
+import { ConfigType } from '@nestjs/config';
+import tgrConfig, { isRelayConfigured } from '../config/tgr.config';
+import { createGroup, deleteGroup } from './nip29';
+import { normalizePubkey } from './pubkey';
+import { RELAY_WRITER, type RelayWriter } from './relay-writer.contract';
+
+/**
+ * Optional config-fallback for the relay's admin pubkey, read directly from the
+ * environment (the shared `tgr.config.ts` is owned by Task 01 and not modified
+ * here). Only consulted when the NIP-11 relay-info document does NOT advertise a
+ * `pubkey`. May be npub or hex; normalized before comparison.
+ */
+export const RELAY_ADMIN_PUBKEY_ENV = 'TG_RELAY_ADMIN_PUBKEY';
+
+/** A reserved `h`-tag for the disposable create/delete publish probe (Req 1). */
+export const HEALTH_PROBE_GROUP_PREFIX = 'tgr-relay-admin-health-probe';
+
+/**
+ * The abuse vector the relay-admin check defends against — included verbatim in
+ * the fail-fast log so an operator sees WHY being relay admin is mandatory.
+ */
+export const ABUSE_VECTOR_NOTE =
+  'A pre-existing event under a managed h-tag (= a future sale_address) blocks a ' +
+  'non-admin create — groups_relay rejects with "Only relay admin can create a ' +
+  'managed group from an unmanaged one" (groups.rs:445–450). Being the relay ' +
+  'admin is the mitigation; this worker must run as the relay-admin key.';
+
+/**
+ * Minimal NIP-11 relay-information shape we read (the `pubkey` field). The
+ * `groups_relay` serves its admin pubkey here (verified — `server.rs:85`,
+ * `supported_nips` includes 11): `RelayInfo { pubkey, supported_nips, … }`.
+ */
+interface Nip11RelayInfo {
+  pubkey?: string;
+  supported_nips?: number[];
+  name?: string;
+}
+
+/**
+ * Startup fail-fast health-check: verifies the bot key is the `groups_relay` admin
+ * and can create/publish (Task 08 Req 1, plan §6.4 / D7). Relay-gated (worker mode
+ * removed — see `deworker-plan.md`): runs only when a relay is configured; with no
+ * relay the writer is dormant, so there is nothing to verify and the check is
+ * skipped (the API still boots).
+ *
+ * On bootstrap it:
+ *  1. derives the bot pubkey from the relay writer (already decoded from
+ *     `TG_BOT_NSEC`; the nsec is NEVER logged, §10);
+ *  2. obtains the relay's advertised admin pubkey — primary: the NIP-11
+ *     relay-info `pubkey` (fetched over `TG_RELAY_URL` with
+ *     `Accept: application/nostr+json`; ws→http); fallback: the
+ *     `TG_RELAY_ADMIN_PUBKEY` env when NIP-11 omits `pubkey`;
+ *  3. asserts bot-pubkey == relay-admin-pubkey;
+ *  4. confirms publish authority via a disposable `9007`(+`9008`) probe under a
+ *     reserved health `h`-tag, expecting an OK / benign already-exists;
+ *  5. THROWS on any failure → crashes the worker container, naming the abuse
+ *     vector ({@link ABUSE_VECTOR_NOTE}) in the log.
+ *
+ * ### Spike outcome (recorded)
+ * `groups_relay` DOES advertise its admin pubkey via NIP-11 (`RelayInfo.pubkey`,
+ * `server.rs:82–91`; `supported_nips: [1,9,11,29,40,42,70]`). The NIP-11 path is
+ * therefore primary; the `TG_RELAY_ADMIN_PUBKEY` config fallback exists only
+ * for relays that omit `pubkey`.
+ */
+@Injectable()
+export class RelayAdminHealthService implements OnApplicationBootstrap {
+  private readonly logger = new Logger(RelayAdminHealthService.name);
+
+  constructor(
+    @Inject(tgrConfig.KEY)
+    private readonly config: ConfigType<typeof tgrConfig>,
+    @Inject(RELAY_WRITER)
+    private readonly relay: RelayWriter,
+  ) {}
+
+  async onApplicationBootstrap(): Promise<void> {
+    if (!isRelayConfigured(this.config)) {
+      this.logger.log(
+        'relay not configured (TG_RELAY_URL/TG_BOT_NSEC unset) — skipping ' +
+          'relay-admin health-check; NIP-29 publishing is disabled',
+      );
+      return;
+    }
+    // Run the check in the BACKGROUND, never blocking app bootstrap. This hook is
+    // awaited inside `app.init()`, so awaiting a relay round-trip here would block
+    // `app.listen()` (port never opens) when the relay is slow/half-open, and a
+    // probe failure would `throw` straight out of the lifecycle hook and crash the
+    // whole process. The HTTP API + indexer MUST come up regardless of the relay
+    // (relay duties self-heal/retry), so we fire-and-forget and downgrade a failure
+    // to a loud log instead of a crash.
+    void this.verifySafely();
+  }
+
+  /** Run {@link verify} detached from bootstrap; a failure is logged, never thrown. */
+  private async verifySafely(): Promise<void> {
+    try {
+      await this.verify();
+    } catch (e) {
+      this.logger.error(
+        `relay-admin health-check failed — NIP-29 publishing may be impaired, ` +
+          `but the API is up and will keep retrying the relay connection: ${
+            (e as Error)?.message ?? e
+          }`,
+      );
+    }
+  }
+
+  /**
+   * Run the two checks; throw (fail fast) on either failure. Exposed (not just
+   * the lifecycle hook) so it is directly unit/integration testable.
+   */
+  async verify(): Promise<void> {
+    const botPubkey = normalizePubkey(this.relay.pubkey);
+    if (!botPubkey) {
+      this.fail('bot pubkey is missing or not 64-hex (check TG_BOT_NSEC)');
+    }
+
+    // 1) bot pubkey == relay admin pubkey -----------------------------------
+    const relayAdmin = await this.resolveRelayAdminPubkey();
+    if (!relayAdmin) {
+      this.fail(
+        'could not determine the relay admin pubkey: the NIP-11 relay-info ' +
+          `served no "pubkey" and ${RELAY_ADMIN_PUBKEY_ENV} is unset`,
+      );
+    }
+    if (relayAdmin !== botPubkey) {
+      this.fail(
+        `bot key is NOT the relay admin: bot=${short(botPubkey)} ` +
+          `relay-admin=${short(relayAdmin)}`,
+      );
+    }
+
+    // 2) can create/publish (disposable probe) ------------------------------
+    await this.verifyCanPublish();
+
+    this.logger.log(
+      `relay-admin health OK: bot ${short(botPubkey)} is the groups_relay admin ` +
+        `and can publish`,
+    );
+  }
+
+  /**
+   * Resolve the relay's admin pubkey: NIP-11 `pubkey` first, then the
+   * `TG_RELAY_ADMIN_PUBKEY` env fallback. Returns normalized hex or
+   * `undefined` if neither is available/parseable.
+   */
+  private async resolveRelayAdminPubkey(): Promise<string | undefined> {
+    const fromNip11 = await this.fetchNip11AdminPubkey();
+    if (fromNip11) {
+      return fromNip11;
+    }
+    const fromEnv = normalizePubkey(process.env[RELAY_ADMIN_PUBKEY_ENV]);
+    if (fromEnv) {
+      this.logger.warn(
+        `NIP-11 served no admin pubkey; falling back to ${RELAY_ADMIN_PUBKEY_ENV}`,
+      );
+      return fromEnv;
+    }
+    return undefined;
+  }
+
+  /**
+   * Fetch the NIP-11 relay-info document over HTTP(S) (ws→http) with
+   * `Accept: application/nostr+json` and return its normalized `pubkey`, or
+   * `undefined` if the relay omits it / the fetch fails (the env fallback then
+   * applies). Never throws — a fetch failure is not, on its own, fatal.
+   */
+  private async fetchNip11AdminPubkey(): Promise<string | undefined> {
+    const httpUrl = wsUrlToHttp(this.config.nostrRelayUrl);
+    if (!httpUrl) {
+      return undefined;
+    }
+    try {
+      const res = await fetch(httpUrl, {
+        headers: { Accept: 'application/nostr+json' },
+      });
+      if (!res.ok) {
+        this.logger.warn(`NIP-11 fetch returned HTTP ${res.status}`);
+        return undefined;
+      }
+      const info = (await res.json()) as Nip11RelayInfo;
+      const hex = normalizePubkey(info?.pubkey);
+      if (!hex) {
+        this.logger.warn('NIP-11 relay-info served no usable "pubkey"');
+      }
+      return hex ?? undefined;
+    } catch (e) {
+      this.logger.warn(`NIP-11 fetch failed: ${(e as Error)?.message ?? e}`);
+      return undefined;
+    }
+  }
+
+  /**
+   * Confirm the bot can create/publish a managed group by publishing a disposable
+   * `9007` under a reserved health `h`-tag and then cleaning it up with a `9008`.
+   * A fresh `9007` from the relay admin succeeds; a non-admin would be rejected
+   * with "Only relay admin can create a managed group from an unmanaged one"
+   * (groups.rs:445–450) once any event exists under that h-tag. "Group already
+   * exists" is a benign success. Anything else fails fast.
+   */
+  private async verifyCanPublish(): Promise<void> {
+    const probeGid = `${HEALTH_PROBE_GROUP_PREFIX}-${Date.now()}`;
+    const created = await this.relay.publish(createGroup(probeGid));
+    const ok =
+      created.ok ||
+      (created.reason ?? '').toLowerCase().includes('already exists');
+    if (!ok) {
+      this.fail(
+        `relay-admin publish probe failed: ${created.reason ?? 'no ACK'}`,
+      );
+    }
+    // Best-effort cleanup of the disposable probe group (a 9008 makes the h-tag
+    // terminal so it is never reused). A cleanup failure is non-fatal.
+    try {
+      await this.relay.publish(deleteGroup(probeGid));
+    } catch {
+      // ignore — the probe id is reserved/disposable.
+    }
+  }
+
+  /** Throw a fail-fast error naming the abuse vector (never logs the nsec). */
+  private fail(reason: string): never {
+    const message = `[token-gated-rooms] relay-admin health-check FAILED: ${reason}. ${ABUSE_VECTOR_NOTE}`;
+    this.logger.error(message);
+    throw new Error(message);
+  }
+}
+
+/**
+ * Convert a relay `ws://`/`wss://` URL to its `http://`/`https://` equivalent for
+ * the NIP-11 fetch. Plain `http(s)://` passes through. Returns `undefined` for a
+ * blank/garbage URL.
+ */
+export function wsUrlToHttp(url: string | undefined): string | undefined {
+  if (!url || url.trim() === '') {
+    return undefined;
+  }
+  const trimmed = url.trim();
+  if (trimmed.startsWith('wss://')) {
+    return 'https://' + trimmed.slice('wss://'.length);
+  }
+  if (trimmed.startsWith('ws://')) {
+    return 'http://' + trimmed.slice('ws://'.length);
+  }
+  if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
+    return trimmed;
+  }
+  return undefined;
+}
+
+/** Short pubkey for logs (never the nsec). */
+function short(pubkey: string | undefined): string {
+  return pubkey ? pubkey.slice(0, 8) : '<none>';
+}

--- a/src/token-gated-rooms/nostr/relay-subscriber.service.ts
+++ b/src/token-gated-rooms/nostr/relay-subscriber.service.ts
@@ -1,0 +1,869 @@
+import { InjectQueue } from '@nestjs/bull';
+import {
+  Inject,
+  Injectable,
+  Logger,
+  OnApplicationShutdown,
+  OnModuleInit,
+} from '@nestjs/common';
+import { ConfigType } from '@nestjs/config';
+import { OnEvent } from '@nestjs/event-emitter';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Queue } from 'bull';
+import { Repository } from 'typeorm';
+import {
+  finalizeEvent,
+  getPublicKey,
+  nip19,
+  Relay,
+  type Event as NostrEvent,
+  type EventTemplate,
+  type Filter,
+} from 'nostr-tools';
+import WebSocket from 'ws';
+import { Token } from '@/tokens/entities/token.entity';
+import { NotificationRedisService } from '@/notifications/services/notification-redis.service';
+import tgrConfig, { isRelayConfigured } from '../config/tgr.config';
+import { CommunityRoom } from '../entities/community-room.entity';
+import { RoomMembership } from '../entities/room-membership.entity';
+import { RoomMessageSeen } from '../entities/room-message-seen.entity';
+import { TGR_ROOM_CREATED, type TgrRoomCreatedPayload } from '../events';
+import { RoomPreferencesService } from '../services/room-preferences.service';
+import {
+  ROOM_MESSAGE_NOTIFY_JOB,
+  ROOM_NOTIFY_QUEUE,
+  roomMessageNotifyJobOptions,
+  type RoomMessageNotifyJob,
+} from '../queues/room-message-notify.types';
+import { ownsGroupId, resolveShardIndex } from './shard';
+import { setRelaySubscriberConnected } from '../observability/tgr-metrics';
+
+// nostr-tools' `Relay` reads the global `WebSocket` at connect time (mirror the
+// writer). Idempotent — safe at module load; no socket is opened here.
+if (typeof (globalThis as { WebSocket?: unknown }).WebSocket === 'undefined') {
+  (globalThis as { WebSocket?: unknown }).WebSocket = WebSocket;
+}
+
+/** NIP-29 chat kinds we subscribe to (kind 9 = chat, kind 11 = threaded reply). */
+const CHAT_KINDS = [9, 11] as const;
+
+const nowSec = (): number => Math.floor(Date.now() / 1000);
+
+/** Per-room coalescing buffer entry (held only for the open window). */
+interface CoalesceEntry {
+  count: number;
+  sampleEventId: string;
+  windowStartedAt: number;
+  /** Pubkeys that authored any message in this window (excluded from fan-out). */
+  authorPubkeys: Set<string>;
+  symbol: string;
+  timer?: ReturnType<typeof setTimeout>;
+}
+
+/**
+ * Long-lived, sharded Nostr **read** subscriber for `groups_relay` (Task 14, plan
+ * §7.1) — **WORKER PROCESS ONLY**.
+ *
+ * ## What it does
+ * Maintains a single relay subscription on chat kinds `9`/`11`, filtered by the
+ * `#h` (group-id) tags of every *created* room this shard owns, with NIP-42 AUTH
+ * as the relay admin so **private** rooms are readable (`group.rs::can_see_event`
+ * requires an authed + authorized reader; the admin satisfies it). For each new
+ * message it dedups on `room_message_seen.event_id`, resolves the room, builds the
+ * added-members recipient set (minus author, minus muted), coalesces per room over
+ * `TG_MSG_COALESCE_WINDOW_SEC`, applies a per-recipient rate cap + a queue-depth
+ * circuit breaker, and enqueues one `room-message` job per recipient per flush onto
+ * the shared `worker:room-notify` queue (Task 12's processor handles the *unnamed*
+ * membership jobs; Task 14's named `room-message` jobs are handled by
+ * {@link RoomMessageNotifyProcessor}).
+ *
+ * ## Reuse / invert the writer
+ * Reuses Task 07's connection identity + mechanics verbatim (decode `TG_BOT_NSEC`
+ * → relay-admin `sk`/`pubkey`, NIP-42 AUTH via `relay.auth`, reconnect-with-backoff
+ * floored at `TG_RELAY_HEALTH_PAUSE_SEC`, pause-on-outage). It opens its OWN socket
+ * (separate from the writer's) because a live long-lived subscription must not share
+ * the publish socket's lifecycle. It writes NO chain/relay state — read + notify only.
+ *
+ * ## Boot-safety
+ * `onModuleInit` is a no-op unless a relay is configured (`isRelayConfigured`), so
+ * with no relay the boot smoke never opens a socket or subscribes. Nothing connects
+ * at construction (worker mode removed — see `deworker-plan.md`).
+ *
+ * ## Sizing model (plan §7.1 — finalize via load test, §18 open question 2)
+ * Throughput ≈ `groups × avg_members × msgs/hr`. Fan-out is O(members)/message →
+ * the cost driver; coalescing collapses a window's messages to one job per
+ * recipient (enqueues ≈ `rooms × recipients / window`, not `messages × recipients`).
+ * `shard_count = ceil(throughput / per_shard_cap)` (`TG_SUBSCRIBER_SHARDS`, default 1).
+ * Backlog is bounded by the circuit breaker: pause this shard's enqueue when the
+ * `worker:room-notify` depth exceeds `TG_ROOM_NOTIFY_DEPTH_BREAK` (default 10000),
+ * resume under the low-water mark (half). Per-recipient `TG_MSG_RATE_CAP` caps a
+ * chatty multi-room user. Concrete values are finalized by the §14 load test.
+ */
+@Injectable()
+export class RelaySubscriberService
+  implements OnModuleInit, OnApplicationShutdown
+{
+  private readonly logger = new Logger(RelaySubscriberService.name);
+
+  private readonly sk: Uint8Array;
+  /** Relay-admin public key (safe to log). */
+  readonly pubkey: string;
+
+  /** This instance's shard index (0-based ordinal); 0 in the single-shard default. */
+  private readonly shardIndex: number;
+
+  private relay?: Relay;
+  private connecting?: Promise<void>;
+  private sub?: { close: () => void };
+  private healthy = false;
+  private shuttingDown = false;
+  private started = false;
+  private reconnectTimer?: ReturnType<typeof setTimeout>;
+  private reconnectAttempts = 0;
+  private resyncTimer?: ReturnType<typeof setInterval>;
+
+  /** Group ids (this shard's) currently in the live subscription filter. */
+  private readonly subscribedGroups = new Set<string>();
+
+  /** Per-room coalescing buffers (sale_address → entry); short-lived. */
+  private readonly coalescing = new Map<string, CoalesceEntry>();
+
+  /** Circuit-breaker latch: true while this shard's enqueue path is paused. */
+  private breakerOpen = false;
+
+  constructor(
+    @InjectRepository(Token)
+    private readonly tokenRepo: Repository<Token>,
+    @InjectRepository(CommunityRoom)
+    private readonly roomRepo: Repository<CommunityRoom>,
+    @InjectRepository(RoomMembership)
+    private readonly membershipRepo: Repository<RoomMembership>,
+    @InjectRepository(RoomMessageSeen)
+    private readonly seenRepo: Repository<RoomMessageSeen>,
+    private readonly roomPreferences: RoomPreferencesService,
+    private readonly redis: NotificationRedisService,
+    @InjectQueue(ROOM_NOTIFY_QUEUE)
+    private readonly notifyQueue: Queue<RoomMessageNotifyJob>,
+    @Inject(tgrConfig.KEY)
+    private readonly config: ConfigType<typeof tgrConfig>,
+  ) {
+    if (!isRelayConfigured(this.config)) {
+      // Relay not configured (worker mode removed — see `deworker-plan.md`): stay
+      // dormant. The constructor must still assign the readonly fields, but
+      // onModuleInit() returns early so no read subscription is ever opened.
+      this.sk = new Uint8Array();
+      this.pubkey = '';
+      this.shardIndex = 0;
+      return;
+    }
+    // Relay vars ARE set; decode the admin nsec. A SET-but-INVALID nsec must NOT
+    // crash the API at boot — degrade to dormant (no read subscription) and log
+    // loudly, exactly as if the relay were unconfigured. onModuleInit() gates on
+    // `pubkey`.
+    const nsec = this.config.nostrBotNsec as string;
+    try {
+      const decoded = nip19.decode(nsec);
+      if (decoded.type !== 'nsec') {
+        throw new Error('not an nsec');
+      }
+      this.sk = decoded.data as Uint8Array;
+      this.pubkey = getPublicKey(this.sk);
+      this.shardIndex = resolveShardIndex(
+        process.env,
+        this.config.subscriberShards,
+      );
+    } catch {
+      this.logger.error(
+        'TG_BOT_NSEC is set but is not a valid bech32 nsec — relay SUBSCRIBER disabled. ' +
+          'The HTTP API + chain indexer still run; fix TG_BOT_NSEC to enable room reads.',
+      );
+      this.sk = new Uint8Array();
+      this.pubkey = '';
+      this.shardIndex = 0;
+    }
+  }
+
+  async onModuleInit(): Promise<void> {
+    // Relay-gated: open a read subscription only when a relay is configured AND the
+    // admin key is valid (an invalid TG_BOT_NSEC leaves `pubkey` empty — see the
+    // constructor). With no relay the service stays dormant (no socket, no resync).
+    if (!isRelayConfigured(this.config) || !this.pubkey) {
+      return;
+    }
+    this.started = true;
+    // Connect in the BACKGROUND — `onModuleInit` must NOT await the relay: Nest runs
+    // init hooks inside `app.init()` and `app.listen()` blocks until they resolve, so
+    // a relay that stalls AUTH would hang here and the HTTP server would never start
+    // (port never opens). Detached, the server boots immediately; failures converge
+    // via `scheduleReconnect()`/`scheduleResync()`. (`authenticate()` is also bounded.)
+    void this.subscribeInitial();
+  }
+
+  /** Initial connect + subscribe, run detached from bootstrap (see {@link onModuleInit}). */
+  private async subscribeInitial(): Promise<void> {
+    try {
+      await this.ensureConnected();
+      await this.refreshSubscription();
+      this.scheduleResync();
+      this.logger.log(
+        `relay subscriber ready: shard ${this.shardIndex}/${this.config.subscriberShards} on ${this.config.nostrRelayUrl} as ${this.shortPk()}`,
+      );
+    } catch (e) {
+      this.logger.error(
+        `initial relay subscribe failed (${(e as Error)?.message}); will retry`,
+      );
+      this.scheduleReconnect();
+      // Still arm the resync so the filter converges once the socket recovers.
+      this.scheduleResync();
+    }
+  }
+
+  onApplicationShutdown(): void {
+    this.shuttingDown = true;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+    }
+    if (this.resyncTimer) {
+      clearInterval(this.resyncTimer);
+    }
+    for (const entry of this.coalescing.values()) {
+      if (entry.timer) {
+        clearTimeout(entry.timer);
+      }
+    }
+    this.coalescing.clear();
+    try {
+      this.sub?.close();
+    } catch {
+      // already closed
+    }
+    this.relay?.close();
+    this.relay = undefined;
+    this.healthy = false;
+    setRelaySubscriberConnected(false); // Task 15 observability (additive).
+  }
+
+  /** Whether the relay socket is connected + AUTHed (gates processing). */
+  isHealthy(): boolean {
+    return this.healthy && !!this.relay?.connected;
+  }
+
+  // ── room-set / subscription management ─────────────────────────────────────
+
+  /**
+   * A NIP-29 group was created + ACKed (Task 09, in-worker). Add it to this
+   * shard's subscription filter if it maps to our shard. EventEmitter2 is
+   * in-process, so this listener only fires in the worker that emits it.
+   */
+  @OnEvent(TGR_ROOM_CREATED, { async: true, promisify: true })
+  async onRoomCreated(payload: TgrRoomCreatedPayload): Promise<void> {
+    if (!this.started) {
+      return;
+    }
+    const gid = payload?.saleAddress;
+    if (!gid || !this.ownsGroup(gid) || this.subscribedGroups.has(gid)) {
+      return;
+    }
+    try {
+      this.subscribedGroups.add(gid);
+      await this.resubscribe();
+      this.logger.debug(
+        `subscribed new room ${gid} (shard ${this.shardIndex})`,
+      );
+    } catch (e) {
+      this.logger.warn(
+        `failed to add room ${gid} to subscription: ${(e as Error)?.message}`,
+      );
+    }
+  }
+
+  /**
+   * Re-derive this shard's room set from `Token WHERE nostr_room_state='created'`
+   * and, if it changed, re-establish the subscription. Run on boot, on reconnect,
+   * and on the periodic resync — convergent + idempotent (relay re-delivers from
+   * its own store, dedup keeps it safe).
+   */
+  async refreshSubscription(): Promise<void> {
+    const desired = await this.loadShardGroupIds();
+    let changed = desired.size !== this.subscribedGroups.size;
+    if (!changed) {
+      for (const g of desired) {
+        if (!this.subscribedGroups.has(g)) {
+          changed = true;
+          break;
+        }
+      }
+    }
+    if (!changed) {
+      return;
+    }
+    this.subscribedGroups.clear();
+    for (const g of desired) {
+      this.subscribedGroups.add(g);
+    }
+    await this.resubscribe();
+  }
+
+  /** Load every created room's group id that maps to THIS shard. */
+  private async loadShardGroupIds(): Promise<Set<string>> {
+    const rows = await this.tokenRepo.find({
+      where: { nostr_room_state: 'created' },
+      select: ['sale_address', 'nostr_group_id'],
+    });
+    const set = new Set<string>();
+    for (const row of rows) {
+      const gid = row.nostr_group_id ?? row.sale_address;
+      if (gid && this.ownsGroup(gid)) {
+        set.add(gid);
+      }
+    }
+    return set;
+  }
+
+  /** True iff this shard owns `gid`. */
+  private ownsGroup(gid: string): boolean {
+    return ownsGroupId(gid, this.shardIndex, this.config.subscriberShards);
+  }
+
+  /**
+   * (Re)open the live subscription for the current `subscribedGroups`. Closes any
+   * prior sub first. With no rooms yet we open NO sub (the relay would reject an
+   * empty `#h` and we'd ingest nothing useful). EOSE is informational — the sub
+   * stays live for new events.
+   */
+  private async resubscribe(): Promise<void> {
+    if (this.shuttingDown) {
+      return;
+    }
+    const relay = await this.ensureConnected();
+
+    try {
+      this.sub?.close();
+    } catch {
+      // already closed
+    }
+    this.sub = undefined;
+
+    if (this.subscribedGroups.size === 0) {
+      return;
+    }
+
+    const filter: Filter = {
+      kinds: [...CHAT_KINDS],
+      '#h': [...this.subscribedGroups],
+    };
+
+    this.sub = relay.subscribe([filter], {
+      onevent: (event: NostrEvent) => {
+        void this.onEvent(event);
+      },
+      oneose: () => {
+        // Informational: backlog drained, keep the sub live for new events.
+      },
+    });
+  }
+
+  /** Schedule the periodic room-set resync (worker-only; idempotent). */
+  private scheduleResync(): void {
+    if (this.resyncTimer || this.shuttingDown) {
+      return;
+    }
+    const everyMs = Math.max(1, this.config.communityTokenRefreshSec) * 1000;
+    this.resyncTimer = setInterval(() => {
+      void this.runResyncSafely();
+    }, everyMs);
+    this.resyncTimer.unref?.();
+  }
+
+  private async runResyncSafely(): Promise<void> {
+    if (this.shuttingDown || !this.isHealthy()) {
+      return;
+    }
+    try {
+      await this.refreshSubscription();
+    } catch (e) {
+      this.logger.warn(`subscription resync failed: ${(e as Error)?.message}`);
+    }
+  }
+
+  // ── event router ───────────────────────────────────────────────────────────
+
+  /**
+   * Route one incoming kind-9/11 event: extract `h`, DEDUP (record-if-absent in
+   * `room_message_seen`), resolve the room, build the recipient set, coalesce, and
+   * enqueue. NEVER throws back into the relay callback — a router error must not
+   * kill the subscription.
+   */
+  async onEvent(event: NostrEvent): Promise<void> {
+    try {
+      const gid = firstHTag(event);
+      if (!gid) {
+        // No `h` tag → not a group message; drop (don't even dedup).
+        return;
+      }
+      // Defensive: ignore events for groups outside this shard (relay should not
+      // serve them given the filter, but a shared admin socket might).
+      if (!this.ownsGroup(gid)) {
+        return;
+      }
+
+      // DEDUP FIRST (§7.1): record event.id; an already-present row ⇒ already
+      // processed ⇒ skip the whole fan-out. This precedes routing so a redelivery
+      // (reconnect / EOSE replay) is a no-op, AND we keep deduping while the
+      // breaker is open so the backlog isn't reprocessed on resume.
+      if (!(await this.recordSeen(event.id, gid))) {
+        return;
+      }
+
+      // Resolve the room AFTER dedup so an unknown/deleted room is still recorded
+      // (we never want to reprocess it).
+      const room = await this.roomRepo.findOne({
+        where: { sale_address: gid },
+        select: ['sale_address', 'symbol', 'deleted'],
+      });
+      if (!room || room.deleted) {
+        this.logger.debug(`event for unknown/deleted room ${gid}; dropped`);
+        return;
+      }
+
+      // Circuit breaker (§7.1): when the notify queue is backed up, pause this
+      // shard's ENQUEUE (we already deduped, so a paused message won't reprocess).
+      if (await this.isBreakerTripped()) {
+        return;
+      }
+
+      await this.coalesce(room.sale_address, room.symbol ?? gid, event);
+    } catch (e) {
+      this.logger.error(
+        `onEvent router error for ${event?.id}: ${(e as Error)?.message}`,
+        e as Error,
+      );
+    }
+  }
+
+  /**
+   * Durable dedup: INSERT `{ event_id, sale_address }`, swallowing the PK conflict.
+   * Returns `true` iff this is the FIRST sight of the event (a row was inserted),
+   * `false` iff it already existed (skip fan-out).
+   */
+  private async recordSeen(eventId: string, gid: string): Promise<boolean> {
+    try {
+      const result = await this.seenRepo
+        .createQueryBuilder()
+        .insert()
+        .into(RoomMessageSeen)
+        .values({ event_id: eventId, sale_address: gid })
+        .orIgnore()
+        .returning(['event_id'])
+        .execute();
+      // `INSERT … ON CONFLICT DO NOTHING RETURNING event_id` yields one row on a
+      // fresh insert and ZERO rows when the PK already existed (verified on PG) →
+      // `raw.length` is the durable first-sight signal.
+      return (result.raw?.length ?? 0) > 0;
+    } catch (e) {
+      // A unique-violation race lands here on some drivers → treat as "already
+      // seen" (safe: another delivery already owns the fan-out).
+      this.logger.debug(
+        `dedup insert for ${eventId} treated as already-seen: ${(e as Error)?.message}`,
+      );
+      return false;
+    }
+  }
+
+  // ── coalescing + fan-out + enqueue ─────────────────────────────────────────
+
+  /**
+   * Per-room coalescing (§4, window `TG_MSG_COALESCE_WINDOW_SEC`). The first message
+   * in a room opens a window and arms a flush timer; subsequent messages within
+   * the window only bump the count. On flush, fan out to recipients ONCE. A window
+   * of `0` disables coalescing (flush immediately).
+   */
+  private async coalesce(
+    saleAddress: string,
+    symbol: string,
+    event: NostrEvent,
+  ): Promise<void> {
+    const windowSec = this.config.msgCoalesceWindowSec;
+    if (windowSec <= 0) {
+      await this.flush(saleAddress, {
+        count: 1,
+        sampleEventId: event.id,
+        windowStartedAt: nowSec(),
+        authorPubkeys: new Set(event.pubkey ? [event.pubkey] : []),
+        symbol,
+      });
+      return;
+    }
+
+    const existing = this.coalescing.get(saleAddress);
+    if (existing) {
+      existing.count += 1;
+      existing.sampleEventId = event.id;
+      if (event.pubkey) {
+        existing.authorPubkeys.add(event.pubkey);
+      }
+      return;
+    }
+
+    const entry: CoalesceEntry = {
+      count: 1,
+      sampleEventId: event.id,
+      windowStartedAt: nowSec(),
+      authorPubkeys: new Set(event.pubkey ? [event.pubkey] : []),
+      symbol,
+    };
+    entry.timer = setTimeout(() => {
+      this.coalescing.delete(saleAddress);
+      void this.flush(saleAddress, entry).catch((e) =>
+        this.logger.error(
+          `coalesce flush failed for ${saleAddress}: ${(e as Error)?.message}`,
+        ),
+      );
+    }, windowSec * 1000);
+    entry.timer.unref?.();
+    this.coalescing.set(saleAddress, entry);
+  }
+
+  /**
+   * Flush a coalesced window: read the recipient set (added members, minus every
+   * member whose `member_pubkey` authored a message in the window), re-read from
+   * Postgres so we never hold a stale cache. Per recipient: room-scoped mute gate
+   * (Task 12) + per-recipient rate cap, then enqueue one coalesced job.
+   */
+  private async flush(
+    saleAddress: string,
+    entry: CoalesceEntry,
+  ): Promise<void> {
+    // Re-check the breaker at flush time too (depth may have crossed while the
+    // window was open) — but we already deduped, so a skipped flush won't reprocess.
+    if (await this.isBreakerTripped()) {
+      return;
+    }
+
+    const recipients = await this.recipientsFor(
+      saleAddress,
+      entry.authorPubkeys,
+    );
+    for (const recipient of recipients) {
+      try {
+        // Mute gate (per-room OR type-level), cheap-first on the hot path.
+        const enabled = await this.roomPreferences.isRoomEnabled(
+          recipient,
+          'room-messages',
+          saleAddress,
+        );
+        if (!enabled) {
+          continue;
+        }
+        // Per-recipient rate cap across rooms.
+        if (await this.isRateCapped(recipient)) {
+          continue;
+        }
+        await this.notifyQueue.add(
+          ROOM_MESSAGE_NOTIFY_JOB,
+          {
+            sale_address: saleAddress,
+            recipient,
+            symbol: entry.symbol,
+            message_count: entry.count,
+            window_started_at: entry.windowStartedAt,
+            sample_event_id: entry.sampleEventId,
+          },
+          roomMessageNotifyJobOptions(),
+        );
+      } catch (e) {
+        this.logger.warn(
+          `enqueue room-message for ${recipient} in ${saleAddress} failed: ${(e as Error)?.message}`,
+        );
+      }
+    }
+  }
+
+  /**
+   * The notify-eligible recipients for a room: `room_membership WHERE
+   * sale_address=gid AND relay_state='added'`, minus any member whose
+   * `member_pubkey` is in `authorPubkeys` (excludes message authors). Returns
+   * distinct æ addresses.
+   */
+  private async recipientsFor(
+    saleAddress: string,
+    authorPubkeys: Set<string>,
+  ): Promise<string[]> {
+    const rows = await this.membershipRepo.find({
+      where: { sale_address: saleAddress, relay_state: 'added' },
+      select: ['member_address', 'member_pubkey'],
+    });
+    const out: string[] = [];
+    const seen = new Set<string>();
+    for (const row of rows) {
+      if (!row.member_address || seen.has(row.member_address)) {
+        continue;
+      }
+      // Exclude any member who authored a message in this window.
+      if (row.member_pubkey && authorPubkeys.has(row.member_pubkey)) {
+        continue;
+      }
+      seen.add(row.member_address);
+      out.push(row.member_address);
+    }
+    return out;
+  }
+
+  // ── circuit breaker + rate cap ─────────────────────────────────────────────
+
+  /**
+   * Circuit breaker (§7.1): trip when `worker:room-notify` depth (waiting+delayed)
+   * exceeds `TG_ROOM_NOTIFY_DEPTH_BREAK`; resume once it drops below the low-water
+   * mark (half). Latched so we don't flap. Fail-open on a probe error.
+   */
+  private async isBreakerTripped(): Promise<boolean> {
+    try {
+      const counts = await this.notifyQueue.getJobCounts();
+      const depth = (counts.waiting ?? 0) + (counts.delayed ?? 0);
+      const high = this.config.roomNotifyDepthBreak;
+      const low = Math.floor(high / 2);
+      if (this.breakerOpen) {
+        if (depth <= low) {
+          this.breakerOpen = false;
+          this.logger.log(
+            `room-notify depth ${depth} ≤ ${low}; circuit breaker reset (shard ${this.shardIndex})`,
+          );
+        }
+      } else if (depth >= high) {
+        this.breakerOpen = true;
+        this.logger.warn(
+          `room-notify depth ${depth} ≥ ${high}; circuit breaker tripped — pausing enqueue (shard ${this.shardIndex})`,
+        );
+      }
+      return this.breakerOpen;
+    } catch (e) {
+      this.logger.warn(
+        `room-notify depth probe failed — failing open: ${(e as Error)?.message}`,
+      );
+      return false;
+    }
+  }
+
+  /**
+   * Per-recipient fixed-window rate cap (§6, `TG_MSG_RATE_CAP`). Off when
+   * `TG_MSG_RATE_CAP=0` (default). Over-cap enqueues are dropped (and counted via the
+   * warn log). Fail-open on a Redis blip.
+   */
+  private async isRateCapped(recipient: string): Promise<boolean> {
+    const cap = this.config.msgRateCap;
+    if (cap <= 0) {
+      return false;
+    }
+    const windowSec = Math.max(1, this.config.msgCoalesceWindowSec || 60);
+    try {
+      const { capped } = await this.redis.incrementWithCap(
+        `tgr:msg-notify:rate:${recipient}`,
+        windowSec,
+        cap,
+      );
+      if (capped) {
+        this.logger.warn(
+          `room-message rate cap hit for ${recipient} (${cap}/${windowSec}s) — dropping until window resets`,
+        );
+      }
+      return capped;
+    } catch (e) {
+      this.logger.warn(
+        `room-message rate-cap check failed for ${recipient} — failing open: ${(e as Error)?.message}`,
+      );
+      return false;
+    }
+  }
+
+  // ── connection lifecycle (mirror RelayWriterService) ───────────────────────
+
+  /** Connect (and AUTH) if not already; returns the live relay. Idempotent. */
+  private async ensureConnected(): Promise<Relay> {
+    if (this.relay?.connected && this.healthy) {
+      return this.relay;
+    }
+    if (!this.connecting) {
+      this.connecting = this.openConnection().finally(() => {
+        this.connecting = undefined;
+      });
+    }
+    await this.connecting;
+    if (!this.relay) {
+      throw new Error('relay not connected');
+    }
+    return this.relay;
+  }
+
+  private async openConnection(): Promise<void> {
+    const url = this.config.nostrRelayUrl;
+    if (!url) {
+      throw new Error('TG_RELAY_URL is required in worker mode');
+    }
+
+    let relay: Relay;
+    try {
+      // Bound the WS connect: a host that accepts the TCP socket but never completes
+      // the WebSocket upgrade (a half-open/non-relay listener) would otherwise leave
+      // `Relay.connect()` pending forever. A timeout lets `ensureConnected()` settle
+      // so the reconnect/backoff loop can recover instead of wedging.
+      relay = await this.withTimeout(
+        Relay.connect(url),
+        this.config.publishAckTimeoutMs,
+      );
+    } catch (e) {
+      const reason = typeof e === 'string' ? e : (e as Error)?.message;
+      throw new Error(`failed to connect to ${url} (${reason})`);
+    }
+
+    relay.onclose = (): void => {
+      if (this.shuttingDown) {
+        return;
+      }
+      this.logger.warn('relay subscription closed; scheduling reconnect');
+      this.markUnhealthy('socket closed');
+      this.sub = undefined;
+      this.scheduleReconnect();
+    };
+    relay.onnotice = (msg: string): void => {
+      this.logger.debug(`relay NOTICE: ${msg}`);
+    };
+
+    this.relay = relay;
+
+    // NIP-42 AUTH as relay admin so private-room chat is served.
+    await this.authenticate(relay);
+
+    this.healthy = true;
+    this.reconnectAttempts = 0;
+    setRelaySubscriberConnected(true); // Task 15 observability (additive).
+  }
+
+  /**
+   * Respond to the relay's NIP-42 AUTH challenge with a signed kind-22242 (mirror
+   * RelayWriterService.authenticate). No-op if the relay never challenges.
+   */
+  private async authenticate(relay: Relay): Promise<void> {
+    try {
+      // Bound the AUTH: `relay.auth()` blocks until the relay sends a NIP-42
+      // challenge, but groups_relay only challenges on a protected REQ — so without
+      // a timeout this awaits forever and hangs the connect. A timeout is benign:
+      // the relay re-challenges on the next protected read.
+      await this.withTimeout(
+        relay.auth(async (evt: EventTemplate) => finalizeEvent(evt, this.sk)),
+        this.config.publishAckTimeoutMs,
+      );
+      this.logger.debug('NIP-42 authenticated as relay admin (subscriber)');
+    } catch (e) {
+      this.logger.debug(
+        `NIP-42 auth skipped/failed: ${(e as Error)?.message ?? e}`,
+      );
+    }
+  }
+
+  /**
+   * Reject `p` if it hasn't settled within `ms` (the subscriber has no shared
+   * publish helper, so this is a local bound for the AUTH step). The timer is
+   * `.unref()`ed so it never keeps the process alive.
+   */
+  private withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error(`timed out after ${ms}ms`)),
+        ms,
+      );
+      timer.unref?.();
+      p.then(
+        (v) => {
+          clearTimeout(timer);
+          resolve(v);
+        },
+        (e) => {
+          clearTimeout(timer);
+          reject(e);
+        },
+      );
+    });
+  }
+
+  private markUnhealthy(reason: string): void {
+    if (this.healthy) {
+      this.logger.warn(`relay subscriber unhealthy: ${reason}`);
+    }
+    this.healthy = false;
+    setRelaySubscriberConnected(false); // Task 15 observability (additive).
+  }
+
+  private scheduleReconnect(): void {
+    if (this.shuttingDown || this.reconnectTimer) {
+      return;
+    }
+    this.reconnectAttempts += 1;
+    // Capped exponential backoff, floored at the health-pause window (§1, shared
+    // with the writer) so we never hammer a dead relay.
+    const base = Math.max(1, this.config.relayHealthPauseSec) * 1000;
+    const delay = Math.min(
+      base * Math.pow(2, Math.min(this.reconnectAttempts - 1, 5)),
+      5 * 60 * 1000,
+    );
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = undefined;
+      void this.reconnect();
+    }, delay);
+    this.reconnectTimer.unref?.();
+  }
+
+  private async reconnect(): Promise<void> {
+    if (this.shuttingDown) {
+      return;
+    }
+    try {
+      this.sub?.close();
+    } catch {
+      // ignore
+    }
+    this.sub = undefined;
+    try {
+      this.relay?.close();
+    } catch {
+      // ignore
+    }
+    this.relay = undefined;
+    try {
+      await this.ensureConnected();
+      // On reconnect, RE-ESTABLISH every subscription from the durable room set
+      // (§1.1): re-derive from Postgres so we never miss a room created while down.
+      await this.refreshSubscriptionForce();
+      this.logger.log('relay subscriber reconnected + resubscribed');
+    } catch (e) {
+      this.logger.warn(
+        `relay subscriber reconnect failed (${(e as Error)?.message}); retrying`,
+      );
+      this.scheduleReconnect();
+    }
+  }
+
+  /** Force a full re-derive + resubscribe (used on reconnect). */
+  private async refreshSubscriptionForce(): Promise<void> {
+    const desired = await this.loadShardGroupIds();
+    this.subscribedGroups.clear();
+    for (const g of desired) {
+      this.subscribedGroups.add(g);
+    }
+    await this.resubscribe();
+  }
+
+  private shortPk(): string {
+    return this.pubkey.slice(0, 8);
+  }
+}
+
+/** Extract the first `["h", gid]` tag's value (verbatim). Undefined if absent. */
+export function firstHTag(event: { tags?: string[][] }): string | undefined {
+  const tags = event?.tags ?? [];
+  for (const tag of tags) {
+    if (tag[0] === 'h' && typeof tag[1] === 'string' && tag[1].length > 0) {
+      return tag[1];
+    }
+  }
+  return undefined;
+}

--- a/src/token-gated-rooms/nostr/relay-writer.contract.ts
+++ b/src/token-gated-rooms/nostr/relay-writer.contract.ts
@@ -1,0 +1,41 @@
+import type { Nip29Template } from './nip29';
+
+/**
+ * Nostr-free contract for the relay write client (Task 07). Kept separate from
+ * `relay-writer.service.ts` so consumers (the `publish-nip29` processor, Task 11
+ * reconciliation) can depend on the INTERFACE + DI token without importing
+ * `nostr-tools` (which pulls in ESM `@noble/*` crypto that ts-jest cannot
+ * transform in plain unit tests). The concrete service implements this and is
+ * provided under {@link RELAY_WRITER}.
+ */
+
+/** DI token for the relay writer (inject the interface, not the concrete class). */
+export const RELAY_WRITER = Symbol('TGR_RELAY_WRITER');
+
+/**
+ * Outcome of a single low-level publish (§1.4). Flat shape (not a discriminated
+ * union) because this repo runs `strictNullChecks:false`, which disables union
+ * narrowing — callers read `ok` then `reason`/`timedOut`.
+ */
+export interface PublishResult {
+  /** ACK ok (relay accepted). */
+  ok: boolean;
+  /** Signed event id. */
+  id: string;
+  /** Relay reject reason (only meaningful when `ok` is false). */
+  reason?: string;
+  /** True when no ACK arrived within `publishAckTimeoutMs`. */
+  timedOut?: boolean;
+}
+
+/** The relay-admin write client surface (§1). */
+export interface RelayWriter {
+  /** Bot/relay-admin public key (hex). */
+  readonly pubkey: string;
+  /** Whether the relay socket is connected + AUTHed (gates the queue). */
+  isHealthy(): boolean;
+  /** Finalize+sign+publish and wait for the relay ACK; never throws on reject. */
+  publish(template: Nip29Template): Promise<PublishResult>;
+  /** One-shot `39002` read of a group's current members (§1.5). */
+  fetchGroupMembers(groupId: string): Promise<Set<string>>;
+}

--- a/src/token-gated-rooms/nostr/relay-writer.service.ts
+++ b/src/token-gated-rooms/nostr/relay-writer.service.ts
@@ -275,6 +275,7 @@ export class RelayWriterService
       };
 
       const timer = setTimeout(finish, this.config.publishAckTimeoutMs);
+      timer.unref?.();
 
       const sub = relay.subscribe(
         [{ kinds: [KIND_GROUP_MEMBERS], '#d': [groupId] }],
@@ -413,6 +414,10 @@ export class RelayWriterService
       this.reconnectTimer = undefined;
       void this.reconnect();
     }, delay);
+    // `.unref()` so a pending reconnect backoff (up to RELAY_RECONNECT_MAX_MS)
+    // never keeps the process alive — mirrors the equivalent timer in
+    // relay-subscriber.service.ts and this file's own healthWatchdog.
+    this.reconnectTimer.unref?.();
   }
 
   private async reconnect(): Promise<void> {
@@ -443,6 +448,7 @@ export class RelayWriterService
   private withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
     return new Promise<T>((resolve, reject) => {
       const timer = setTimeout(() => reject(new PublishTimeoutError(ms)), ms);
+      timer.unref?.();
       p.then(
         (v) => {
           clearTimeout(timer);

--- a/src/token-gated-rooms/nostr/relay-writer.service.ts
+++ b/src/token-gated-rooms/nostr/relay-writer.service.ts
@@ -1,0 +1,466 @@
+import {
+  Inject,
+  Injectable,
+  Logger,
+  OnApplicationShutdown,
+  OnModuleInit,
+} from '@nestjs/common';
+import { ConfigType } from '@nestjs/config';
+import {
+  finalizeEvent,
+  getPublicKey,
+  nip19,
+  Relay,
+  type Event as NostrEvent,
+  type EventTemplate,
+} from 'nostr-tools';
+import WebSocket from 'ws';
+import tgrConfig, { isRelayConfigured } from '../config/tgr.config';
+import type { Nip29Template } from './nip29';
+import type { PublishResult, RelayWriter } from './relay-writer.contract';
+import {
+  incrementPublishFailed,
+  incrementPublishOk,
+  incrementRelayReconnect,
+  setRelayWriterConnected,
+} from '../observability/tgr-metrics';
+
+export { PublishResult, RelayWriter } from './relay-writer.contract';
+export { RELAY_WRITER } from './relay-writer.contract';
+
+// nostr-tools' `Relay` reads the global `WebSocket` at connect time. Node 21+
+// ships one, but install the `ws` implementation when missing so the worker
+// runs on older runtimes too. Idempotent — safe at module load.
+if (typeof (globalThis as { WebSocket?: unknown }).WebSocket === 'undefined') {
+  (globalThis as { WebSocket?: unknown }).WebSocket = WebSocket;
+}
+
+const nowSec = (): number => Math.floor(Date.now() / 1000);
+
+/**
+ * Steady-state reconnect cadence under a SUSTAINED relay outage (10 min). The
+ * capped-exponential backoff ramps from `relayHealthPauseSec` up to this, so a
+ * blip recovers fast while a long outage retries quietly every ~10 min instead of
+ * crashing the API or flooding the logs.
+ */
+const RELAY_RECONNECT_MAX_MS = 10 * 60 * 1000;
+
+/** Relay-served `39002` member kind we read for `fetchGroupMembers`. */
+const KIND_GROUP_MEMBERS = 39002;
+
+/**
+ * Long-lived, relay-admin-authed write client for `groups_relay` (Task 07 §1).
+ *
+ * WORKER PROCESS ONLY. Holds the single connection through which every NIP-29
+ * publish flows (the `publish-nip29` processor is the sole producer). It owns:
+ *   - connect + NIP-42 AUTH as the relay admin (`TG_BOT_NSEC` → admin pubkey),
+ *   - reconnect-with-backoff + an `isHealthy()` gate (the processor pauses the
+ *     queue while unhealthy rather than burning retries),
+ *   - `publish(template)` finalize+sign+publish that waits for the relay ACK up
+ *     to `publishAckTimeoutMs` and distinguishes ok / reject / timeout,
+ *   - `fetchGroupMembers(groupId)` one-shot `39002` read (for Task 11).
+ *
+ * It holds NO desired-state and NO membership cache — idempotency is relay-owned
+ * (§6.3). The nsec is decoded once and NEVER logged (only the pubkey is).
+ */
+@Injectable()
+export class RelayWriterService
+  implements RelayWriter, OnModuleInit, OnApplicationShutdown
+{
+  private readonly logger = new Logger(RelayWriterService.name);
+
+  private readonly sk: Uint8Array;
+  /** Bot/relay-admin public key (safe to log). */
+  readonly pubkey: string;
+
+  private relay?: Relay;
+  private connecting?: Promise<void>;
+  private healthy = false;
+  private shuttingDown = false;
+  private reconnectTimer?: ReturnType<typeof setTimeout>;
+  private reconnectAttempts = 0;
+  private healthWatchdog?: ReturnType<typeof setInterval>;
+
+  constructor(
+    @Inject(tgrConfig.KEY)
+    private readonly config: ConfigType<typeof tgrConfig>,
+  ) {
+    if (!isRelayConfigured(this.config)) {
+      // Relay not configured (worker mode removed — see `deworker-plan.md`): stay
+      // dormant. Assign placeholder keys; onModuleInit() opens no socket and
+      // isHealthy() stays false, so the publish queue never drains. Nothing
+      // enqueues publishes when the relay is unconfigured anyway.
+      this.sk = new Uint8Array();
+      this.pubkey = '';
+      return;
+    }
+    // Relay vars ARE set; decode the admin nsec. A SET-but-INVALID nsec must NOT
+    // crash the API at boot — degrade to dormant (publish nothing) and log loudly,
+    // exactly as if the relay were unconfigured. onModuleInit() gates on `pubkey`.
+    const nsec = this.config.nostrBotNsec as string;
+    try {
+      const decoded = nip19.decode(nsec);
+      if (decoded.type !== 'nsec') {
+        throw new Error('not an nsec');
+      }
+      this.sk = decoded.data;
+      this.pubkey = getPublicKey(this.sk);
+    } catch {
+      this.logger.error(
+        'TG_BOT_NSEC is set but is not a valid bech32 nsec — relay WRITER disabled. ' +
+          'The HTTP API + chain indexer still run; fix TG_BOT_NSEC to enable NIP-29 publishing.',
+      );
+      this.sk = new Uint8Array();
+      this.pubkey = '';
+    }
+  }
+
+  async onModuleInit(): Promise<void> {
+    // Relay-gated: dormant unless a relay is configured AND the admin key is valid
+    // (an invalid TG_BOT_NSEC leaves `pubkey` empty — see the constructor).
+    if (!isRelayConfigured(this.config) || !this.pubkey) {
+      return;
+    }
+    // Connect in the BACKGROUND — `onModuleInit` must NOT await the relay, because
+    // Nest runs init hooks inside `app.init()` and `app.listen()` blocks until they
+    // all resolve. A relay that accepts the socket but never completes NIP-42 AUTH
+    // would hang `ensureConnected()` here with no timeout, and the HTTP API +
+    // indexer would never start (port never opens). Firing it detached lets the
+    // server boot immediately; connect failures/hangs converge via
+    // `scheduleReconnect()` + the health watchdog. (`authenticate()` is also bounded
+    // by a timeout so the connect always settles and can recover.)
+    void this.connectInitial();
+    this.startHealthWatchdog();
+  }
+
+  /** Initial relay connect, run detached from bootstrap (see {@link onModuleInit}). */
+  private async connectInitial(): Promise<void> {
+    try {
+      await this.ensureConnected();
+      this.logger.log(
+        `relay writer ready: ${this.config.nostrRelayUrl} as bot ${this.shortPk()}`,
+      );
+    } catch (e) {
+      this.logger.error(
+        `initial relay connect failed (${(e as Error)?.message}); will retry`,
+      );
+      this.scheduleReconnect();
+    }
+  }
+
+  /**
+   * Safety net against a wedged-unhealthy writer. `healthy` can be flipped false
+   * without a socket-close (e.g. a publish ACK timeout), and when the publish queue
+   * is paused there are no publishes to drive a recovery — so nothing would ever
+   * call `scheduleReconnect` and the writer would stay unhealthy forever (queue
+   * permanently paused). This periodic check forces a reconnect whenever we're
+   * unhealthy with no reconnect already in flight, so health always recovers on its
+   * own. `.unref()` so it never keeps the process alive.
+   */
+  private startHealthWatchdog(): void {
+    const everyMs = Math.max(1, this.config.relayHealthPauseSec) * 1000;
+    this.healthWatchdog = setInterval(() => {
+      if (
+        this.shuttingDown ||
+        this.isHealthy() ||
+        this.connecting ||
+        this.reconnectTimer
+      ) {
+        return;
+      }
+      this.logger.warn(
+        'relay writer unhealthy with no reconnect pending — forcing reconnect',
+      );
+      this.scheduleReconnect();
+    }, everyMs);
+    this.healthWatchdog.unref?.();
+  }
+
+  onApplicationShutdown(): void {
+    this.shuttingDown = true;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+    }
+    if (this.healthWatchdog) {
+      clearInterval(this.healthWatchdog);
+      this.healthWatchdog = undefined;
+    }
+    this.relay?.close();
+    this.relay = undefined;
+    this.healthy = false;
+    setRelayWriterConnected(false); // Task 15 observability (additive).
+  }
+
+  /** Whether the relay socket is connected + AUTHed (gates the queue). */
+  isHealthy(): boolean {
+    return this.healthy && !!this.relay?.connected;
+  }
+
+  /**
+   * Finalize+sign+publish a template and wait for the relay ACK up to
+   * `publishAckTimeoutMs`. Resolves a discriminated result; NEVER throws on a
+   * relay-level reject/timeout (the processor decides retry vs. terminal vs.
+   * already-exists from the reason string).
+   */
+  async publish(template: Nip29Template): Promise<PublishResult> {
+    const relay = await this.ensureConnected();
+    const event = finalizeEvent(
+      {
+        kind: template.kind,
+        created_at: nowSec(),
+        tags: template.tags,
+        content: template.content ?? '',
+      },
+      this.sk,
+    );
+
+    try {
+      // nostr-tools' relay.publish() resolves with the relay reason on OK:true
+      // and rejects with the reason on OK:false; it has its own publishTimeout
+      // (set to ours on connect) but we also race a hard timeout to classify a
+      // missing ACK distinctly from a rejection.
+      await this.withTimeout(
+        relay.publish(event as NostrEvent),
+        this.config.publishAckTimeoutMs,
+      );
+      incrementPublishOk(); // Task 15 observability (additive, no behavior change).
+      return { ok: true, id: event.id };
+    } catch (e) {
+      const timedOut = e instanceof PublishTimeoutError;
+      // Task 15 observability (additive): count the failure (+ ACK timeout when
+      // it was a timeout — handled inside incrementPublishFailed).
+      incrementPublishFailed(timedOut);
+      if (timedOut) {
+        // No ACK in the window: the relay may be wedged — mark unhealthy so the
+        // processor pauses rather than retry-spinning against a dead socket.
+        // CRUCIAL: also schedule a reconnect. A publish ACK timeout does NOT close
+        // the socket, so `onclose` never fires — without this, `healthy` would stay
+        // false forever (the socket looks "connected" but we've flagged it down),
+        // which permanently pauses the publish queue. Reconnecting restores health
+        // within the backoff window so the queue resumes.
+        this.markUnhealthy('publish ACK timeout');
+        this.scheduleReconnect();
+      }
+      const reason =
+        typeof e === 'string' ? e : ((e as Error)?.message ?? 'publish failed');
+      return { ok: false, id: event.id, reason, timedOut };
+    }
+  }
+
+  /**
+   * One-shot read of a group's current members from the relay-signed `39002`
+   * (Task 07 §1.5). Issues a `REQ` for `kinds:[39002]` `#d:[groupId]`, collects
+   * the `["p", …]` pubkeys, awaits EOSE, then closes the sub. NOT a live
+   * subscription (the kind-9/11 message subscriber is Task 14). Task 11 calls
+   * this instead of opening its own connection.
+   */
+  async fetchGroupMembers(groupId: string): Promise<Set<string>> {
+    const relay = await this.ensureConnected();
+    const members = new Set<string>();
+
+    return await new Promise<Set<string>>((resolve) => {
+      let settled = false;
+      const finish = (): void => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timer);
+        try {
+          sub.close();
+        } catch {
+          // already closed
+        }
+        resolve(members);
+      };
+
+      const timer = setTimeout(finish, this.config.publishAckTimeoutMs);
+
+      const sub = relay.subscribe(
+        [{ kinds: [KIND_GROUP_MEMBERS], '#d': [groupId] }],
+        {
+          onevent: (event: NostrEvent) => {
+            // 39002 carries one `p` tag per member; collect them all.
+            for (const tag of event.tags) {
+              if (tag[0] === 'p' && typeof tag[1] === 'string') {
+                members.add(tag[1]);
+              }
+            }
+          },
+          oneose: finish,
+          onclose: finish,
+        },
+      );
+    });
+  }
+
+  // ---- connection lifecycle -------------------------------------------------
+
+  /** Connect (and AUTH) if not already; returns the live relay. Idempotent. */
+  private async ensureConnected(): Promise<Relay> {
+    if (this.relay?.connected && this.healthy) {
+      return this.relay;
+    }
+    if (!this.connecting) {
+      this.connecting = this.openConnection().finally(() => {
+        this.connecting = undefined;
+      });
+    }
+    await this.connecting;
+    if (!this.relay) {
+      throw new Error('relay not connected');
+    }
+    return this.relay;
+  }
+
+  private async openConnection(): Promise<void> {
+    const url = this.config.nostrRelayUrl;
+    if (!url) {
+      throw new Error('TG_RELAY_URL is required in worker mode');
+    }
+
+    let relay: Relay;
+    try {
+      // Bound the WS connect: a host that accepts the TCP socket but never completes
+      // the WebSocket upgrade (a half-open/non-relay listener) would otherwise leave
+      // `Relay.connect()` pending forever. A timeout lets `ensureConnected()` settle
+      // so the reconnect/backoff loop can recover instead of wedging.
+      relay = await this.withTimeout(
+        Relay.connect(url),
+        this.config.publishAckTimeoutMs,
+      );
+    } catch (e) {
+      const reason = typeof e === 'string' ? e : (e as Error)?.message;
+      throw new Error(`failed to connect to ${url} (${reason})`);
+    }
+
+    // Align the library's per-publish timeout with ours so its internal ACK
+    // wait and our `withTimeout` race agree.
+    relay.publishTimeout = this.config.publishAckTimeoutMs;
+
+    relay.onclose = (): void => {
+      if (this.shuttingDown) {
+        return;
+      }
+      this.logger.warn('relay connection closed; scheduling reconnect');
+      this.markUnhealthy('socket closed');
+      this.scheduleReconnect();
+    };
+    relay.onnotice = (msg: string): void => {
+      this.logger.debug(`relay NOTICE: ${msg}`);
+    };
+
+    this.relay = relay;
+
+    // NIP-42 AUTH as relay admin so the bot can READ private-group state.
+    await this.authenticate(relay);
+
+    this.healthy = true;
+    this.reconnectAttempts = 0;
+    setRelayWriterConnected(true); // Task 15 observability (additive).
+  }
+
+  /**
+   * Respond to the relay's NIP-42 AUTH challenge with a signed kind-22242. The
+   * bot must be the relay admin (D7). No-op if the relay never challenges.
+   */
+  private async authenticate(relay: Relay): Promise<void> {
+    try {
+      // Bound the AUTH: `relay.auth()` blocks until the relay sends a NIP-42
+      // challenge, but groups_relay only challenges on a protected REQ — so without
+      // a timeout this awaits forever and hangs the connect. A timeout is benign:
+      // the relay re-challenges on the next protected read.
+      await this.withTimeout(
+        relay.auth(async (evt: EventTemplate) => finalizeEvent(evt, this.sk)),
+        this.config.publishAckTimeoutMs,
+      );
+      this.logger.debug('NIP-42 authenticated as relay admin');
+    } catch (e) {
+      // Some relays only challenge on the first protected read; a benign "no
+      // challenge" must not flip the connection unhealthy. Real auth failures
+      // surface on the next protected REQ.
+      this.logger.debug(
+        `NIP-42 auth skipped/failed: ${(e as Error)?.message ?? e}`,
+      );
+    }
+  }
+
+  private markUnhealthy(reason: string): void {
+    if (this.healthy) {
+      this.logger.warn(`relay unhealthy: ${reason}`);
+    }
+    this.healthy = false;
+    setRelayWriterConnected(false); // Task 15 observability (additive).
+  }
+
+  private scheduleReconnect(): void {
+    if (this.shuttingDown || this.reconnectTimer) {
+      return;
+    }
+    this.reconnectAttempts += 1;
+    incrementRelayReconnect(); // Task 15 observability (additive).
+    // Capped exponential backoff: quick early retries recover a transient blip
+    // fast, then it settles to a steady ~10-minute cadence under a SUSTAINED relay
+    // outage (so we never crash the API and never flood the logs — the relay being
+    // offline only means NIP-29 publishing pauses; the HTTP API + indexer keep
+    // running). Floored at the health-pause window so we never hammer a dead relay.
+    const base = Math.max(1, this.config.relayHealthPauseSec) * 1000;
+    const delay = Math.min(
+      base * Math.pow(2, this.reconnectAttempts - 1),
+      RELAY_RECONNECT_MAX_MS,
+    );
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = undefined;
+      void this.reconnect();
+    }, delay);
+  }
+
+  private async reconnect(): Promise<void> {
+    if (this.shuttingDown) {
+      return;
+    }
+    try {
+      this.relay?.close();
+    } catch {
+      // ignore
+    }
+    this.relay = undefined;
+    try {
+      await this.ensureConnected();
+      this.logger.log('relay reconnected');
+    } catch (e) {
+      this.logger.warn(
+        `relay reconnect failed (${(e as Error)?.message}); retrying`,
+      );
+      this.scheduleReconnect();
+    }
+  }
+
+  private shortPk(): string {
+    return this.pubkey.slice(0, 8);
+  }
+
+  private withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new PublishTimeoutError(ms)), ms);
+      p.then(
+        (v) => {
+          clearTimeout(timer);
+          resolve(v);
+        },
+        (e) => {
+          clearTimeout(timer);
+          reject(e);
+        },
+      );
+    });
+  }
+}
+
+/** Thrown when a publish ACK does not arrive within `publishAckTimeoutMs`. */
+export class PublishTimeoutError extends Error {
+  constructor(ms: number) {
+    super(`relay ACK timed out after ${ms}ms`);
+    this.name = 'PublishTimeoutError';
+  }
+}

--- a/src/token-gated-rooms/nostr/room-admins.spec.ts
+++ b/src/token-gated-rooms/nostr/room-admins.spec.ts
@@ -1,0 +1,163 @@
+import { nip19 } from 'nostr-tools';
+import { putUser } from './nip29';
+import {
+  diffRoomAdmins,
+  isConfiguredAdmin,
+  isHex64,
+  parseRoomAdmins,
+  RoomAdminConfigError,
+} from './room-admins';
+
+/** A deterministic 64-hex pubkey for index `n`. */
+const hex = (n: number): string =>
+  (n.toString(16).padStart(2, '0') + 'a'.repeat(62)).slice(0, 64);
+
+/** The npub bech32 form of a hex pubkey. */
+const npub = (h: string): string => nip19.npubEncode(h);
+
+describe('room-admins (pure)', () => {
+  describe('parseRoomAdmins', () => {
+    it('hex passthrough, lowercased', () => {
+      const h = hex(1);
+      expect(parseRoomAdmins(h.toUpperCase())).toEqual([h]);
+    });
+
+    it('npub → hex', () => {
+      const h = hex(2);
+      expect(parseRoomAdmins(npub(h))).toEqual([h]);
+    });
+
+    it('accepts a comma-separated string and an array form identically', () => {
+      const a = hex(3);
+      const b = hex(4);
+      expect(parseRoomAdmins(`${a},${b}`)).toEqual([a, b]);
+      expect(parseRoomAdmins([a, b])).toEqual([a, b]);
+    });
+
+    it('trims whitespace and ignores empty entries (trailing/blank slots)', () => {
+      const a = hex(5);
+      const b = hex(6);
+      expect(parseRoomAdmins(` ${a} , , ${b} ,`)).toEqual([a, b]);
+    });
+
+    it('de-duplicates (npub and its hex collapse to one)', () => {
+      const a = hex(7);
+      expect(parseRoomAdmins(`${a},${npub(a)},${a.toUpperCase()}`)).toEqual([
+        a,
+      ]);
+    });
+
+    it('throws RoomAdminConfigError on a malformed entry (not a silent skip)', () => {
+      const a = hex(8);
+      expect(() => parseRoomAdmins(`${a},not-a-pubkey`)).toThrow(
+        RoomAdminConfigError,
+      );
+      expect(() => parseRoomAdmins('deadbeef')).toThrow(/unparseable/i);
+    });
+
+    it('rejects a non-npub bech32 (e.g. an nsec) as malformed', () => {
+      const sk = new Uint8Array(32).fill(1);
+      const nsec = nip19.nsecEncode(sk);
+      expect(() => parseRoomAdmins(nsec)).toThrow(RoomAdminConfigError);
+    });
+
+    it('empty / unset → []', () => {
+      expect(parseRoomAdmins('')).toEqual([]);
+      expect(parseRoomAdmins('   ')).toEqual([]);
+      expect(parseRoomAdmins(undefined)).toEqual([]);
+      expect(parseRoomAdmins(null)).toEqual([]);
+      expect(parseRoomAdmins([])).toEqual([]);
+    });
+
+    it('every output entry is HEX64', () => {
+      const out = parseRoomAdmins([hex(1), npub(hex(2)), hex(3)]);
+      for (const o of out) {
+        expect(isHex64(o)).toBe(true);
+      }
+    });
+  });
+
+  describe('isConfiguredAdmin (exemption predicate)', () => {
+    const configured = [hex(10), hex(11)];
+
+    it('true for a configured hex', () => {
+      expect(isConfiguredAdmin(hex(10), configured)).toBe(true);
+    });
+
+    it('true for the npub form of a configured admin (format-insensitive)', () => {
+      expect(isConfiguredAdmin(npub(hex(11)), configured)).toBe(true);
+    });
+
+    it('true for an upper-cased hex form', () => {
+      expect(isConfiguredAdmin(hex(10).toUpperCase(), configured)).toBe(true);
+    });
+
+    it('false for a non-configured pubkey', () => {
+      expect(isConfiguredAdmin(hex(99), configured)).toBe(false);
+    });
+
+    it('false for malformed / empty / null input', () => {
+      expect(isConfiguredAdmin('garbage', configured)).toBe(false);
+      expect(isConfiguredAdmin('', configured)).toBe(false);
+      expect(isConfiguredAdmin(null, configured)).toBe(false);
+      expect(isConfiguredAdmin(undefined, configured)).toBe(false);
+    });
+  });
+
+  describe('diffRoomAdmins (converge)', () => {
+    const bot = hex(0);
+
+    it('configured ⊃ relay → promotes the missing ones', () => {
+      const configured = [hex(1), hex(2), hex(3)];
+      const current = [hex(1), bot];
+      const { toPromote, toDemote } = diffRoomAdmins(configured, current, bot);
+      expect(new Set(toPromote)).toEqual(new Set([hex(2), hex(3)]));
+      expect(toDemote).toEqual([]);
+    });
+
+    it('relay ⊃ configured → demotes the no-longer-configured ones', () => {
+      const configured = [hex(1)];
+      const current = [hex(1), hex(2), hex(3), bot];
+      const { toPromote, toDemote } = diffRoomAdmins(configured, current, bot);
+      expect(toPromote).toEqual([]);
+      expect(new Set(toDemote)).toEqual(new Set([hex(2), hex(3)]));
+    });
+
+    it('equal sets → no publishes', () => {
+      const configured = [hex(1), hex(2)];
+      const current = [hex(2), hex(1), bot];
+      const diff = diffRoomAdmins(configured, current, bot);
+      expect(diff.toPromote).toEqual([]);
+      expect(diff.toDemote).toEqual([]);
+    });
+
+    it('never demotes the bot key even when it is not in the configured set', () => {
+      // The bot is the relay admin (§10): it is the sole current admin but not
+      // configured — it must NOT be demoted (last-admin guard).
+      const configured: string[] = [];
+      const current = [bot];
+      const { toPromote, toDemote } = diffRoomAdmins(configured, current, bot);
+      expect(toDemote).toEqual([]);
+      expect(toPromote).toEqual([]);
+    });
+
+    it('normalizes npub/mixed-case inputs before diffing', () => {
+      const configured = [npub(hex(1)), hex(2).toUpperCase()];
+      const current = [hex(1), npub(bot)];
+      const { toPromote, toDemote } = diffRoomAdmins(configured, current, bot);
+      expect(toPromote).toEqual([hex(2)]);
+      expect(toDemote).toEqual([]);
+    });
+  });
+
+  describe('9000 admin event shape', () => {
+    it('p tag is exactly ["p", <hex>, "admin"], kind 9000, h = group id', () => {
+      const gid = 'ct_RoomAdmins1';
+      const h = hex(42);
+      const t = putUser(gid, h, 'admin');
+      expect(t.kind).toBe(9000);
+      expect(t.tags[0]).toEqual(['h', gid]);
+      expect(t.tags[1]).toEqual(['p', h, 'admin']);
+    });
+  });
+});

--- a/src/token-gated-rooms/nostr/room-admins.ts
+++ b/src/token-gated-rooms/nostr/room-admins.ts
@@ -1,0 +1,181 @@
+/**
+ * Pure parse / normalize / exemption / diff helpers for the configured
+ * `TG_ROOM_ADMINS` set (Task 08, D9, plan §6.7).
+ *
+ * Kept Nest-free (no DI, no I/O) so the parse/normalize, exemption predicate and
+ * converge-diff are unit-testable in isolation and reusable on the hot path. The
+ * worker-side {@link RoomAdminsService} and the startup
+ * {@link RelayAdminHealthService} compose these; Task 10 consumes
+ * {@link isConfiguredAdmin} for its balance-gating exemption.
+ *
+ * ## Config, not input (§10)
+ * `TG_ROOM_ADMINS` is reviewed, version-controlled config — a comma-separated
+ * list of **nostr pubkeys** (`npub1…` bech32 OR 64-char hex), NOT aeternity
+ * addresses and NOT user input. Every value that leaves this module is a
+ * lowercase 64-hex pubkey ({@link HEX64}); a malformed entry is a startup
+ * configuration error and {@link parseRoomAdmins} THROWS (never silently skips)
+ * so a bad list is caught once at boot, not per-room.
+ */
+
+import { HEX64, normalizePubkey } from './pubkey';
+
+export { HEX64 } from './pubkey';
+
+/** Thrown when `TG_ROOM_ADMINS` contains an entry that is neither npub nor 64-hex. */
+export class RoomAdminConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RoomAdminConfigError';
+  }
+}
+
+/**
+ * Parse + normalize the configured room-admin list into a de-duplicated array of
+ * lowercase 64-hex pubkeys.
+ *
+ * Accepts either the raw comma-separated env string OR an already-split array
+ * (the config layer's `parseList` produces the latter as `config.nostrRoomAdmins`).
+ *
+ * - trims whitespace, ignores empty entries;
+ * - normalizes each entry via {@link normalizePubkey} (npub→hex, hex→lowercased);
+ * - de-duplicates (an npub and its hex form collapse to one);
+ * - THROWS {@link RoomAdminConfigError} naming the first unparseable entry;
+ * - empty / unset input → `[]` (rooms then have only the bot/creator as admin;
+ *   this is NOT an error).
+ */
+export function parseRoomAdmins(
+  input: string | readonly string[] | null | undefined,
+): string[] {
+  const rawEntries: string[] =
+    input == null
+      ? []
+      : Array.isArray(input)
+        ? (input as readonly string[]).slice()
+        : String(input).split(',');
+
+  const seen = new Set<string>();
+  const out: string[] = [];
+
+  for (const raw of rawEntries) {
+    const trimmed = typeof raw === 'string' ? raw.trim() : '';
+    if (trimmed === '') {
+      // Ignore empty entries (trailing comma, blank slot) — not an error.
+      continue;
+    }
+    const hex = normalizePubkey(trimmed);
+    if (!hex) {
+      throw new RoomAdminConfigError(
+        `TG_ROOM_ADMINS contains an unparseable nostr pubkey: "${trimmed}" ` +
+          `(expected an npub1… or 64-char hex)`,
+      );
+    }
+    if (!seen.has(hex)) {
+      seen.add(hex);
+      out.push(hex);
+    }
+  }
+
+  return out;
+}
+
+/**
+ * `true` iff `pubkey` (hex or npub) normalizes to one of the configured room
+ * admins. Format-insensitive: an npub and its hex form both match. A malformed /
+ * unparseable input is never a configured admin (`false`).
+ *
+ * Task 10 consumes this as the **balance-gating exemption predicate**: a
+ * configured admin must NOT be `9001`-removed on balance/eligibility loss — they
+ * are admins, not balance-gated members.
+ */
+export function isConfiguredAdmin(
+  pubkey: string | null | undefined,
+  configuredHex: readonly string[],
+): boolean {
+  const hex = normalizePubkey(pubkey);
+  if (!hex) {
+    return false;
+  }
+  for (const admin of configuredHex) {
+    if (admin === hex) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** The add/demote actions {@link diffRoomAdmins} computes for a single room. */
+export interface RoomAdminDiff {
+  /** Configured admins not yet admin on the relay → publish `9000` role=admin. */
+  toPromote: string[];
+  /** Relay admins no longer configured → publish `9006` set-roles=member (or `9001`). */
+  toDemote: string[];
+}
+
+/**
+ * Diff the configured admin set against the relay's CURRENT admin set (read from
+ * the relay-served `39001`, lowercased hex) for one group.
+ *
+ * - `toPromote` = configured − current  (admins to add/promote, role=admin).
+ * - `toDemote`  = current − configured  (admins to demote/remove), **excluding**
+ *   the bot key, which is the creator + relay admin (§10) and always remains
+ *   admin — so the relay's last-admin guard (`group.rs` set_roles 846–851) is
+ *   never hit in normal operation.
+ *
+ * Equal sets (modulo the always-retained bot key) → both lists empty (no
+ * publishes). Inputs are normalized defensively so a caller passing npub or
+ * mixed-case hex still diffs correctly. Pure: no I/O, no publishes.
+ *
+ * @param configured normalized configured admin hex (output of {@link parseRoomAdmins}).
+ * @param current the relay's current admin pubkeys (hex/npub; normalized here).
+ * @param botPubkey the bot/relay-admin pubkey (hex); never demoted. Optional.
+ */
+export function diffRoomAdmins(
+  configured: readonly string[],
+  current: readonly string[],
+  botPubkey?: string | null,
+): RoomAdminDiff {
+  const configuredSet = toHexSet(configured);
+  const currentSet = toHexSet(current);
+  const botHex = normalizePubkey(botPubkey);
+
+  const toPromote: string[] = [];
+  for (const hex of configuredSet) {
+    if (!currentSet.has(hex)) {
+      toPromote.push(hex);
+    }
+  }
+
+  const toDemote: string[] = [];
+  for (const hex of currentSet) {
+    // Never demote the bot/relay-admin key (creator + relay admin, §10): keeping
+    // it admin guarantees the relay's last-admin guard is not tripped.
+    if (hex === botHex) {
+      continue;
+    }
+    if (!configuredSet.has(hex)) {
+      toDemote.push(hex);
+    }
+  }
+
+  return { toPromote, toDemote };
+}
+
+/** Normalize a list of pubkeys (hex/npub) into a de-duped Set of lowercase hex. */
+function toHexSet(values: readonly string[]): Set<string> {
+  const set = new Set<string>();
+  for (const value of values) {
+    const hex = normalizePubkey(value);
+    if (hex) {
+      set.add(hex);
+    }
+  }
+  return set;
+}
+
+/** Re-exported so call sites validating raw hex share one regex (= identity §6.6). */
+export { normalizePubkey } from './pubkey';
+
+/** Sanity guard a value is HEX64 (used in tests / defensive asserts). */
+export function isHex64(value: string): boolean {
+  return HEX64.test(value);
+}

--- a/src/token-gated-rooms/nostr/shard.ts
+++ b/src/token-gated-rooms/nostr/shard.ts
@@ -1,0 +1,90 @@
+/**
+ * Stable group-id → shard assignment for the relay subscriber (Task 14, plan §7.1).
+ *
+ * The kind-9/11 firehose is split across `TG_SUBSCRIBER_SHARDS` subscriber instances
+ * so a single socket never has to ingest + fan-out every room's messages. Each
+ * instance owns one shard index and only subscribes for / processes events whose
+ * group id maps to its index. The assignment MUST be:
+ *   - **pure + deterministic** — the same gid always maps to the same shard, in
+ *     every process, with no shared state (so two instances agree on ownership);
+ *   - **range-bound** — always in `[0, shardCount)`;
+ *   - **reasonably balanced** — sample gids spread roughly evenly across shards.
+ *
+ * `shardCount = 1` (the default) collapses to "one shard owns everything" → the
+ * function always returns `0`. Raising the count per the §7.1 sizing model splits
+ * the firehose; the partition is the testable unit (how the index reaches an
+ * instance — env/ordinal — is a deployment concern, see {@link resolveShardIndex}).
+ */
+
+/**
+ * FNV-1a 32-bit hash of a UTF-8 string. A small, well-distributed,
+ * dependency-free non-cryptographic hash — we only need an even spread across a
+ * handful of shards, not collision resistance. Kept inline (vs. importing a hash
+ * lib) so the hot path has zero allocation beyond the loop.
+ */
+function fnv1a32(input: string): number {
+  let hash = 0x811c9dc5; // FNV offset basis
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i) & 0xff;
+    // Use the high/low byte separately so multi-byte code units still mix in.
+    const hi = (input.charCodeAt(i) >> 8) & 0xff;
+    if (hi !== 0) {
+      hash = Math.imul(hash, 0x01000193);
+      hash ^= hi;
+    }
+    hash = Math.imul(hash, 0x01000193); // FNV prime, 32-bit via Math.imul
+  }
+  // Math.imul yields a signed 32-bit int; fold to unsigned.
+  return hash >>> 0;
+}
+
+/**
+ * Assign a group id to a shard index in `[0, shardCount)` via a stable hash mod
+ * `shardCount`. Pure: no globals, no I/O. `shardCount <= 1` ⇒ always `0`.
+ *
+ * @param groupId    the NIP-29 group id (= `Token.sale_address`), verbatim.
+ * @param shardCount total number of subscriber shards (`TG_SUBSCRIBER_SHARDS`).
+ */
+export function shardForGroupId(groupId: string, shardCount: number): number {
+  if (!Number.isFinite(shardCount) || shardCount <= 1) {
+    return 0;
+  }
+  const count = Math.floor(shardCount);
+  return fnv1a32(groupId) % count;
+}
+
+/**
+ * Resolve THIS subscriber instance's shard index from the environment. The index
+ * is supplied per-instance via `TG_SUBSCRIBER_SHARD_INDEX` (a 0-based ordinal, e.g.
+ * the StatefulSet pod ordinal). Out-of-range / unset ⇒ `0` (single-shard default),
+ * so an unsharded worker simply owns the whole firehose.
+ *
+ * @param env        process env (injected for testability).
+ * @param shardCount total shard count (`TG_SUBSCRIBER_SHARDS`).
+ */
+export function resolveShardIndex(
+  env: Record<string, string | undefined>,
+  shardCount: number,
+): number {
+  const raw = env.TG_SUBSCRIBER_SHARD_INDEX;
+  if (raw === undefined || raw.trim() === '') {
+    return 0;
+  }
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 0 || parsed >= shardCount) {
+    return 0;
+  }
+  return parsed;
+}
+
+/**
+ * Whether THIS shard (`shardIndex`) owns a given group id. The membership test the
+ * subscriber applies before subscribing-to / processing a room.
+ */
+export function ownsGroupId(
+  groupId: string,
+  shardIndex: number,
+  shardCount: number,
+): boolean {
+  return shardForGroupId(groupId, shardCount) === shardIndex;
+}

--- a/src/token-gated-rooms/notifications/room-membership.notification.spec.ts
+++ b/src/token-gated-rooms/notifications/room-membership.notification.spec.ts
@@ -95,7 +95,7 @@ describe('RoomMembershipNotification', () => {
       change: 'added',
       isFirstGrant: false,
     }).toExpo();
-    expect(regained.body).toContain("back in");
+    expect(regained.body).toContain('back in');
     expect(regained.body).toContain('FOO');
   });
 

--- a/src/token-gated-rooms/notifications/room-membership.notification.spec.ts
+++ b/src/token-gated-rooms/notifications/room-membership.notification.spec.ts
@@ -1,0 +1,96 @@
+import { RoomMembershipNotification } from './room-membership.notification';
+
+describe('RoomMembershipNotification', () => {
+  const SALE = 'ct_sale';
+  const ADDR = 'ak_member' as any;
+
+  it('has the room-membership META and mirrors it onto the instance', () => {
+    expect(RoomMembershipNotification.META.type).toBe('room-membership');
+    expect(RoomMembershipNotification.META.title).toBe('Room membership');
+    expect(RoomMembershipNotification.META.description.length).toBeGreaterThan(
+      0,
+    );
+    const n = new RoomMembershipNotification({
+      saleAddress: SALE,
+      change: 'added',
+    });
+    expect(n.type).toBe(RoomMembershipNotification.META.type);
+    expect(n.title).toBe(RoomMembershipNotification.META.title);
+    expect(n.description).toBe(RoomMembershipNotification.META.description);
+  });
+
+  it('routes through the expo channel only', () => {
+    const n = new RoomMembershipNotification({
+      saleAddress: SALE,
+      change: 'added',
+    });
+    expect(n.via()).toEqual(['expo']);
+  });
+
+  it('builds a dedup key distinct per (saleAddress, change, address)', () => {
+    const added = new RoomMembershipNotification({
+      saleAddress: SALE,
+      change: 'added',
+    });
+    const removed = new RoomMembershipNotification({
+      saleAddress: SALE,
+      change: 'removed',
+    });
+    expect(added.dedupKey({ address: ADDR })).toBe(
+      `room-membership:${SALE}:added:${ADDR}`,
+    );
+    // add vs remove are distinct (never collapse)
+    expect(removed.dedupKey({ address: ADDR })).not.toBe(
+      added.dedupKey({ address: ADDR }),
+    );
+    // repeated adds for same (room, recipient) collapse
+    const added2 = new RoomMembershipNotification({
+      saleAddress: SALE,
+      change: 'added',
+    });
+    expect(added2.dedupKey({ address: ADDR })).toBe(
+      added.dedupKey({ address: ADDR }),
+    );
+    // different recipient → distinct key
+    expect(added.dedupKey({ address: 'ak_other' as any })).not.toBe(
+      added.dedupKey({ address: ADDR }),
+    );
+  });
+
+  it('renders distinct added vs removed copy and a data payload', () => {
+    const added = new RoomMembershipNotification({
+      saleAddress: SALE,
+      symbol: 'FOO',
+      change: 'added',
+    }).toExpo();
+    expect(added.title).toBe('Room access');
+    expect(added.body).toContain('now have access');
+    expect(added.body).toContain('FOO');
+    expect(added.data).toEqual({
+      type: 'room-membership',
+      saleAddress: SALE,
+      change: 'added',
+    });
+
+    const removed = new RoomMembershipNotification({
+      saleAddress: SALE,
+      symbol: 'FOO',
+      change: 'removed',
+    }).toExpo();
+    expect(removed.body).toContain('no longer have access');
+    expect(removed.body).not.toBe(added.body);
+    expect(removed.data).toEqual({
+      type: 'room-membership',
+      saleAddress: SALE,
+      change: 'removed',
+    });
+  });
+
+  it('falls back to generic copy without a symbol', () => {
+    const n = new RoomMembershipNotification({
+      saleAddress: SALE,
+      change: 'added',
+    }).toExpo();
+    expect(n.body).toContain('a room');
+  });
+});

--- a/src/token-gated-rooms/notifications/room-membership.notification.spec.ts
+++ b/src/token-gated-rooms/notifications/room-membership.notification.spec.ts
@@ -57,6 +57,48 @@ describe('RoomMembershipNotification', () => {
     );
   });
 
+  it('keys the dedup on the ledger event id so distinct transitions never collapse', () => {
+    // Two DISTINCT access transitions (e.g. a grant then a real regain within the
+    // dedup TTL) both carry change='added' but different ledger event ids → the
+    // Redis dedup must NOT collapse them (that would drop the "you're back" push).
+    const grant = new RoomMembershipNotification({
+      saleAddress: SALE,
+      change: 'added',
+      accessEventId: '1',
+    });
+    const regain = new RoomMembershipNotification({
+      saleAddress: SALE,
+      change: 'added',
+      accessEventId: '2',
+    });
+    expect(grant.dedupKey({ address: ADDR })).toBe(
+      `room-membership:${SALE}:evt:1:${ADDR}`,
+    );
+    expect(regain.dedupKey({ address: ADDR })).not.toBe(
+      grant.dedupKey({ address: ADDR }),
+    );
+    // Same event redelivered (Bull retry) → SAME key (true-duplicate idempotency).
+    const grantRetry = new RoomMembershipNotification({
+      saleAddress: SALE,
+      change: 'added',
+      accessEventId: '1',
+    });
+    expect(grantRetry.dedupKey({ address: ADDR })).toBe(
+      grant.dedupKey({ address: ADDR }),
+    );
+  });
+
+  it('renders a "you\'re back" copy for a non-first-grant re-add', () => {
+    const regained = new RoomMembershipNotification({
+      saleAddress: SALE,
+      symbol: 'FOO',
+      change: 'added',
+      isFirstGrant: false,
+    }).toExpo();
+    expect(regained.body).toContain("back in");
+    expect(regained.body).toContain('FOO');
+  });
+
   it('renders distinct added vs removed copy and a data payload', () => {
     const added = new RoomMembershipNotification({
       saleAddress: SALE,

--- a/src/token-gated-rooms/notifications/room-membership.notification.ts
+++ b/src/token-gated-rooms/notifications/room-membership.notification.ts
@@ -16,6 +16,12 @@ export interface RoomMembershipParams {
   symbol?: string;
   /** Whether the holder was added to or removed from the room. */
   change: RoomMembershipChange;
+  /**
+   * For an `added` change: whether this is the member's first-ever access grant
+   * (access-ledger plan). `true` → a "welcome" copy; `false` → a "you're back"
+   * copy (access regained after a real lapse). Ignored for `removed`.
+   */
+  isFirstGrant?: boolean;
 }
 
 /**
@@ -53,10 +59,15 @@ export class RoomMembershipNotification implements AppNotification {
     const room = this.params.symbol
       ? `the ${this.params.symbol} room`
       : 'a room';
-    const body =
-      this.params.change === 'added'
-        ? `You now have access to ${room}.`
-        : `You no longer have access to ${room}.`;
+    let body: string;
+    if (this.params.change === 'added') {
+      body =
+        this.params.isFirstGrant === false
+          ? `You're back in ${room}.`
+          : `You now have access to ${room}.`;
+    } else {
+      body = `You no longer have access to ${room}.`;
+    }
     return {
       title: 'Room access',
       body,

--- a/src/token-gated-rooms/notifications/room-membership.notification.ts
+++ b/src/token-gated-rooms/notifications/room-membership.notification.ts
@@ -1,0 +1,70 @@
+import { Notifiable } from '@/notifications/core/notifiable.interface';
+import {
+  AppNotification,
+  ExpoMessageContent,
+  NotificationChannelName,
+  NotificationMeta,
+} from '@/notifications/core/notification.interface';
+
+/** Membership change this notification represents — drives copy + dedup key. */
+export type RoomMembershipChange = 'added' | 'removed';
+
+export interface RoomMembershipParams {
+  /** `Token.sale_address` — the NIP-29 group id / room key. */
+  saleAddress: string;
+  /** Optional human room label (token symbol); falls back to a generic copy. */
+  symbol?: string;
+  /** Whether the holder was added to or removed from the room. */
+  change: RoomMembershipChange;
+}
+
+/**
+ * "You were added to / removed from a token-gated room" — fired off the in-process
+ * `tgr.membership.changed` event (Task 12), with **no relay read**. Membership
+ * pushes are gated by the `room-membership` type switch (catalog) and the per-room
+ * mute (`room_notification_preference`). This is the reference TGR notification:
+ * copy `incoming-transfer.notification.ts`'s shape.
+ */
+export class RoomMembershipNotification implements AppNotification {
+  static readonly META: NotificationMeta = {
+    type: 'room-membership',
+    title: 'Room membership',
+    description:
+      "Notifies you when you're added to or removed from a token-gated room.",
+  };
+
+  readonly type = RoomMembershipNotification.META.type;
+  readonly title = RoomMembershipNotification.META.title;
+  readonly description = RoomMembershipNotification.META.description;
+
+  constructor(private readonly params: RoomMembershipParams) {}
+
+  via(): NotificationChannelName[] {
+    return ['expo'];
+  }
+
+  dedupKey(notifiable: Notifiable): string {
+    // Distinct per (room, change, recipient): an add and a later remove never
+    // collapse, while repeated adds for the same room collapse to one push.
+    return `room-membership:${this.params.saleAddress}:${this.params.change}:${notifiable.address}`;
+  }
+
+  toExpo(): ExpoMessageContent {
+    const room = this.params.symbol
+      ? `the ${this.params.symbol} room`
+      : 'a room';
+    const body =
+      this.params.change === 'added'
+        ? `You now have access to ${room}.`
+        : `You no longer have access to ${room}.`;
+    return {
+      title: 'Room access',
+      body,
+      data: {
+        type: this.type,
+        saleAddress: this.params.saleAddress,
+        change: this.params.change,
+      },
+    };
+  }
+}

--- a/src/token-gated-rooms/notifications/room-membership.notification.ts
+++ b/src/token-gated-rooms/notifications/room-membership.notification.ts
@@ -22,6 +22,15 @@ export interface RoomMembershipParams {
    * copy (access regained after a real lapse). Ignored for `removed`.
    */
   isFirstGrant?: boolean;
+  /**
+   * `room_membership_event.id` — the durable identity of THIS access transition
+   * (access-ledger plan). When present it keys the dedup so distinct transitions
+   * (e.g. a real regain within `NOTIF_DEDUP_TTL_MS`) never collapse onto an earlier
+   * push; the Redis dedup then only collapses true duplicates (Bull re-delivery of
+   * the same event), matching the `notified_at` guard. Falls back to the
+   * (room, change, recipient) key when absent (non-ledger callers).
+   */
+  accessEventId?: string;
 }
 
 /**
@@ -50,8 +59,17 @@ export class RoomMembershipNotification implements AppNotification {
   }
 
   dedupKey(notifiable: Notifiable): string {
-    // Distinct per (room, change, recipient): an add and a later remove never
-    // collapse, while repeated adds for the same room collapse to one push.
+    // Prefer the durable per-transition ledger id: distinct access transitions
+    // (a grant, a later revoke, a real regain) each get a UNIQUE key, so the Redis
+    // dedup only collapses true duplicates (Bull re-delivery of the SAME event) —
+    // never two legitimate transitions that happen to fall within the dedup TTL.
+    // This keeps the Redis backstop consistent with the ledger's `notified_at`
+    // guard (both keyed on the event), so a Redis-suppressed send can never mark an
+    // undelivered distinct transition as notified.
+    if (this.params.accessEventId) {
+      return `room-membership:${this.params.saleAddress}:evt:${this.params.accessEventId}:${notifiable.address}`;
+    }
+    // Fallback (non-ledger callers): per (room, change, recipient).
     return `room-membership:${this.params.saleAddress}:${this.params.change}:${notifiable.address}`;
   }
 

--- a/src/token-gated-rooms/notifications/room-message.notification.spec.ts
+++ b/src/token-gated-rooms/notifications/room-message.notification.spec.ts
@@ -1,0 +1,48 @@
+import { RoomMessageNotification } from './room-message.notification';
+
+describe('RoomMessageNotification', () => {
+  const SALE = 'ct_sale';
+  const ADDR = 'ak_member' as any;
+
+  it('has the room-messages META and mirrors it onto the instance', () => {
+    expect(RoomMessageNotification.META.type).toBe('room-messages');
+    expect(RoomMessageNotification.META.title).toBe('Room messages');
+    expect(RoomMessageNotification.META.description.length).toBeGreaterThan(0);
+    const n = new RoomMessageNotification({ saleAddress: SALE });
+    expect(n.type).toBe(RoomMessageNotification.META.type);
+    expect(n.title).toBe(RoomMessageNotification.META.title);
+    expect(n.description).toBe(RoomMessageNotification.META.description);
+  });
+
+  it('routes through the expo channel only', () => {
+    const n = new RoomMessageNotification({ saleAddress: SALE });
+    expect(n.via()).toEqual(['expo']);
+  });
+
+  it('builds a room-scoped dedup key (with optional messageKey suffix)', () => {
+    const base = new RoomMessageNotification({ saleAddress: SALE });
+    expect(base.dedupKey({ address: ADDR })).toBe(
+      `room-messages:${SALE}:${ADDR}`,
+    );
+    const keyed = new RoomMessageNotification({
+      saleAddress: SALE,
+      messageKey: 'w1',
+    });
+    expect(keyed.dedupKey({ address: ADDR })).toBe(
+      `room-messages:${SALE}:${ADDR}:w1`,
+    );
+    expect(keyed.dedupKey({ address: ADDR })).not.toBe(
+      base.dedupKey({ address: ADDR }),
+    );
+  });
+
+  it('renders the expo body + room-scoped data payload', () => {
+    const msg = new RoomMessageNotification({
+      saleAddress: SALE,
+      symbol: 'BAR',
+    }).toExpo();
+    expect(msg.title).toBe('New messages');
+    expect(msg.body).toContain('BAR');
+    expect(msg.data).toEqual({ type: 'room-messages', saleAddress: SALE });
+  });
+});

--- a/src/token-gated-rooms/notifications/room-message.notification.ts
+++ b/src/token-gated-rooms/notifications/room-message.notification.ts
@@ -1,0 +1,66 @@
+import { Notifiable } from '@/notifications/core/notifiable.interface';
+import {
+  AppNotification,
+  ExpoMessageContent,
+  NotificationChannelName,
+  NotificationMeta,
+} from '@/notifications/core/notification.interface';
+
+export interface RoomMessageParams {
+  /** `Token.sale_address` — the NIP-29 group id / room key. */
+  saleAddress: string;
+  /** Optional human room label (token symbol); falls back to a generic copy. */
+  symbol?: string;
+  /**
+   * Optional opaque per-message key used by the relay subscriber (Task 14) to keep
+   * dedup keys distinct across coalesced new-message pushes (e.g. a coalescing
+   * window id or the latest event id). Omitted → one push per (room, recipient).
+   */
+  messageKey?: string;
+}
+
+/**
+ * "New messages in a token-gated room" — the notification **class** is owned and
+ * defined here (Task 12) so the catalog is complete (`type: 'room-messages'`), but
+ * the relay-read subscriber that FIRES it (dedup via `room_message_seen`,
+ * coalescing, sharding) is Task 14. Task 12 only defines the class + its catalog
+ * entry; it does not dispatch this notification.
+ */
+export class RoomMessageNotification implements AppNotification {
+  static readonly META: NotificationMeta = {
+    type: 'room-messages',
+    title: 'Room messages',
+    description: 'Notifies you about new messages in a token-gated room.',
+  };
+
+  readonly type = RoomMessageNotification.META.type;
+  readonly title = RoomMessageNotification.META.title;
+  readonly description = RoomMessageNotification.META.description;
+
+  constructor(private readonly params: RoomMessageParams) {}
+
+  via(): NotificationChannelName[] {
+    return ['expo'];
+  }
+
+  dedupKey(notifiable: Notifiable): string {
+    // Room-scoped per recipient; an optional messageKey lets Task 14 distinguish
+    // coalesced new-message pushes without re-defining this class.
+    const suffix = this.params.messageKey ? `:${this.params.messageKey}` : '';
+    return `room-messages:${this.params.saleAddress}:${notifiable.address}${suffix}`;
+  }
+
+  toExpo(): ExpoMessageContent {
+    const room = this.params.symbol
+      ? `the ${this.params.symbol} room`
+      : 'a room';
+    return {
+      title: 'New messages',
+      body: `There are new messages in ${room}.`,
+      data: {
+        type: this.type,
+        saleAddress: this.params.saleAddress,
+      },
+    };
+  }
+}

--- a/src/token-gated-rooms/notifications/room-mute.message.spec.ts
+++ b/src/token-gated-rooms/notifications/room-mute.message.spec.ts
@@ -1,0 +1,71 @@
+import {
+  buildRoomMuteMessage,
+  canonicalRoomMuteHash,
+} from './room-mute.message';
+import { buildPreferencesUpdateMessage } from '@/notifications/notifications.constants';
+
+const ADDR = 'ak_member';
+const SALE = 'ct_sale';
+const NONCE = 'abcdef0123456789';
+
+describe('room-mute.message', () => {
+  describe('canonicalRoomMuteHash', () => {
+    it('binds to the (muted, mute_all) tuple', () => {
+      const a = canonicalRoomMuteHash(true, true);
+      const b = canonicalRoomMuteHash(false, true);
+      const c = canonicalRoomMuteHash(true, false);
+      expect(a).not.toBe(b); // muted differs
+      expect(a).not.toBe(c); // mute_all differs
+    });
+
+    it('distinguishes "mute_all omitted" from explicit true/false', () => {
+      const omitted = canonicalRoomMuteHash(true, undefined);
+      const explicitFalse = canonicalRoomMuteHash(true, false);
+      const explicitTrue = canonicalRoomMuteHash(true, true);
+      expect(omitted).not.toBe(explicitFalse);
+      expect(omitted).not.toBe(explicitTrue);
+    });
+
+    it('is stable for the same inputs (hex sha256)', () => {
+      expect(canonicalRoomMuteHash(true, undefined)).toBe(
+        canonicalRoomMuteHash(true, undefined),
+      );
+      expect(canonicalRoomMuteHash(true, undefined)).toMatch(/^[0-9a-f]{64}$/);
+    });
+  });
+
+  describe('buildRoomMuteMessage', () => {
+    it('produces the documented 4-line format', () => {
+      const msg = buildRoomMuteMessage(ADDR, NONCE, SALE, true, undefined);
+      expect(msg).toBe(
+        `Superhero Rooms\nMute ${SALE} for ${ADDR}\nbody: ${canonicalRoomMuteHash(
+          true,
+          undefined,
+        )}\nnonce: ${NONCE}`,
+      );
+    });
+
+    it('is distinct from the preferences-update message (no cross-replay)', () => {
+      const roomMsg = buildRoomMuteMessage(ADDR, NONCE, SALE, true, undefined);
+      const prefMsg = buildPreferencesUpdateMessage(ADDR, NONCE, [
+        { type: 'room-messages', enabled: false },
+      ]);
+      expect(roomMsg).not.toBe(prefMsg);
+      // different first line / intent header
+      expect(roomMsg.startsWith('Superhero Rooms')).toBe(true);
+      expect(prefMsg.startsWith('Superhero Notifications')).toBe(true);
+    });
+
+    it('binds to the room — swapping saleAddress changes the message', () => {
+      const a = buildRoomMuteMessage(ADDR, NONCE, 'ct_a', true, false);
+      const b = buildRoomMuteMessage(ADDR, NONCE, 'ct_b', true, false);
+      expect(a).not.toBe(b);
+    });
+
+    it('binds to the body — swapping muted changes the message', () => {
+      const a = buildRoomMuteMessage(ADDR, NONCE, SALE, true, false);
+      const b = buildRoomMuteMessage(ADDR, NONCE, SALE, false, false);
+      expect(a).not.toBe(b);
+    });
+  });
+});

--- a/src/token-gated-rooms/notifications/room-mute.message.ts
+++ b/src/token-gated-rooms/notifications/room-mute.message.ts
@@ -1,0 +1,47 @@
+import { createHash } from 'crypto';
+
+/**
+ * Canonical hash of the room-mute body the user signs. Binds the signature to the
+ * exact `(muted, mute_all)` delta so a captured nonce+sig cannot be replayed with
+ * a swapped payload (mirrors `canonicalPreferencesHash`).
+ *
+ * `mute_all` is tri-state on the wire (`true` / `false` / omitted = "don't
+ * touch"). We serialize the absent case distinctly (`-`) so a signature for
+ * "set mute_all=false" cannot be replayed as "leave mute_all untouched" or vice
+ * versa. ASCII-only tokens — same codepoint-ordering rationale as the prefs hash.
+ */
+export function canonicalRoomMuteHash(
+  muted: boolean,
+  muteAll?: boolean,
+): string {
+  const muteAllToken = muteAll === undefined ? '-' : muteAll ? '1' : '0';
+  const canonical = `muted=${muted ? '1' : '0'};mute_all=${muteAllToken}`;
+  return createHash('sha256').update(canonical).digest('hex');
+}
+
+/**
+ * Intent-bound message for the per-room mute flow (Task 13 Req 5). Distinct from
+ * `buildPreferencesUpdateMessage` (different first/second lines) AND from the
+ * device-link/unlink messages, so a signature captured for any other intent
+ * cannot be replayed here. The `sale_address` and the body hash are committed to
+ * the signature, so a sig for one room — or for a different `(muted, mute_all)` —
+ * is rejected.
+ *
+ * Format (reproduce byte-for-byte on the client):
+ *   Superhero Rooms
+ *   Mute <saleAddress> for <address>
+ *   body: <sha256(muted|mute_all)>
+ *   nonce: <nonce>
+ */
+export function buildRoomMuteMessage(
+  address: string,
+  nonce: string,
+  saleAddress: string,
+  muted: boolean,
+  muteAll?: boolean,
+): string {
+  return `Superhero Rooms\nMute ${saleAddress} for ${address}\nbody: ${canonicalRoomMuteHash(
+    muted,
+    muteAll,
+  )}\nnonce: ${nonce}`;
+}

--- a/src/token-gated-rooms/observability/__tests__/tgr-metrics.collector.spec.ts
+++ b/src/token-gated-rooms/observability/__tests__/tgr-metrics.collector.spec.ts
@@ -1,0 +1,452 @@
+import {
+  AlertInputs,
+  evaluateAlerts,
+  formatAlertLogLine,
+  formatMetricsLogLine,
+  FiredAlert,
+  mapQueueGauge,
+  overallStatusFrom,
+  QueueGauge,
+  ResolvedThresholds,
+  safePercent,
+  safeRatio,
+  TgrMetricsReport,
+  worseSeverity,
+} from '../tgr-metrics.collector';
+import { TGR_ALERT_RULES } from '../tgr-metrics.constants';
+
+const THRESHOLDS: ResolvedThresholds = {
+  failedRoomRatio: 0.05,
+  driftRatio: 0.02,
+  reconcileStaleSeconds: 86400,
+  relayDownAlertSeconds: 60,
+  queueBacklogThreshold: 5000,
+  queueLagAlertMs: 300000,
+  roomNotifyDepthBreak: 10000,
+};
+
+const emptyQueues: QueueGauge[] = [];
+
+function baseInputs(over: Partial<AlertInputs> = {}): AlertInputs {
+  return {
+    roomFailed: 0,
+    roomTotal: 1000,
+    driftCount: 0,
+    membershipTotal: 1000,
+    reconcileMaxAgeS: 0,
+    reconcileStaleCount: 0,
+    relayWriterConnected: true,
+    relaySubscriberConnected: true,
+    relayWriterDownSeconds: 0,
+    queues: emptyQueues,
+    ...over,
+  };
+}
+
+function ruleOf(alerts: FiredAlert[], rule: string): FiredAlert | undefined {
+  return alerts.find((a) => a.rule === rule);
+}
+
+describe('safeRatio / safePercent (zero-total guards)', () => {
+  it('guards divide-by-zero → 0, never NaN', () => {
+    expect(safeRatio(5, 0)).toBe(0);
+    expect(safePercent(5, 0)).toBe(0);
+    expect(Number.isNaN(safeRatio(0, 0))).toBe(false);
+  });
+
+  it('computes correctly otherwise', () => {
+    expect(safeRatio(1, 4)).toBe(0.25);
+    expect(safePercent(1, 4)).toBe(25);
+    expect(safePercent(1, 3)).toBe(33.33);
+  });
+});
+
+describe('worseSeverity / overallStatusFrom', () => {
+  it('picks the worse of two severities', () => {
+    expect(worseSeverity('ok', 'warning')).toBe('warning');
+    expect(worseSeverity('warning', 'critical')).toBe('critical');
+    expect(worseSeverity('critical', 'warning')).toBe('critical');
+  });
+
+  it('aggregates the alert list to the worst severity', () => {
+    expect(overallStatusFrom([])).toBe('healthy');
+    expect(
+      overallStatusFrom([
+        { rule: 'a', severity: 'warning', value: 1, threshold: 0 },
+      ]),
+    ).toBe('warning');
+    expect(
+      overallStatusFrom([
+        { rule: 'a', severity: 'warning', value: 1, threshold: 0 },
+        { rule: 'b', severity: 'critical', value: 1, threshold: 0 },
+      ]),
+    ).toBe('critical');
+  });
+});
+
+describe('mapQueueGauge', () => {
+  it('computes depth fields + lag = now − head.timestamp', () => {
+    const now = 1_000_000;
+    const gauge = mapQueueGauge(
+      { key: 'publish', name: 'worker:publish-nip29' },
+      { waiting: 7, active: 1, delayed: 2, failed: 3 },
+      true,
+      now - 4500,
+      now,
+    );
+    expect(gauge.waiting).toBe(7);
+    expect(gauge.active).toBe(1);
+    expect(gauge.delayed).toBe(2);
+    expect(gauge.failed).toBe(3);
+    expect(gauge.paused).toBe(true);
+    expect(gauge.lagMs).toBe(4500);
+  });
+
+  it('lag is null when there is no waiting job', () => {
+    const gauge = mapQueueGauge(
+      { key: 'backfill', name: 'worker:room-backfill' },
+      { waiting: 0 },
+      false,
+      null,
+      1000,
+    );
+    expect(gauge.lagMs).toBeNull();
+    expect(gauge.waiting).toBe(0);
+  });
+
+  it('absent queue (null counts) → all-null gauge', () => {
+    const gauge = mapQueueGauge(
+      { key: 'notify', name: 'worker:room-notify' },
+      null,
+      null,
+      null,
+    );
+    expect(gauge).toMatchObject({
+      key: 'notify',
+      waiting: null,
+      paused: null,
+      lagMs: null,
+    });
+  });
+
+  it('clamps negative lag (clock skew) to 0', () => {
+    const gauge = mapQueueGauge(
+      { key: 'publish', name: 'worker:publish-nip29' },
+      { waiting: 1 },
+      false,
+      2000, // head timestamp in the "future"
+      1000,
+    );
+    expect(gauge.lagMs).toBe(0);
+  });
+});
+
+describe('evaluateAlerts — table-driven (Req 4)', () => {
+  it('stays quiet when everything is within thresholds', () => {
+    expect(evaluateAlerts(baseInputs(), THRESHOLDS)).toEqual([]);
+  });
+
+  // 4.1 failed_room_ratio
+  it('failed_room_ratio: fires warning above threshold, critical at 2×', () => {
+    // 6% > 5% → warning (not yet 2×=10%)
+    const warn = evaluateAlerts(
+      baseInputs({ roomFailed: 60, roomTotal: 1000 }),
+      THRESHOLDS,
+    );
+    expect(ruleOf(warn, TGR_ALERT_RULES.FAILED_ROOM_RATIO)?.severity).toBe(
+      'warning',
+    );
+    // 11% > 10% → critical
+    const crit = evaluateAlerts(
+      baseInputs({ roomFailed: 110, roomTotal: 1000 }),
+      THRESHOLDS,
+    );
+    expect(ruleOf(crit, TGR_ALERT_RULES.FAILED_ROOM_RATIO)?.severity).toBe(
+      'critical',
+    );
+    // exactly at threshold → quiet (strictly greater)
+    const quiet = evaluateAlerts(
+      baseInputs({ roomFailed: 50, roomTotal: 1000 }),
+      THRESHOLDS,
+    );
+    expect(ruleOf(quiet, TGR_ALERT_RULES.FAILED_ROOM_RATIO)).toBeUndefined();
+  });
+
+  // 4.2 drift_ratio
+  it('drift_ratio: warning above threshold; quiet at/below', () => {
+    const fire = evaluateAlerts(
+      baseInputs({ driftCount: 30, membershipTotal: 1000 }),
+      THRESHOLDS,
+    );
+    expect(ruleOf(fire, TGR_ALERT_RULES.DRIFT_RATIO)?.severity).toBe('warning');
+    const quiet = evaluateAlerts(
+      baseInputs({ driftCount: 20, membershipTotal: 1000 }),
+      THRESHOLDS,
+    );
+    expect(ruleOf(quiet, TGR_ALERT_RULES.DRIFT_RATIO)).toBeUndefined();
+  });
+
+  // 4.3 stale_reconcile
+  it('stale_reconcile: critical when max-age > SLA or any stale row', () => {
+    const byAge = evaluateAlerts(
+      baseInputs({ reconcileMaxAgeS: 86401 }),
+      THRESHOLDS,
+    );
+    expect(ruleOf(byAge, TGR_ALERT_RULES.STALE_RECONCILE)?.severity).toBe(
+      'critical',
+    );
+    const byCount = evaluateAlerts(
+      baseInputs({ reconcileMaxAgeS: 0, reconcileStaleCount: 3 }),
+      THRESHOLDS,
+    );
+    expect(ruleOf(byCount, TGR_ALERT_RULES.STALE_RECONCILE)?.severity).toBe(
+      'critical',
+    );
+    const quiet = evaluateAlerts(
+      baseInputs({ reconcileMaxAgeS: 86400, reconcileStaleCount: 0 }),
+      THRESHOLDS,
+    );
+    expect(ruleOf(quiet, TGR_ALERT_RULES.STALE_RECONCILE)).toBeUndefined();
+  });
+
+  // 4.4 relay_down (debounce)
+  it('relay_down: writer down past debounce → critical; within debounce → quiet', () => {
+    const debounced = evaluateAlerts(
+      baseInputs({ relayWriterConnected: false, relayWriterDownSeconds: 30 }),
+      THRESHOLDS,
+    );
+    expect(ruleOf(debounced, TGR_ALERT_RULES.RELAY_DOWN)).toBeUndefined();
+
+    const fired = evaluateAlerts(
+      baseInputs({ relayWriterConnected: false, relayWriterDownSeconds: 61 }),
+      THRESHOLDS,
+    );
+    expect(ruleOf(fired, TGR_ALERT_RULES.RELAY_DOWN)?.severity).toBe(
+      'critical',
+    );
+  });
+
+  it('relay_down: subscriber-only down → warning (writer up)', () => {
+    const fired = evaluateAlerts(
+      baseInputs({
+        relayWriterConnected: true,
+        relaySubscriberConnected: false,
+      }),
+      THRESHOLDS,
+    );
+    expect(ruleOf(fired, TGR_ALERT_RULES.RELAY_DOWN)?.severity).toBe('warning');
+  });
+
+  // 4.5 queue_backlog
+  it('queue_backlog: depth above threshold → warning, 2× → critical', () => {
+    const warn = evaluateAlerts(
+      baseInputs({
+        queues: [
+          mapQueueGauge(
+            { key: 'publish', name: 'worker:publish-nip29' },
+            { waiting: 6000 },
+            false,
+            null,
+            1000,
+          ),
+        ],
+      }),
+      THRESHOLDS,
+    );
+    expect(ruleOf(warn, TGR_ALERT_RULES.QUEUE_BACKLOG)?.severity).toBe(
+      'warning',
+    );
+
+    const crit = evaluateAlerts(
+      baseInputs({
+        queues: [
+          mapQueueGauge(
+            { key: 'publish', name: 'worker:publish-nip29' },
+            { waiting: 10001 },
+            false,
+            null,
+            1000,
+          ),
+        ],
+      }),
+      THRESHOLDS,
+    );
+    expect(ruleOf(crit, TGR_ALERT_RULES.QUEUE_BACKLOG)?.severity).toBe(
+      'critical',
+    );
+  });
+
+  it('queue_backlog: lag above threshold also fires', () => {
+    const fired = evaluateAlerts(
+      baseInputs({
+        queues: [
+          mapQueueGauge(
+            { key: 'backfill', name: 'worker:room-backfill' },
+            { waiting: 1 },
+            false,
+            1000 - 400000, // 400s old > 300s threshold
+            1000,
+          ),
+        ],
+      }),
+      THRESHOLDS,
+    );
+    expect(ruleOf(fired, TGR_ALERT_RULES.QUEUE_BACKLOG)?.severity).toBe(
+      'warning',
+    );
+  });
+
+  it('queue_backlog: room-notify depth-break fires below generic threshold', () => {
+    const tighter: ResolvedThresholds = {
+      ...THRESHOLDS,
+      roomNotifyDepthBreak: 100,
+      queueBacklogThreshold: 5000,
+    };
+    const fired = evaluateAlerts(
+      baseInputs({
+        queues: [
+          mapQueueGauge(
+            { key: 'notify', name: 'worker:room-notify' },
+            { waiting: 200 }, // < 5000 generic, > 100 depth-break
+            false,
+            null,
+            1000,
+          ),
+        ],
+      }),
+      tighter,
+    );
+    expect(ruleOf(fired, TGR_ALERT_RULES.QUEUE_BACKLOG)?.value).toContain(
+      'notify',
+    );
+  });
+});
+
+describe('formatMetricsLogLine (Req 2 — every key once)', () => {
+  const report: TgrMetricsReport = {
+    overallStatus: 'healthy',
+    queues: [
+      mapQueueGauge(
+        { key: 'publish', name: 'worker:publish-nip29' },
+        { waiting: 5 },
+        false,
+        900,
+        1900,
+      ),
+      mapQueueGauge(
+        { key: 'backfill', name: 'worker:room-backfill' },
+        { waiting: 2 },
+        false,
+        null,
+        1900,
+      ),
+      mapQueueGauge(
+        { key: 'reconcile_balance', name: 'main:reconcile-balance' },
+        { waiting: 0 },
+        false,
+        null,
+        1900,
+      ),
+      mapQueueGauge(
+        { key: 'reconcile_membership', name: 'worker:reconcile-membership' },
+        { waiting: 1 },
+        false,
+        null,
+        1900,
+      ),
+      mapQueueGauge(
+        { key: 'notify', name: 'worker:room-notify' },
+        null,
+        null,
+        null,
+        1900,
+      ),
+    ],
+    relay: {
+      writerConnected: true,
+      subscriberConnected: false,
+      reconnects: 2,
+      lastDisconnectAt: null,
+      writerDownSeconds: 0,
+    },
+    relayState: { pending_add: 1, added: 2, pending_remove: 3, removed: 4 },
+    roomState: { none: 5, pending: 6, created: 7, failed: 8, deleted: 9 },
+    drift: { count: 4, ratio: 0.1, membershipTotal: 40 },
+    reconcile: { maxAgeSeconds: 120, staleCount: 0 },
+    backfill: {
+      created: 7,
+      total: 35,
+      failed: 8,
+      percent: 20,
+      cursorHeight: 42,
+    },
+    counters: { publishOk: 11, publishFailed: 1, ackTimeouts: 0 },
+    alerts: [],
+    processLocal: true,
+  };
+
+  const EXPECTED_KEYS = [
+    'publish_q_depth',
+    'publish_q_lag_ms',
+    'backfill_q_depth',
+    'reconcile_balance_q_depth',
+    'reconcile_membership_q_depth',
+    'notify_q_depth',
+    'relay_writer_connected',
+    'relay_subscriber_connected',
+    'relay_reconnects',
+    'ms_pending_add',
+    'ms_added',
+    'ms_pending_remove',
+    'ms_removed',
+    'room_none',
+    'room_pending',
+    'room_created',
+    'room_failed',
+    'room_deleted',
+    'drift_count',
+    'drift_ratio',
+    'reconcile_max_age_s',
+    'reconcile_stale_count',
+    'backfill_created',
+    'backfill_total',
+    'backfill_pct',
+    'publish_ok',
+    'publish_failed',
+    'ack_timeouts',
+  ];
+
+  it('contains the [TgrMetrics] tag + every Req-2 key exactly once', () => {
+    const line = formatMetricsLogLine(report);
+    expect(line.startsWith('[TgrMetrics]')).toBe(true);
+    for (const key of EXPECTED_KEYS) {
+      const matches = line.match(new RegExp(`(?:^| )${key}=`, 'g')) ?? [];
+      expect(matches.length).toBe(1);
+    }
+  });
+
+  it('renders absent queue depth as n/a + values from the report', () => {
+    const line = formatMetricsLogLine(report);
+    expect(line).toContain('publish_q_depth=5');
+    expect(line).toContain('publish_q_lag_ms=1000');
+    expect(line).toContain('notify_q_depth=n/a');
+    expect(line).toContain('ms_pending_add=1');
+    expect(line).toContain('room_created=7');
+    expect(line).toContain('drift_count=4');
+    expect(line).toContain('backfill_pct=20');
+  });
+});
+
+describe('formatAlertLogLine', () => {
+  it('renders rule=/value=/threshold=/severity=', () => {
+    const line = formatAlertLogLine({
+      rule: TGR_ALERT_RULES.DRIFT_RATIO,
+      severity: 'warning',
+      value: 0.1,
+      threshold: 0.02,
+    });
+    expect(line).toBe(
+      '[TgrAlert] rule=drift_ratio value=0.1 threshold=0.02 severity=warning',
+    );
+  });
+});

--- a/src/token-gated-rooms/observability/__tests__/tgr-metrics.constants.spec.ts
+++ b/src/token-gated-rooms/observability/__tests__/tgr-metrics.constants.spec.ts
@@ -1,0 +1,40 @@
+import {
+  resolveMetricsCron,
+  TGR_METRICS_CRON_DEFAULT,
+  TGR_METRICS_QUEUES,
+} from '../tgr-metrics.constants';
+
+describe('resolveMetricsCron', () => {
+  it('defaults to the 1-min cron when unset/blank', () => {
+    expect(resolveMetricsCron({})).toBe(TGR_METRICS_CRON_DEFAULT);
+    expect(resolveMetricsCron({ TG_METRICS_CRON: '   ' })).toBe(
+      TGR_METRICS_CRON_DEFAULT,
+    );
+  });
+
+  it('accepts a 5- or 6-field crontab', () => {
+    expect(resolveMetricsCron({ TG_METRICS_CRON: '*/5 * * * *' })).toBe(
+      '*/5 * * * *',
+    );
+    expect(resolveMetricsCron({ TG_METRICS_CRON: '0 */1 * * * *' })).toBe(
+      '0 */1 * * * *',
+    );
+  });
+
+  it('falls back on a malformed expression', () => {
+    expect(resolveMetricsCron({ TG_METRICS_CRON: 'every-minute' })).toBe(
+      TGR_METRICS_CRON_DEFAULT,
+    );
+  });
+});
+
+describe('TGR_METRICS_QUEUES', () => {
+  it('lists the five canonical TGR queues with prefixed names', () => {
+    const byKey = Object.fromEntries(TGR_METRICS_QUEUES.map((q) => [q.key, q]));
+    expect(byKey.publish.name).toBe('worker:publish-nip29');
+    expect(byKey.backfill.name).toBe('worker:room-backfill');
+    expect(byKey.reconcile_balance.name).toBe('main:reconcile-balance');
+    expect(byKey.reconcile_membership.name).toBe('worker:reconcile-membership');
+    expect(byKey.notify.name).toBe('worker:room-notify');
+  });
+});

--- a/src/token-gated-rooms/observability/__tests__/tgr-metrics.controller.spec.ts
+++ b/src/token-gated-rooms/observability/__tests__/tgr-metrics.controller.spec.ts
@@ -1,0 +1,67 @@
+import { TgrMetricsController } from '../tgr-metrics.controller';
+import type { TgrMetricsReport } from '../tgr-metrics.collector';
+
+describe('TgrMetricsController', () => {
+  function report(over: Partial<TgrMetricsReport> = {}): TgrMetricsReport {
+    return {
+      overallStatus: 'healthy',
+      queues: [],
+      relay: {
+        writerConnected: false,
+        subscriberConnected: false,
+        reconnects: 0,
+        lastDisconnectAt: null,
+        writerDownSeconds: 0,
+      },
+      relayState: { pending_add: 0, added: 0, pending_remove: 0, removed: 0 },
+      roomState: { none: 0, pending: 0, created: 0, failed: 0, deleted: 0 },
+      drift: { count: 0, ratio: 0, membershipTotal: 0 },
+      reconcile: { maxAgeSeconds: 0, staleCount: 0 },
+      backfill: {
+        created: 0,
+        total: 0,
+        failed: 0,
+        percent: 0,
+        cursorHeight: null,
+      },
+      counters: { publishOk: 0, publishFailed: 0, ackTimeouts: 0 },
+      alerts: [],
+      processLocal: true,
+      ...over,
+    };
+  }
+
+  it('serves the report from the main process with processLocal=false + slos + thresholds', async () => {
+    const collect = jest.fn(async (processLocal: boolean) =>
+      report({ processLocal }),
+    );
+    const thresholds = { driftRatio: 0.02 } as any;
+    const service: any = {
+      collect,
+      getThresholds: () => thresholds,
+    };
+    const controller = new TgrMetricsController(service);
+
+    const result = await controller.getMetrics();
+
+    // Controller MUST request the main-served (non-authoritative) view.
+    expect(collect).toHaveBeenCalledWith(false);
+    expect(result.processLocal).toBe(false);
+    expect(result.thresholds).toBe(thresholds);
+    expect(result.slos).toMatchObject({
+      roomCreatedWithinSeconds: 300,
+      membershipPublishedWithinSeconds: 60,
+    });
+    expect(result.overallStatus).toBe('healthy');
+  });
+
+  it('propagates a critical overallStatus', async () => {
+    const service: any = {
+      collect: async () => report({ overallStatus: 'critical' }),
+      getThresholds: () => ({}),
+    };
+    const controller = new TgrMetricsController(service);
+    const result = await controller.getMetrics();
+    expect(result.overallStatus).toBe('critical');
+  });
+});

--- a/src/token-gated-rooms/observability/__tests__/tgr-metrics.integration.spec.ts
+++ b/src/token-gated-rooms/observability/__tests__/tgr-metrics.integration.spec.ts
@@ -1,0 +1,212 @@
+import 'dotenv/config';
+import { DataSource, Repository } from 'typeorm';
+import { DATABASE_CONFIG } from '@/configs/database';
+import { Token } from '@/tokens/entities/token.entity';
+import { RoomMembership } from '../../entities/room-membership.entity';
+import { RoomBackfillState } from '../../entities/room-backfill-state.entity';
+import { TgrMetricsService } from '../tgr-metrics.service';
+import { __resetTgrMetricsForTests } from '../tgr-metrics';
+
+/**
+ * DB integration for the Task 15 metrics surface. Mirrors the Task 09 isolated-
+ * schema harness: a real Postgres backs `token` + `room_membership` +
+ * `room_backfill_state` in a DEDICATED `tgr15_test` schema (created/dropped here,
+ * `synchronize: true`), so the gauge `GROUP BY`/counts run against real rows and
+ * never touch the shared `public` schema.
+ *
+ * No relay socket is opened — the relay/queue counters are exercised by the unit
+ * tests; here we assert the Postgres gauges (distributions, drift, reconcile age,
+ * backfill progress) + the cron log line + the alert evaluation end-to-end.
+ *
+ * Requires the local Postgres (`DB_HOST`); auto-skips otherwise so unit-only runs
+ * stay green.
+ */
+const HAS_DB = !!process.env.DB_HOST;
+const d = HAS_DB ? describe : describe.skip;
+
+const SCHEMA = 'tgr15_test';
+
+const makeTokenRow = (
+  sale: string,
+  state: string,
+  hasRoom = state === 'created',
+): Partial<Token> => ({
+  sale_address: sale,
+  address: 'ct_token_' + sale,
+  name: 'N' + sale,
+  symbol: 'SYM',
+  owner_address: 'ak_owner_' + sale,
+  creator_address: 'ak_creator_' + sale,
+  nostr_room_state: state as any,
+  has_nostr_room: hasRoom,
+});
+
+const makeMembershipRow = (
+  sale: string,
+  member: string,
+  relayState: string,
+  reconciledAt: Date | null,
+): Partial<RoomMembership> => ({
+  sale_address: sale,
+  member_address: member,
+  member_pubkey: member.padEnd(64, '0'),
+  role: 'member',
+  eligible: true,
+  relay_state: relayState as any,
+  last_reconciled_at: reconciledAt as any,
+});
+
+d('TGR metrics surface (integration)', () => {
+  let ds: DataSource;
+  let tokenRepo: Repository<Token>;
+  let membershipRepo: Repository<RoomMembership>;
+  let stateRepo: Repository<RoomBackfillState>;
+  let service: TgrMetricsService;
+
+  const CONFIG = { roomNotifyDepthBreak: 10000 } as any;
+
+  beforeAll(async () => {
+    const boot = new DataSource({
+      ...(DATABASE_CONFIG as any),
+      synchronize: false,
+      entities: [],
+    });
+    await boot.initialize();
+    await boot.query(`DROP SCHEMA IF EXISTS "${SCHEMA}" CASCADE`);
+    await boot.query(`CREATE SCHEMA "${SCHEMA}"`);
+    await boot.destroy();
+
+    ds = new DataSource({
+      ...(DATABASE_CONFIG as any),
+      schema: SCHEMA,
+      synchronize: true,
+      entities: [Token, RoomMembership, RoomBackfillState],
+    });
+    await ds.initialize();
+
+    tokenRepo = ds.getRepository(Token);
+    membershipRepo = ds.getRepository(RoomMembership);
+    stateRepo = ds.getRepository(RoomBackfillState);
+  }, 60_000);
+
+  beforeEach(async () => {
+    await membershipRepo.clear();
+    await tokenRepo.clear();
+    await stateRepo.clear();
+    __resetTgrMetricsForTests();
+    service = new TgrMetricsService(
+      membershipRepo,
+      tokenRepo,
+      stateRepo,
+      CONFIG,
+    );
+  });
+
+  afterAll(async () => {
+    if (ds?.isInitialized) {
+      await ds.destroy();
+    }
+    const cleanup = new DataSource({
+      ...(DATABASE_CONFIG as any),
+      synchronize: false,
+      entities: [],
+    });
+    await cleanup.initialize();
+    await cleanup.query(`DROP SCHEMA IF EXISTS "${SCHEMA}" CASCADE`);
+    await cleanup.destroy();
+  }, 60_000);
+
+  it('reports exact distribution counts, backfill created/total, and reconcile age', async () => {
+    const recent = new Date();
+    await tokenRepo.save([
+      tokenRepo.create(makeTokenRow('ct_a', 'created')),
+      tokenRepo.create(makeTokenRow('ct_b', 'created')),
+      tokenRepo.create(makeTokenRow('ct_c', 'pending', false)),
+      tokenRepo.create(makeTokenRow('ct_d', 'failed', false)),
+      tokenRepo.create(makeTokenRow('ct_e', 'none', false)),
+    ]);
+    await membershipRepo.save([
+      membershipRepo.create(makeMembershipRow('ct_a', 'ak_1', 'added', recent)),
+      membershipRepo.create(makeMembershipRow('ct_a', 'ak_2', 'added', recent)),
+      membershipRepo.create(
+        makeMembershipRow('ct_b', 'ak_3', 'pending_add', recent),
+      ),
+      membershipRepo.create(
+        makeMembershipRow('ct_b', 'ak_4', 'removed', recent),
+      ),
+    ]);
+    await stateRepo.save(stateRepo.create({ id: 'global', last_height: 777 }));
+
+    const report = await service.collect(true);
+
+    expect(report.roomState).toMatchObject({
+      none: 1,
+      pending: 1,
+      created: 2,
+      failed: 1,
+      deleted: 0,
+    });
+    expect(report.relayState).toEqual({
+      pending_add: 1,
+      added: 2,
+      pending_remove: 0,
+      removed: 1,
+    });
+    // drift = pending_add(1) + pending_remove(0) = 1; total memberships = 4
+    expect(report.drift.count).toBe(1);
+    expect(report.drift.membershipTotal).toBe(4);
+    expect(report.drift.ratio).toBeCloseTo(0.25, 5);
+    // backfill: created 2 / total 5 = 40%, failed 1, cursor 777
+    expect(report.backfill).toMatchObject({
+      created: 2,
+      total: 5,
+      failed: 1,
+      percent: 40,
+      cursorHeight: 777,
+    });
+    // all rows reconciled recently → low max-age, no stale alert
+    expect(report.reconcile.staleCount).toBe(0);
+    expect(report.reconcile.maxAgeSeconds).toBeLessThan(60);
+    expect(report.alerts.some((a) => a.rule === 'stale_reconcile')).toBe(false);
+  });
+
+  it('a stale last_reconciled_at fires the stale_reconcile alert', async () => {
+    const old = new Date(Date.now() - 90_000 * 1000); // ~25h ago
+    await tokenRepo.save([tokenRepo.create(makeTokenRow('ct_s', 'created'))]);
+    await membershipRepo.save([
+      membershipRepo.create(makeMembershipRow('ct_s', 'ak_x', 'added', old)),
+    ]);
+
+    const report = await service.collect(true);
+    expect(report.reconcile.staleCount).toBe(1);
+    expect(report.reconcile.maxAgeSeconds).toBeGreaterThan(86400);
+    expect(report.alerts.some((a) => a.rule === 'stale_reconcile')).toBe(true);
+    expect(report.overallStatus).toBe('critical');
+  });
+
+  it('drift_ratio alert fires when pending memberships exceed the threshold', async () => {
+    await tokenRepo.save([tokenRepo.create(makeTokenRow('ct_dr', 'created'))]);
+    const recent = new Date();
+    // 5 of 5 memberships pending_add → drift ratio 1.0 ≫ 0.02
+    await membershipRepo.save(
+      ['a', 'b', 'c', 'd', 'e'].map((m) =>
+        membershipRepo.create(
+          makeMembershipRow('ct_dr', 'ak_' + m, 'pending_add', recent),
+        ),
+      ),
+    );
+
+    const report = await service.collect(true);
+    expect(report.drift.count).toBe(5);
+    expect(report.drift.ratio).toBe(1);
+    expect(report.alerts.some((a) => a.rule === 'drift_ratio')).toBe(true);
+  });
+
+  it('empty DB → healthy, zero gauges, no NaN', async () => {
+    const report = await service.collect(true);
+    expect(report.overallStatus).toBe('healthy');
+    expect(report.drift.ratio).toBe(0);
+    expect(report.backfill.percent).toBe(0);
+    expect(report.reconcile.maxAgeSeconds).toBe(0);
+  });
+});

--- a/src/token-gated-rooms/observability/__tests__/tgr-metrics.service.spec.ts
+++ b/src/token-gated-rooms/observability/__tests__/tgr-metrics.service.spec.ts
@@ -1,0 +1,345 @@
+import { Logger } from '@nestjs/common';
+import { TgrMetricsService } from '../tgr-metrics.service';
+import {
+  __resetTgrMetricsForTests,
+  incrementPublishOk,
+  setRelayWriterConnected,
+} from '../tgr-metrics';
+
+/**
+ * Build a stub TypeORM repository whose query-builder + count behaviour is
+ * scripted per test. We bypass DI and construct the service directly with these
+ * stubs so the gauge math is exercised without a Postgres connection.
+ */
+function makeMembershipRepo(opts: {
+  relayStateRows?: { relay_state: string; count: string }[];
+  total?: number;
+  reconcileRow?: {
+    oldest: Date | null;
+    never: string;
+    stale: string;
+    total: string;
+  };
+}): any {
+  const qb: any = {
+    select: () => qb,
+    addSelect: () => qb,
+    groupBy: () => qb,
+    setParameter: () => qb,
+    getRawMany: async () => opts.relayStateRows ?? [],
+    getRawOne: async () =>
+      opts.reconcileRow ?? {
+        oldest: null,
+        never: '0',
+        stale: '0',
+        total: '0',
+      },
+  };
+  return {
+    createQueryBuilder: () => qb,
+    count: async () => opts.total ?? 0,
+  };
+}
+
+function makeTokenRepo(opts: {
+  roomStateRows?: { state: string; count: string }[];
+  total?: number;
+  created?: number;
+  failed?: number;
+}): any {
+  const qb: any = {
+    select: () => qb,
+    addSelect: () => qb,
+    groupBy: () => qb,
+    getRawMany: async () => opts.roomStateRows ?? [],
+  };
+  return {
+    createQueryBuilder: () => qb,
+    count: async (arg?: any) => {
+      const state = arg?.where?.nostr_room_state;
+      if (state === 'created') return opts.created ?? 0;
+      if (state === 'failed') return opts.failed ?? 0;
+      return opts.total ?? 0;
+    },
+  };
+}
+
+function makeBackfillRepo(lastHeight: number | null): any {
+  return {
+    findOne: async () =>
+      lastHeight == null ? null : { last_height: lastHeight },
+  };
+}
+
+const CONFIG = { roomNotifyDepthBreak: 10000 } as any;
+
+function makeQueue(
+  counts: Record<string, number>,
+  paused = false,
+  headTs: number | null = null,
+): any {
+  return {
+    getJobCounts: async () => counts,
+    isPaused: async () => paused,
+    getWaiting: async () => (headTs == null ? [] : [{ timestamp: headTs }]),
+  };
+}
+
+describe('TgrMetricsService.collect', () => {
+  beforeEach(() => {
+    __resetTgrMetricsForTests();
+    // Quiet the cron logger noise.
+    jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
+    jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it('computes distributions, drift, reconcile age, backfill from stubbed rows', async () => {
+    const membershipRepo = makeMembershipRepo({
+      relayStateRows: [
+        { relay_state: 'pending_add', count: '3' },
+        { relay_state: 'added', count: '10' },
+        { relay_state: 'pending_remove', count: '1' },
+        { relay_state: 'removed', count: '6' },
+      ],
+      total: 20,
+      reconcileRow: { oldest: null, never: '0', stale: '0', total: '20' },
+    });
+    const tokenRepo = makeTokenRepo({
+      roomStateRows: [
+        { state: 'none', count: '2' },
+        { state: 'created', count: '7' },
+        { state: 'failed', count: '1' },
+      ],
+      total: 10,
+      created: 7,
+      failed: 1,
+    });
+
+    const service = new TgrMetricsService(
+      membershipRepo,
+      tokenRepo,
+      makeBackfillRepo(42),
+      CONFIG,
+    );
+
+    const report = await service.collect(true);
+
+    expect(report.relayState).toEqual({
+      pending_add: 3,
+      added: 10,
+      pending_remove: 1,
+      removed: 6,
+    });
+    expect(report.roomState).toMatchObject({
+      none: 2,
+      created: 7,
+      failed: 1,
+    });
+    // drift = pending_add + pending_remove = 4; ratio = 4/20 = 0.2
+    expect(report.drift.count).toBe(4);
+    expect(report.drift.ratio).toBeCloseTo(0.2, 5);
+    expect(report.drift.membershipTotal).toBe(20);
+    // backfill: created 7 / total 10 → 70%
+    expect(report.backfill).toMatchObject({
+      created: 7,
+      total: 10,
+      failed: 1,
+      percent: 70,
+      cursorHeight: 42,
+    });
+  });
+
+  it('never-reconciled rows pin max-age over the SLA and fire stale_reconcile', async () => {
+    const membershipRepo = makeMembershipRepo({
+      total: 5,
+      reconcileRow: { oldest: null, never: '5', stale: '5', total: '5' },
+    });
+    const tokenRepo = makeTokenRepo({ total: 0 });
+    const service = new TgrMetricsService(
+      membershipRepo,
+      tokenRepo,
+      makeBackfillRepo(null),
+      CONFIG,
+    );
+
+    const report = await service.collect(true);
+    expect(report.reconcile.staleCount).toBe(5);
+    expect(report.reconcile.maxAgeSeconds).toBeGreaterThan(
+      service.getThresholds().reconcileStaleSeconds,
+    );
+    expect(report.alerts.some((a) => a.rule === 'stale_reconcile')).toBe(true);
+    expect(report.overallStatus).toBe('critical');
+  });
+
+  it('zero-total guards: empty DB → no NaN, healthy status', async () => {
+    const membershipRepo = makeMembershipRepo({
+      total: 0,
+      reconcileRow: { oldest: null, never: '0', stale: '0', total: '0' },
+    });
+    const tokenRepo = makeTokenRepo({ total: 0 });
+    const service = new TgrMetricsService(
+      membershipRepo,
+      tokenRepo,
+      makeBackfillRepo(null),
+      CONFIG,
+    );
+
+    const report = await service.collect(true);
+    expect(Number.isNaN(report.drift.ratio)).toBe(false);
+    expect(report.drift.ratio).toBe(0);
+    expect(report.backfill.percent).toBe(0);
+    expect(report.reconcile.maxAgeSeconds).toBe(0);
+    expect(report.overallStatus).toBe('healthy');
+  });
+
+  it('reads queue depth + lag from injected queues', async () => {
+    const now = Date.now();
+    const membershipRepo = makeMembershipRepo({
+      total: 0,
+      reconcileRow: { oldest: null, never: '0', stale: '0', total: '0' },
+    });
+    const tokenRepo = makeTokenRepo({ total: 0 });
+    const publishQueue = makeQueue(
+      { waiting: 42, active: 1, delayed: 0, failed: 0 },
+      true,
+      now - 2000,
+    );
+
+    const service = new TgrMetricsService(
+      membershipRepo,
+      tokenRepo,
+      makeBackfillRepo(null),
+      CONFIG,
+      publishQueue, // publish
+    );
+
+    const report = await service.collect(true);
+    const publish = report.queues.find((q) => q.key === 'publish');
+    expect(publish?.waiting).toBe(42);
+    expect(publish?.paused).toBe(true);
+    expect(publish?.lagMs).toBeGreaterThanOrEqual(2000);
+
+    // Un-injected queues report null depth (not a crash).
+    const notify = report.queues.find((q) => q.key === 'notify');
+    expect(notify?.waiting).toBeNull();
+  });
+
+  it('emitMetrics logs the [TgrMetrics] line and resets rate counters', async () => {
+    const logSpy = jest
+      .spyOn(Logger.prototype, 'log')
+      .mockImplementation(() => undefined);
+
+    const membershipRepo = makeMembershipRepo({
+      total: 0,
+      reconcileRow: { oldest: null, never: '0', stale: '0', total: '0' },
+    });
+    const tokenRepo = makeTokenRepo({ total: 0 });
+    const service = new TgrMetricsService(
+      membershipRepo,
+      tokenRepo,
+      makeBackfillRepo(null),
+      CONFIG,
+    );
+
+    incrementPublishOk();
+    setRelayWriterConnected(true);
+
+    await service.emitMetrics();
+
+    const lines = logSpy.mock.calls.map((c) => String(c[0]));
+    const metricLine = lines.find((l) => l.startsWith('[TgrMetrics]'));
+    expect(metricLine).toBeDefined();
+    expect(metricLine).toContain('publish_ok=1');
+
+    // After emit, the rate counter is reset but the flag persists.
+    const report = await service.collect(true);
+    expect(report.counters.publishOk).toBe(0);
+    expect(report.relay.writerConnected).toBe(true);
+  });
+
+  it('emitMetrics logs a [TgrAlert] warn line per breached rule', async () => {
+    const warnSpy = jest
+      .spyOn(Logger.prototype, 'warn')
+      .mockImplementation(() => undefined);
+
+    const membershipRepo = makeMembershipRepo({
+      relayStateRows: [{ relay_state: 'pending_add', count: '50' }],
+      total: 100, // drift 50/100 = 0.5 > 0.02
+      reconcileRow: { oldest: null, never: '0', stale: '0', total: '100' },
+    });
+    const tokenRepo = makeTokenRepo({ total: 0 });
+    const service = new TgrMetricsService(
+      membershipRepo,
+      tokenRepo,
+      makeBackfillRepo(null),
+      CONFIG,
+    );
+
+    await service.emitMetrics();
+
+    const warns = warnSpy.mock.calls.map((c) => String(c[0]));
+    expect(
+      warns.some(
+        (l) => l.startsWith('[TgrAlert]') && l.includes('drift_ratio'),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe('TgrMetricsService.resolveThresholds (env)', () => {
+  const saved: Record<string, string | undefined> = {};
+  const KEYS = [
+    'TG_FAILED_ROOM_RATIO_THRESHOLD',
+    'TG_DRIFT_RATIO_THRESHOLD',
+    'TG_RECONCILE_STALE_SECONDS',
+    'TG_RELAY_DOWN_ALERT_SECONDS',
+    'TG_QUEUE_BACKLOG_THRESHOLD',
+    'TG_QUEUE_LAG_ALERT_MS',
+  ];
+
+  beforeEach(() => {
+    for (const k of KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+  afterEach(() => {
+    for (const k of KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  it('falls back to §18 defaults when env is unset', () => {
+    const service = new TgrMetricsService(
+      makeMembershipRepo({}),
+      makeTokenRepo({}),
+      makeBackfillRepo(null),
+      CONFIG,
+    );
+    expect(service.getThresholds()).toMatchObject({
+      failedRoomRatio: 0.05,
+      driftRatio: 0.02,
+      reconcileStaleSeconds: 86400,
+      relayDownAlertSeconds: 60,
+      queueBacklogThreshold: 5000,
+      queueLagAlertMs: 300000,
+      roomNotifyDepthBreak: 10000,
+    });
+  });
+
+  it('reads overrides from env (garbage falls back)', () => {
+    process.env.TG_DRIFT_RATIO_THRESHOLD = '0.1';
+    process.env.TG_QUEUE_BACKLOG_THRESHOLD = 'not-a-number';
+    const service = new TgrMetricsService(
+      makeMembershipRepo({}),
+      makeTokenRepo({}),
+      makeBackfillRepo(null),
+      CONFIG,
+    );
+    expect(service.getThresholds().driftRatio).toBe(0.1);
+    expect(service.getThresholds().queueBacklogThreshold).toBe(5000);
+  });
+});

--- a/src/token-gated-rooms/observability/__tests__/tgr-metrics.spec.ts
+++ b/src/token-gated-rooms/observability/__tests__/tgr-metrics.spec.ts
@@ -1,0 +1,85 @@
+import {
+  __resetTgrMetricsForTests,
+  getTgrMetricsSnapshot,
+  incrementAckTimeout,
+  incrementPublishFailed,
+  incrementPublishOk,
+  incrementRelayReconnect,
+  resetTgrCounters,
+  setRelaySubscriberConnected,
+  setRelayWriterConnected,
+} from '../tgr-metrics';
+
+describe('tgr-metrics (in-memory counters)', () => {
+  beforeEach(() => {
+    __resetTgrMetricsForTests();
+  });
+
+  it('each setter mutates the right field; snapshot returns them', () => {
+    incrementPublishOk();
+    incrementPublishOk();
+    incrementPublishFailed();
+    incrementAckTimeout();
+    incrementRelayReconnect();
+
+    const snap = getTgrMetricsSnapshot();
+    expect(snap.publishOk).toBe(2);
+    expect(snap.publishFailed).toBe(1);
+    expect(snap.ackTimeouts).toBe(1);
+    expect(snap.relayReconnects).toBe(1);
+  });
+
+  it('incrementPublishFailed(true) also bumps ackTimeouts', () => {
+    incrementPublishFailed(true);
+    const snap = getTgrMetricsSnapshot();
+    expect(snap.publishFailed).toBe(1);
+    expect(snap.ackTimeouts).toBe(1);
+  });
+
+  it('connection flags + edge timestamps update on transitions', () => {
+    const before = Date.now();
+    setRelayWriterConnected(true);
+    let snap = getTgrMetricsSnapshot();
+    expect(snap.relayWriterConnected).toBe(true);
+    expect(snap.lastRelayConnectAt).toBeGreaterThanOrEqual(before);
+    expect(snap.lastRelayDisconnectAt).toBeNull();
+
+    setRelayWriterConnected(false);
+    snap = getTgrMetricsSnapshot();
+    expect(snap.relayWriterConnected).toBe(false);
+    expect(snap.lastRelayDisconnectAt).toBeGreaterThanOrEqual(before);
+
+    setRelaySubscriberConnected(true);
+    expect(getTgrMetricsSnapshot().relaySubscriberConnected).toBe(true);
+  });
+
+  it('idempotent flag set does not re-stamp the disconnect timestamp', () => {
+    setRelayWriterConnected(true);
+    setRelayWriterConnected(false);
+    const first = getTgrMetricsSnapshot().lastRelayDisconnectAt;
+    // Setting false again (no edge) must not move the timestamp.
+    setRelayWriterConnected(false);
+    expect(getTgrMetricsSnapshot().lastRelayDisconnectAt).toBe(first);
+  });
+
+  it('resetTgrCounters zeroes rate counters but LEAVES flags + timestamps', () => {
+    incrementPublishOk();
+    incrementPublishFailed(true);
+    incrementRelayReconnect();
+    setRelayWriterConnected(true);
+    setRelayWriterConnected(false);
+
+    const disconnectAt = getTgrMetricsSnapshot().lastRelayDisconnectAt;
+
+    resetTgrCounters();
+
+    const snap = getTgrMetricsSnapshot();
+    expect(snap.publishOk).toBe(0);
+    expect(snap.publishFailed).toBe(0);
+    expect(snap.ackTimeouts).toBe(0);
+    expect(snap.relayReconnects).toBe(0);
+    // Flags + timestamps survive a counter reset.
+    expect(snap.relayWriterConnected).toBe(false);
+    expect(snap.lastRelayDisconnectAt).toBe(disconnectAt);
+  });
+});

--- a/src/token-gated-rooms/observability/tgr-metrics.collector.ts
+++ b/src/token-gated-rooms/observability/tgr-metrics.collector.ts
@@ -1,0 +1,371 @@
+/**
+ * Pure metric math + alert evaluation + log-line formatting for the TGR
+ * observability surface (Task 15). Kept dependency-free (no Nest, no TypeORM, no
+ * bull import) so every branch unit-tests without a DI container or a DB — the
+ * service injects the repos/queues and feeds raw rows into these helpers.
+ *
+ * Three responsibilities:
+ *  1. shape the computed gauge values into a typed snapshot,
+ *  2. evaluate the Req-4 alert rules (name + condition + severity) into a list,
+ *  3. render the single grep-friendly `[TgrMetrics] key=value …` line (Req 2).
+ */
+
+import {
+  AlertSeverity,
+  OverallStatus,
+  TGR_ALERT_RULES,
+  TGR_METRICS_LOG_TAG,
+  TGR_METRICS_QUEUES,
+} from './tgr-metrics.constants';
+
+/** Per-queue depth + lag gauge (Req 1.1). */
+export interface QueueGauge {
+  /** Short key (`publish`, `backfill`, …). */
+  key: string;
+  /** Prefixed queue name (`worker:publish-nip29`, …). */
+  name: string;
+  /** Waiting jobs (the "depth"); null when the queue is not registered here. */
+  waiting: number | null;
+  active: number | null;
+  delayed: number | null;
+  failed: number | null;
+  /** `queue.isPaused()`; null when unknown. */
+  paused: boolean | null;
+  /** Age (ms) of the oldest waiting job (`now − head.timestamp`); null when none. */
+  lagMs: number | null;
+}
+
+/** `room_membership.relay_state` distribution (Req 1.3). */
+export interface RelayStateDistribution {
+  pending_add: number;
+  added: number;
+  pending_remove: number;
+  removed: number;
+}
+
+/** `Token.nostr_room_state` distribution (Req 1.4). */
+export interface RoomStateDistribution {
+  none: number;
+  pending: number;
+  created: number;
+  failed: number;
+  deleted: number;
+}
+
+/** Thresholds used by the alert evaluator (resolved from env by the service). */
+export interface ResolvedThresholds {
+  failedRoomRatio: number;
+  driftRatio: number;
+  reconcileStaleSeconds: number;
+  relayDownAlertSeconds: number;
+  queueBacklogThreshold: number;
+  queueLagAlertMs: number;
+  roomNotifyDepthBreak: number;
+}
+
+/** Inputs to {@link evaluateAlerts} — already-computed gauge numbers. */
+export interface AlertInputs {
+  roomFailed: number;
+  roomTotal: number;
+  driftCount: number;
+  membershipTotal: number;
+  reconcileMaxAgeS: number;
+  reconcileStaleCount: number;
+  relayWriterConnected: boolean;
+  relaySubscriberConnected: boolean;
+  /** Seconds the relay writer has been continuously down (0 when connected). */
+  relayWriterDownSeconds: number;
+  queues: QueueGauge[];
+}
+
+/** One fired alert (Req 4). */
+export interface FiredAlert {
+  rule: string;
+  severity: Exclude<AlertSeverity, 'ok'>;
+  value: number | string;
+  threshold: number | string;
+}
+
+/** Divide guarding zero-total (Req: no NaN / divide-by-zero). */
+export function safeRatio(numerator: number, denominator: number): number {
+  if (!denominator || denominator <= 0) {
+    return 0;
+  }
+  return numerator / denominator;
+}
+
+/** Percentage [0..100], two decimals, zero-total guarded. */
+export function safePercent(part: number, total: number): number {
+  return Number((safeRatio(part, total) * 100).toFixed(2));
+}
+
+/**
+ * Worst of two severities along the ok < warning < critical ladder.
+ */
+export function worseSeverity(
+  a: AlertSeverity,
+  b: AlertSeverity,
+): AlertSeverity {
+  const rank: Record<AlertSeverity, number> = {
+    ok: 0,
+    warning: 1,
+    critical: 2,
+  };
+  return rank[a] >= rank[b] ? a : b;
+}
+
+/** Map the worst fired severity to the controller's `overallStatus`. */
+export function overallStatusFrom(alerts: FiredAlert[]): OverallStatus {
+  let worst: AlertSeverity = 'ok';
+  for (const a of alerts) {
+    worst = worseSeverity(worst, a.severity);
+  }
+  return worst === 'ok' ? 'healthy' : worst;
+}
+
+/**
+ * Evaluate every Req-4 alert rule against the computed inputs. Returns only the
+ * rules that BREACHED, each with its value+threshold (so the cron emitter can log
+ * `[TgrAlert] rule=… value=… threshold=…` and the JSON endpoint can list them).
+ *
+ * Severity escalation to `critical` at 2× the threshold is applied where Req 4
+ * specifies it (`failed_room_ratio`, `queue_backlog`).
+ */
+export function evaluateAlerts(
+  input: AlertInputs,
+  t: ResolvedThresholds,
+): FiredAlert[] {
+  const alerts: FiredAlert[] = [];
+
+  // 4.1 failed_room_ratio — warning; critical at 2×.
+  const failedRatio = safeRatio(input.roomFailed, input.roomTotal);
+  if (failedRatio > t.failedRoomRatio) {
+    alerts.push({
+      rule: TGR_ALERT_RULES.FAILED_ROOM_RATIO,
+      severity: failedRatio > t.failedRoomRatio * 2 ? 'critical' : 'warning',
+      value: Number(failedRatio.toFixed(4)),
+      threshold: t.failedRoomRatio,
+    });
+  }
+
+  // 4.2 drift_ratio — warning.
+  const driftRatio = safeRatio(input.driftCount, input.membershipTotal);
+  if (driftRatio > t.driftRatio) {
+    alerts.push({
+      rule: TGR_ALERT_RULES.DRIFT_RATIO,
+      severity: 'warning',
+      value: Number(driftRatio.toFixed(4)),
+      threshold: t.driftRatio,
+    });
+  }
+
+  // 4.3 stale_reconcile — critical when max-age > SLA OR any stale row.
+  if (
+    input.reconcileMaxAgeS > t.reconcileStaleSeconds ||
+    input.reconcileStaleCount > 0
+  ) {
+    alerts.push({
+      rule: TGR_ALERT_RULES.STALE_RECONCILE,
+      severity: 'critical',
+      value:
+        input.reconcileStaleCount > 0
+          ? `stale_count=${input.reconcileStaleCount}`
+          : Math.round(input.reconcileMaxAgeS),
+      threshold: t.reconcileStaleSeconds,
+    });
+  }
+
+  // 4.4 relay_down — writer down past the debounce ⇒ critical;
+  // subscriber-only down ⇒ warning. (Writer-down dominates.)
+  if (
+    !input.relayWriterConnected &&
+    input.relayWriterDownSeconds >= t.relayDownAlertSeconds
+  ) {
+    alerts.push({
+      rule: TGR_ALERT_RULES.RELAY_DOWN,
+      severity: 'critical',
+      value: `writer_down_s=${Math.round(input.relayWriterDownSeconds)}`,
+      threshold: t.relayDownAlertSeconds,
+    });
+  } else if (input.relayWriterConnected && !input.relaySubscriberConnected) {
+    alerts.push({
+      rule: TGR_ALERT_RULES.RELAY_DOWN,
+      severity: 'warning',
+      value: 'subscriber_down',
+      threshold: t.relayDownAlertSeconds,
+    });
+  }
+
+  // 4.5 queue_backlog — any TGR queue waiting > threshold OR lag > lag-alert;
+  // warning, critical at 2×. room-notify also has its own depth-break.
+  for (const q of input.queues) {
+    const waiting = q.waiting ?? 0;
+    const lag = q.lagMs ?? 0;
+    const isNotify = q.key === 'notify';
+
+    const depthBreached = waiting > t.queueBacklogThreshold;
+    const lagBreached = lag > t.queueLagAlertMs;
+    if (depthBreached || lagBreached) {
+      const depthCritical = waiting > t.queueBacklogThreshold * 2;
+      const lagCritical = lag > t.queueLagAlertMs * 2;
+      alerts.push({
+        rule: TGR_ALERT_RULES.QUEUE_BACKLOG,
+        severity: depthCritical || lagCritical ? 'critical' : 'warning',
+        value: `${q.key} waiting=${waiting} lag_ms=${lag}`,
+        threshold: `waiting>${t.queueBacklogThreshold} lag_ms>${t.queueLagAlertMs}`,
+      });
+    } else if (isNotify && waiting > t.roomNotifyDepthBreak) {
+      // §18 depth-break (only meaningful if below the generic backlog threshold,
+      // i.e. when the operator tuned the depth-break lower).
+      alerts.push({
+        rule: TGR_ALERT_RULES.QUEUE_BACKLOG,
+        severity: 'warning',
+        value: `notify waiting=${waiting}`,
+        threshold: `notify_depth_break>${t.roomNotifyDepthBreak}`,
+      });
+    }
+  }
+
+  return alerts;
+}
+
+/**
+ * The full computed metrics object (the JSON endpoint body + the source for the
+ * log line). Every Req-1 metric appears here exactly once.
+ */
+export interface TgrMetricsReport {
+  overallStatus: OverallStatus;
+  /** Per-queue depth+lag (Req 1.1). */
+  queues: QueueGauge[];
+  /** Relay health (Req 1.2). */
+  relay: {
+    writerConnected: boolean;
+    subscriberConnected: boolean;
+    reconnects: number;
+    lastDisconnectAt: number | null;
+    writerDownSeconds: number;
+  };
+  /** relay_state distribution (Req 1.3). */
+  relayState: RelayStateDistribution;
+  /** nostr_room_state distribution (Req 1.4). */
+  roomState: RoomStateDistribution;
+  /** Postgres-vs-relay drift (Req 1.5). */
+  drift: { count: number; ratio: number; membershipTotal: number };
+  /** Reconciliation staleness (Req 1.6). */
+  reconcile: { maxAgeSeconds: number; staleCount: number };
+  /** Backfill progress (Req 1.7). */
+  backfill: {
+    created: number;
+    total: number;
+    failed: number;
+    percent: number;
+    cursorHeight: number | null;
+  };
+  /** Process-local rate counters (Req 1, accumulated in worker memory). */
+  counters: {
+    publishOk: number;
+    publishFailed: number;
+    ackTimeouts: number;
+  };
+  /** Fired alerts (Req 4). */
+  alerts: FiredAlert[];
+  /** Whether the worker-local counters/flags are served from the worker. */
+  processLocal: boolean;
+}
+
+/**
+ * Render the single grep-friendly `[TgrMetrics] key=value …` line (Req 2). Field
+ * order/keys are fixed so a log filter (and the unit-test regex) can rely on
+ * exactly-one occurrence of each key.
+ */
+export function formatMetricsLogLine(report: TgrMetricsReport): string {
+  const byKey = new Map(report.queues.map((q) => [q.key, q]));
+  const q = (key: string): QueueGauge | undefined => byKey.get(key);
+  const depth = (key: string): string => `${q(key)?.waiting ?? 'n/a'}`;
+  const lag = (key: string): string => `${q(key)?.lagMs ?? 'n/a'}`;
+
+  const parts: string[] = [
+    TGR_METRICS_LOG_TAG,
+    `publish_q_depth=${depth('publish')}`,
+    `publish_q_lag_ms=${lag('publish')}`,
+    `backfill_q_depth=${depth('backfill')}`,
+    `reconcile_balance_q_depth=${depth('reconcile_balance')}`,
+    `reconcile_membership_q_depth=${depth('reconcile_membership')}`,
+    `notify_q_depth=${depth('notify')}`,
+    `relay_writer_connected=${report.relay.writerConnected}`,
+    `relay_subscriber_connected=${report.relay.subscriberConnected}`,
+    `relay_reconnects=${report.relay.reconnects}`,
+    `ms_pending_add=${report.relayState.pending_add}`,
+    `ms_added=${report.relayState.added}`,
+    `ms_pending_remove=${report.relayState.pending_remove}`,
+    `ms_removed=${report.relayState.removed}`,
+    `room_none=${report.roomState.none}`,
+    `room_pending=${report.roomState.pending}`,
+    `room_created=${report.roomState.created}`,
+    `room_failed=${report.roomState.failed}`,
+    `room_deleted=${report.roomState.deleted}`,
+    `drift_count=${report.drift.count}`,
+    `drift_ratio=${report.drift.ratio}`,
+    `reconcile_max_age_s=${report.reconcile.maxAgeSeconds}`,
+    `reconcile_stale_count=${report.reconcile.staleCount}`,
+    `backfill_created=${report.backfill.created}`,
+    `backfill_total=${report.backfill.total}`,
+    `backfill_pct=${report.backfill.percent}`,
+    `publish_ok=${report.counters.publishOk}`,
+    `publish_failed=${report.counters.publishFailed}`,
+    `ack_timeouts=${report.counters.ackTimeouts}`,
+  ];
+  return parts.join(' ');
+}
+
+/** Render one `[TgrAlert] rule=… value=… threshold=… severity=…` line (Req 4). */
+export function formatAlertLogLine(alert: FiredAlert): string {
+  return `[TgrAlert] rule=${alert.rule} value=${alert.value} threshold=${alert.threshold} severity=${alert.severity}`;
+}
+
+/**
+ * Build a {@link QueueGauge} from a raw `getJobCounts()` result + `isPaused()` +
+ * the head-of-waiting job timestamp (Req 1.1 / test "queue gauge mapper").
+ *
+ * @param counts  bull v4 `{ waiting, active, completed, failed, delayed, paused }`
+ * @param paused  `queue.isPaused()`
+ * @param headWaitingTimestampMs epoch-ms of the oldest waiting job (null = none)
+ * @param now     injected clock (defaults to Date.now) for deterministic tests
+ */
+export function mapQueueGauge(
+  descriptor: { key: string; name: string },
+  counts: Partial<Record<string, number>> | null,
+  paused: boolean | null,
+  headWaitingTimestampMs: number | null,
+  now: number = Date.now(),
+): QueueGauge {
+  if (!counts) {
+    return {
+      key: descriptor.key,
+      name: descriptor.name,
+      waiting: null,
+      active: null,
+      delayed: null,
+      failed: null,
+      paused: null,
+      lagMs: null,
+    };
+  }
+  const lagMs =
+    headWaitingTimestampMs != null
+      ? Math.max(0, now - headWaitingTimestampMs)
+      : null;
+  return {
+    key: descriptor.key,
+    name: descriptor.name,
+    waiting: counts.waiting ?? 0,
+    active: counts.active ?? 0,
+    delayed: counts.delayed ?? 0,
+    failed: counts.failed ?? 0,
+    paused: paused ?? false,
+    lagMs,
+  };
+}
+
+/** All queue descriptors (re-exported for the service + tests). */
+export const QUEUE_DESCRIPTORS = TGR_METRICS_QUEUES;

--- a/src/token-gated-rooms/observability/tgr-metrics.constants.ts
+++ b/src/token-gated-rooms/observability/tgr-metrics.constants.ts
@@ -1,0 +1,171 @@
+/**
+ * Token-gated-rooms observability constants (Task 15, plan §13).
+ *
+ * Metric names, the alert-rule registry (name + default threshold env key), the
+ * emit cron, and the two SLO definitions. Kept dependency-free so the in-memory
+ * metrics module, the cron emitter service, the HTTP controller, and the unit
+ * tests all import the SAME canonical names (no drift between the grep-friendly
+ * log line, the JSON endpoint, and the alert evaluator).
+ *
+ * NOTE: this task ADDS machine-readable depth/lag/distribution/drift metrics on
+ * top of the existing observability stack (in-memory counters like
+ * `utils/stabilization-metrics.ts` + a `@Cron` log line like
+ * `StabilizationService` + a `@Get` health JSON like `MdwController` + Bull
+ * Board). It introduces NO new exporter/heavy dep (prom-client/OTel deferred to
+ * Task 16, plan §13 / task §"Out of scope").
+ */
+
+import type { QueueOwner } from '../config/queue-prefix';
+import { prefixQueue, TGR_QUEUE_NAMES } from '../config/queue-prefix';
+
+/** Grep tags for the cron log lines (mirror `[StabilizationChecklist]`). */
+export const TGR_METRICS_LOG_TAG = '[TgrMetrics]';
+export const TGR_ALERT_LOG_TAG = '[TgrAlert]';
+
+/** Default metrics-emit cron (1-min); overridable via `TG_METRICS_CRON`. */
+export const TGR_METRICS_CRON_DEFAULT = '*/1 * * * *';
+
+/**
+ * Resolve the metrics-emit cron from env (`TG_METRICS_CRON`), falling back to
+ * the 1-min default for blank/garbage. A bare 5-field crontab is accepted as-is;
+ * anything else falls back so a typo can never silently disable the emitter.
+ */
+export function resolveMetricsCron(
+  env: Record<string, string | undefined> = process.env,
+): string {
+  const raw = env.TG_METRICS_CRON;
+  if (raw === undefined || raw.trim() === '') {
+    return TGR_METRICS_CRON_DEFAULT;
+  }
+  const value = raw.trim();
+  // Accept a 5- or 6-field crontab expression; otherwise fall back.
+  const fields = value.split(/\s+/);
+  if (fields.length === 5 || fields.length === 6) {
+    return value;
+  }
+  return TGR_METRICS_CRON_DEFAULT;
+}
+
+/**
+ * The five canonical TGR queues, resolved to their PREFIXED names + the process
+ * that consumes each (plan §9). The collector gauges depth/lag against these.
+ *
+ * `room-notify` is registered only inside the worker-only
+ * `RoomNotificationsModule`, so its queue token is absent when the collector runs
+ * in the main process — the queue injection is therefore `@Optional()` and its
+ * depth is reported as `null` from main (documented in the controller).
+ */
+export interface TgrQueueDescriptor {
+  /** Base name (`publish-nip29`, …). */
+  base: string;
+  /** Prefixed registered queue name (`worker:publish-nip29`, …). */
+  name: string;
+  /** Process that consumes (and therefore registers the @Processor for) it. */
+  consumer: QueueOwner;
+  /** Short key used in the log line / JSON (`publish`, `backfill`, …). */
+  key: string;
+}
+
+export const TGR_METRICS_QUEUES: readonly TgrQueueDescriptor[] = [
+  {
+    base: TGR_QUEUE_NAMES.PUBLISH_NIP29,
+    name: prefixQueue(TGR_QUEUE_NAMES.PUBLISH_NIP29, 'worker'),
+    consumer: 'worker',
+    key: 'publish',
+  },
+  {
+    base: TGR_QUEUE_NAMES.ROOM_BACKFILL,
+    name: prefixQueue(TGR_QUEUE_NAMES.ROOM_BACKFILL, 'worker'),
+    consumer: 'worker',
+    key: 'backfill',
+  },
+  {
+    base: TGR_QUEUE_NAMES.RECONCILE_BALANCE,
+    name: prefixQueue(TGR_QUEUE_NAMES.RECONCILE_BALANCE, 'main'),
+    consumer: 'main',
+    key: 'reconcile_balance',
+  },
+  {
+    base: TGR_QUEUE_NAMES.RECONCILE_MEMBERSHIP,
+    name: prefixQueue(TGR_QUEUE_NAMES.RECONCILE_MEMBERSHIP, 'worker'),
+    consumer: 'worker',
+    key: 'reconcile_membership',
+  },
+  {
+    base: TGR_QUEUE_NAMES.ROOM_NOTIFY,
+    name: prefixQueue(TGR_QUEUE_NAMES.ROOM_NOTIFY, 'worker'),
+    consumer: 'worker',
+    key: 'notify',
+  },
+] as const;
+
+/** Severity ladder; `overallStatus` aggregates to the worst across all rules. */
+export type AlertSeverity = 'ok' | 'warning' | 'critical';
+
+/** Map an alert severity to the controller's `overallStatus` vocabulary. */
+export type OverallStatus = 'healthy' | 'warning' | 'critical';
+
+/**
+ * Alert-rule identifiers (Req 4). Stable strings — they appear verbatim in the
+ * `[TgrAlert] rule=<name> …` log line and in the JSON `alerts[]` array, so
+ * dashboards/log filters key on them.
+ */
+export const TGR_ALERT_RULES = {
+  FAILED_ROOM_RATIO: 'failed_room_ratio',
+  DRIFT_RATIO: 'drift_ratio',
+  STALE_RECONCILE: 'stale_reconcile',
+  RELAY_DOWN: 'relay_down',
+  QUEUE_BACKLOG: 'queue_backlog',
+} as const;
+
+/**
+ * Threshold env keys + defaults (Req 5 env table, plan §18). Parsed by the
+ * collector via the shared numeric parser; blank/garbage falls back to default.
+ */
+export const TGR_METRICS_THRESHOLD_DEFAULTS = {
+  /** `failed_room_ratio` warning; critical at 2× (Req 4.1, plan §4.7). */
+  failedRoomRatio: 0.05,
+  /** `drift_ratio` warning (Req 4.2). */
+  driftRatio: 0.02,
+  /** `stale_reconcile` critical — §11 24h SLA (Req 4.3). */
+  reconcileStaleSeconds: 86400,
+  /** `relay_down` debounce seconds (Req 4.4). */
+  relayDownAlertSeconds: 60,
+  /** `queue_backlog` waiting-count warning; critical at 2× (Req 4.5). */
+  queueBacklogThreshold: 5000,
+  /** `queue_backlog` lag warning (ms, 5m); critical at 2× (Req 4.5). */
+  queueLagAlertMs: 300000,
+  /** `worker:room-notify` depth-break (§18 knob; alert against, owned elsewhere). */
+  roomNotifyDepthBreak: 10000,
+} as const;
+
+/** Env var names for the thresholds (documented in `.env.example`). */
+export const TGR_METRICS_THRESHOLD_ENV = {
+  failedRoomRatio: 'TG_FAILED_ROOM_RATIO_THRESHOLD',
+  driftRatio: 'TG_DRIFT_RATIO_THRESHOLD',
+  reconcileStaleSeconds: 'TG_RECONCILE_STALE_SECONDS',
+  relayDownAlertSeconds: 'TG_RELAY_DOWN_ALERT_SECONDS',
+  queueBacklogThreshold: 'TG_QUEUE_BACKLOG_THRESHOLD',
+  queueLagAlertMs: 'TG_QUEUE_LAG_ALERT_MS',
+  roomNotifyDepthBreak: 'TG_ROOM_NOTIFY_DEPTH_BREAK',
+} as const;
+
+/**
+ * SLO definitions (Req 7, plan §13) — codified so Task 16 cutover can gate on
+ * them. These are documented thresholds (not enforced here); the proxy metric
+ * that proves each is named so a dashboard can chart it.
+ */
+export const TGR_SLOS = {
+  /**
+   * SLO-1 — room created within T of token creation. T default 300s.
+   * Proxy: `nostr_room_created_at − blockTime(community_room.created_height)`
+   * over rooms reaching `nostr_room_state='created'`; alert when p95 > T.
+   */
+  roomCreatedWithinSeconds: 300,
+  /**
+   * SLO-2 — membership change published within U seconds. U default 60s.
+   * Proxy: `room_membership.last_published_at − tgr.membership.changed` (and
+   * `relay_state` reaching `added`/`removed`); alert when p95 > U.
+   */
+  membershipPublishedWithinSeconds: 60,
+} as const;

--- a/src/token-gated-rooms/observability/tgr-metrics.controller.ts
+++ b/src/token-gated-rooms/observability/tgr-metrics.controller.ts
@@ -1,0 +1,64 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
+import { RateLimitGuard } from '@/api-core/guards/rate-limit.guard';
+import { TgrMetricsService } from './tgr-metrics.service';
+import { TGR_SLOS } from './tgr-metrics.constants';
+import type { TgrMetricsReport } from './tgr-metrics.collector';
+
+/**
+ * Token-gated-rooms observability read surface (Task 15, plan §13).
+ *
+ * MAIN process. Mounted under the global `api` prefix → `GET /api/tgr/metrics`.
+ * Route `tgr/metrics` (the task's alternate to `rooms/metrics`) is deliberately
+ * chosen so it can never collide with Task 13's `GET /api/rooms/:saleAddress`
+ * param route.
+ *
+ * Returns the same computed object as the cron `[TgrMetrics] …` line plus an
+ * `overallStatus` (healthy/warning/critical from the alert rules), modeled on
+ * `MdwController.getHealth()`. Read-only and public (validated by nothing — it
+ * exposes no PII, only aggregate counts), rate-limited like the other read APIs.
+ *
+ * ## Process-local caveat (documented per Req 3)
+ * The relay-writer/subscriber flags + the publish rate counters
+ * (`publishOk`/`publishFailed`/`ackTimeouts`/reconnects) live in **worker**
+ * memory. Served from the main process they read as their main-process values
+ * (the relay socket lives only in the worker), so `processLocal:false` flags that
+ * the relay/counter fields here are NOT authoritative — the WORKER's
+ * `[TgrMetrics]` log line + Bull Board are the source for those. The Postgres
+ * gauges (distributions, drift, reconcile age, backfill) are authoritative from
+ * either process.
+ */
+@ApiTags('token-gated-rooms')
+@Controller('tgr')
+@UseGuards(RateLimitGuard)
+export class TgrMetricsController {
+  constructor(private readonly metrics: TgrMetricsService) {}
+
+  /**
+   * Machine-readable TGR pipeline health/metrics. The `slos` block restates the
+   * codified SLO targets (Req 7) so a dashboard can chart the proxy latency
+   * against them without hard-coding the thresholds.
+   */
+  @Get('metrics')
+  @ApiOkResponse({
+    description:
+      'TGR pipeline metrics: queue depth/lag, relay health, relay_state + ' +
+      'nostr_room_state distributions, Postgres-vs-relay drift, reconcile ' +
+      'staleness, backfill progress, and an overallStatus. The relay/counter ' +
+      'fields are worker-local (processLocal=false when served from main).',
+  })
+  async getMetrics(): Promise<
+    TgrMetricsReport & {
+      thresholds: ReturnType<TgrMetricsService['getThresholds']>;
+      slos: typeof TGR_SLOS;
+    }
+  > {
+    // Served from main → worker-local counters/flags are not authoritative here.
+    const report = await this.metrics.collect(false);
+    return {
+      ...report,
+      thresholds: this.metrics.getThresholds(),
+      slos: TGR_SLOS,
+    };
+  }
+}

--- a/src/token-gated-rooms/observability/tgr-metrics.service.ts
+++ b/src/token-gated-rooms/observability/tgr-metrics.service.ts
@@ -1,0 +1,439 @@
+import { InjectQueue } from '@nestjs/bull';
+import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
+import { ConfigType } from '@nestjs/config';
+import { Cron } from '@nestjs/schedule';
+import { InjectRepository } from '@nestjs/typeorm';
+import type { Queue } from 'bull';
+import { Repository } from 'typeorm';
+import { Token } from '@/tokens/entities/token.entity';
+import tgrConfig from '../config/tgr.config';
+import { prefixQueue, TGR_QUEUE_NAMES } from '../config/queue-prefix';
+import { RoomMembership } from '../entities/room-membership.entity';
+import { RoomBackfillState } from '../entities/room-backfill-state.entity';
+import {
+  evaluateAlerts,
+  formatAlertLogLine,
+  formatMetricsLogLine,
+  mapQueueGauge,
+  overallStatusFrom,
+  QUEUE_DESCRIPTORS,
+  QueueGauge,
+  RelayStateDistribution,
+  ResolvedThresholds,
+  RoomStateDistribution,
+  safePercent,
+  safeRatio,
+  TgrMetricsReport,
+} from './tgr-metrics.collector';
+import {
+  resolveMetricsCron,
+  TGR_METRICS_THRESHOLD_DEFAULTS,
+  TGR_METRICS_THRESHOLD_ENV,
+} from './tgr-metrics.constants';
+import { getTgrMetricsSnapshot, resetTgrCounters } from './tgr-metrics';
+
+/** Cron evaluated at decoration time; env override via `TG_METRICS_CRON`. */
+const METRICS_CRON = resolveMetricsCron(process.env);
+
+const MS_PER_SECOND = 1000;
+
+/**
+ * Token-gated-rooms observability collector + emitter (Task 15, plan §13).
+ *
+ * Composes the three existing observability patterns:
+ *  - the in-memory counters in `tgr-metrics.ts` (process-local, worker memory),
+ *  - a `@Cron(TG_METRICS_CRON)` that logs ONE grep-friendly `[TgrMetrics] …`
+ *    line + any `[TgrAlert] …` breaches, then resets the rate counters
+ *    (mirrors `StabilizationService`),
+ *  - on-demand Postgres gauges (state distributions, drift, reconcile age,
+ *    backfill progress) + Bull depth/lag, served to the controller as JSON
+ *    (mirrors `MdwController.getHealth()`).
+ *
+ * Mode: `shared` — the same collector class constructs in BOTH processes. The
+ * worker's tick carries authoritative relay counters/flags; the main process
+ * serves the Postgres gauges to the read API (worker-local counters read as
+ * their main-process values there — documented on the controller). Queue
+ * injections are `@Optional()` so a queue absent in the current process (e.g.
+ * `worker:room-notify`, registered only in the worker) yields a `null` depth
+ * rather than a DI failure.
+ *
+ * Boot-safe: NOTHING is scheduled/enqueued in a lifecycle hook — the only
+ * recurring work is the read-only `@Cron`, which never enqueues and only reads.
+ */
+@Injectable()
+export class TgrMetricsService {
+  private readonly logger = new Logger(TgrMetricsService.name);
+  private readonly thresholds: ResolvedThresholds;
+  private readonly queueByKey: Map<string, Queue | undefined>;
+
+  constructor(
+    @InjectRepository(RoomMembership)
+    private readonly membershipRepo: Repository<RoomMembership>,
+    @InjectRepository(Token)
+    private readonly tokenRepo: Repository<Token>,
+    @InjectRepository(RoomBackfillState)
+    private readonly backfillStateRepo: Repository<RoomBackfillState>,
+    @Inject(tgrConfig.KEY)
+    private readonly config: ConfigType<typeof tgrConfig>,
+    @Optional()
+    @InjectQueue(prefixQueue(TGR_QUEUE_NAMES.PUBLISH_NIP29, 'worker'))
+    private readonly publishQueue?: Queue,
+    @Optional()
+    @InjectQueue(prefixQueue(TGR_QUEUE_NAMES.ROOM_BACKFILL, 'worker'))
+    private readonly backfillQueue?: Queue,
+    @Optional()
+    @InjectQueue(prefixQueue(TGR_QUEUE_NAMES.RECONCILE_BALANCE, 'main'))
+    private readonly reconcileBalanceQueue?: Queue,
+    @Optional()
+    @InjectQueue(prefixQueue(TGR_QUEUE_NAMES.RECONCILE_MEMBERSHIP, 'worker'))
+    private readonly reconcileMembershipQueue?: Queue,
+    @Optional()
+    @InjectQueue(prefixQueue(TGR_QUEUE_NAMES.ROOM_NOTIFY, 'worker'))
+    private readonly roomNotifyQueue?: Queue,
+  ) {
+    this.thresholds = this.resolveThresholds(process.env);
+    this.queueByKey = new Map([
+      ['publish', this.publishQueue],
+      ['backfill', this.backfillQueue],
+      ['reconcile_balance', this.reconcileBalanceQueue],
+      ['reconcile_membership', this.reconcileMembershipQueue],
+      ['notify', this.roomNotifyQueue],
+    ]);
+  }
+
+  /** The resolved alert thresholds (tests/observability). */
+  getThresholds(): ResolvedThresholds {
+    return this.thresholds;
+  }
+
+  /**
+   * Cron emitter (Req 2/4): compute the report, log ONE `[TgrMetrics] …` line,
+   * log a `[TgrAlert] …` line per breached rule, then reset ONLY the rate
+   * counters (gauges + flags persist). Mirrors `StabilizationService`.
+   */
+  @Cron(METRICS_CRON)
+  async emitMetrics(): Promise<void> {
+    let report: TgrMetricsReport;
+    try {
+      report = await this.collect();
+    } catch (error: any) {
+      // Never let a transient gauge-query error wedge the cron; log + bail.
+      this.logger.error(
+        `metrics collection failed: ${error?.message ?? error}`,
+      );
+      return;
+    }
+
+    this.logger.log(formatMetricsLogLine(report));
+    for (const alert of report.alerts) {
+      this.logger.warn(formatAlertLogLine(alert));
+    }
+    resetTgrCounters();
+  }
+
+  /**
+   * Compute the full metrics report (the controller body + the cron source).
+   * Read-only: indexed `GROUP BY`/counts + Bull `getJobCounts()` — no full scans,
+   * no relay reads (drift uses the STORED ledger, not a live `39002` read).
+   *
+   * @param processLocal whether the worker-local counters/flags are authoritative
+   *   in this process (true in the worker; the controller passes false from main).
+   */
+  async collect(processLocal = true): Promise<TgrMetricsReport> {
+    const [
+      queues,
+      relayState,
+      roomState,
+      membershipTotal,
+      reconcile,
+      backfill,
+    ] = await Promise.all([
+      this.collectQueueGauges(),
+      this.collectRelayStateDistribution(),
+      this.collectRoomStateDistribution(),
+      this.membershipRepo.count(),
+      this.collectReconcileAge(),
+      this.collectBackfillProgress(),
+    ]);
+
+    const driftCount = relayState.pending_add + relayState.pending_remove;
+    const snapshot = getTgrMetricsSnapshot();
+
+    const writerDownSeconds =
+      !snapshot.relayWriterConnected && snapshot.lastRelayDisconnectAt != null
+        ? Math.max(
+            0,
+            (Date.now() - snapshot.lastRelayDisconnectAt) / MS_PER_SECOND,
+          )
+        : 0;
+
+    const alerts = evaluateAlerts(
+      {
+        roomFailed: roomState.failed,
+        roomTotal:
+          roomState.none +
+          roomState.pending +
+          roomState.created +
+          roomState.failed +
+          roomState.deleted,
+        driftCount,
+        membershipTotal,
+        reconcileMaxAgeS: reconcile.maxAgeSeconds,
+        reconcileStaleCount: reconcile.staleCount,
+        relayWriterConnected: snapshot.relayWriterConnected,
+        relaySubscriberConnected: snapshot.relaySubscriberConnected,
+        relayWriterDownSeconds: writerDownSeconds,
+        queues,
+      },
+      this.thresholds,
+    );
+
+    return {
+      overallStatus: overallStatusFrom(alerts),
+      queues,
+      relay: {
+        writerConnected: snapshot.relayWriterConnected,
+        subscriberConnected: snapshot.relaySubscriberConnected,
+        reconnects: snapshot.relayReconnects,
+        lastDisconnectAt: snapshot.lastRelayDisconnectAt,
+        writerDownSeconds: Number(writerDownSeconds.toFixed(0)),
+      },
+      relayState,
+      roomState,
+      drift: {
+        count: driftCount,
+        ratio: Number(safeRatio(driftCount, membershipTotal).toFixed(4)),
+        membershipTotal,
+      },
+      reconcile,
+      backfill,
+      counters: {
+        publishOk: snapshot.publishOk,
+        publishFailed: snapshot.publishFailed,
+        ackTimeouts: snapshot.ackTimeouts,
+      },
+      alerts,
+      processLocal,
+    };
+  }
+
+  // ── gauge collectors ────────────────────────────────────────────────────────
+
+  /** Per-queue depth + lag (Req 1.1). Absent queues map to all-`null`. */
+  private async collectQueueGauges(): Promise<QueueGauge[]> {
+    const now = Date.now();
+    return Promise.all(
+      QUEUE_DESCRIPTORS.map(async (d) => {
+        const queue = this.queueByKey.get(d.key);
+        if (!queue) {
+          return mapQueueGauge(d, null, null, null, now);
+        }
+        try {
+          const [counts, paused, head] = await Promise.all([
+            queue.getJobCounts(),
+            typeof queue.isPaused === 'function' ? queue.isPaused() : false,
+            this.headWaitingTimestamp(queue),
+          ]);
+          return mapQueueGauge(d, counts as any, paused, head, now);
+        } catch (error: any) {
+          this.logger.debug(
+            `queue gauge ${d.name} failed: ${error?.message ?? error}`,
+          );
+          return mapQueueGauge(d, null, null, null, now);
+        }
+      }),
+    );
+  }
+
+  /** Oldest waiting job's `timestamp` (ms) for lag, or null when none. */
+  private async headWaitingTimestamp(queue: Queue): Promise<number | null> {
+    try {
+      // bull v4: getWaiting(start, end) — fetch only the head (oldest) job.
+      const head = await queue.getWaiting(0, 0);
+      const job = Array.isArray(head) ? head[0] : undefined;
+      const ts = job?.timestamp;
+      return typeof ts === 'number' && Number.isFinite(ts) ? ts : null;
+    } catch {
+      return null;
+    }
+  }
+
+  /** `room_membership.relay_state` distribution (Req 1.3). */
+  private async collectRelayStateDistribution(): Promise<RelayStateDistribution> {
+    const rows = await this.membershipRepo
+      .createQueryBuilder('m')
+      .select('m.relay_state', 'relay_state')
+      .addSelect('COUNT(*)', 'count')
+      .groupBy('m.relay_state')
+      .getRawMany<{ relay_state: string; count: string }>();
+
+    const dist: RelayStateDistribution = {
+      pending_add: 0,
+      added: 0,
+      pending_remove: 0,
+      removed: 0,
+    };
+    for (const row of rows) {
+      if (row.relay_state in dist) {
+        dist[row.relay_state as keyof RelayStateDistribution] = Number(
+          row.count,
+        );
+      }
+    }
+    return dist;
+  }
+
+  /** `Token.nostr_room_state` distribution (Req 1.4). */
+  private async collectRoomStateDistribution(): Promise<RoomStateDistribution> {
+    const rows = await this.tokenRepo
+      .createQueryBuilder('t')
+      .select('t.nostr_room_state', 'state')
+      .addSelect('COUNT(*)', 'count')
+      .groupBy('t.nostr_room_state')
+      .getRawMany<{ state: string; count: string }>();
+
+    const dist: RoomStateDistribution = {
+      none: 0,
+      pending: 0,
+      created: 0,
+      failed: 0,
+      deleted: 0,
+    };
+    for (const row of rows) {
+      if (row.state in dist) {
+        dist[row.state as keyof RoomStateDistribution] = Number(row.count);
+      }
+    }
+    return dist;
+  }
+
+  /**
+   * Reconciliation staleness (Req 1.6): max age of the oldest
+   * `last_reconciled_at` (seconds) + count of rows older than the SLA. A NULL
+   * `last_reconciled_at` (never reconciled) counts as stale and pins max-age to
+   * the SLA boundary so the `stale_reconcile` alert fires.
+   */
+  private async collectReconcileAge(): Promise<{
+    maxAgeSeconds: number;
+    staleCount: number;
+  }> {
+    const staleSeconds = this.thresholds.reconcileStaleSeconds;
+    const row = await this.membershipRepo
+      .createQueryBuilder('m')
+      .select('MIN(m.last_reconciled_at)', 'oldest')
+      .addSelect(
+        'COUNT(*) FILTER (WHERE m.last_reconciled_at IS NULL)',
+        'never',
+      )
+      .addSelect(
+        `COUNT(*) FILTER (WHERE m.last_reconciled_at IS NULL OR m.last_reconciled_at < (NOW() - (:stale || ' seconds')::interval))`,
+        'stale',
+      )
+      .addSelect('COUNT(*)', 'total')
+      .setParameter('stale', staleSeconds)
+      .getRawOne<{
+        oldest: Date | null;
+        never: string;
+        stale: string;
+        total: string;
+      }>();
+
+    const total = Number(row?.total ?? 0);
+    const never = Number(row?.never ?? 0);
+    const staleCount = Number(row?.stale ?? 0);
+
+    let maxAgeSeconds = 0;
+    if (total === 0) {
+      maxAgeSeconds = 0;
+    } else if (never > 0) {
+      // Never-reconciled rows are maximally stale; report just over the SLA so
+      // the alert fires without serializing Infinity to JSON.
+      maxAgeSeconds = staleSeconds + 1;
+    } else if (row?.oldest) {
+      maxAgeSeconds = Math.max(
+        0,
+        Math.round(
+          (Date.now() - new Date(row.oldest).getTime()) / MS_PER_SECOND,
+        ),
+      );
+    }
+
+    return { maxAgeSeconds, staleCount };
+  }
+
+  /**
+   * Backfill progress (Req 1.7): created/total/failed + percentage, tied to the
+   * `room_backfill_state` cursor height when present.
+   */
+  private async collectBackfillProgress(): Promise<{
+    created: number;
+    total: number;
+    failed: number;
+    percent: number;
+    cursorHeight: number | null;
+  }> {
+    const [total, created, failed, cursor] = await Promise.all([
+      this.tokenRepo.count(),
+      this.tokenRepo.count({ where: { nostr_room_state: 'created' as any } }),
+      this.tokenRepo.count({ where: { nostr_room_state: 'failed' as any } }),
+      this.backfillStateRepo
+        .findOne({ where: { id: 'global' } })
+        .catch(() => null),
+    ]);
+
+    return {
+      created,
+      total,
+      failed,
+      percent: safePercent(created, total),
+      cursorHeight: cursor?.last_height ?? null,
+    };
+  }
+
+  // ── env parsing ───────────────────────────────────────────────────────────
+
+  /** Resolve the alert thresholds from env, falling back to the §18 defaults. */
+  private resolveThresholds(
+    env: Record<string, string | undefined>,
+  ): ResolvedThresholds {
+    const num = (key: string, fallback: number): number => {
+      const raw = env[key];
+      if (raw === undefined || raw.trim() === '') {
+        return fallback;
+      }
+      const parsed = Number(raw);
+      return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+    };
+    return {
+      failedRoomRatio: num(
+        TGR_METRICS_THRESHOLD_ENV.failedRoomRatio,
+        TGR_METRICS_THRESHOLD_DEFAULTS.failedRoomRatio,
+      ),
+      driftRatio: num(
+        TGR_METRICS_THRESHOLD_ENV.driftRatio,
+        TGR_METRICS_THRESHOLD_DEFAULTS.driftRatio,
+      ),
+      reconcileStaleSeconds: num(
+        TGR_METRICS_THRESHOLD_ENV.reconcileStaleSeconds,
+        TGR_METRICS_THRESHOLD_DEFAULTS.reconcileStaleSeconds,
+      ),
+      relayDownAlertSeconds: num(
+        TGR_METRICS_THRESHOLD_ENV.relayDownAlertSeconds,
+        TGR_METRICS_THRESHOLD_DEFAULTS.relayDownAlertSeconds,
+      ),
+      queueBacklogThreshold: num(
+        TGR_METRICS_THRESHOLD_ENV.queueBacklogThreshold,
+        TGR_METRICS_THRESHOLD_DEFAULTS.queueBacklogThreshold,
+      ),
+      queueLagAlertMs: num(
+        TGR_METRICS_THRESHOLD_ENV.queueLagAlertMs,
+        TGR_METRICS_THRESHOLD_DEFAULTS.queueLagAlertMs,
+      ),
+      // TG_ROOM_NOTIFY_DEPTH_BREAK is owned by tgrConfig (§18); read it from there so
+      // the alert tracks the SAME value the circuit-breaker uses.
+      roomNotifyDepthBreak:
+        this.config?.roomNotifyDepthBreak ??
+        TGR_METRICS_THRESHOLD_DEFAULTS.roomNotifyDepthBreak,
+    };
+  }
+}

--- a/src/token-gated-rooms/observability/tgr-metrics.ts
+++ b/src/token-gated-rooms/observability/tgr-metrics.ts
@@ -1,0 +1,150 @@
+/**
+ * Lightweight in-memory metrics for the token-gated-rooms relay pipeline
+ * (Task 15, plan §13). Mirrors the canonical repo pattern in
+ * `utils/stabilization-metrics.ts`: a module-level `state` object with
+ * `incrementX`/`recordX`/`setX` setters + a `getTgrMetricsSnapshot()` reader +
+ * a `resetTgrCounters()` that zeroes ONLY the rate counters.
+ *
+ * These are **process-local** (worker memory): the relay writer/subscriber +
+ * publish processors run in the worker, so `publishOk`/`publishFailed`/
+ * `ackTimeouts`/`relayReconnects` and the connection flags reflect THAT process.
+ * When the JSON endpoint is served from the main process these fields read as
+ * their main-process values (no relay socket there → `relayWriterConnected`
+ * stays false, counters 0). The cron log line emitted by the WORKER carries the
+ * authoritative values; the controller documents the main-served caveat.
+ *
+ * Grep-friendly log tags live in `tgr-metrics.constants.ts`: `[TgrMetrics]`,
+ * `[TgrAlert]`.
+ */
+
+interface TgrMetricsState {
+  // ── rate counters (reset each cron tick) ─────────────────────────────────
+  /** Relay publishes the writer ACKed ok since the last reset. */
+  publishOk: number;
+  /** Relay publishes that failed (reject/timeout) since the last reset. */
+  publishFailed: number;
+  /** Publish ACK timeouts since the last reset (subset of `publishFailed`). */
+  ackTimeouts: number;
+  /** Relay writer reconnect attempts since the last reset. */
+  relayReconnects: number;
+
+  // ── connection flags / timestamps (NOT reset — point-in-time gauges) ──────
+  /** Relay WRITE client connected + AUTHed (Task 07 `isHealthy()`). */
+  relayWriterConnected: boolean;
+  /** Relay READ/subscriber client connected (Task 14; false until it lands). */
+  relaySubscriberConnected: boolean;
+  /** Epoch ms of the most recent relay-writer disconnect (null = never). */
+  lastRelayDisconnectAt: number | null;
+  /** Epoch ms of the most recent relay-writer (re)connect (null = never). */
+  lastRelayConnectAt: number | null;
+}
+
+const state: TgrMetricsState = {
+  publishOk: 0,
+  publishFailed: 0,
+  ackTimeouts: 0,
+  relayReconnects: 0,
+  relayWriterConnected: false,
+  relaySubscriberConnected: false,
+  lastRelayDisconnectAt: null,
+  lastRelayConnectAt: null,
+};
+
+// ── rate-counter setters ────────────────────────────────────────────────────
+
+/** A relay publish was ACKed ok (call from the relay writer / publish path). */
+export function incrementPublishOk(): void {
+  state.publishOk += 1;
+}
+
+/** A relay publish failed (reject or timeout). `timedOut` also bumps the ACK-timeout counter. */
+export function incrementPublishFailed(timedOut = false): void {
+  state.publishFailed += 1;
+  if (timedOut) {
+    state.ackTimeouts += 1;
+  }
+}
+
+/** A publish ACK did not arrive within `publishAckTimeoutMs`. */
+export function incrementAckTimeout(): void {
+  state.ackTimeouts += 1;
+}
+
+/** The relay writer attempted a reconnect. */
+export function incrementRelayReconnect(): void {
+  state.relayReconnects += 1;
+}
+
+// ── connection-flag setters ─────────────────────────────────────────────────
+
+/**
+ * Set the relay WRITE-client connection flag. A false→true edge stamps
+ * `lastRelayConnectAt`; a true→false edge stamps `lastRelayDisconnectAt`, so the
+ * `relay_down` debounce (Req 4.4) can measure how long the writer has been down.
+ */
+export function setRelayWriterConnected(connected: boolean): void {
+  const was = state.relayWriterConnected;
+  state.relayWriterConnected = connected;
+  if (connected && !was) {
+    state.lastRelayConnectAt = Date.now();
+  } else if (!connected && was) {
+    state.lastRelayDisconnectAt = Date.now();
+  }
+}
+
+/** Set the relay READ/subscriber connection flag (Task 14). */
+export function setRelaySubscriberConnected(connected: boolean): void {
+  state.relaySubscriberConnected = connected;
+}
+
+// ── reader ──────────────────────────────────────────────────────────────────
+
+export interface TgrMetricsSnapshot {
+  publishOk: number;
+  publishFailed: number;
+  ackTimeouts: number;
+  relayReconnects: number;
+  relayWriterConnected: boolean;
+  relaySubscriberConnected: boolean;
+  lastRelayDisconnectAt: number | null;
+  lastRelayConnectAt: number | null;
+}
+
+/** Snapshot of the current in-process counters + flags. */
+export function getTgrMetricsSnapshot(): TgrMetricsSnapshot {
+  return {
+    publishOk: state.publishOk,
+    publishFailed: state.publishFailed,
+    ackTimeouts: state.ackTimeouts,
+    relayReconnects: state.relayReconnects,
+    relayWriterConnected: state.relayWriterConnected,
+    relaySubscriberConnected: state.relaySubscriberConnected,
+    lastRelayDisconnectAt: state.lastRelayDisconnectAt,
+    lastRelayConnectAt: state.lastRelayConnectAt,
+  };
+}
+
+/**
+ * Reset the RATE counters after a cron emit (mirrors
+ * `resetStabilizationCounters`). Connection flags + timestamps are point-in-time
+ * gauges and are intentionally LEFT untouched (a reset must not "forget" that the
+ * relay is currently down, nor when it disconnected).
+ */
+export function resetTgrCounters(): void {
+  state.publishOk = 0;
+  state.publishFailed = 0;
+  state.ackTimeouts = 0;
+  state.relayReconnects = 0;
+}
+
+/**
+ * Full reset incl. flags/timestamps — TESTS ONLY (so a prior test's edges don't
+ * leak into the next). Production code uses {@link resetTgrCounters}.
+ */
+export function __resetTgrMetricsForTests(): void {
+  resetTgrCounters();
+  state.relayWriterConnected = false;
+  state.relaySubscriberConnected = false;
+  state.lastRelayDisconnectAt = null;
+  state.lastRelayConnectAt = null;
+}

--- a/src/token-gated-rooms/observability/tgr-observability.module.ts
+++ b/src/token-gated-rooms/observability/tgr-observability.module.ts
@@ -1,0 +1,36 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Token } from '@/tokens/entities/token.entity';
+import tgrConfig from '../config/tgr.config';
+import { RoomMembership } from '../entities/room-membership.entity';
+import { RoomBackfillState } from '../entities/room-backfill-state.entity';
+import { TgrMetricsService } from './tgr-metrics.service';
+import { TgrMetricsController } from './tgr-metrics.controller';
+
+/**
+ * Observability & SLOs for token-gated rooms (plan §13).
+ *
+ * Plain self-contained `@Module` (worker mode removed — see `deworker-plan.md`).
+ * The collector (`TgrMetricsService`, a `@Cron` emitter) and the HTTP read surface
+ * (`TgrMetricsController`, `GET /api/tgr/metrics`) both load in the single process.
+ *
+ * ## Queues
+ * The collector reads depth/lag via `@Optional() @InjectQueue` against the
+ * canonical TGR queues. It registers NONE of them (avoids double-registration):
+ * `TokenGatedRoomsModule` / `RoomNotificationsModule` already do. Imported by
+ * `TokenGatedRoomsModule` AFTER those queue registrations so the tokens resolve.
+ *
+ * Boot-safe: nothing schedules/enqueues in a lifecycle hook; the only recurring
+ * work is the read-only metrics `@Cron`.
+ */
+@Module({
+  imports: [
+    ConfigModule.forFeature(tgrConfig),
+    TypeOrmModule.forFeature([Token, RoomMembership, RoomBackfillState]),
+  ],
+  providers: [TgrMetricsService],
+  controllers: [TgrMetricsController],
+  exports: [TgrMetricsService],
+})
+export class TgrObservabilityModule {}

--- a/src/token-gated-rooms/plugins/aci/FungibleTokenFull.aci.json
+++ b/src/token-gated-rooms/plugins/aci/FungibleTokenFull.aci.json
@@ -1,0 +1,433 @@
+[
+  {
+    "namespace": {
+      "name": "ListInternal",
+      "typedefs": []
+    }
+  },
+  {
+    "namespace": {
+      "name": "List",
+      "typedefs": []
+    }
+  },
+  {
+    "namespace": {
+      "name": "String",
+      "typedefs": []
+    }
+  },
+  {
+    "contract": {
+      "event": {
+        "variant": [
+          {
+            "Transfer": [
+              "address",
+              "address",
+              "int"
+            ]
+          },
+          {
+            "Allowance": [
+              "address",
+              "address",
+              "int"
+            ]
+          },
+          {
+            "Burn": [
+              "address",
+              "int"
+            ]
+          },
+          {
+            "Mint": [
+              "address",
+              "int"
+            ]
+          },
+          {
+            "Swap": [
+              "address",
+              "int"
+            ]
+          }
+        ]
+      },
+      "functions": [
+        {
+          "arguments": [],
+          "name": "aex9_extensions",
+          "payable": false,
+          "returns": {
+            "list": [
+              "string"
+            ]
+          },
+          "stateful": false
+        },
+        {
+          "arguments": [
+            {
+              "name": "name",
+              "type": "string"
+            },
+            {
+              "name": "decimals",
+              "type": "int"
+            },
+            {
+              "name": "symbol",
+              "type": "string"
+            },
+            {
+              "name": "initial_owner_balance",
+              "type": {
+                "option": [
+                  "int"
+                ]
+              }
+            }
+          ],
+          "name": "init",
+          "payable": false,
+          "returns": "FungibleTokenFull.state",
+          "stateful": false
+        },
+        {
+          "arguments": [],
+          "name": "meta_info",
+          "payable": false,
+          "returns": "FungibleTokenFull.meta_info",
+          "stateful": false
+        },
+        {
+          "arguments": [],
+          "name": "total_supply",
+          "payable": false,
+          "returns": "int",
+          "stateful": false
+        },
+        {
+          "arguments": [],
+          "name": "owner",
+          "payable": false,
+          "returns": "address",
+          "stateful": false
+        },
+        {
+          "arguments": [],
+          "name": "balances",
+          "payable": false,
+          "returns": "FungibleTokenFull.balances",
+          "stateful": false
+        },
+        {
+          "arguments": [
+            {
+              "name": "account",
+              "type": "address"
+            }
+          ],
+          "name": "balance",
+          "payable": false,
+          "returns": {
+            "option": [
+              "int"
+            ]
+          },
+          "stateful": false
+        },
+        {
+          "arguments": [],
+          "name": "swapped",
+          "payable": false,
+          "returns": {
+            "map": [
+              "address",
+              "int"
+            ]
+          },
+          "stateful": false
+        },
+        {
+          "arguments": [],
+          "name": "allowances",
+          "payable": false,
+          "returns": "FungibleTokenFull.allowances",
+          "stateful": false
+        },
+        {
+          "arguments": [
+            {
+              "name": "allowance_accounts",
+              "type": "FungibleTokenFull.allowance_accounts"
+            }
+          ],
+          "name": "allowance",
+          "payable": false,
+          "returns": {
+            "option": [
+              "int"
+            ]
+          },
+          "stateful": false
+        },
+        {
+          "arguments": [
+            {
+              "name": "from_account",
+              "type": "address"
+            }
+          ],
+          "name": "allowance_for_caller",
+          "payable": false,
+          "returns": {
+            "option": [
+              "int"
+            ]
+          },
+          "stateful": false
+        },
+        {
+          "arguments": [
+            {
+              "name": "from_account",
+              "type": "address"
+            },
+            {
+              "name": "to_account",
+              "type": "address"
+            },
+            {
+              "name": "value",
+              "type": "int"
+            }
+          ],
+          "name": "transfer_allowance",
+          "payable": false,
+          "returns": {
+            "tuple": []
+          },
+          "stateful": true
+        },
+        {
+          "arguments": [
+            {
+              "name": "for_account",
+              "type": "address"
+            },
+            {
+              "name": "value",
+              "type": "int"
+            }
+          ],
+          "name": "create_allowance",
+          "payable": false,
+          "returns": {
+            "tuple": []
+          },
+          "stateful": true
+        },
+        {
+          "arguments": [
+            {
+              "name": "for_account",
+              "type": "address"
+            },
+            {
+              "name": "value_change",
+              "type": "int"
+            }
+          ],
+          "name": "change_allowance",
+          "payable": false,
+          "returns": {
+            "tuple": []
+          },
+          "stateful": true
+        },
+        {
+          "arguments": [
+            {
+              "name": "for_account",
+              "type": "address"
+            }
+          ],
+          "name": "reset_allowance",
+          "payable": false,
+          "returns": {
+            "tuple": []
+          },
+          "stateful": true
+        },
+        {
+          "arguments": [
+            {
+              "name": "to_account",
+              "type": "address"
+            },
+            {
+              "name": "value",
+              "type": "int"
+            }
+          ],
+          "name": "transfer",
+          "payable": false,
+          "returns": {
+            "tuple": []
+          },
+          "stateful": true
+        },
+        {
+          "arguments": [
+            {
+              "name": "value",
+              "type": "int"
+            }
+          ],
+          "name": "burn",
+          "payable": false,
+          "returns": {
+            "tuple": []
+          },
+          "stateful": true
+        },
+        {
+          "arguments": [
+            {
+              "name": "account",
+              "type": "address"
+            },
+            {
+              "name": "value",
+              "type": "int"
+            }
+          ],
+          "name": "mint",
+          "payable": false,
+          "returns": {
+            "tuple": []
+          },
+          "stateful": true
+        },
+        {
+          "arguments": [],
+          "name": "swap",
+          "payable": false,
+          "returns": {
+            "tuple": []
+          },
+          "stateful": true
+        },
+        {
+          "arguments": [
+            {
+              "name": "account",
+              "type": "address"
+            }
+          ],
+          "name": "check_swap",
+          "payable": false,
+          "returns": "int",
+          "stateful": true
+        }
+      ],
+      "kind": "contract_main",
+      "name": "FungibleTokenFull",
+      "payable": false,
+      "state": {
+        "record": [
+          {
+            "name": "owner",
+            "type": "address"
+          },
+          {
+            "name": "total_supply",
+            "type": "int"
+          },
+          {
+            "name": "balances",
+            "type": "FungibleTokenFull.balances"
+          },
+          {
+            "name": "meta_info",
+            "type": "FungibleTokenFull.meta_info"
+          },
+          {
+            "name": "allowances",
+            "type": "FungibleTokenFull.allowances"
+          },
+          {
+            "name": "swapped",
+            "type": {
+              "map": [
+                "address",
+                "int"
+              ]
+            }
+          }
+        ]
+      },
+      "typedefs": [
+        {
+          "name": "meta_info",
+          "typedef": {
+            "record": [
+              {
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "name": "symbol",
+                "type": "string"
+              },
+              {
+                "name": "decimals",
+                "type": "int"
+              }
+            ]
+          },
+          "vars": []
+        },
+        {
+          "name": "allowance_accounts",
+          "typedef": {
+            "record": [
+              {
+                "name": "from_account",
+                "type": "address"
+              },
+              {
+                "name": "for_account",
+                "type": "address"
+              }
+            ]
+          },
+          "vars": []
+        },
+        {
+          "name": "balances",
+          "typedef": {
+            "map": [
+              "address",
+              "int"
+            ]
+          },
+          "vars": []
+        },
+        {
+          "name": "allowances",
+          "typedef": {
+            "map": [
+              "FungibleTokenFull.allowance_accounts",
+              "int"
+            ]
+          },
+          "vars": []
+        }
+      ]
+    }
+  }
+]

--- a/src/token-gated-rooms/plugins/aex9-transfer-plugin.module.ts
+++ b/src/token-gated-rooms/plugins/aex9-transfer-plugin.module.ts
@@ -1,0 +1,62 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { BullModule } from '@nestjs/bull';
+import { ConfigModule } from '@nestjs/config';
+import { Tx } from '@/mdw-sync/entities/tx.entity';
+import { PluginSyncState } from '@/mdw-sync/entities/plugin-sync-state.entity';
+import { SyncState } from '@/mdw-sync/entities/sync-state.entity';
+import { Token } from '@/tokens/entities/token.entity';
+import { AeModule } from '@/ae/ae.module';
+import { TokenBalance } from '../entities/token-balance.entity';
+import { RoomMembership } from '../entities/room-membership.entity';
+import tgrConfig from '../config/tgr.config';
+import { BalanceIndexerService } from '../services/balance-indexer.service';
+import { BalanceReconciliationService } from '../services/balance-reconciliation.service';
+import { RECONCILE_BALANCE_QUEUE } from '../services/balance-reconciliation.service';
+import { ReorgEvictionService } from '../services/reorg-eviction.service';
+import { Aex9TransferSyncService } from './aex9-transfer-sync.service';
+import { Aex9TransferPlugin } from './aex9-transfer.plugin';
+
+/**
+ * AEX9 balance indexer plugin module (Task 03), mirroring `BclPluginModule`. This
+ * is a **main-mode** indexer plugin: the integrator adds `Aex9TransferPluginModule`
+ * to `PLUGIN_MODULES` and `Aex9TransferPlugin` to `getPluginProvider()` in
+ * `src/plugins/index.ts`.
+ *
+ * It owns the `reconcile-balance` Bull queue (prefixed via `TGR_QUEUE_OWNER`,
+ * which maps `reconcile-balance` to the **main** process → `main:reconcile-balance`;
+ * the AEX9 sweep is driven by the indexer, not the relay worker), the
+ * AEX9-transfer sync service, the community-token allowlist
+ * (`BalanceIndexerService`), and the repeatable reconciliation sweep.
+ *
+ * `BalanceIndexerService` and `Aex9TransferPlugin` are exported so the global
+ * plugin registry can inject the plugin (and tests/Task 06 can read the allowlist
+ * helpers).
+ */
+@Module({
+  imports: [
+    ConfigModule.forFeature(tgrConfig),
+    TypeOrmModule.forFeature([
+      Tx,
+      PluginSyncState,
+      SyncState,
+      Token,
+      TokenBalance,
+      RoomMembership,
+    ]),
+    AeModule,
+    BullModule.registerQueue({ name: RECONCILE_BALANCE_QUEUE }),
+  ],
+  providers: [
+    BalanceIndexerService,
+    Aex9TransferSyncService,
+    Aex9TransferPlugin,
+    BalanceReconciliationService,
+    // Task 11: the plugin's onReorg buffers at-risk evictions (main-side). The
+    // worker-only collaborators (publish queue + RoomAdminsService) are @Optional
+    // on ReorgEvictionService, so it constructs here with repos only.
+    ReorgEvictionService,
+  ],
+  exports: [Aex9TransferPlugin, BalanceIndexerService],
+})
+export class Aex9TransferPluginModule {}

--- a/src/token-gated-rooms/plugins/aex9-transfer-sync.service.ts
+++ b/src/token-gated-rooms/plugins/aex9-transfer-sync.service.ts
@@ -1,0 +1,220 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { BigNumber } from 'bignumber.js';
+import { AeSdkService } from '@/ae/ae-sdk.service';
+import { Tx } from '@/mdw-sync/entities/tx.entity';
+import { Encoded } from '@aeternity/aepp-sdk';
+import { serializeBigInts } from '@/utils/common';
+import { BasePluginSyncService } from '@/plugins/base-plugin-sync.service';
+import { SyncDirection } from '@/plugins/plugin.interface';
+import { BalanceIndexerService } from '../services/balance-indexer.service';
+import FungibleTokenFullACI from './aci/FungibleTokenFull.aci.json';
+
+/** Plugin name — must match `Aex9TransferPlugin.name` (the `tx.logs[...]` key). */
+export const AEX9_TRANSFER_PLUGIN_NAME = 'aex9-transfer';
+/** Plugin version — bump to force a full re-decode of indexed transfers. */
+export const AEX9_TRANSFER_PLUGIN_VERSION = 1;
+
+/** A decoded AEX9 event as returned by `$decodeEvents` + `serializeBigInts`. */
+interface DecodedAex9Event {
+  name: string;
+  args: unknown[];
+}
+
+/**
+ * Decodes AEX9 `Transfer` events from `tx.raw.log` and applies the balance
+ * deltas to `token_balance` in **raw integer base units** (plan §5.4). `Allowance`
+ * (and every non-`Transfer` event) is dropped — only `Transfer` moves balances
+ * (mirrors the bot's `decodeAex9Events`).
+ *
+ * Idempotency: the decoded transfers are persisted onto `tx.logs[name]` by
+ * `BasePlugin` with a `_version` stamp. We only mutate balances once per tx — the
+ * first time the tx is seen at the current plugin version (`tx.logs[name] === undefined`
+ * pre-`processBatch`). On a re-process (live + backfill both touch a tx, or a
+ * version bump) the legs are decoded again but NOT re-applied, so a transfer is
+ * counted exactly once.
+ */
+@Injectable()
+export class Aex9TransferSyncService extends BasePluginSyncService {
+  protected readonly logger = new Logger(Aex9TransferSyncService.name);
+
+  constructor(
+    aeSdkService: AeSdkService,
+    private readonly balanceIndexer: BalanceIndexerService,
+    @InjectRepository(Tx)
+    private readonly txRepository: Repository<Tx>,
+  ) {
+    super(aeSdkService);
+  }
+
+  /**
+   * Decode logs from `tx.raw.log` with the AEX9 ACI, keeping only `Transfer`
+   * events. Returns the decoded array (stored on `tx.logs[name]` by BasePlugin)
+   * or `null` when there is nothing to decode. The contract instance is keyed by
+   * `tx.contract_id` (the AEX9 token) so each token gets its own cached decoder.
+   */
+  async decodeLogs(tx: Tx): Promise<DecodedAex9Event[] | null> {
+    if (!tx?.raw?.log || !tx.contract_id) {
+      return null;
+    }
+    try {
+      const contract = await this.getContract(
+        tx.contract_id as Encoded.ContractAddress,
+        FungibleTokenFullACI,
+      );
+      const decoded = contract.$decodeEvents(tx.raw.log, {
+        omitUnknown: true,
+      });
+      const transfers = (
+        serializeBigInts(decoded) as DecodedAex9Event[]
+      ).filter((event) => event?.name === 'Transfer');
+      return transfers.length > 0 ? transfers : null;
+    } catch (error: any) {
+      const isUnknownEventError =
+        error?.name === 'MissingEventDefinitionError' ||
+        error?.message?.includes("Can't find definition");
+      if (isUnknownEventError) {
+        this.logger.warn(
+          `Failed to decode AEX9 logs for tx ${tx.hash} due to unknown event definition`,
+        );
+      } else {
+        this.logger.error(
+          `Failed to decode AEX9 logs for tx ${tx.hash}`,
+          error.stack,
+        );
+      }
+      return null;
+    }
+  }
+
+  /**
+   * Apply a single tx's decoded `Transfer` legs to `token_balance`. Idempotent:
+   * `alreadyApplied` short-circuits a re-process so live+backfill (or a version
+   * re-decode) never double-counts. Emits `tgr.balance.changed` for each holder
+   * whose persisted balance actually changed.
+   */
+  async processTransaction(
+    tx: Tx,
+    _syncDirection: SyncDirection,
+  ): Promise<void> {
+    void _syncDirection;
+    if (!tx.contract_id) {
+      return;
+    }
+    // Defense in depth: the predicate already gated on the allowlist, but a
+    // re-decode/backfill path could feed a tx for a token no longer indexed.
+    if (!this.balanceIndexer.isCommunityToken(tx.contract_id)) {
+      return;
+    }
+    if (this.alreadyApplied(tx)) {
+      return;
+    }
+
+    const transfers = this.extractTransfers(tx);
+    if (transfers.length === 0) {
+      await this.markApplied(tx);
+      return;
+    }
+
+    const tokenAddress = tx.contract_id;
+    const height = tx.block_height ?? 0;
+    const changedHolders = new Set<string>();
+
+    for (const transfer of transfers) {
+      const [from, to, rawValue] = transfer.args as [string, string, string];
+      let value: BigNumber;
+      try {
+        value = new BigNumber(rawValue as any);
+      } catch {
+        continue;
+      }
+      if (!value.isFinite() || value.lte(0)) {
+        continue;
+      }
+
+      if (from) {
+        const next = await this.balanceIndexer.applyDelta(
+          tokenAddress,
+          from,
+          value.negated(),
+          height,
+        );
+        if (next !== null) {
+          changedHolders.add(from);
+        }
+      }
+      if (to) {
+        const next = await this.balanceIndexer.applyDelta(
+          tokenAddress,
+          to,
+          value,
+          height,
+        );
+        if (next !== null) {
+          changedHolders.add(to);
+        }
+      }
+    }
+
+    await this.markApplied(tx);
+
+    for (const holder of changedHolders) {
+      this.balanceIndexer.emitBalanceChanged(tokenAddress, holder);
+    }
+  }
+
+  /**
+   * Read the `Transfer` legs for a tx from the persisted decoded version on
+   * `tx.logs[name]` (written by `BasePlugin.processBatch`/`syncHistoricalTransactions`
+   * via `decodeLogs` BEFORE `processTransaction` runs). Returns `[]` when there is
+   * no decoded payload — there is nothing to apply. Already filtered to `Transfer`
+   * at decode time; filtered again here defensively.
+   */
+  private extractTransfers(tx: Tx): DecodedAex9Event[] {
+    const persisted = tx.logs?.[AEX9_TRANSFER_PLUGIN_NAME]?.data as
+      | DecodedAex9Event[]
+      | undefined;
+    if (Array.isArray(persisted)) {
+      return persisted.filter((event) => event?.name === 'Transfer');
+    }
+    return [];
+  }
+
+  /**
+   * Idempotency guard. A tx whose balance legs were already applied carries an
+   * `_applied: true` marker (set by `markApplied`, persisted via the data merge
+   * BasePlugin saves). Returns true when the tx must NOT be re-applied.
+   */
+  private alreadyApplied(tx: Tx): boolean {
+    return tx.data?.[AEX9_TRANSFER_PLUGIN_NAME]?.data?._applied === true;
+  }
+
+  /**
+   * Mark the tx as balance-applied and **persist** it, so a later re-process
+   * (live↔backfill overlap, version re-decode, or restart) is a no-op. BasePlugin
+   * also stamps `_version`; here we set the `_applied` flag the guard reads. The
+   * write is guarded so a persistence failure does not crash the batch (the
+   * balance legs already committed; worst case a future re-process re-applies and
+   * is caught by the clamp/equality no-op).
+   */
+  private async markApplied(tx: Tx): Promise<void> {
+    const current = tx.data || {};
+    const existing = current[AEX9_TRANSFER_PLUGIN_NAME]?.data || {};
+    tx.data = {
+      ...current,
+      [AEX9_TRANSFER_PLUGIN_NAME]: {
+        _version: AEX9_TRANSFER_PLUGIN_VERSION,
+        data: { ...existing, _applied: true },
+      },
+    };
+    try {
+      await this.txRepository.update({ hash: tx.hash }, { data: tx.data });
+    } catch (error: any) {
+      this.logger.warn(
+        `Failed to persist _applied marker for tx ${tx.hash}; idempotency relies on the in-memory flag for this run`,
+        error,
+      );
+    }
+  }
+}

--- a/src/token-gated-rooms/plugins/aex9-transfer.plugin.ts
+++ b/src/token-gated-rooms/plugins/aex9-transfer.plugin.ts
@@ -1,0 +1,107 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Tx } from '@/mdw-sync/entities/tx.entity';
+import { PluginSyncState } from '@/mdw-sync/entities/plugin-sync-state.entity';
+import { BasePlugin } from '@/plugins/base-plugin';
+import { PluginFilter } from '@/plugins/plugin.interface';
+import { BCL_FACTORY } from '@/configs/contracts';
+import { ACTIVE_NETWORK } from '@/configs/network';
+import { BalanceIndexerService } from '../services/balance-indexer.service';
+import { ReorgEvictionService } from '../services/reorg-eviction.service';
+import {
+  Aex9TransferSyncService,
+  AEX9_TRANSFER_PLUGIN_NAME,
+  AEX9_TRANSFER_PLUGIN_VERSION,
+} from './aex9-transfer-sync.service';
+
+/**
+ * Indexer plugin (MAIN mode only) that indexes AEX9 `Transfer` events for
+ * community tokens into the `token_balance` ledger (plan §5.3/§5.4). It closes the
+ * gap where `TokenHolderService` only tracks BCL buy/sell — any plain AEX9
+ * transfer, DEX swap, or airdrop is now reflected in the authoritative raw-balance
+ * table that token gating (Task 06) reads.
+ *
+ * The filter is a single **predicate** mirroring `BclPlugin`: gate on
+ * `ContractCallTx` whose `contract_id` is in the community-token allowlist
+ * (`BalanceIndexerService.isCommunityToken`). The `Transfer`-event check itself is
+ * done at decode time in the sync service (not every call on the token is a
+ * transfer).
+ *
+ * Reorg (Task 11 §6): precise per-tx balance rollback stays out of scope (the
+ * reverted txs are already deleted and balances were applied additively → drift is
+ * self-healed by the AEX9 reconciliation sweep + eligibility recompute). What this
+ * plugin DOES do on reorg is hand any at-risk membership rows (published, now
+ * `eligible=false`, non-admin) to {@link ReorgEvictionService.bufferAllPendingEvictions}
+ * so a balance drop from a not-yet-confirmed block does NOT evict a member from
+ * `39002` prematurely — the worker's scheduled flush publishes the `9001` only once
+ * the reorg depth has passed (plan §6.5).
+ */
+@Injectable()
+export class Aex9TransferPlugin extends BasePlugin {
+  protected readonly logger = new Logger(Aex9TransferPlugin.name);
+  readonly name = AEX9_TRANSFER_PLUGIN_NAME;
+  readonly version = AEX9_TRANSFER_PLUGIN_VERSION;
+
+  constructor(
+    @InjectRepository(Tx)
+    protected readonly txRepository: Repository<Tx>,
+    @InjectRepository(PluginSyncState)
+    protected readonly pluginSyncStateRepository: Repository<PluginSyncState>,
+    private readonly balanceIndexer: BalanceIndexerService,
+    private readonly aex9TransferSyncService: Aex9TransferSyncService,
+    private readonly reorgEviction: ReorgEvictionService,
+  ) {
+    super();
+  }
+
+  /**
+   * Earliest relevant height: the BCL factory deploy height (community tokens
+   * cannot predate it), the same source `BclPlugin.startFromHeight` uses.
+   */
+  startFromHeight(): number {
+    const networkId = ACTIVE_NETWORK.networkId;
+    return BCL_FACTORY[networkId]?.deployed_at_block_height ?? 0;
+  }
+
+  filters(): PluginFilter[] {
+    return [
+      {
+        predicate: (tx) =>
+          tx.type === 'ContractCallTx' &&
+          !!tx.contract_id &&
+          this.balanceIndexer.isCommunityToken(tx.contract_id),
+      },
+    ];
+  }
+
+  protected getSyncService(): Aex9TransferSyncService {
+    return this.aex9TransferSyncService;
+  }
+
+  /**
+   * Reorg-gated eviction buffering (Task 11 §6). Precise balance rollback is out of
+   * scope (deferred to the reconciliation sweep); what we MUST do here is ensure a
+   * balance drop caused by a reverted block does not evict a member from `39002`
+   * before the reorg depth confirms — so we buffer every currently at-risk
+   * membership (drift-bounded, not registry-wide). The flush (worker) publishes the
+   * `9001` only after `TG_REORG_CONFIRMATION_DEPTH_BLOCKS`, and cancels it if the
+   * member becomes eligible again. An empty `removedTxHashes` is a no-op.
+   */
+  async onReorg(removedTxHashes: string[]): Promise<void> {
+    if (!removedTxHashes || removedTxHashes.length === 0) {
+      return;
+    }
+    try {
+      const buffered = await this.reorgEviction.bufferAllPendingEvictions();
+      this.logger.log(
+        `[${this.name}] reorg: buffered ${buffered} at-risk eviction(s) ` +
+          `(${removedTxHashes.length} removed tx(s))`,
+      );
+    } catch (error: any) {
+      this.logger.error(
+        `[${this.name}] reorg: bufferAllPendingEvictions failed: ${error?.message ?? error}`,
+      );
+    }
+  }
+}

--- a/src/token-gated-rooms/plugins/community-room-state-plugin.module.ts
+++ b/src/token-gated-rooms/plugins/community-room-state-plugin.module.ts
@@ -1,0 +1,61 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Tx } from '@/mdw-sync/entities/tx.entity';
+import { PluginSyncState } from '@/mdw-sync/entities/plugin-sync-state.entity';
+import { SyncState } from '@/mdw-sync/entities/sync-state.entity';
+import { Token } from '@/tokens/entities/token.entity';
+import { AeModule } from '@/ae/ae.module';
+import tgrConfig from '../config/tgr.config';
+import { CommunityRoom } from '../entities/community-room.entity';
+import { RoomMembership } from '../entities/room-membership.entity';
+import { RoomStateService } from '../services/room-state.service';
+import { CommunityRoomBackfillService } from '../services/community-room-backfill.service';
+import { ReorgEvictionService } from '../services/reorg-eviction.service';
+import { CommunityRoomStateSyncService } from './community-room-state-sync.service';
+import { CommunityRoomStatePlugin } from './community-room-state.plugin';
+
+/**
+ * Community-room state indexer module (Task 04, MAIN process).
+ *
+ * Mirrors `BclPluginModule`: registers the plugin + its sync service + the
+ * shared read/backfill services and the repos they need. The integrator wires
+ * `CommunityRoomStatePlugin` into `src/plugins/index.ts`
+ * (`PLUGIN_MODULES` + `getPluginProvider` → `MDW_PLUGIN`) so the reorg service
+ * and live indexer reach it. EventEmitter2 is global (registered by mdw-sync),
+ * so it is injectable without importing anything here.
+ *
+ * `RoomStateService` is exported so eligibility (06) / eager backfill (09) can
+ * reuse the canonical read path; `CommunityRoomBackfillService` is exported so a
+ * scheduler/CLI can drive the resumable sweep.
+ */
+@Module({
+  imports: [
+    ConfigModule.forFeature(tgrConfig),
+    TypeOrmModule.forFeature([
+      Tx,
+      PluginSyncState,
+      SyncState,
+      Token,
+      CommunityRoom,
+      RoomMembership,
+    ]),
+    AeModule,
+  ],
+  providers: [
+    RoomStateService,
+    CommunityRoomBackfillService,
+    CommunityRoomStateSyncService,
+    CommunityRoomStatePlugin,
+    // Task 11: the plugin's onReorg buffers at-risk evictions (main-side). The
+    // worker-only collaborators (publish queue + RoomAdminsService) are @Optional
+    // on ReorgEvictionService, so it constructs here with repos only.
+    ReorgEvictionService,
+  ],
+  exports: [
+    CommunityRoomStatePlugin,
+    RoomStateService,
+    CommunityRoomBackfillService,
+  ],
+})
+export class CommunityRoomStatePluginModule {}

--- a/src/token-gated-rooms/plugins/community-room-state-sync.service.ts
+++ b/src/token-gated-rooms/plugins/community-room-state-sync.service.ts
@@ -1,0 +1,64 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { AeSdkService } from '@/ae/ae-sdk.service';
+import { Tx } from '@/mdw-sync/entities/tx.entity';
+import { BasePluginSyncService } from '@/plugins/base-plugin-sync.service';
+import { SyncDirection } from '@/plugins/plugin.interface';
+import CommunityManagementACI from '@/plugins/bcl/contract/aci/CommunityManagement.aci.json';
+
+/**
+ * Sync-service seam for the community-room-state plugin.
+ *
+ * The plugin's reactive work is driven by `LIVE_TX_EVENT` (see the plugin), not
+ * the indexer `processBatch` pipeline, so `processTransaction` is intentionally a
+ * no-op here and the plugin's `filters()` are empty. This class exists only to
+ * satisfy `BasePlugin`'s abstract `getSyncService()` and to reuse the cached,
+ * SDK-backed `getContract` helper for decoding `CommunityManagement` event logs.
+ */
+@Injectable()
+export class CommunityRoomStateSyncService extends BasePluginSyncService {
+  protected readonly logger = new Logger(CommunityRoomStateSyncService.name);
+
+  constructor(aeSdkService: AeSdkService) {
+    super(aeSdkService);
+  }
+
+  // Reactive upserts happen in the plugin's LIVE_TX_EVENT handler; nothing to do
+  // in the batch pipeline (filters() is empty so this is never reached anyway).
+  async processTransaction(
+    _tx: Tx,
+    _syncDirection: SyncDirection,
+  ): Promise<void> {
+    void _tx;
+    void _syncDirection;
+  }
+
+  /**
+   * Decode the event names emitted by a `CommunityManagement` contract call from
+   * `tx.raw.log`. Returns the decoded event `name`s (e.g. `MuteUserId`,
+   * `AddModerator`); unknown events are omitted. Tolerant of decode failures —
+   * returns `[]` so the caller can decide based on the allowlist alone.
+   */
+  async decodeManagementEventNames(
+    contractAddress: string,
+    logs: any,
+  ): Promise<string[]> {
+    if (!Array.isArray(logs) || logs.length === 0) {
+      return [];
+    }
+    try {
+      const contract = await this.getContract(
+        contractAddress as any,
+        CommunityManagementACI,
+      );
+      const decoded = contract.$decodeEvents(logs, { omitUnknown: true });
+      return (decoded || [])
+        .map((e: any) => e?.name)
+        .filter((n: any): n is string => typeof n === 'string');
+    } catch (error: any) {
+      this.logger.debug(
+        `Failed to decode management events for ${contractAddress}: ${error?.message ?? error}`,
+      );
+      return [];
+    }
+  }
+}

--- a/src/token-gated-rooms/plugins/community-room-state.plugin.spec.ts
+++ b/src/token-gated-rooms/plugins/community-room-state.plugin.spec.ts
@@ -1,0 +1,255 @@
+import {
+  CommunityRoomStatePlugin,
+  MANAGEMENT_CHANGED_EVENTS,
+} from './community-room-state.plugin';
+import { BCL_CONTRACT } from '@/plugins/bcl/config/bcl.config';
+import { BCL_FUNCTIONS } from '@/configs/constants';
+import type { Tx } from '@/mdw-sync/entities/tx.entity';
+import type { Token } from '@/tokens/entities/token.entity';
+
+/**
+ * Unit coverage for the reactive plugin shell (Task 04 req §1, §8).
+ *
+ * Predicates: `create_community` on the BCL factory matches community-created; a
+ * `MuteUserId` log on an allowlisted management address matches
+ * management-changed; an unrelated call matches neither. Reorg: `onReorg`
+ * resolves affected rooms from the rolled-back create-tx hashes and re-derives
+ * via `readAndUpsertRoomState` (live `get_state()`), and is a no-op on empty /
+ * unrelated hashes.
+ */
+describe('CommunityRoomStatePlugin', () => {
+  const FACTORY = BCL_CONTRACT.contractAddress;
+  const MGMT = 'ct_mgmt_allow';
+  const SALE = 'ct_sale_1';
+
+  type Deps = {
+    plugin: CommunityRoomStatePlugin;
+    roomState: {
+      readAndUpsertRoomState: jest.Mock;
+      resolveManagementAddress: jest.Mock;
+    };
+    sync: { decodeManagementEventNames: jest.Mock };
+    tokenRepo: { findOne: jest.Mock; find: jest.Mock };
+    roomRepo: { find: jest.Mock };
+    reorgEviction: { bufferEvictions: jest.Mock };
+  };
+
+  const makePlugin = (): Deps => {
+    const roomState = {
+      readAndUpsertRoomState: jest.fn().mockResolvedValue({ emitted: true }),
+      resolveManagementAddress: jest.fn().mockResolvedValue(MGMT),
+    };
+    const sync = {
+      decodeManagementEventNames: jest.fn().mockResolvedValue(['MuteUserId']),
+    };
+    const tokenRepo = {
+      findOne: jest.fn().mockResolvedValue({ sale_address: SALE } as Token),
+      find: jest.fn().mockResolvedValue([]),
+    };
+    const roomRepo = { find: jest.fn().mockResolvedValue([]) };
+    const config = { communityTokenRefreshSec: 300 } as any;
+
+    const reorgEviction = { bufferEvictions: jest.fn().mockResolvedValue(0) };
+
+    const plugin = new CommunityRoomStatePlugin(
+      {} as any, // txRepository
+      {} as any, // pluginSyncStateRepository
+      tokenRepo as any,
+      roomRepo as any,
+      roomState as any,
+      sync as any,
+      reorgEviction as any,
+      config,
+    );
+    return { plugin, roomState, sync, tokenRepo, roomRepo, reorgEviction };
+  };
+
+  it('exposes the canonical name + version and empty batch filters', () => {
+    const { plugin } = makePlugin();
+    expect(plugin.name).toBe('community-room-state');
+    expect(plugin.version).toBe(1);
+    expect(plugin.filters()).toEqual([]);
+  });
+
+  it('matches create_community on the BCL factory (community-created)', () => {
+    const { plugin } = makePlugin();
+    expect(
+      plugin.isCommunityCreatedTx({
+        type: 'ContractCallTx',
+        function: BCL_FUNCTIONS.create_community,
+        contract_id: FACTORY,
+      } as Partial<Tx>),
+    ).toBe(true);
+  });
+
+  it('does NOT match create_community on a non-factory contract', () => {
+    const { plugin } = makePlugin();
+    expect(
+      plugin.isCommunityCreatedTx({
+        type: 'ContractCallTx',
+        function: BCL_FUNCTIONS.create_community,
+        contract_id: 'ct_some_other',
+      } as Partial<Tx>),
+    ).toBe(false);
+  });
+
+  it('does NOT match a non-create function on the factory', () => {
+    const { plugin } = makePlugin();
+    expect(
+      plugin.isCommunityCreatedTx({
+        type: 'ContractCallTx',
+        function: BCL_FUNCTIONS.buy,
+        contract_id: FACTORY,
+      } as Partial<Tx>),
+    ).toBe(false);
+  });
+
+  it('matches a call on an allowlisted management address (management-changed)', () => {
+    const { plugin } = makePlugin();
+    plugin.setManagementAllowlistEntry(MGMT, SALE);
+    expect(
+      plugin.isManagementContract({
+        type: 'ContractCallTx',
+        contract_id: MGMT,
+      } as Partial<Tx>),
+    ).toBe(true);
+  });
+
+  it('does NOT match a management call on an un-allowlisted address', () => {
+    const { plugin } = makePlugin();
+    expect(
+      plugin.isManagementContract({
+        type: 'ContractCallTx',
+        contract_id: 'ct_unknown_mgmt',
+      } as Partial<Tx>),
+    ).toBe(false);
+  });
+
+  it('MANAGEMENT_CHANGED_EVENTS contains the verified ACI variants', () => {
+    for (const name of [
+      'ChangeMinimumTokenThreshold',
+      'AddModerator',
+      'DeleteModerator',
+      'MuteUserId',
+      'UnmuteUserId',
+      'SetOwner',
+      'ChangedMetaInfo',
+    ]) {
+      expect(MANAGEMENT_CHANGED_EVENTS.has(name)).toBe(true);
+    }
+  });
+
+  it('onLiveTx (community-created) → resolves the token by create_tx_hash and upserts', async () => {
+    const { plugin, roomState, tokenRepo } = makePlugin();
+    plugin.refreshAllowlist = jest.fn().mockResolvedValue(undefined);
+    tokenRepo.findOne.mockResolvedValue({ sale_address: SALE } as Token);
+
+    await plugin.onLiveTx({
+      hash: 'th_create_1',
+      type: 'ContractCallTx',
+      function: BCL_FUNCTIONS.create_community,
+      contract_id: FACTORY,
+    } as any);
+
+    expect(tokenRepo.findOne).toHaveBeenCalledWith({
+      where: { create_tx_hash: 'th_create_1' },
+    });
+    expect(roomState.readAndUpsertRoomState).toHaveBeenCalledTimes(1);
+  });
+
+  it('onLiveTx (management-changed, MuteUserId) → re-reads room state', async () => {
+    const { plugin, roomState, sync } = makePlugin();
+    plugin.setManagementAllowlistEntry(MGMT, SALE);
+    sync.decodeManagementEventNames.mockResolvedValue(['MuteUserId']);
+
+    await plugin.onLiveTx({
+      hash: 'th_mute_1',
+      type: 'ContractCallTx',
+      contract_id: MGMT,
+      raw: { log: [{ address: MGMT }] },
+    } as any);
+
+    expect(sync.decodeManagementEventNames).toHaveBeenCalled();
+    expect(roomState.readAndUpsertRoomState).toHaveBeenCalledTimes(1);
+  });
+
+  it('onLiveTx (management call with only non-management events) → does nothing', async () => {
+    const { plugin, roomState, sync } = makePlugin();
+    plugin.setManagementAllowlistEntry(MGMT, SALE);
+    sync.decodeManagementEventNames.mockResolvedValue(['SomeUnrelatedEvent']);
+
+    await plugin.onLiveTx({
+      hash: 'th_x',
+      type: 'ContractCallTx',
+      contract_id: MGMT,
+      raw: { log: [{ address: MGMT }] },
+    } as any);
+
+    expect(roomState.readAndUpsertRoomState).not.toHaveBeenCalled();
+  });
+
+  it('onLiveTx ignores an unrelated contract call', async () => {
+    const { plugin, roomState } = makePlugin();
+    await plugin.onLiveTx({
+      hash: 'th_unrelated',
+      type: 'ContractCallTx',
+      contract_id: 'ct_random',
+      function: 'do_thing',
+    } as any);
+    expect(roomState.readAndUpsertRoomState).not.toHaveBeenCalled();
+  });
+
+  it('onReorg recomputes affected rooms from create_tx_hash and re-derives live state, then buffers evictions', async () => {
+    const { plugin, roomState, tokenRepo, reorgEviction } = makePlugin();
+    plugin.refreshAllowlist = jest.fn().mockResolvedValue(undefined);
+    const affected = [
+      { sale_address: 'ct_a', create_tx_hash: 'th_1' },
+      { sale_address: 'ct_b', create_tx_hash: 'th_2' },
+    ] as Token[];
+    tokenRepo.find.mockResolvedValue(affected);
+
+    await plugin.onReorg(['th_1', 'th_2']);
+
+    expect(tokenRepo.find).toHaveBeenCalledTimes(1);
+    expect(roomState.readAndUpsertRoomState).toHaveBeenCalledTimes(2);
+    expect(roomState.readAndUpsertRoomState).toHaveBeenCalledWith(affected[0]);
+    expect(roomState.readAndUpsertRoomState).toHaveBeenCalledWith(affected[1]);
+    // Task 11: removals are buffered, never published from onReorg (§6).
+    expect(reorgEviction.bufferEvictions).toHaveBeenCalledWith([
+      'ct_a',
+      'ct_b',
+    ]);
+  });
+
+  it('onReorg is a no-op on empty removedTxHashes', async () => {
+    const { plugin, roomState, tokenRepo } = makePlugin();
+    await plugin.onReorg([]);
+    expect(tokenRepo.find).not.toHaveBeenCalled();
+    expect(roomState.readAndUpsertRoomState).not.toHaveBeenCalled();
+  });
+
+  it('onReorg is a no-op when no rooms reference the rolled-back txs', async () => {
+    const { plugin, roomState, tokenRepo } = makePlugin();
+    tokenRepo.find.mockResolvedValue([]);
+    await plugin.onReorg(['th_unrelated']);
+    expect(roomState.readAndUpsertRoomState).not.toHaveBeenCalled();
+  });
+
+  it('refreshAllowlist rebuilds the set from is_community rooms', async () => {
+    const { plugin, roomState, roomRepo } = makePlugin();
+    roomRepo.find.mockResolvedValue([
+      { sale_address: 'ct_s1' },
+      { sale_address: 'ct_s2' },
+    ]);
+    roomState.resolveManagementAddress
+      .mockResolvedValueOnce('ct_m1')
+      .mockResolvedValueOnce('ct_m2');
+
+    await plugin.refreshAllowlist(true);
+
+    const allow = plugin.getManagementAllowlist();
+    expect(allow.get('ct_m1')).toBe('ct_s1');
+    expect(allow.get('ct_m2')).toBe('ct_s2');
+    expect(allow.size).toBe(2);
+  });
+});

--- a/src/token-gated-rooms/plugins/community-room-state.plugin.ts
+++ b/src/token-gated-rooms/plugins/community-room-state.plugin.ts
@@ -1,0 +1,391 @@
+import { Inject, Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { OnEvent } from '@nestjs/event-emitter';
+import { ConfigType } from '@nestjs/config';
+import { In, IsNull, Not, Repository } from 'typeorm';
+import { Tx } from '@/mdw-sync/entities/tx.entity';
+import { PluginSyncState } from '@/mdw-sync/entities/plugin-sync-state.entity';
+import { Token } from '@/tokens/entities/token.entity';
+import { BasePlugin } from '@/plugins/base-plugin';
+import { PluginFilter } from '@/plugins/plugin.interface';
+import { LIVE_TX_EVENT, LiveTxEventPayload } from '@/mdw-sync/events';
+import { BCL_CONTRACT } from '@/plugins/bcl/config/bcl.config';
+import { BCL_FUNCTIONS } from '@/configs/constants';
+import { isDatabaseConnectionOrPoolError } from '@/utils/database-issue-logging';
+import { CommunityRoom } from '../entities/community-room.entity';
+import { RoomStateService } from '../services/room-state.service';
+import { ReorgEvictionService } from '../services/reorg-eviction.service';
+import { CommunityRoomStateSyncService } from './community-room-state-sync.service';
+import tgrConfig from '../config/tgr.config';
+
+/**
+ * The `CommunityManagement` event variants that signal a *management-changed*
+ * event (verified against `CommunityManagement.aci.json`). On any of them we
+ * re-read `get_state()` and upsert — never mutate fields piecemeal from the
+ * payload.
+ */
+export const MANAGEMENT_CHANGED_EVENTS = new Set<string>([
+  'ChangeMinimumTokenThreshold',
+  'AddModerator',
+  'DeleteModerator',
+  'MuteUserId',
+  'UnmuteUserId',
+  'SetOwner',
+  'ChangedMetaInfo',
+]);
+
+/**
+ * Community-room state indexer (Task 04, MAIN process only).
+ *
+ * Reactively derives `community_room` desired state from two on-chain signals
+ * and persists it (NO relay writes — Task 10 consumes `tgr.community.upserted`):
+ *
+ *  - **community-created**: a BCL `create_community` tx on the factory. Detected
+ *    via `LIVE_TX_EVENT` (approach (b) — no change to the BCL plugin): on match,
+ *    resolve the `Token` by `sale_address` then `readAndUpsertRoomState`.
+ *  - **management-changed**: a `CommunityManagement` contract call whose decoded
+ *    log contains one of `MANAGEMENT_CHANGED_EVENTS`. The management address is
+ *    NOT in the BCL filter, so we keep a refreshed allowlist of all known
+ *    `CommunityManagement` addresses (from `community_room`-mapped tokens),
+ *    refreshed on community-created and on a TTL (`communityTokenRefreshSec`,
+ *    default 5m). NOTE: Task 03 owns the shared AEX9 community-token allowlist;
+ *    this management-address allowlist is a separate, room-state-specific set —
+ *    coordinate with Task 03's refresh rather than forking the AEX9 one.
+ *
+ * Registered as a `BasePlugin` so the reorg service invokes `onReorg`; the batch
+ * pipeline is unused here (`filters()` is empty), all reactive work runs off
+ * `LIVE_TX_EVENT`.
+ */
+@Injectable()
+export class CommunityRoomStatePlugin
+  extends BasePlugin
+  implements OnModuleInit
+{
+  protected readonly logger = new Logger(CommunityRoomStatePlugin.name);
+  readonly name = 'community-room-state';
+  readonly version = 1;
+
+  /** Allowlist of known `CommunityManagement` addresses → their token sale_address. */
+  private managementAllowlist = new Map<string, string>();
+  private lastAllowlistRefreshMs = 0;
+
+  constructor(
+    @InjectRepository(Tx)
+    protected readonly txRepository: Repository<Tx>,
+    @InjectRepository(PluginSyncState)
+    protected readonly pluginSyncStateRepository: Repository<PluginSyncState>,
+    @InjectRepository(Token)
+    private readonly tokenRepository: Repository<Token>,
+    @InjectRepository(CommunityRoom)
+    private readonly communityRoomRepository: Repository<CommunityRoom>,
+    private readonly roomStateService: RoomStateService,
+    private readonly syncService: CommunityRoomStateSyncService,
+    private readonly reorgEviction: ReorgEvictionService,
+    @Inject(tgrConfig.KEY)
+    private readonly config: ConfigType<typeof tgrConfig>,
+  ) {
+    super();
+  }
+
+  onModuleInit(): void {
+    // Warm the allowlist in the BACKGROUND — do NOT await. `refreshAllowlist`
+    // makes sequential on-chain calls (`Contract.initialize` +
+    // `get_community_management` against the æternity node) for every community
+    // room, and `onModuleInit` is awaited inside `app.init()`, so awaiting here
+    // blocks `app.listen()` — the HTTP API never starts — whenever the node is
+    // slow/unreachable (observed: boot wedged on the first chain call once any
+    // `is_community` room existed). The warm-up is best-effort: the TTL refresh
+    // (`maybeRefreshAllowlist`) and the periodic reconcile re-derive the set, and a
+    // management tx missed during warm-up self-heals — so a late/failed warm-up
+    // never loses data, it only delays recognizing a brand-new management contract.
+    void this.refreshAllowlist(true).catch((e) =>
+      this.logger.warn(`Initial allowlist refresh failed: ${e?.message ?? e}`),
+    );
+  }
+
+  startFromHeight(): number {
+    return BCL_CONTRACT.startHeight ?? 0;
+  }
+
+  /**
+   * No batch-pipeline filtering: reactive work is driven by `LIVE_TX_EVENT`
+   * (approach (b)) and the resumable backfill, so the indexer never needs to
+   * persist/route txs to this plugin. `onReorg` is still wired (it is called for
+   * every plugin regardless of `filters()`).
+   */
+  filters(): PluginFilter[] {
+    return [];
+  }
+
+  protected getSyncService(): CommunityRoomStateSyncService {
+    return this.syncService;
+  }
+
+  // ---- Predicate helpers (unit-tested) -------------------------------------
+
+  /** True iff the tx is a `create_community` call on the BCL factory. */
+  isCommunityCreatedTx(tx: Partial<Tx>): boolean {
+    return (
+      tx?.type === 'ContractCallTx' &&
+      tx?.function === BCL_FUNCTIONS.create_community &&
+      !!tx?.contract_id &&
+      tx.contract_id === BCL_CONTRACT.contractAddress
+    );
+  }
+
+  /** True iff the tx targets a known `CommunityManagement` contract. */
+  isManagementContract(tx: Partial<Tx>): boolean {
+    return (
+      tx?.type === 'ContractCallTx' &&
+      !!tx?.contract_id &&
+      this.managementAllowlist.has(tx.contract_id)
+    );
+  }
+
+  // ---- Reactive entry point ------------------------------------------------
+
+  @OnEvent(LIVE_TX_EVENT, { async: true })
+  async onLiveTx(tx: LiveTxEventPayload): Promise<void> {
+    try {
+      await this.maybeRefreshAllowlist();
+
+      if (this.isCommunityCreatedTx(tx)) {
+        await this.handleCommunityCreated(tx);
+        return;
+      }
+
+      if (this.isManagementContract(tx)) {
+        await this.handleManagementChanged(tx);
+        return;
+      }
+    } catch (error: any) {
+      // A transient DB pool/connection blip (e.g. "timeout exceeded when trying
+      // to connect" under a backlog drain) is NOT a real failure here: the
+      // resumable backfill re-derives community-created rooms and the periodic
+      // state-sync re-reads management changes, so anything skipped self-heals.
+      // Log it at WARN (no stack) to avoid scary ERROR spam during load spikes;
+      // keep ERROR for genuine logic faults.
+      if (isDatabaseConnectionOrPoolError(error)) {
+        this.logger.warn(
+          `onLiveTx deferred to backfill for ${tx?.hash} (transient DB pressure): ${error?.message ?? error}`,
+        );
+      } else {
+        this.logger.error(
+          `onLiveTx failed for ${tx?.hash}: ${error?.message ?? error}`,
+          error?.stack,
+        );
+      }
+    }
+  }
+
+  /**
+   * create_community → resolve the new `Token` and upsert its room.
+   *
+   * The newly-created token's `sale_address` is NOT on the call tx (the call
+   * targets the factory `contract_id`); the BCL plugin creates the `Token` from
+   * the same tx and stamps `create_tx_hash = tx.hash`. We resolve by that hash.
+   * If the BCL plugin hasn't landed the row yet (it processes the same live tx
+   * asynchronously), the resumable backfill picks it up — community-created is
+   * never lost.
+   */
+  private async handleCommunityCreated(tx: Partial<Tx>): Promise<void> {
+    const token = tx.hash
+      ? await this.tokenRepository.findOne({
+          where: { create_tx_hash: tx.hash },
+        })
+      : null;
+    if (!token) {
+      this.logger.debug(
+        `community-created: token not yet present for tx ${tx.hash}; deferring to backfill`,
+      );
+      return;
+    }
+    // Token-create auto-creates the room: readAndUpsertRoomState emits
+    // `tgr.community.upserted` on first insert, which the decoupled
+    // RoomBackfillService (relay 9007 create) + EligibilityService (member seed)
+    // consume. `room_id` is then stamped on the 9007 ok ACK. This is the canonical
+    // create path — the provisioning cron / buy-listener only cover retries (the
+    // room was never confirmed), so there is NO duplicate listener here.
+    await this.roomStateService.readAndUpsertRoomState(token);
+    // A new community room means a new management address to watch.
+    await this.refreshAllowlist(true);
+  }
+
+  /**
+   * A call on a known management contract. Decode its log; if it carries a
+   * management-changed event, resolve the room by management address and re-read
+   * authoritative state. (We never mutate from the event payload.)
+   */
+  private async handleManagementChanged(tx: Partial<Tx>): Promise<void> {
+    const managementAddress = tx.contract_id as string;
+    const eventNames = await this.syncService.decodeManagementEventNames(
+      managementAddress,
+      tx.raw?.log,
+    );
+    // Decode succeeded with at least one event and none are a management change →
+    // skip. If we couldn't decode any events (empty/decode failure) on a KNOWN
+    // management contract, re-read defensively: the read is one cheap dry-run and
+    // `readAndUpsertRoomState` emits nothing when nothing actually changed.
+    const decodedSomething = eventNames.length > 0;
+    const isManagementChange = decodedSomething
+      ? eventNames.some((n) => MANAGEMENT_CHANGED_EVENTS.has(n))
+      : true;
+    if (!isManagementChange) {
+      return;
+    }
+
+    const saleAddress = this.managementAllowlist.get(managementAddress);
+    if (!saleAddress) {
+      return;
+    }
+    const token = await this.tokenRepository.findOne({
+      where: { sale_address: saleAddress },
+    });
+    if (!token) {
+      this.logger.warn(
+        `management-changed: no token for sale_address ${saleAddress}`,
+      );
+      return;
+    }
+    await this.roomStateService.readAndUpsertRoomState(token);
+  }
+
+  // ---- Allowlist refresh ---------------------------------------------------
+
+  private async maybeRefreshAllowlist(): Promise<void> {
+    const ttlMs = (this.config.communityTokenRefreshSec ?? 300) * 1000;
+    if (Date.now() - this.lastAllowlistRefreshMs >= ttlMs) {
+      await this.refreshAllowlist(false);
+    }
+  }
+
+  /**
+   * Rebuild the management-address allowlist from the `community_room` rows that
+   * resolved to a community. We re-derive each room's management address via the
+   * factory so the set stays correct without persisting it separately.
+   *
+   * Kept cheap by only resolving rooms flagged `is_community = true` (the [TG]
+   * defaults rows carry no management contract). `force` bypasses the TTL guard.
+   */
+  async refreshAllowlist(force: boolean): Promise<void> {
+    const ttlMs = (this.config.communityTokenRefreshSec ?? 300) * 1000;
+    if (!force && Date.now() - this.lastAllowlistRefreshMs < ttlMs) {
+      return;
+    }
+    this.lastAllowlistRefreshMs = Date.now();
+
+    const communityRooms = await this.communityRoomRepository.find({
+      where: { is_community: true },
+      select: ['sale_address'],
+    });
+    if (communityRooms.length === 0) {
+      return;
+    }
+
+    const next = new Map<string, string>();
+    for (const room of communityRooms) {
+      try {
+        const managementAddress = await this.resolveManagement(
+          room.sale_address,
+        );
+        if (managementAddress) {
+          next.set(managementAddress, room.sale_address);
+        }
+      } catch (error: any) {
+        this.logger.debug(
+          `allowlist: failed to resolve management for ${room.sale_address}: ${error?.message ?? error}`,
+        );
+      }
+    }
+    this.managementAllowlist = next;
+    this.logger.debug(`allowlist refreshed: ${next.size} management contracts`);
+  }
+
+  /** Resolve a management address; delegates to the shared read service. */
+  private async resolveManagement(
+    saleAddress: string,
+  ): Promise<string | undefined> {
+    return this.roomStateService.resolveManagementAddress(saleAddress);
+  }
+
+  /** Test/introspection helper for the allowlist. */
+  getManagementAllowlist(): Map<string, string> {
+    return this.managementAllowlist;
+  }
+
+  /** Test/introspection helper to seed the allowlist (e.g. unit predicate tests). */
+  setManagementAllowlistEntry(
+    managementAddress: string,
+    saleAddress: string,
+  ): void {
+    this.managementAllowlist.set(managementAddress, saleAddress);
+  }
+
+  // ---- Reorg ---------------------------------------------------------------
+
+  /**
+   * Reorg seam (Task 04 req §8; Task 11 buffers evictions, plan §6.5).
+   *
+   * The reverted txs are already deleted from `txs` at this point, so we resolve
+   * the affected `community_room` rows by the create-community tx hash recorded
+   * on their `Token` (`create_tx_hash IN removedTxHashes`) and re-derive their
+   * authoritative state from live `get_state()` (reorg-safe — we never trust the
+   * reverted event payload). An empty / unrelated `removedTxHashes` is a no-op.
+   *
+   * **Reorg-gated eviction (Task 11 §6):** after recomputing each affected room's
+   * desired state, we DO NOT publish removals from here (`onReorg` fires
+   * synchronously in the indexer and a transient fork would flap members out of
+   * `39002`). Instead we hand the affected sale_addresses to
+   * {@link ReorgEvictionService.bufferEvictions}, which stamps `held_until_height`
+   * on every now-ineligible non-admin published member and leaves them in `39002`;
+   * the worker's scheduled flush publishes the `9001` only once the reorg depth has
+   * passed (and cancels the eviction if the member becomes eligible again). ADDS
+   * are unaffected — a member who *becomes* eligible flows through the normal Task
+   * 06 → Task 10 prompt path.
+   */
+  async onReorg(removedTxHashes: string[]): Promise<void> {
+    if (!removedTxHashes || removedTxHashes.length === 0) {
+      return;
+    }
+
+    const affectedTokens = await this.tokenRepository.find({
+      where: {
+        create_tx_hash: In(removedTxHashes),
+        sale_address: Not(IsNull()),
+      },
+    });
+
+    if (affectedTokens.length === 0) {
+      this.logger.debug(
+        `[${this.name}] reorg: no community rooms affected by ${removedTxHashes.length} removed txs`,
+      );
+      return;
+    }
+
+    this.logger.log(
+      `[${this.name}] reorg: recomputing ${affectedTokens.length} affected community room(s)`,
+    );
+    const affectedSales: string[] = [];
+    for (const token of affectedTokens) {
+      try {
+        await this.roomStateService.readAndUpsertRoomState(token);
+        affectedSales.push(token.sale_address);
+      } catch (error: any) {
+        this.logger.error(
+          `[${this.name}] reorg: failed to recompute room ${token.sale_address}: ${error?.message ?? error}`,
+        );
+      }
+    }
+    await this.refreshAllowlist(true);
+
+    // Buffer (do NOT publish) any now-ineligible memberships in the affected rooms
+    // until the reorg depth passes (Task 11 §6 — prevents membership flapping).
+    try {
+      await this.reorgEviction.bufferEvictions(affectedSales);
+    } catch (error: any) {
+      this.logger.error(
+        `[${this.name}] reorg: bufferEvictions failed: ${error?.message ?? error}`,
+      );
+    }
+  }
+}

--- a/src/token-gated-rooms/queues/__tests__/publish-nip29.job-options.spec.ts
+++ b/src/token-gated-rooms/queues/__tests__/publish-nip29.job-options.spec.ts
@@ -1,0 +1,28 @@
+import {
+  cappedBackoffStrategy,
+  publishNip29JobOptions,
+  TGR_CAPPED_BACKOFF,
+} from '../publish-nip29.job-options';
+
+describe('publishNip29JobOptions', () => {
+  it('sets attempts = maxRetries + 1 and the capped backoff strategy', () => {
+    const opts = publishNip29JobOptions(5);
+    expect(opts.attempts).toBe(6);
+    expect(opts.backoff).toEqual({ type: TGR_CAPPED_BACKOFF });
+    expect(opts.removeOnComplete).toBe(true);
+    expect(opts.removeOnFail).toBe(false);
+  });
+
+  it('floors attempts at 1 for zero retries', () => {
+    expect(publishNip29JobOptions(0).attempts).toBe(1);
+  });
+});
+
+describe('cappedBackoffStrategy', () => {
+  it('matches capped-exponential across attempts and clamps at 300000ms', () => {
+    expect(cappedBackoffStrategy(1)).toBe(1000);
+    expect(cappedBackoffStrategy(2)).toBe(2000);
+    expect(cappedBackoffStrategy(3)).toBe(4000);
+    expect(cappedBackoffStrategy(20)).toBe(300000);
+  });
+});

--- a/src/token-gated-rooms/queues/__tests__/publish-nip29.job-options.spec.ts
+++ b/src/token-gated-rooms/queues/__tests__/publish-nip29.job-options.spec.ts
@@ -10,7 +10,10 @@ describe('publishNip29JobOptions', () => {
     expect(opts.attempts).toBe(6);
     expect(opts.backoff).toEqual({ type: TGR_CAPPED_BACKOFF });
     expect(opts.removeOnComplete).toBe(true);
-    expect(opts.removeOnFail).toBe(false);
+    // Failed publishes are cleaned (not retained forever) to avoid unbounded
+    // Redis growth on the highest-volume queue; failures are surfaced via the
+    // `tgr.publish.ack(ok:false)` seam + ERROR logs, so the raw jobs add no value.
+    expect(opts.removeOnFail).toBe(true);
   });
 
   it('floors attempts at 1 for zero retries', () => {

--- a/src/token-gated-rooms/queues/__tests__/publish-nip29.processor.spec.ts
+++ b/src/token-gated-rooms/queues/__tests__/publish-nip29.processor.spec.ts
@@ -1,0 +1,336 @@
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import type { Job, Queue } from 'bull';
+import {
+  TGR_GROUP_MISSING,
+  TGR_PUBLISH_ACK,
+  type TgrGroupMissingPayload,
+  type TgrPublishAckPayload,
+} from '../../events';
+import type { RelayWriter } from '../../nostr/relay-writer.contract';
+import { PublishNip29Processor } from '../publish-nip29.processor';
+import { TerminalPublishError } from '../publish-policy';
+import type { PublishNip29Job } from '../publish-nip29.types';
+
+const PK = 'a'.repeat(64);
+const GID = 'ct_Group1';
+
+function makeConfig(overrides: Partial<Record<string, number>> = {}) {
+  return {
+    publishRatePerSec: 1000,
+    publishAckTimeoutMs: 5000,
+    publishMaxRetries: 5,
+    relayHealthPauseSec: 5,
+    ...overrides,
+  } as any;
+}
+
+function makeQueue(): jest.Mocked<
+  Pick<Queue, 'pause' | 'resume' | 'isPaused' | 'getJobCounts'>
+> {
+  return {
+    pause: jest.fn().mockResolvedValue(undefined),
+    resume: jest.fn().mockResolvedValue(undefined),
+    isPaused: jest.fn().mockResolvedValue(false),
+    getJobCounts: jest.fn().mockResolvedValue({
+      waiting: 0,
+      active: 0,
+      completed: 0,
+      failed: 0,
+      delayed: 0,
+    }),
+  } as any;
+}
+
+function makeJob(
+  data: PublishNip29Job,
+  opts: { attempts?: number; attemptsMade?: number } = {},
+): Job<PublishNip29Job> {
+  return {
+    data,
+    opts: { attempts: opts.attempts ?? 6 },
+    attemptsMade: opts.attemptsMade ?? 0,
+    discard: jest.fn(),
+  } as any;
+}
+
+function membershipJob(kind = 9000): PublishNip29Job {
+  return {
+    template: {
+      kind,
+      tags: [
+        ['h', GID],
+        ['p', PK],
+      ],
+      content: '',
+    },
+    groupId: GID,
+    meta: { saleAddress: GID },
+  };
+}
+
+function groupJob(): PublishNip29Job {
+  return {
+    template: { kind: 9007, tags: [['h', GID]], content: '' },
+    groupId: GID,
+    meta: { saleAddress: GID },
+  };
+}
+
+describe('PublishNip29Processor', () => {
+  let relay: jest.Mocked<Pick<RelayWriter, 'isHealthy' | 'publish'>>;
+  let emitter: EventEmitter2;
+  let emitted: Array<{ name: string; payload: TgrPublishAckPayload }>;
+  let groupMissing: TgrGroupMissingPayload[];
+  let queue: ReturnType<typeof makeQueue>;
+  let processor: PublishNip29Processor;
+
+  function build(config = makeConfig()): void {
+    processor = new PublishNip29Processor(
+      relay as unknown as RelayWriter,
+      emitter,
+      config,
+      queue as unknown as Queue<PublishNip29Job>,
+    );
+  }
+
+  beforeEach(() => {
+    relay = {
+      isHealthy: jest.fn().mockReturnValue(true),
+      publish: jest.fn(),
+    } as any;
+    emitter = new EventEmitter2();
+    emitted = [];
+    groupMissing = [];
+    emitter.on(TGR_PUBLISH_ACK, (payload: TgrPublishAckPayload) =>
+      emitted.push({ name: TGR_PUBLISH_ACK, payload }),
+    );
+    emitter.on(TGR_GROUP_MISSING, (payload: TgrGroupMissingPayload) =>
+      groupMissing.push(payload),
+    );
+    queue = makeQueue();
+    build();
+  });
+
+  afterEach(() => {
+    // Clear the outage resume-loop timer armed by the pause tests.
+    processor.onApplicationShutdown();
+  });
+
+  describe('onApplicationBootstrap (clears a stale pause after restart)', () => {
+    it('resumes the queue when it boots up paused', async () => {
+      queue.isPaused.mockResolvedValue(true);
+      await processor.onApplicationBootstrap();
+      expect(queue.resume).toHaveBeenCalledTimes(1);
+    });
+
+    it('does nothing when the queue is not paused', async () => {
+      queue.isPaused.mockResolvedValue(false);
+      await processor.onApplicationBootstrap();
+      expect(queue.resume).not.toHaveBeenCalled();
+    });
+
+    it('never throws if the resume check fails', async () => {
+      queue.isPaused.mockRejectedValue(new Error('redis down'));
+      await expect(processor.onApplicationBootstrap()).resolves.toBeUndefined();
+    });
+  });
+
+  it('on relay ACK ok: resolves and emits tgr.publish.ack ok:true with pubkey', async () => {
+    relay.publish.mockResolvedValue({ ok: true, id: 'evt1' });
+
+    const res = await processor.process(makeJob(membershipJob()));
+
+    expect(res).toEqual({ id: 'evt1' });
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].payload).toEqual({
+      saleAddress: GID,
+      kind: 9000,
+      ok: true,
+      pubkey: PK,
+    });
+  });
+
+  it('group-level publish: ack payload has no pubkey', async () => {
+    relay.publish.mockResolvedValue({ ok: true, id: 'evt-g' });
+
+    await processor.process(makeJob(groupJob()));
+
+    expect(emitted[0].payload).toEqual({
+      saleAddress: GID,
+      kind: 9007,
+      ok: true,
+    });
+    expect(emitted[0].payload.pubkey).toBeUndefined();
+  });
+
+  it('"Group already exists" reject: resolves successfully, ack ok:true, no throw', async () => {
+    relay.publish.mockResolvedValue({
+      ok: false,
+      id: 'evt2',
+      reason: 'Group already exists',
+      timedOut: false,
+    });
+
+    const res = await processor.process(makeJob(groupJob()));
+
+    expect(res).toEqual({ id: 'evt2' });
+    expect(emitted[0].payload.ok).toBe(true);
+    expect(emitted[0].payload.kind).toBe(9007);
+  });
+
+  it('terminal "Only relay admin…" reject: throws TerminalPublishError, ack ok:false', async () => {
+    relay.publish.mockResolvedValue({
+      ok: false,
+      id: 'evt3',
+      reason:
+        'Only relay admin can create a managed group from an unmanaged one',
+      timedOut: false,
+    });
+
+    await expect(processor.process(makeJob(groupJob()))).rejects.toBeInstanceOf(
+      TerminalPublishError,
+    );
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].payload.ok).toBe(false);
+  });
+
+  it('terminal "…was deleted" reject: throws TerminalPublishError, ack ok:false', async () => {
+    relay.publish.mockResolvedValue({
+      ok: false,
+      id: 'evt3b',
+      reason: 'Group existed before and was deleted',
+      timedOut: false,
+    });
+
+    await expect(processor.process(makeJob(groupJob()))).rejects.toBeInstanceOf(
+      TerminalPublishError,
+    );
+    expect(emitted[0].payload.ok).toBe(false);
+  });
+
+  it('"Group not found" on a 9000 add: discards (no retry), emits TGR_GROUP_MISSING + ack ok:false', async () => {
+    relay.publish.mockResolvedValue({
+      ok: false,
+      id: 'evt-gm',
+      reason: 'error: [PutUser] Group not found',
+      timedOut: false,
+    });
+    const job = makeJob(membershipJob(9000));
+
+    await expect(processor.process(job)).rejects.toThrow(/group not found/i);
+
+    // No retry-spam: the job is discarded so Bull won't re-attempt it.
+    expect(job.discard).toHaveBeenCalledTimes(1);
+    // The owner is asked to re-create the group...
+    expect(groupMissing).toEqual([{ saleAddress: GID }]);
+    // ...and the member is left pending (ack ok:false → membership stays pending_add).
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].payload).toEqual({
+      saleAddress: GID,
+      kind: 9000,
+      ok: false,
+      pubkey: PK,
+    });
+  });
+
+  it('"Group not found" on a 9001 remove: absence already satisfied → ack ok:true, no re-create, no throw', async () => {
+    relay.publish.mockResolvedValue({
+      ok: false,
+      id: 'evt-gm2',
+      reason: 'error: [RemoveUser] Group not found',
+      timedOut: false,
+    });
+    const job = makeJob(membershipJob(9001));
+
+    const res = await processor.process(job);
+
+    expect(res).toEqual({ id: 'evt-gm2' });
+    expect(groupMissing).toHaveLength(0); // a remove needs no re-create
+    expect(job.discard).not.toHaveBeenCalled();
+    expect(emitted[0].payload.ok).toBe(true);
+    expect(emitted[0].payload.kind).toBe(9001);
+  });
+
+  it('retryable reject on a NON-final attempt: throws, emits NO ack (wait for retry)', async () => {
+    relay.publish.mockResolvedValue({
+      ok: false,
+      id: 'evt4',
+      reason: 'connection reset',
+      timedOut: false,
+    });
+
+    await expect(
+      processor.process(
+        makeJob(membershipJob(), { attempts: 6, attemptsMade: 0 }),
+      ),
+    ).rejects.toThrow('connection reset');
+    expect(emitted).toHaveLength(0);
+  });
+
+  it('retryable reject on the FINAL attempt: throws and emits ack ok:false (exhausted)', async () => {
+    relay.publish.mockResolvedValue({
+      ok: false,
+      id: 'evt5',
+      reason: 'connection reset',
+      timedOut: false,
+    });
+
+    await expect(
+      processor.process(
+        makeJob(membershipJob(), { attempts: 6, attemptsMade: 5 }),
+      ),
+    ).rejects.toThrow('connection reset');
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].payload).toEqual({
+      saleAddress: GID,
+      kind: 9000,
+      ok: false,
+      pubkey: PK,
+    });
+  });
+
+  it('unhealthy relay: pauses the queue and throws WITHOUT publishing or acking', async () => {
+    relay.isHealthy.mockReturnValue(false);
+
+    await expect(processor.process(makeJob(membershipJob()))).rejects.toThrow(
+      /unhealthy/,
+    );
+    expect(relay.publish).not.toHaveBeenCalled();
+    expect(queue.pause).toHaveBeenCalled();
+    expect(emitted).toHaveLength(0);
+  });
+
+  it('ACK timeout reject: pauses the queue, then retries (non-final → no ack)', async () => {
+    relay.publish.mockResolvedValue({
+      ok: false,
+      id: 'evt6',
+      reason: 'relay ACK timed out after 5000ms',
+      timedOut: true,
+    });
+
+    await expect(
+      processor.process(
+        makeJob(membershipJob(), { attempts: 6, attemptsMade: 0 }),
+      ),
+    ).rejects.toThrow(/timed out/);
+    expect(queue.pause).toHaveBeenCalled();
+    expect(emitted).toHaveLength(0);
+  });
+
+  it('uses saleAddress from meta and falls back to groupId when meta omitted', async () => {
+    relay.publish.mockResolvedValue({ ok: true, id: 'evt7' });
+    const job = makeJob({
+      template: {
+        kind: 9001,
+        tags: [
+          ['h', GID],
+          ['p', PK],
+        ],
+      },
+      groupId: GID,
+    });
+
+    await processor.process(job);
+    expect(emitted[0].payload.saleAddress).toBe(GID);
+  });
+});

--- a/src/token-gated-rooms/queues/__tests__/publish-policy.spec.ts
+++ b/src/token-gated-rooms/queues/__tests__/publish-policy.spec.ts
@@ -1,0 +1,144 @@
+import {
+  cappedExponentialBackoff,
+  isAlreadyExists,
+  isGroupNotFound,
+  isTerminalReject,
+  PUBLISH_BACKOFF_CAP_MS,
+  pubkeyFromTags,
+  reasonText,
+  TerminalPublishError,
+} from '../publish-policy';
+
+describe('cappedExponentialBackoff', () => {
+  it('grows exponentially from the base across attempts 1..5', () => {
+    expect(cappedExponentialBackoff(1, 1000)).toBe(1000);
+    expect(cappedExponentialBackoff(2, 1000)).toBe(2000);
+    expect(cappedExponentialBackoff(3, 1000)).toBe(4000);
+    expect(cappedExponentialBackoff(4, 1000)).toBe(8000);
+    expect(cappedExponentialBackoff(5, 1000)).toBe(16000);
+  });
+
+  it('clamps at 300000 ms (5m) for high attempts', () => {
+    expect(PUBLISH_BACKOFF_CAP_MS).toBe(300000);
+    for (let attempt = 10; attempt <= 100; attempt++) {
+      expect(cappedExponentialBackoff(attempt, 1000)).toBe(300000);
+    }
+  });
+
+  it('never exceeds the cap across the default retry range', () => {
+    for (let attempt = 1; attempt <= 5; attempt++) {
+      expect(cappedExponentialBackoff(attempt)).toBeLessThanOrEqual(
+        PUBLISH_BACKOFF_CAP_MS,
+      );
+    }
+  });
+
+  it('does not overflow for very large attempt numbers (stays at cap)', () => {
+    expect(cappedExponentialBackoff(1000, 1000)).toBe(300000);
+    expect(Number.isFinite(cappedExponentialBackoff(1000, 1000))).toBe(true);
+  });
+
+  it('clamps non-positive attempts to the base', () => {
+    expect(cappedExponentialBackoff(0, 1000)).toBe(1000);
+    expect(cappedExponentialBackoff(-3, 1000)).toBe(1000);
+  });
+});
+
+describe('reasonText', () => {
+  it('lowercases strings and error messages, tolerates null', () => {
+    expect(reasonText('Group Already Exists')).toBe('group already exists');
+    expect(reasonText(new Error('Boom'))).toBe('boom');
+    expect(reasonText(null)).toBe('');
+    expect(reasonText(undefined)).toBe('');
+  });
+});
+
+describe('isAlreadyExists', () => {
+  it('is true for "Group already exists" (groups.rs:388)', () => {
+    expect(isAlreadyExists('Group already exists')).toBe(true);
+    expect(isAlreadyExists(new Error('Group already exists'))).toBe(true);
+  });
+
+  it('is true for "duplicate"', () => {
+    expect(isAlreadyExists('duplicate: event')).toBe(true);
+  });
+
+  it('is false for unrelated rejects', () => {
+    expect(isAlreadyExists('rate-limited')).toBe(false);
+    expect(isAlreadyExists('invalid event')).toBe(false);
+  });
+});
+
+describe('isGroupNotFound', () => {
+  it('is true for the relay "[PutUser] Group not found" member-op reject', () => {
+    expect(isGroupNotFound('error: [PutUser] Group not found')).toBe(true);
+    expect(isGroupNotFound(new Error('[RemoveUser] Group not found'))).toBe(
+      true,
+    );
+  });
+
+  it('is false for unrelated rejects (incl. terminal / already-exists)', () => {
+    expect(isGroupNotFound('Group already exists')).toBe(false);
+    expect(isGroupNotFound('Only relay admin can create a managed group')).toBe(
+      false,
+    );
+    expect(isGroupNotFound('connection reset')).toBe(false);
+  });
+});
+
+describe('isTerminalReject', () => {
+  it('is true for "Only relay admin can create a managed group …" (D7)', () => {
+    expect(
+      isTerminalReject(
+        'Only relay admin can create a managed group from an unmanaged one',
+      ),
+    ).toBe(true);
+  });
+
+  it('is true for "Group existed before and was deleted" (9008-deleted)', () => {
+    expect(isTerminalReject('Group existed before and was deleted')).toBe(true);
+  });
+
+  it('is false for already-exists (that is a success no-op, not terminal)', () => {
+    expect(isTerminalReject('Group already exists')).toBe(false);
+  });
+
+  it('is false for ordinary retryable rejects', () => {
+    expect(isTerminalReject('connection reset')).toBe(false);
+    expect(isTerminalReject('timeout')).toBe(false);
+  });
+});
+
+describe('TerminalPublishError', () => {
+  it('carries a terminal flag', () => {
+    const e = new TerminalPublishError('nope');
+    expect(e.terminal).toBe(true);
+    expect(e.message).toBe('nope');
+    expect(e).toBeInstanceOf(Error);
+  });
+});
+
+describe('pubkeyFromTags', () => {
+  const PK = 'a'.repeat(64);
+  it('extracts the pubkey from a ["p", …] tag', () => {
+    expect(
+      pubkeyFromTags([
+        ['h', 'ct_x'],
+        ['p', PK],
+      ]),
+    ).toBe(PK);
+  });
+
+  it('extracts from a ["p", pubkey, role] tag', () => {
+    expect(
+      pubkeyFromTags([
+        ['h', 'ct_x'],
+        ['p', PK, 'admin'],
+      ]),
+    ).toBe(PK);
+  });
+
+  it('returns undefined for group-level events (no p tag)', () => {
+    expect(pubkeyFromTags([['h', 'ct_x']])).toBeUndefined();
+  });
+});

--- a/src/token-gated-rooms/queues/__tests__/reconcile.processor.spec.ts
+++ b/src/token-gated-rooms/queues/__tests__/reconcile.processor.spec.ts
@@ -1,0 +1,110 @@
+import type { Queue } from 'bull';
+import {
+  RECONCILE_MEMBERSHIP_JOB,
+  RECONCILE_MEMBERSHIP_QUEUE,
+  REORG_FLUSH_JOB,
+  ReconcileProcessor,
+} from '../reconcile.processor';
+
+/**
+ * Unit coverage for the `worker:reconcile-membership` consumer (Task 11): the two
+ * `@Process` handlers delegate to the services, and boot scheduling + the handlers
+ * are relay-gated — they run iff a relay is configured (`isRelayConfigured` on the
+ * injected `tgrConfig`: `nostrRelayUrl` + `nostrBotNsec` both set). Worker mode is
+ * gone (see `deworker-plan.md`); with no relay configured the processor still
+ * instantiates (boot-safe) but schedules/runs nothing.
+ */
+describe('ReconcileProcessor (unit)', () => {
+  /**
+   * @param relayConfigured when true, the injected config carries
+   *   `nostrRelayUrl` + `nostrBotNsec` (relay enabled → jobs scheduled / handlers
+   *   active). When false those are unset (relay dormant → no scheduling / no-op
+   *   handlers).
+   */
+  const build = (relayConfigured: boolean) => {
+    const queue = { add: jest.fn().mockResolvedValue({ id: 'j' }) };
+    const reconciliation = {
+      reconcileBatch: jest.fn().mockResolvedValue({
+        roomsScanned: 1,
+        added: 0,
+        removed: 0,
+        nextCursor: null,
+      }),
+    };
+    const reorgEviction = {
+      flushDueEvictions: jest
+        .fn()
+        .mockResolvedValue({ published: 0, cancelled: 0 }),
+    };
+    const config = {
+      reconcileIntervalSec: 600,
+      nostrRelayUrl: relayConfigured ? 'ws://relay' : undefined,
+      nostrBotNsec: relayConfigured ? 'nsec1abc' : undefined,
+    };
+    const processor = new ReconcileProcessor(
+      queue as unknown as Queue,
+      reconciliation as any,
+      reorgEviction as any,
+      config as any,
+    );
+    return { processor, queue, reconciliation, reorgEviction };
+  };
+
+  it('exposes the canonical worker-prefixed queue name', () => {
+    expect(RECONCILE_MEMBERSHIP_QUEUE).toBe('worker:reconcile-membership');
+  });
+
+  describe('onModuleInit (relay-gated)', () => {
+    it('schedules BOTH repeatable jobs when a relay is configured', async () => {
+      const { processor, queue } = build(true);
+
+      await processor.onModuleInit();
+
+      const jobNames = queue.add.mock.calls.map((c) => c[0]);
+      expect(jobNames).toEqual(
+        expect.arrayContaining([RECONCILE_MEMBERSHIP_JOB, REORG_FLUSH_JOB]),
+      );
+      expect(queue.add).toHaveBeenCalledTimes(2);
+      // Both repeat on the configured interval (10m default → 600s).
+      for (const call of queue.add.mock.calls) {
+        expect(call[2].repeat).toEqual({ every: 600_000 });
+      }
+    });
+
+    it('schedules NOTHING when no relay is configured (boot-safe)', async () => {
+      const { processor, queue } = build(false);
+
+      await processor.onModuleInit();
+
+      expect(queue.add).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handlers (relay-gated)', () => {
+    it('reconcile() delegates to reconcileBatch when a relay is configured', async () => {
+      const { processor, reconciliation } = build(true);
+
+      await processor.reconcile();
+
+      expect(reconciliation.reconcileBatch).toHaveBeenCalledTimes(1);
+    });
+
+    it('flush() delegates to flushDueEvictions when a relay is configured', async () => {
+      const { processor, reorgEviction } = build(true);
+
+      await processor.flush();
+
+      expect(reorgEviction.flushDueEvictions).toHaveBeenCalledTimes(1);
+    });
+
+    it('reconcile()/flush() are no-ops when no relay is configured', async () => {
+      const { processor, reconciliation, reorgEviction } = build(false);
+
+      await processor.reconcile();
+      await processor.flush();
+
+      expect(reconciliation.reconcileBatch).not.toHaveBeenCalled();
+      expect(reorgEviction.flushDueEvictions).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/token-gated-rooms/queues/__tests__/reconcile.processor.spec.ts
+++ b/src/token-gated-rooms/queues/__tests__/reconcile.processor.spec.ts
@@ -1,5 +1,6 @@
 import type { Queue } from 'bull';
 import {
+  ACCESS_REVOKE_FINALIZE_JOB,
   RECONCILE_MEMBERSHIP_JOB,
   RECONCILE_MEMBERSHIP_QUEUE,
   REORG_FLUSH_JOB,
@@ -36,6 +37,11 @@ describe('ReconcileProcessor (unit)', () => {
         .fn()
         .mockResolvedValue({ published: 0, cancelled: 0 }),
     };
+    const membershipAccess = {
+      finalizeDueRevokes: jest
+        .fn()
+        .mockResolvedValue({ revoked: 0, cancelled: 0 }),
+    };
     const config = {
       reconcileIntervalSec: 600,
       nostrRelayUrl: relayConfigured ? 'ws://relay' : undefined,
@@ -45,38 +51,51 @@ describe('ReconcileProcessor (unit)', () => {
       queue as unknown as Queue,
       reconciliation as any,
       reorgEviction as any,
+      membershipAccess as any,
       config as any,
     );
-    return { processor, queue, reconciliation, reorgEviction };
+    return { processor, queue, reconciliation, reorgEviction, membershipAccess };
   };
 
   it('exposes the canonical worker-prefixed queue name', () => {
     expect(RECONCILE_MEMBERSHIP_QUEUE).toBe('worker:reconcile-membership');
   });
 
-  describe('onModuleInit (relay-gated)', () => {
-    it('schedules BOTH repeatable jobs when a relay is configured', async () => {
+  describe('onModuleInit', () => {
+    it('schedules the relay jobs + the finalizer when a relay is configured', async () => {
       const { processor, queue } = build(true);
 
       await processor.onModuleInit();
 
       const jobNames = queue.add.mock.calls.map((c) => c[0]);
       expect(jobNames).toEqual(
-        expect.arrayContaining([RECONCILE_MEMBERSHIP_JOB, REORG_FLUSH_JOB]),
+        expect.arrayContaining([
+          RECONCILE_MEMBERSHIP_JOB,
+          REORG_FLUSH_JOB,
+          ACCESS_REVOKE_FINALIZE_JOB,
+        ]),
       );
-      expect(queue.add).toHaveBeenCalledTimes(2);
-      // Both repeat on the configured interval (10m default → 600s).
+      expect(queue.add).toHaveBeenCalledTimes(3);
+      // The two relay jobs repeat on the configured interval (10m → 600s).
       for (const call of queue.add.mock.calls) {
-        expect(call[2].repeat).toEqual({ every: 600_000 });
+        if (call[0] === ACCESS_REVOKE_FINALIZE_JOB) {
+          // The finalizer runs more often: min(30s, interval).
+          expect(call[2].repeat).toEqual({ every: 30_000 });
+        } else {
+          expect(call[2].repeat).toEqual({ every: 600_000 });
+        }
       }
     });
 
-    it('schedules NOTHING when no relay is configured (boot-safe)', async () => {
+    it('still schedules the relay-independent finalizer when no relay is configured', async () => {
       const { processor, queue } = build(false);
 
       await processor.onModuleInit();
 
-      expect(queue.add).not.toHaveBeenCalled();
+      // Only the finalizer (pure DB + event-emit) — no relay read/publish jobs.
+      const jobNames = queue.add.mock.calls.map((c) => c[0]);
+      expect(jobNames).toEqual([ACCESS_REVOKE_FINALIZE_JOB]);
+      expect(queue.add).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -105,6 +124,14 @@ describe('ReconcileProcessor (unit)', () => {
 
       expect(reconciliation.reconcileBatch).not.toHaveBeenCalled();
       expect(reorgEviction.flushDueEvictions).not.toHaveBeenCalled();
+    });
+
+    it('finalizeRevokes() delegates regardless of relay config', async () => {
+      for (const relay of [true, false]) {
+        const { processor, membershipAccess } = build(relay);
+        await processor.finalizeRevokes();
+        expect(membershipAccess.finalizeDueRevokes).toHaveBeenCalledTimes(1);
+      }
     });
   });
 });

--- a/src/token-gated-rooms/queues/__tests__/reconcile.processor.spec.ts
+++ b/src/token-gated-rooms/queues/__tests__/reconcile.processor.spec.ts
@@ -54,7 +54,13 @@ describe('ReconcileProcessor (unit)', () => {
       membershipAccess as any,
       config as any,
     );
-    return { processor, queue, reconciliation, reorgEviction, membershipAccess };
+    return {
+      processor,
+      queue,
+      reconciliation,
+      reorgEviction,
+      membershipAccess,
+    };
   };
 
   it('exposes the canonical worker-prefixed queue name', () => {

--- a/src/token-gated-rooms/queues/__tests__/room-backfill.constants.spec.ts
+++ b/src/token-gated-rooms/queues/__tests__/room-backfill.constants.spec.ts
@@ -1,0 +1,40 @@
+import {
+  BACKFILL_KICKOFF_JOB,
+  BACKFILL_ON_BOOT_ENV,
+  BACKFILL_STALE_SWEEP_JOB,
+  parseBool,
+  ROOM_BACKFILL_QUEUE,
+  ROOM_BACKFILL_STATE_ID,
+  STALE_PENDING_MS,
+} from '../room-backfill.constants';
+
+describe('room-backfill constants (Task 09)', () => {
+  it('registers under the worker: prefix (never steals main: indexer jobs)', () => {
+    expect(ROOM_BACKFILL_QUEUE).toBe('worker:room-backfill');
+  });
+
+  it('declares the canonical job names + cursor id + boot flag', () => {
+    expect(BACKFILL_KICKOFF_JOB).toBe('backfill-kickoff');
+    expect(BACKFILL_STALE_SWEEP_JOB).toBe('backfill-stale-sweep');
+    expect(ROOM_BACKFILL_STATE_ID).toBe('global');
+    expect(BACKFILL_ON_BOOT_ENV).toBe('TG_BACKFILL_ON_BOOT');
+  });
+
+  it('stale-pending threshold is 24h in ms', () => {
+    expect(STALE_PENDING_MS).toBe(24 * 60 * 60 * 1000);
+  });
+
+  describe('parseBool', () => {
+    it('defaults on blank/undefined', () => {
+      expect(parseBool(undefined, false)).toBe(false);
+      expect(parseBool('', true)).toBe(true);
+      expect(parseBool('   ', false)).toBe(false);
+    });
+    it('parses true/false case-insensitively', () => {
+      expect(parseBool('true', false)).toBe(true);
+      expect(parseBool('TRUE', false)).toBe(true);
+      expect(parseBool('false', true)).toBe(false);
+      expect(parseBool('yes', false)).toBe(false); // only "true" is truthy
+    });
+  });
+});

--- a/src/token-gated-rooms/queues/__tests__/room-backfill.processor.spec.ts
+++ b/src/token-gated-rooms/queues/__tests__/room-backfill.processor.spec.ts
@@ -1,0 +1,121 @@
+import type { Job, Queue } from 'bull';
+import { RoomBackfillProcessor } from '../room-backfill.processor';
+import type { BackfillKickoffJob } from '../room-backfill.processor';
+import {
+  BACKFILL_KICKOFF_JOB,
+  BACKFILL_STALE_SWEEP_JOB,
+} from '../room-backfill.constants';
+
+/**
+ * Unit coverage for the `worker:room-backfill` consumer (Task 09): the kickoff
+ * delegates to the service's `processPage`, chains the next page (keyset cursor)
+ * only while `hasMore`, and the stale sweep delegates to `sweepStalePending`.
+ */
+describe('RoomBackfillProcessor (unit)', () => {
+  const makeJob = (data: BackfillKickoffJob): Job<BackfillKickoffJob> =>
+    ({ data }) as any;
+
+  const build = (
+    processPage: jest.Mock,
+    sweepStalePending: jest.Mock = jest.fn().mockResolvedValue(0),
+    backfillPageDelayMs = 1000,
+  ) => {
+    const queue = { add: jest.fn().mockResolvedValue({ id: 'j' }) } as any;
+    const backfill = { processPage, sweepStalePending } as any;
+    const processor = new RoomBackfillProcessor(
+      backfill,
+      queue as unknown as Queue,
+      { backfillPageDelayMs } as any,
+    );
+    return { processor, queue, backfill };
+  };
+
+  it('first page (no cursor) → calls processPage(undefined) and chains by nextCursor while hasMore', async () => {
+    const processPage = jest.fn().mockResolvedValue({
+      requested: 2,
+      nextCursor: 'ct_b',
+      hasMore: true,
+    });
+    const { processor, queue } = build(processPage);
+
+    await processor.kickoff(makeJob({}));
+
+    expect(processPage).toHaveBeenCalledWith(undefined);
+    expect(queue.add).toHaveBeenCalledTimes(1);
+    expect(queue.add).toHaveBeenCalledWith(
+      BACKFILL_KICKOFF_JOB,
+      { afterSaleAddress: 'ct_b' },
+      expect.objectContaining({ removeOnComplete: true, delay: 1000 }),
+    );
+  });
+
+  it('paces the chained page with the configured backfillPageDelayMs', async () => {
+    const processPage = jest.fn().mockResolvedValue({
+      requested: 1,
+      nextCursor: 'ct_c',
+      hasMore: true,
+    });
+    const { processor, queue } = build(processPage, undefined, 250);
+
+    await processor.kickoff(makeJob({}));
+
+    expect(queue.add).toHaveBeenCalledWith(
+      BACKFILL_KICKOFF_JOB,
+      { afterSaleAddress: 'ct_c' },
+      expect.objectContaining({ delay: 250 }),
+    );
+  });
+
+  it('passes the supplied keyset cursor through to processPage', async () => {
+    const processPage = jest.fn().mockResolvedValue({
+      requested: 0,
+      nextCursor: undefined,
+      hasMore: false,
+    });
+    const { processor } = build(processPage);
+
+    await processor.kickoff(makeJob({ afterSaleAddress: 'ct_m' }));
+
+    expect(processPage).toHaveBeenCalledWith('ct_m');
+  });
+
+  it('does NOT chain when the working set is drained (!hasMore)', async () => {
+    const processPage = jest.fn().mockResolvedValue({
+      requested: 1,
+      nextCursor: 'ct_z',
+      hasMore: false,
+    });
+    const { processor, queue } = build(processPage);
+
+    await processor.kickoff(makeJob({}));
+
+    expect(queue.add).not.toHaveBeenCalled();
+  });
+
+  it('does NOT chain when hasMore but no cursor (defensive guard)', async () => {
+    const processPage = jest.fn().mockResolvedValue({
+      requested: 0,
+      nextCursor: undefined,
+      hasMore: true,
+    });
+    const { processor, queue } = build(processPage);
+
+    await processor.kickoff(makeJob({}));
+
+    expect(queue.add).not.toHaveBeenCalled();
+  });
+
+  it('stale sweep delegates to sweepStalePending', async () => {
+    const sweep = jest.fn().mockResolvedValue(3);
+    const { processor, backfill } = build(jest.fn(), sweep);
+
+    await processor.staleSweep();
+
+    expect(backfill.sweepStalePending).toHaveBeenCalledTimes(1);
+  });
+
+  it('exposes the canonical job names', () => {
+    expect(BACKFILL_KICKOFF_JOB).toBe('backfill-kickoff');
+    expect(BACKFILL_STALE_SWEEP_JOB).toBe('backfill-stale-sweep');
+  });
+});

--- a/src/token-gated-rooms/queues/__tests__/room-message-notify.processor.spec.ts
+++ b/src/token-gated-rooms/queues/__tests__/room-message-notify.processor.spec.ts
@@ -1,0 +1,130 @@
+import type { Job } from 'bull';
+import { RoomMessageNotification } from '../../notifications/room-message.notification';
+import { RoomMessageNotifyProcessor } from '../room-message-notify.processor';
+import type { RoomMessageNotifyJob } from '../room-message-notify.types';
+
+const SALE = 'ct_msg_sale';
+const RECIPIENT = 'ak_recipient';
+
+function makeProcessor(
+  over: {
+    getActiveTokens?: jest.Mock;
+    isRoomEnabled?: jest.Mock;
+    send?: jest.Mock;
+    findToken?: jest.Mock;
+  } = {},
+) {
+  const getActiveTokens =
+    over.getActiveTokens ??
+    jest.fn().mockResolvedValue(['ExponentPushToken[x]']);
+  const isRoomEnabled = over.isRoomEnabled ?? jest.fn().mockResolvedValue(true);
+  const send = over.send ?? jest.fn().mockResolvedValue({ outcome: 'sent' });
+  const findToken =
+    over.findToken ??
+    jest.fn().mockResolvedValue({ sale_address: SALE, symbol: 'FRESH' });
+
+  const tokenRepo = { findOne: findToken } as any;
+  const devices = { getActiveTokens } as any;
+  const roomPreferences = { isRoomEnabled } as any;
+  const notifications = { send } as any;
+
+  const processor = new RoomMessageNotifyProcessor(
+    tokenRepo,
+    devices,
+    roomPreferences,
+    notifications,
+  );
+  return { processor, getActiveTokens, isRoomEnabled, send, findToken };
+}
+
+function job(
+  over: Partial<RoomMessageNotifyJob> = {},
+): Job<RoomMessageNotifyJob> {
+  return {
+    data: {
+      sale_address: SALE,
+      recipient: RECIPIENT,
+      symbol: 'QUEUED',
+      message_count: 3,
+      window_started_at: 1700000000,
+      sample_event_id: 'evt1',
+      ...over,
+    },
+  } as Job<RoomMessageNotifyJob>;
+}
+
+describe('RoomMessageNotifyProcessor', () => {
+  it('dispatches a RoomMessageNotification when a device exists and not muted', async () => {
+    const { processor, send } = makeProcessor();
+    await processor.process(job());
+    expect(send).toHaveBeenCalledTimes(1);
+    const [notifiable, notification] = send.mock.calls[0];
+    expect(notifiable).toEqual({ address: RECIPIENT });
+    expect(notification).toBeInstanceOf(RoomMessageNotification);
+    expect(notification.type).toBe('room-messages');
+    expect(notification.toExpo().data).toMatchObject({
+      type: 'room-messages',
+      saleAddress: SALE,
+    });
+  });
+
+  it('re-resolves the room symbol (prefers DB over the queued snapshot)', async () => {
+    const { processor, send } = makeProcessor();
+    await processor.process(job({ symbol: 'STALE' }));
+    const notification = send.mock.calls[0][1] as RoomMessageNotification;
+    // FRESH (from findOne) wins over the queued STALE.
+    expect(notification.toExpo().body).toContain('FRESH');
+  });
+
+  it('falls back to the queued symbol when the token is gone', async () => {
+    const { processor, send } = makeProcessor({
+      findToken: jest.fn().mockResolvedValue(null),
+    });
+    await processor.process(job({ symbol: 'QUEUED' }));
+    const notification = send.mock.calls[0][1] as RoomMessageNotification;
+    expect(notification.toExpo().body).toContain('QUEUED');
+  });
+
+  it('keys the dedup key off the coalescing window', async () => {
+    const { processor, send } = makeProcessor();
+    await processor.process(job({ window_started_at: 1700000123 }));
+    const notification = send.mock.calls[0][1] as RoomMessageNotification;
+    expect(notification.dedupKey({ address: RECIPIENT as any })).toBe(
+      `room-messages:${SALE}:${RECIPIENT}:w1700000123`,
+    );
+  });
+
+  it('SKIPs when the recipient has no registered device', async () => {
+    const { processor, send } = makeProcessor({
+      getActiveTokens: jest.fn().mockResolvedValue([]),
+    });
+    await processor.process(job());
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('SKIPs when room-scoped mute is on (per-room or type-level)', async () => {
+    const { processor, send } = makeProcessor({
+      isRoomEnabled: jest.fn().mockResolvedValue(false),
+    });
+    await processor.process(job());
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('ignores a malformed payload (missing keys)', async () => {
+    const { processor, send } = makeProcessor();
+    await processor.process({ data: {} } as Job<RoomMessageNotifyJob>);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('does not throw on a failed SendOutcome (logs only)', async () => {
+    const { processor, send } = makeProcessor({
+      send: jest.fn().mockResolvedValue({
+        outcome: 'failed',
+        channel: 'expo',
+        error: 'boom',
+      }),
+    });
+    await expect(processor.process(job())).resolves.toBeUndefined();
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/token-gated-rooms/queues/__tests__/token-bucket.spec.ts
+++ b/src/token-gated-rooms/queues/__tests__/token-bucket.spec.ts
@@ -1,0 +1,107 @@
+import { TokenBucket } from '../token-bucket';
+
+/**
+ * A controllable fake clock: `now()` is read from `t`; `sleep(ms)` advances `t`
+ * and resolves on a microtask, so the bucket's wait loop is deterministic and
+ * fast (no real timers).
+ */
+function fakeClock() {
+  let t = 0;
+  return {
+    now: () => t,
+    sleep: async (ms: number) => {
+      t += ms;
+    },
+    advance: (ms: number) => {
+      t += ms;
+    },
+  };
+}
+
+describe('TokenBucket', () => {
+  it('paces steady-state to ratePerSec per second after the initial burst', async () => {
+    const clock = fakeClock();
+    const rate = 10;
+    const bucket = new TokenBucket(rate, {
+      now: clock.now,
+      sleep: clock.sleep,
+    });
+
+    const grantTimes: number[] = [];
+    // Burst of 30 takes against a rate of 10/s with a full initial bucket.
+    for (let i = 0; i < 30; i++) {
+      await bucket.take();
+      grantTimes.push(clock.now());
+    }
+
+    // After the one-time initial burst of `capacity` grants (which land at t=0),
+    // every `rate` consecutive grants must span at least ~1000ms — i.e. the
+    // sustained throughput never exceeds `ratePerSec`.
+    for (let i = rate; i + rate < grantTimes.length; i++) {
+      const windowSpan = grantTimes[i + rate] - grantTimes[i];
+      expect(windowSpan).toBeGreaterThanOrEqual(1000 - 1);
+    }
+  });
+
+  it('bounds the initial burst to capacity (= ratePerSec) at t=0', async () => {
+    const clock = fakeClock();
+    const rate = 8;
+    const bucket = new TokenBucket(rate, {
+      now: clock.now,
+      sleep: clock.sleep,
+    });
+
+    let freeGrants = 0;
+    for (let i = 0; i < 20; i++) {
+      await bucket.take();
+      if (clock.now() === 0) {
+        freeGrants += 1;
+      }
+    }
+    expect(freeGrants).toBe(rate);
+  });
+
+  it('drains the initial capacity immediately then paces', async () => {
+    const clock = fakeClock();
+    const rate = 5;
+    const bucket = new TokenBucket(rate, {
+      now: clock.now,
+      sleep: clock.sleep,
+    });
+
+    // First `rate` takes are free (full bucket) — clock should not advance.
+    for (let i = 0; i < rate; i++) {
+      await bucket.take();
+    }
+    expect(clock.now()).toBe(0);
+
+    // The next take must wait for a refill (clock advances).
+    await bucket.take();
+    expect(clock.now()).toBeGreaterThan(0);
+  });
+
+  it('refills over time so a later take is free again', async () => {
+    const clock = fakeClock();
+    const rate = 4;
+    const bucket = new TokenBucket(rate, {
+      now: clock.now,
+      sleep: clock.sleep,
+    });
+
+    for (let i = 0; i < rate; i++) {
+      await bucket.take();
+    }
+    // Let a full second pass — bucket refills to capacity.
+    clock.advance(1000);
+    const before = clock.now();
+    await bucket.take();
+    // No additional wait needed (token was available after refill).
+    expect(clock.now()).toBe(before);
+  });
+
+  it('treats rate < 1 as a capacity of at least 1', async () => {
+    const clock = fakeClock();
+    const bucket = new TokenBucket(0, { now: clock.now, sleep: clock.sleep });
+    await expect(bucket.take()).resolves.toBeUndefined();
+  });
+});

--- a/src/token-gated-rooms/queues/publish-nip29.job-options.ts
+++ b/src/token-gated-rooms/queues/publish-nip29.job-options.ts
@@ -1,0 +1,38 @@
+import type { JobOptions } from 'bull';
+import {
+  cappedExponentialBackoff,
+  PUBLISH_BACKOFF_BASE_MS,
+  PUBLISH_BACKOFF_CAP_MS,
+} from './publish-policy';
+
+/** Custom Bull backoff-strategy name registered on the `publish-nip29` queue. */
+export const TGR_CAPPED_BACKOFF = 'tgr-capped';
+
+/**
+ * Bull custom backoff strategy: capped exponential clamped to 5m (§18). Registered
+ * via the queue's `settings.backoffStrategies` so enqueued jobs can reference it
+ * by name. Bull passes the 1-based `attemptsMade`.
+ */
+export function cappedBackoffStrategy(attemptsMade: number): number {
+  return cappedExponentialBackoff(
+    attemptsMade,
+    PUBLISH_BACKOFF_BASE_MS,
+    PUBLISH_BACKOFF_CAP_MS,
+  );
+}
+
+/**
+ * Recommended `JobOptions` for enqueuing onto `worker:publish-nip29`
+ * (Tasks 08/09/10 spread this when they `queue.add(...)`). Encodes the §18
+ * retry/backoff contract: `attempts = maxRetries + 1`, capped-exponential backoff.
+ *
+ * `maxRetries` should come from `tgrConfig.publishMaxRetries`.
+ */
+export function publishNip29JobOptions(maxRetries: number): JobOptions {
+  return {
+    attempts: Math.max(1, maxRetries + 1),
+    backoff: { type: TGR_CAPPED_BACKOFF },
+    removeOnComplete: true,
+    removeOnFail: true,
+  };
+}

--- a/src/token-gated-rooms/queues/publish-nip29.module.ts
+++ b/src/token-gated-rooms/queues/publish-nip29.module.ts
@@ -1,0 +1,63 @@
+import { BullModule } from '@nestjs/bull';
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import tgrConfig from '../config/tgr.config';
+import { RELAY_WRITER } from '../nostr/relay-writer.contract';
+import { RelayWriterService } from '../nostr/relay-writer.service';
+import {
+  cappedBackoffStrategy,
+  TGR_CAPPED_BACKOFF,
+} from './publish-nip29.job-options';
+import {
+  PublishNip29Processor,
+  PUBLISH_NIP29_QUEUE,
+} from './publish-nip29.processor';
+
+/**
+ * Bull queue rate ceiling, read at module load (Bull needs the limiter at
+ * registration time). Caps publishes to `TG_PUBLISH_RATE_PER_SEC`/sec across the
+ * worker (the in-process `TokenBucket` is the second line of defence). The
+ * limiter only PACES — a throttled job waits for the next window, never dropped.
+ */
+function publishLimiter(): { max: number; duration: number } {
+  const max = Number(process.env.TG_PUBLISH_RATE_PER_SEC);
+  return {
+    max: Number.isFinite(max) && max > 0 ? max : 100,
+    duration: 1000,
+  };
+}
+
+/**
+ * The `groups_relay` write path (Task 07). Bundles the long-lived
+ * `RelayWriterService`, the `worker:publish-nip29` consumer, the queue
+ * registration (token-bucket limiter + capped-exponential backoff strategy), and
+ * exports the writer so Task 11 can call `fetchGroupMembers`.
+ *
+ * Always imported by `TokenGatedRoomsModule` (worker mode removed — see
+ * `deworker-plan.md`); the writer stays dormant and the queue idle until a relay
+ * is configured (`isRelayConfigured`).
+ */
+@Module({
+  imports: [
+    ConfigModule.forFeature(tgrConfig),
+    BullModule.registerQueue({
+      name: PUBLISH_NIP29_QUEUE,
+      limiter: publishLimiter(),
+      settings: {
+        backoffStrategies: {
+          [TGR_CAPPED_BACKOFF]: (attemptsMade: number) =>
+            cappedBackoffStrategy(attemptsMade),
+        },
+      },
+    }),
+  ],
+  providers: [
+    RelayWriterService,
+    // Expose the writer under the nostr-free DI token so consumers (the
+    // processor, Task 11) inject the interface, not the concrete class.
+    { provide: RELAY_WRITER, useExisting: RelayWriterService },
+    PublishNip29Processor,
+  ],
+  exports: [RelayWriterService, RELAY_WRITER],
+})
+export class PublishNip29Module {}

--- a/src/token-gated-rooms/queues/publish-nip29.processor.ts
+++ b/src/token-gated-rooms/queues/publish-nip29.processor.ts
@@ -1,0 +1,284 @@
+import { InjectQueue, Process, Processor } from '@nestjs/bull';
+import {
+  Inject,
+  Logger,
+  OnApplicationBootstrap,
+  OnApplicationShutdown,
+} from '@nestjs/common';
+import { ConfigType } from '@nestjs/config';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { Job, Queue } from 'bull';
+import tgrConfig from '../config/tgr.config';
+import { prefixQueue } from '../config/queue-prefix';
+import {
+  TGR_GROUP_MISSING,
+  TGR_PUBLISH_ACK,
+  type TgrGroupMissingPayload,
+  type TgrPublishAckPayload,
+} from '../events';
+import { NIP29_KIND } from '../nostr/nip29';
+import { RELAY_WRITER } from '../nostr/relay-writer.contract';
+import type { RelayWriter } from '../nostr/relay-writer.contract';
+import type { PublishNip29Job } from './publish-nip29.types';
+import {
+  isAlreadyExists,
+  isGroupNotFound,
+  isTerminalReject,
+  pubkeyFromTags,
+  TerminalPublishError,
+} from './publish-policy';
+import { TokenBucket } from './token-bucket';
+
+/** Resolved queue name (`worker:publish-nip29`) — registered worker-side. */
+export const PUBLISH_NIP29_QUEUE = prefixQueue('publish-nip29', 'worker');
+
+/**
+ * Concurrency must be a decorator-time constant; default to §18's `2`. The actual
+ * runtime cap on parallel ACK waits comes from `TG_PUBLISH_CONCURRENCY`; the
+ * token-bucket then smooths the publish rate across those slots.
+ */
+export const PUBLISH_NIP29_CONCURRENCY = Number(
+  process.env.TG_PUBLISH_CONCURRENCY || 2,
+);
+
+/**
+ * Consumer for `worker:publish-nip29` (Task 07 §4).
+ *
+ * The single publish path: take a token-bucket slot, publish through the
+ * relay-admin connection, wait for the relay ACK, classify the outcome, and emit
+ * `tgr.publish.ack` exactly once per settled job. This is the SOLE owner of the
+ * `tgr.publish.ack` emit; Tasks 10/11 consume that event — they never read ACKs.
+ *
+ * Idempotency is relay-owned (no process-local cache): a duplicate `9007`
+ * resolves successfully via the already-exists predicate (§6.2). Retry/backoff
+ * is configured on the enqueued job (`attempts` + capped-exponential `backoff`);
+ * terminal rejects fail fast without exhausting retries.
+ */
+@Processor(PUBLISH_NIP29_QUEUE)
+export class PublishNip29Processor
+  implements OnApplicationBootstrap, OnApplicationShutdown
+{
+  private readonly logger = new Logger(PublishNip29Processor.name);
+  private readonly bucket: TokenBucket;
+  private resumeTimer?: ReturnType<typeof setTimeout>;
+  private stopped = false;
+
+  constructor(
+    @Inject(RELAY_WRITER)
+    private readonly relay: RelayWriter,
+    private readonly eventEmitter: EventEmitter2,
+    @Inject(tgrConfig.KEY)
+    private readonly config: ConfigType<typeof tgrConfig>,
+    @InjectQueue(PUBLISH_NIP29_QUEUE)
+    private readonly queue: Queue<PublishNip29Job>,
+  ) {
+    // One shared bucket per worker (across all concurrency slots), §4.
+    this.bucket = new TokenBucket(this.config.publishRatePerSec);
+  }
+
+  /**
+   * Clear a STALE pause on boot. {@link pauseForOutage} pauses the queue in Redis
+   * (durable) but the resume loop ({@link armResume}/{@link tryResume}) is purely
+   * in-memory — so if the process restarts while the queue is paused, the pause
+   * survives in Redis with no live timer to lift it, and the queue stays paused
+   * FOREVER (every publish — room creates + member adds — backs up unprocessed).
+   * Resuming here is idempotent and safe: if the relay is genuinely down, the first
+   * publish fails and `pauseForOutage` re-pauses WITH a fresh in-memory resume loop
+   * that this live process will honor. Runs after `onModuleInit` (the relay writer
+   * has connected by `OnApplicationBootstrap`).
+   */
+  async onApplicationBootstrap(): Promise<void> {
+    try {
+      if (await this.queue.isPaused()) {
+        const counts = await this.queue.getJobCounts();
+        await this.queue.resume();
+        this.logger.warn(
+          `resumed a stale-paused publish queue on boot ` +
+            `(${JSON.stringify(counts)} — these were stuck unprocessed)`,
+        );
+      }
+    } catch (e) {
+      this.logger.warn(
+        `failed to check/resume queue on boot: ${(e as Error)?.message}`,
+      );
+    }
+  }
+
+  @Process({ concurrency: PUBLISH_NIP29_CONCURRENCY })
+  async process(job: Job<PublishNip29Job>): Promise<{ id?: string }> {
+    const { template, groupId, meta } = job.data;
+    const saleAddress = meta?.saleAddress ?? groupId;
+    const pubkey = pubkeyFromTags(template.tags);
+
+    // Health gating (§1.3 / §4): if the relay is down, pause the queue for the
+    // configured window and re-throw so Bull re-attempts AFTER the pause — we do
+    // NOT retry-spin against a dead socket.
+    if (!this.relay.isHealthy()) {
+      await this.pauseForOutage();
+      throw new Error('relay unhealthy; paused publishes');
+    }
+
+    // Token-bucket rate limit, shared across the worker's concurrency slots.
+    await this.bucket.take();
+
+    const result = await this.relay.publish(template);
+
+    if (result.ok) {
+      this.emitAck(saleAddress, template.kind, pubkey, true);
+      return { id: result.id };
+    }
+
+    const reason = result.reason ?? 'publish failed';
+
+    // Reject classification ---------------------------------------------------
+    if (isAlreadyExists(reason)) {
+      // Resumable-backfill no-op (§6.2): treat as success, do not retry.
+      this.logger.debug(
+        `publish kind ${template.kind} for ${groupId}: already exists (no-op)`,
+      );
+      this.emitAck(saleAddress, template.kind, pubkey, true);
+      return { id: result.id };
+    }
+
+    if (isTerminalReject(reason)) {
+      // Permanent (D7 / 9008-deleted): fail fast, surface for alerting, ack false.
+      this.logger.error(
+        `terminal publish reject kind ${template.kind} for ${groupId}: ${reason}`,
+      );
+      this.emitAck(saleAddress, template.kind, pubkey, false);
+      throw new TerminalPublishError(reason);
+    }
+
+    if (isGroupNotFound(reason)) {
+      // The relay has no such group (DB↔relay desync — e.g. the relay was reset)
+      // while the DB still marks the room created. Retrying member ops is futile
+      // until the group is re-created, so do NOT retry-spam: `discard()` this job,
+      // and route by intent:
+      //   • 9001 remove / 9008 delete → the desired ABSENCE is already satisfied by
+      //     the group being gone → ack success (no re-create needed).
+      //   • 9000 add / 9002 metadata / 9006 role → ask the owner to re-create the
+      //     group (TGR_GROUP_MISSING → a queued 9007, debounced per group) and leave
+      //     the member `pending`; it is re-added once the group is back (the 9007
+      //     ok-ACK re-fires tgr.room.created → publishPendingForRoom).
+      if (
+        template.kind === NIP29_KIND.REMOVE_USER ||
+        template.kind === NIP29_KIND.DELETE_GROUP
+      ) {
+        this.logger.debug(
+          `group ${groupId} not found for kind ${template.kind} — absence already satisfied`,
+        );
+        this.emitAck(saleAddress, template.kind, pubkey, true);
+        return { id: result.id };
+      }
+      job.discard();
+      this.eventEmitter.emit(TGR_GROUP_MISSING, {
+        saleAddress,
+      } as TgrGroupMissingPayload);
+      this.logger.debug(
+        `group ${groupId} missing on relay → requested re-create; kind ${template.kind} deferred (member stays pending)`,
+      );
+      this.emitAck(saleAddress, template.kind, pubkey, false);
+      throw new Error(reason);
+    }
+
+    // ACK timeout: pause the queue (relay likely unreachable) before failing so
+    // Bull's backoff doesn't fire into a dead relay.
+    if (result.timedOut) {
+      await this.pauseForOutage();
+    }
+
+    // Retryable: throw so Bull re-attempts with its configured backoff. Emit a
+    // failure ack ONLY when retries are exhausted (this is the last attempt).
+    if (this.isLastAttempt(job)) {
+      this.logger.error(
+        `publish kind ${template.kind} for ${groupId} exhausted retries: ${reason}`,
+      );
+      this.emitAck(saleAddress, template.kind, pubkey, false);
+    } else {
+      this.logger.warn(
+        `publish kind ${template.kind} for ${groupId} failed (will retry): ${reason}`,
+      );
+    }
+    throw new Error(reason);
+  }
+
+  /** Emit the single-source-of-truth `tgr.publish.ack` (§4 publish ACK seam). */
+  private emitAck(
+    saleAddress: string,
+    kind: number,
+    pubkey: string | undefined,
+    ok: boolean,
+  ): void {
+    const payload: TgrPublishAckPayload = { saleAddress, kind, ok };
+    if (pubkey) {
+      payload.pubkey = pubkey;
+    }
+    this.eventEmitter.emit(TGR_PUBLISH_ACK, payload);
+  }
+
+  /** Pause the queue for `relayHealthPauseSec`, then resume (best-effort). */
+  private async pauseForOutage(): Promise<void> {
+    try {
+      const alreadyPaused = await this.queue.isPaused();
+      if (!alreadyPaused) {
+        await this.queue.pause();
+        this.logger.warn(
+          `relay outage: paused ${PUBLISH_NIP29_QUEUE} for ${this.config.relayHealthPauseSec}s`,
+        );
+      }
+    } catch (e) {
+      this.logger.warn(`failed to pause queue: ${(e as Error)?.message}`);
+    }
+    // Arm a single resume loop that retries until the relay is healthy again.
+    // Fire and forget — Bull holds the (re-thrown) job until the queue resumes.
+    this.armResume();
+  }
+
+  /** Arm the resume timer (at most one outstanding loop). */
+  private armResume(): void {
+    if (this.resumeTimer || this.stopped) {
+      return;
+    }
+    const pauseMs = Math.max(1, this.config.relayHealthPauseSec) * 1000;
+    this.resumeTimer = setTimeout(() => {
+      this.resumeTimer = undefined;
+      void this.tryResume();
+    }, pauseMs);
+    // Don't keep the event loop alive solely for the resume probe.
+    this.resumeTimer.unref?.();
+  }
+
+  private async tryResume(): Promise<void> {
+    if (this.stopped) {
+      return;
+    }
+    try {
+      if (this.relay.isHealthy()) {
+        if (await this.queue.isPaused()) {
+          await this.queue.resume();
+          this.logger.log(`relay healthy: resumed ${PUBLISH_NIP29_QUEUE}`);
+        }
+      } else {
+        // Still down — check again after another pause window.
+        this.armResume();
+      }
+    } catch (e) {
+      this.logger.warn(`failed to resume queue: ${(e as Error)?.message}`);
+      this.armResume();
+    }
+  }
+
+  onApplicationShutdown(): void {
+    this.stopped = true;
+    if (this.resumeTimer) {
+      clearTimeout(this.resumeTimer);
+      this.resumeTimer = undefined;
+    }
+  }
+
+  /** True when this is the final Bull attempt (no further retry will happen). */
+  private isLastAttempt(job: Job<PublishNip29Job>): boolean {
+    const attempts = job.opts.attempts ?? this.config.publishMaxRetries + 1;
+    return job.attemptsMade + 1 >= attempts;
+  }
+}

--- a/src/token-gated-rooms/queues/publish-nip29.types.ts
+++ b/src/token-gated-rooms/queues/publish-nip29.types.ts
@@ -1,0 +1,23 @@
+import type { Nip29Template } from '../nostr/nip29';
+
+/**
+ * Job payload for the `worker:publish-nip29` Bull queue (Task 07 §4).
+ *
+ * Callers (Tasks 08/09/10) build `template` with the `nip29.ts` builders and
+ * enqueue; this task's processor consumes, signs, publishes, waits for the relay
+ * ACK, and emits `tgr.publish.ack`. The processor reads `meta.saleAddress` /
+ * `template.kind` / the `["p", …]` tag for the ack payload.
+ */
+export interface PublishNip29Job {
+  /** A finalize-ready NIP-29 event template (`{ kind, tags, content? }`). */
+  template: Nip29Template;
+  /** The group id (= `Token.sale_address`); also present as `template.tags[0]`. */
+  groupId: string;
+  /** Optional correlation metadata for the ack seam / observability. */
+  meta?: {
+    /** `Token.sale_address` for the ack payload (falls back to `groupId`). */
+    saleAddress?: string;
+    /** Human reason this publish was enqueued (logging only). */
+    reason?: string;
+  };
+}

--- a/src/token-gated-rooms/queues/publish-policy.ts
+++ b/src/token-gated-rooms/queues/publish-policy.ts
@@ -1,0 +1,96 @@
+/**
+ * Pure retry/classification policy for the `publish-nip29` processor (Task 07 §4).
+ *
+ * No I/O — these helpers decide how a relay reject string is interpreted and how
+ * long to back off, so the processor stays a thin orchestrator and the policy is
+ * trivially unit-testable. Relay-reason strings are sourced from `groups_relay`:
+ *   - `"Group already exists"` (`groups.rs:388`)            → benign no-op success
+ *   - `"Only relay admin can create a managed group …"`     → terminal (D7)
+ *   - `"…existed before and was deleted"` (`groups.rs:414`) → terminal (9008)
+ */
+
+/** Default capped-exponential backoff ceiling (5m) per §18. */
+export const PUBLISH_BACKOFF_CAP_MS = 5 * 60 * 1000;
+
+/** Base unit for the exponential backoff series (ms). */
+export const PUBLISH_BACKOFF_BASE_MS = 1000;
+
+/**
+ * Capped exponential backoff: `base * 2^(attempt-1)` clamped to `capMs`.
+ * `attemptsMade` is Bull's 1-based attempt number (1 = first retry delay).
+ * Negative/zero attempts clamp to the base; the result never exceeds `capMs`.
+ */
+export function cappedExponentialBackoff(
+  attemptsMade: number,
+  baseMs: number = PUBLISH_BACKOFF_BASE_MS,
+  capMs: number = PUBLISH_BACKOFF_CAP_MS,
+): number {
+  const n = Math.max(1, Math.floor(attemptsMade));
+  // 2^(n-1) can overflow for large n; guard before multiplying.
+  const factor = Math.pow(2, n - 1);
+  const delay = Number.isFinite(factor) ? baseMs * factor : capMs;
+  return Math.min(delay, capMs);
+}
+
+/** Lowercases an unknown error/reason into a comparable message string. */
+export function reasonText(e: unknown): string {
+  if (typeof e === 'string') {
+    return e.toLowerCase();
+  }
+  const msg = (e as { message?: string } | null | undefined)?.message;
+  return (msg ?? '').toLowerCase();
+}
+
+/**
+ * True when a relay reject means the group already exists — a resumable-backfill
+ * no-op that must resolve the job successfully (do NOT retry). Mirrors the
+ * reference `isAlreadyExists()`: `"Group already exists"` or `"duplicate"`.
+ */
+export function isAlreadyExists(e: unknown): boolean {
+  const msg = reasonText(e);
+  return msg.includes('already exists') || msg.includes('duplicate');
+}
+
+/**
+ * True when a relay reject is PERMANENT and must fail fast (no retry, surface for
+ * alerting): the bot is not the relay admin, or the group was deleted (9008).
+ */
+export function isTerminalReject(e: unknown): boolean {
+  const msg = reasonText(e);
+  return (
+    msg.includes('only relay admin') ||
+    (msg.includes('was deleted') && msg.includes('existed before')) ||
+    msg.includes('group existed before and was deleted')
+  );
+}
+
+/**
+ * True when a relay reject means the target group does not exist on the relay
+ * (`groups_relay` answers member/metadata ops with `"... Group not found"`). This
+ * is NOT permanent: the group can be (re)created. It signals a DB↔relay desync —
+ * the API thinks the room is created (`room_id`/`nostr_room_state='created'`) but
+ * the relay has no such group (e.g. its data was reset). The owner re-creates the
+ * group, then the deferred member adds succeed.
+ */
+export function isGroupNotFound(e: unknown): boolean {
+  return reasonText(e).includes('group not found');
+}
+
+/** A non-retryable error wrapper so Bull does not re-attempt terminal rejects. */
+export class TerminalPublishError extends Error {
+  readonly terminal = true as const;
+  constructor(message: string) {
+    super(message);
+    this.name = 'TerminalPublishError';
+  }
+}
+
+/** Extracts the `["p", pubkey, …]` member pubkey from a template, if present. */
+export function pubkeyFromTags(tags: string[][]): string | undefined {
+  for (const tag of tags) {
+    if (tag[0] === 'p' && typeof tag[1] === 'string') {
+      return tag[1];
+    }
+  }
+  return undefined;
+}

--- a/src/token-gated-rooms/queues/reconcile.processor.ts
+++ b/src/token-gated-rooms/queues/reconcile.processor.ts
@@ -1,0 +1,132 @@
+import { InjectQueue, Process, Processor } from '@nestjs/bull';
+import { Inject, Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { ConfigType } from '@nestjs/config';
+import { Queue } from 'bull';
+import tgrConfig, { isRelayConfigured } from '../config/tgr.config';
+import { prefixQueue, TGR_QUEUE_NAMES } from '../config/queue-prefix';
+import { ReconciliationService } from '../services/reconciliation.service';
+import { ReorgEvictionService } from '../services/reorg-eviction.service';
+
+/**
+ * Resolved queue name (`worker:reconcile-membership`) — registered + consumed
+ * WORKER-side (canonical literal from Task 01's `prefixQueue`/`TGR_QUEUE_NAMES`).
+ * Distinct from Task 03's `main:reconcile-balance` (AEX9 balances): the old single
+ * `reconcile` queue is split so a relay-outage backlog of membership reconciles
+ * cannot starve the indexer's balance sweep (§9).
+ */
+export const RECONCILE_MEMBERSHIP_QUEUE = prefixQueue(
+  TGR_QUEUE_NAMES.RECONCILE_MEMBERSHIP,
+  'worker',
+);
+
+/**
+ * Bull job names on `worker:reconcile-membership`.
+ *
+ * - {@link RECONCILE_MEMBERSHIP_JOB}: the rotating read-back driver (one job = one
+ *   batch of rooms; {@link ReconciliationService.reconcileBatch}). Repeats every
+ *   `TG_RECONCILE_INTERVAL` (default 10m).
+ * - {@link REORG_FLUSH_JOB}: the reorg-buffer flush
+ *   ({@link ReorgEvictionService.flushDueEvictions}) — publishes `9001` for
+ *   evictions whose `held_until_height` has passed. Repeats on the same interval
+ *   (the buffer depth, not the interval, sets the eviction delay).
+ */
+export const RECONCILE_MEMBERSHIP_JOB = 'reconcile-membership-batch';
+export const REORG_FLUSH_JOB = 'reorg-eviction-flush';
+
+/**
+ * Consumer for `worker:reconcile-membership` (Task 11).
+ *
+ * Owns two repeatable jobs (both registered on boot, relay-gated):
+ *  - the rotating membership read-back/diff/self-heal (Task §A), and
+ *  - the reorg-eviction flush (Task §B.7).
+ *
+ * Relay-gating (worker mode removed — see `deworker-plan.md`): both jobs publish
+ * to / read from the relay, so we schedule NOTHING and short-circuit each
+ * `@Process` handler unless a relay is configured (`isRelayConfigured`). With no
+ * relay the boot smoke instantiates the processor but nothing is enqueued or run.
+ */
+@Injectable()
+@Processor(RECONCILE_MEMBERSHIP_QUEUE)
+export class ReconcileProcessor implements OnModuleInit {
+  private readonly logger = new Logger(ReconcileProcessor.name);
+
+  constructor(
+    @InjectQueue(RECONCILE_MEMBERSHIP_QUEUE)
+    private readonly queue: Queue,
+    private readonly reconciliation: ReconciliationService,
+    private readonly reorgEviction: ReorgEvictionService,
+    @Inject(tgrConfig.KEY)
+    private readonly config: ConfigType<typeof tgrConfig>,
+  ) {}
+
+  /**
+   * Schedule both repeatable jobs on boot — relay-gated. Bull dedupes by job id +
+   * repeat-opts so re-registering on every restart is safe. Interval =
+   * `TG_RECONCILE_INTERVAL` (default 10m). With no relay configured this is a no-op
+   * (nothing to read back / publish).
+   */
+  async onModuleInit(): Promise<void> {
+    if (!isRelayConfigured(this.config)) {
+      return;
+    }
+    const everyMs = Math.max(1, this.config.reconcileIntervalSec) * 1000;
+    try {
+      await this.queue.add(
+        RECONCILE_MEMBERSHIP_JOB,
+        {},
+        {
+          jobId: RECONCILE_MEMBERSHIP_JOB,
+          repeat: { every: everyMs },
+          removeOnComplete: true,
+          removeOnFail: true,
+        },
+      );
+      await this.queue.add(
+        REORG_FLUSH_JOB,
+        {},
+        {
+          jobId: REORG_FLUSH_JOB,
+          repeat: { every: everyMs },
+          removeOnComplete: true,
+          removeOnFail: true,
+        },
+      );
+      this.logger.log(
+        `scheduled reconcile-membership + reorg-flush every ${everyMs}ms on ` +
+          `'${RECONCILE_MEMBERSHIP_QUEUE}'`,
+      );
+    } catch (error: any) {
+      this.logger.error(
+        `failed to schedule reconcile-membership jobs: ${error?.message ?? error}`,
+      );
+    }
+  }
+
+  /** One rotating reconcile batch (read-back + diff + corrective enqueue). */
+  @Process({ name: RECONCILE_MEMBERSHIP_JOB, concurrency: 1 })
+  async reconcile(): Promise<void> {
+    if (!isRelayConfigured(this.config)) {
+      return;
+    }
+    const result = await this.reconciliation.reconcileBatch();
+    this.logger.debug(
+      `[reconcile] rooms=${result.roomsScanned} +${result.added} -${result.removed} ` +
+        `cursor=${result.nextCursor ?? '<wrapped>'}`,
+    );
+  }
+
+  /** Flush reorg-buffered evictions whose hold has passed. */
+  @Process({ name: REORG_FLUSH_JOB, concurrency: 1 })
+  async flush(): Promise<void> {
+    if (!isRelayConfigured(this.config)) {
+      return;
+    }
+    const { published, cancelled } =
+      await this.reorgEviction.flushDueEvictions();
+    if (published > 0 || cancelled > 0) {
+      this.logger.debug(
+        `[reorg-flush] published=${published} cancelled=${cancelled}`,
+      );
+    }
+  }
+}

--- a/src/token-gated-rooms/queues/reconcile.processor.ts
+++ b/src/token-gated-rooms/queues/reconcile.processor.ts
@@ -4,6 +4,7 @@ import { ConfigType } from '@nestjs/config';
 import { Queue } from 'bull';
 import tgrConfig, { isRelayConfigured } from '../config/tgr.config';
 import { prefixQueue, TGR_QUEUE_NAMES } from '../config/queue-prefix';
+import { MembershipAccessService } from '../services/membership-access.service';
 import { ReconciliationService } from '../services/reconciliation.service';
 import { ReorgEvictionService } from '../services/reorg-eviction.service';
 
@@ -34,6 +35,19 @@ export const RECONCILE_MEMBERSHIP_JOB = 'reconcile-membership-batch';
 export const REORG_FLUSH_JOB = 'reorg-eviction-flush';
 
 /**
+ * Access-revoke debounce finalizer (access-ledger plan §3.5). Emits the single
+ * `access_revoked` push for members whose access loss has outlived the grace
+ * window (and silently clears rows re-added within it). Unlike the other two jobs
+ * this is pure DB + event-emit, so it is scheduled + run **regardless of relay
+ * configuration** (a revoke can be armed by a room deletion even with no relay).
+ */
+export const ACCESS_REVOKE_FINALIZE_JOB = 'access-revoke-finalize';
+
+/** Finalizer cadence — frequent enough that the effective revoke latency is
+ * grace + at most this interval. Bounded to [30s, reconcileInterval]. */
+const REVOKE_FINALIZE_MIN_SEC = 30;
+
+/**
  * Consumer for `worker:reconcile-membership` (Task 11).
  *
  * Owns two repeatable jobs (both registered on boot, relay-gated):
@@ -55,6 +69,7 @@ export class ReconcileProcessor implements OnModuleInit {
     private readonly queue: Queue,
     private readonly reconciliation: ReconciliationService,
     private readonly reorgEviction: ReorgEvictionService,
+    private readonly membershipAccess: MembershipAccessService,
     @Inject(tgrConfig.KEY)
     private readonly config: ConfigType<typeof tgrConfig>,
   ) {}
@@ -66,10 +81,35 @@ export class ReconcileProcessor implements OnModuleInit {
    * (nothing to read back / publish).
    */
   async onModuleInit(): Promise<void> {
+    const everyMs = Math.max(1, this.config.reconcileIntervalSec) * 1000;
+
+    // The revoke finalizer is relay-independent (pure DB + event-emit): schedule it
+    // even when no relay is configured, so a room-deletion-armed revoke still fires.
+    const finalizeEveryMs =
+      Math.min(
+        Math.max(REVOKE_FINALIZE_MIN_SEC, 1),
+        Math.max(1, this.config.reconcileIntervalSec),
+      ) * 1000;
+    try {
+      await this.queue.add(
+        ACCESS_REVOKE_FINALIZE_JOB,
+        {},
+        {
+          jobId: ACCESS_REVOKE_FINALIZE_JOB,
+          repeat: { every: finalizeEveryMs },
+          removeOnComplete: true,
+          removeOnFail: true,
+        },
+      );
+    } catch (error: any) {
+      this.logger.error(
+        `failed to schedule access-revoke-finalize job: ${error?.message ?? error}`,
+      );
+    }
+
     if (!isRelayConfigured(this.config)) {
       return;
     }
-    const everyMs = Math.max(1, this.config.reconcileIntervalSec) * 1000;
     try {
       await this.queue.add(
         RECONCILE_MEMBERSHIP_JOB,
@@ -126,6 +166,21 @@ export class ReconcileProcessor implements OnModuleInit {
     if (published > 0 || cancelled > 0) {
       this.logger.debug(
         `[reorg-flush] published=${published} cancelled=${cancelled}`,
+      );
+    }
+  }
+
+  /**
+   * Emit debounced access-revoke pushes (relay-independent — always runs). A row
+   * re-added within the grace window is cleared silently (flap absorbed).
+   */
+  @Process({ name: ACCESS_REVOKE_FINALIZE_JOB, concurrency: 1 })
+  async finalizeRevokes(): Promise<void> {
+    const { revoked, cancelled } =
+      await this.membershipAccess.finalizeDueRevokes();
+    if (revoked > 0 || cancelled > 0) {
+      this.logger.debug(
+        `[access-revoke-finalize] revoked=${revoked} cancelled=${cancelled}`,
       );
     }
   }

--- a/src/token-gated-rooms/queues/room-backfill.constants.ts
+++ b/src/token-gated-rooms/queues/room-backfill.constants.ts
@@ -1,0 +1,63 @@
+import { prefixQueue } from '../config/queue-prefix';
+
+/**
+ * Constants for the eager room-backfill queue (Task 09).
+ *
+ * Worst case (stated for the load-test gate, §6.2 / Task 16): ~54k BCL factory
+ * tokens × 2 group-level publishes (`9007` create-group + `9002` edit-metadata)
+ * ≈ 108k publishes flowing through `worker:publish-nip29`. This path MUST be
+ * load-tested against `groups_relay` before cutover; do NOT raise
+ * `TG_PUBLISH_CONCURRENCY` / `TG_PUBLISH_RATE_PER_SEC` past their configured values.
+ */
+
+/**
+ * Resolved queue name (`worker:room-backfill`) — registered + consumed worker-side
+ * (canonical literal from Task 01's `prefixQueue`/`TGR_QUEUE_NAMES`). The driver
+ * never steals `main:` indexer jobs because it runs under the `worker:` prefix.
+ */
+export const ROOM_BACKFILL_QUEUE = prefixQueue('room-backfill', 'worker');
+
+/**
+ * Bull job names on `worker:room-backfill`.
+ *
+ * - {@link BACKFILL_KICKOFF_JOB}: the driver loop — selects the next page of
+ *   tokens needing a room and fans out one publish-sequence per token, then
+ *   re-enqueues itself for the following page until the working set is empty.
+ * - {@link BACKFILL_STALE_SWEEP_JOB}: re-publishes `pending` rows that have had
+ *   no ACK for > 24h (relay idempotency makes the re-publish safe).
+ */
+export const BACKFILL_KICKOFF_JOB = 'backfill-kickoff';
+export const BACKFILL_STALE_SWEEP_JOB = 'backfill-stale-sweep';
+
+/** Single-row cursor PK in `room_backfill_state` (mirrors the indexer SyncState). */
+export const ROOM_BACKFILL_STATE_ID = 'global';
+
+/**
+ * Env flag gating the eager backfill kickoff (Task 09, boot-safety): the full
+ * AppModule loads in BOTH processes and tests boot the module, so the driver must
+ * NEVER auto-run on module init (it would enqueue ~54k jobs and race app.close in
+ * the boot smoke). The driver schedules nothing unless this is `'true'` AND the
+ * process is the worker. NOTE: the integrator should also add `backfillOnBoot`
+ * (parseBool, default false) to `tgr.config.ts` + a `TG_BACKFILL_ON_BOOT=false` row
+ * to `.env.example`; this service reads `process.env` directly because the shared
+ * config file is off-limits to this task.
+ */
+export const BACKFILL_ON_BOOT_ENV = 'TG_BACKFILL_ON_BOOT';
+
+/**
+ * A `pending` row with no ACK for longer than this is re-published (§4.7 — relay
+ * idempotency makes the duplicate `9007`/`9002` a no-op). Stays `pending` (not a
+ * state change). 24h in milliseconds.
+ */
+export const STALE_PENDING_MS = 24 * 60 * 60 * 1000;
+
+/** Local `TG_BACKFILL_ON_BOOT`-style boolean parse (config file is off-limits, §wiring). */
+export function parseBool(
+  value: string | undefined,
+  defaultValue: boolean,
+): boolean {
+  if (value === undefined || value.trim() === '') {
+    return defaultValue;
+  }
+  return value.trim().toLowerCase() === 'true';
+}

--- a/src/token-gated-rooms/queues/room-backfill.processor.ts
+++ b/src/token-gated-rooms/queues/room-backfill.processor.ts
@@ -1,0 +1,88 @@
+import { InjectQueue, Process, Processor } from '@nestjs/bull';
+import { Inject, Logger } from '@nestjs/common';
+import { ConfigType } from '@nestjs/config';
+import { Job, Queue } from 'bull';
+import tgrConfig from '../config/tgr.config';
+import { RoomBackfillService } from '../services/room-backfill.service';
+import {
+  BACKFILL_KICKOFF_JOB,
+  BACKFILL_STALE_SWEEP_JOB,
+  ROOM_BACKFILL_QUEUE,
+} from './room-backfill.constants';
+
+/** Payload for the kickoff/driver job: the keyset cursor to process after. */
+export interface BackfillKickoffJob {
+  /** Process tokens with `sale_address > afterSaleAddress` (omit for first page). */
+  afterSaleAddress?: string;
+}
+
+/**
+ * Consumer for `worker:room-backfill` (Task 09) — WORKER PROCESS ONLY.
+ *
+ * Two job types:
+ *  - {@link BACKFILL_KICKOFF_JOB}: process one page of the working set via
+ *    {@link RoomBackfillService.processPage}; if the page was full (more may
+ *    remain) re-enqueue the next page so the sweep walks the whole registry
+ *    without holding a single long-lived job. Concurrency is 1 so pages are
+ *    processed serially (the publish fan-out itself is rate-limited by the Task 07
+ *    `worker:publish-nip29` token-bucket / limiter — this queue must NOT add a
+ *    second parallel pressure source on the relay).
+ *  - {@link BACKFILL_STALE_SWEEP_JOB}: re-publish `pending` rooms with no ACK for
+ *    > 24h (relay idempotency makes the duplicate publish safe).
+ *
+ * This queue runs under the `worker:` prefix (Task 01) so it can never steal the
+ * `main:` indexer's jobs (§9). Worst case driven from here: ~54k tokens × 2
+ * publishes ≈ 108k publishes — load-test before cutover (§6.2 / Task 16).
+ */
+@Processor(ROOM_BACKFILL_QUEUE)
+export class RoomBackfillProcessor {
+  private readonly logger = new Logger(RoomBackfillProcessor.name);
+
+  constructor(
+    private readonly backfill: RoomBackfillService,
+    @InjectQueue(ROOM_BACKFILL_QUEUE)
+    private readonly queue: Queue,
+    @Inject(tgrConfig.KEY)
+    private readonly config: ConfigType<typeof tgrConfig>,
+  ) {}
+
+  /** Drive one page, then chain the next if the page was full. */
+  @Process({ name: BACKFILL_KICKOFF_JOB, concurrency: 1 })
+  async kickoff(job: Job<BackfillKickoffJob>): Promise<void> {
+    const after = job.data?.afterSaleAddress;
+    const result = await this.backfill.processPage(after);
+    this.logger.log(
+      `[room-backfill] page after=${after ?? '<start>'}: ` +
+        `requested=${result.requested} hasMore=${result.hasMore} ` +
+        `nextCursor=${result.nextCursor ?? '<end>'}`,
+    );
+
+    if (result.hasMore && result.nextCursor) {
+      // Chain the next page after a pacing delay so back-to-back pages don't
+      // sustain pressure on the DB pool / relay (`backfillPageDelayMs`, default
+      // 1s; 0 chains immediately). A fresh jobId per page keeps the fixed-id
+      // kickoff collapse (in startBackfill) for the FIRST page only; subsequent
+      // pages are distinct so they are not collapsed onto a stale completed job.
+      await this.queue.add(
+        BACKFILL_KICKOFF_JOB,
+        { afterSaleAddress: result.nextCursor },
+        {
+          delay: this.config.backfillPageDelayMs,
+          removeOnComplete: true,
+          removeOnFail: true,
+        },
+      );
+    } else {
+      this.logger.log('[room-backfill] working set drained — kickoff complete');
+    }
+  }
+
+  /** Re-publish stale (>24h, no ACK) pending rooms. */
+  @Process({ name: BACKFILL_STALE_SWEEP_JOB, concurrency: 1 })
+  async staleSweep(): Promise<void> {
+    const republished = await this.backfill.sweepStalePending();
+    this.logger.debug(
+      `[room-backfill] stale sweep re-published ${republished} room(s)`,
+    );
+  }
+}

--- a/src/token-gated-rooms/queues/room-message-notify.processor.ts
+++ b/src/token-gated-rooms/queues/room-message-notify.processor.ts
@@ -1,0 +1,141 @@
+import { Process, Processor } from '@nestjs/bull';
+import { Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Encoded } from '@aeternity/aepp-sdk';
+import { Job } from 'bull';
+import { Repository } from 'typeorm';
+import { Token } from '@/tokens/entities/token.entity';
+import { NotificationService } from '@/notifications/core/notification.service';
+import { DeviceService } from '@/notifications/services/device.service';
+import { RoomMessageNotification } from '../notifications/room-message.notification';
+import { RoomPreferencesService } from '../services/room-preferences.service';
+import {
+  ROOM_MESSAGE_NOTIFY_JOB,
+  ROOM_NOTIFY_QUEUE,
+  type RoomMessageNotifyJob,
+} from './room-message-notify.types';
+
+/**
+ * Consumer of the **`room-message`-named** jobs on `worker:room-notify` (Task 14,
+ * plan §7.1) — **WORKER PROCESS ONLY**.
+ *
+ * Sibling to Task 12's {@link RoomNotifyProcessor} (which owns the *unnamed* default
+ * job = membership pushes) on the SAME queue: Bull routes by job name, so this
+ * named `@Process('room-message')` only sees the message-notification jobs the
+ * relay subscriber enqueues. Keeping both on one queue means the §7.1 circuit
+ * breaker measures a single shared depth.
+ *
+ * Per job (the heavy half of the message-push path — cheap checks already done by
+ * the subscriber on the hot path):
+ *   1. resolve the recipient's device(s) — SKIP if none (the holder has no app;
+ *      a `no-channel` outcome, NOT a failure — mirror `chain-transfer.listener.ts`);
+ *   2. re-check the room-scoped mute (`RoomPreferencesService.isRoomEnabled` —
+ *      per-room `room_notification_preference.muted` OR the type-level
+ *      `room-messages` switch) so a mute toggled between enqueue and delivery is
+ *      still honored before we build the notification;
+ *   3. re-resolve the room symbol (never trust the queued snapshot);
+ *   4. dispatch the coalesced {@link RoomMessageNotification} via
+ *      {@link NotificationService} (which re-applies its own type-level chokepoint).
+ *
+ * It NEVER throws on a benign skip and logs (never throws) on a `failed`
+ * `SendOutcome`. NOTE (Task 12 dependency): `RoomMessageNotification` renders a
+ * generic "new messages" body — it does NOT yet accept `message_count` to render
+ * the "N new messages in $SYM" copy required by §4. The coalesced count is carried
+ * on the job for when Task 12's class gains a count param; today it only salts the
+ * dedup key via `messageKey`. See the manifest notes.
+ */
+@Processor(ROOM_NOTIFY_QUEUE)
+export class RoomMessageNotifyProcessor {
+  private readonly logger = new Logger(RoomMessageNotifyProcessor.name);
+
+  constructor(
+    @InjectRepository(Token)
+    private readonly tokenRepo: Repository<Token>,
+    private readonly devices: DeviceService,
+    private readonly roomPreferences: RoomPreferencesService,
+    private readonly notifications: NotificationService,
+  ) {}
+
+  @Process({
+    name: ROOM_MESSAGE_NOTIFY_JOB,
+    // Conservative, like the publish path: a small cap so message fan-out never
+    // starves the indexer / publish workers (TG_PUBLISH_CONCURRENCY semantics, §5).
+    concurrency: 2,
+  })
+  async process(job: Job<RoomMessageNotifyJob>): Promise<void> {
+    const data = job.data ?? ({} as RoomMessageNotifyJob);
+    const {
+      sale_address,
+      recipient,
+      symbol,
+      window_started_at,
+      sample_event_id,
+    } = data;
+    if (!sale_address || !recipient) {
+      return;
+    }
+
+    // (1) Device-token reality: only addresses with a registered device are
+    // reachable. No device → no push (not a failure).
+    const tokens = await this.devices.getActiveTokens(recipient);
+    if (tokens.length === 0) {
+      return;
+    }
+
+    // (2) Room-scoped mute re-check (honor a mute toggled after enqueue).
+    const enabled = await this.roomPreferences.isRoomEnabled(
+      recipient,
+      RoomMessageNotification.META.type,
+      sale_address,
+    );
+    if (!enabled) {
+      return;
+    }
+
+    // (3) Best-effort fresh room label (fall back to the queued symbol).
+    const freshSymbol = (await this.resolveSymbol(sale_address)) ?? symbol;
+
+    // (4) Dispatch the coalesced push. `messageKey` keys the dedup key off this
+    // coalescing window so successive windows for the same (room, recipient) are
+    // distinct pushes, but a re-delivered job within a window is deduped.
+    const outcome = await this.notifications.send(
+      { address: recipient as Encoded.AccountAddress },
+      new RoomMessageNotification({
+        saleAddress: sale_address,
+        symbol: freshSymbol,
+        messageKey: this.messageKey(window_started_at, sample_event_id),
+      }),
+    );
+    if (outcome.outcome === 'failed') {
+      this.logger.warn(
+        `room-message notification failed for ${recipient} in ${sale_address}: ${outcome.error}`,
+      );
+    }
+  }
+
+  /** Per-window dedup salt: prefer the window start, fall back to a sample id. */
+  private messageKey(
+    windowStartedAt: number | undefined,
+    sampleEventId: string | undefined,
+  ): string | undefined {
+    if (typeof windowStartedAt === 'number' && windowStartedAt > 0) {
+      return `w${windowStartedAt}`;
+    }
+    return sampleEventId || undefined;
+  }
+
+  /** Resolve the token symbol for nicer copy; undefined when unknown. */
+  private async resolveSymbol(
+    saleAddress: string,
+  ): Promise<string | undefined> {
+    try {
+      const token = await this.tokenRepo.findOne({
+        where: { sale_address: saleAddress },
+        select: ['sale_address', 'symbol'],
+      });
+      return token?.symbol ?? undefined;
+    } catch {
+      return undefined;
+    }
+  }
+}

--- a/src/token-gated-rooms/queues/room-message-notify.types.ts
+++ b/src/token-gated-rooms/queues/room-message-notify.types.ts
@@ -1,0 +1,59 @@
+import type { JobOptions } from 'bull';
+import { ROOM_NOTIFY_QUEUE } from './room-notify.types';
+
+/**
+ * Job NAME for room **message** notifications on the shared `worker:room-notify`
+ * queue (Task 14, plan §7.1).
+ *
+ * ## Why a named job on the SAME queue (not a new queue)
+ * Task 12 already owns the `worker:room-notify` queue + its **unnamed** `@Process()`
+ * consumer for membership pushes (`RoomNotifyJob`). Bull's unnamed processor only
+ * picks up the default job name, so message notifications ride the same queue under
+ * a distinct name (`'room-message'`) consumed by a separate named `@Process()` in
+ * {@link RoomMessageNotifyProcessor}. The two job shapes never collide, and the
+ * circuit-breaker (§7.1) measures one shared depth across both producers — exactly
+ * the "queue isolation per process, not per notification type" model of plan §9.
+ * (The task file's `room-notify.types.ts`/`room-notify.processor.ts` names were
+ * taken by Task 12 landing first; these `room-message-notify.*` files are the
+ * Task-14 counterparts, kept distinct so neither task edits the other's wiring.)
+ */
+export const ROOM_MESSAGE_NOTIFY_JOB = 'room-message';
+
+/** Re-export so the producer/consumer reference one canonical queue name. */
+export { ROOM_NOTIFY_QUEUE };
+
+/**
+ * Payload for a coalesced room-message notification (plan §7.1, requirement §5).
+ * Thin by design: the consumer re-checks device(s) + mute + symbol from the DB at
+ * dispatch time, so a stale snapshot never travels through the queue. One job per
+ * `(recipient, room)` per coalescing flush — NOT one per message.
+ */
+export interface RoomMessageNotifyJob {
+  /** `Token.sale_address` — the room key / NIP-29 group id. */
+  sale_address: string;
+  /** æternity account address to notify. */
+  recipient: string;
+  /** Room label (token symbol) captured at flush; consumer may re-resolve. */
+  symbol: string;
+  /** Number of messages seen for this room within the coalescing window. */
+  message_count: number;
+  /** Unix-seconds timestamp the coalescing window opened (dedup-key salt). */
+  window_started_at: number;
+  /** A representative event id from the window (kept for the dedup key / logs). */
+  sample_event_id: string;
+}
+
+/**
+ * Job options for `worker:room-notify` message jobs. Coalesced message pushes are
+ * best-effort and low-value once stale; a couple of retries cover a transient
+ * device-lookup / Redis blip without spinning, and rows are removed on
+ * settle so the queue (and the circuit-breaker depth) doesn't grow unbounded.
+ */
+export function roomMessageNotifyJobOptions(): JobOptions {
+  return {
+    attempts: 3,
+    backoff: { type: 'fixed', delay: 2000 },
+    removeOnComplete: true,
+    removeOnFail: true,
+  };
+}

--- a/src/token-gated-rooms/queues/room-notify.integration.spec.ts
+++ b/src/token-gated-rooms/queues/room-notify.integration.spec.ts
@@ -1,0 +1,182 @@
+import 'dotenv/config';
+import { DataSource, Repository } from 'typeorm';
+import { DATABASE_CONFIG } from '@/configs/database';
+import { Token } from '@/tokens/entities/token.entity';
+import { NotificationPreference } from '@/notifications/entities/notification-preference.entity';
+import { NotificationPreferencesService } from '@/notifications/services/notification-preferences.service';
+import { CommunityRoom } from '../entities/community-room.entity';
+import { RoomMembership } from '../entities/room-membership.entity';
+import { RoomNotificationPreference } from '../entities/room-notification-preference.entity';
+import { RoomMessageSeen } from '../entities/room-message-seen.entity';
+import { TokenBalance } from '../entities/token-balance.entity';
+import { RoomBackfillState } from '../entities/room-backfill-state.entity';
+import { RoomPreferencesService } from '../services/room-preferences.service';
+import { RoomMembershipNotification } from '../notifications/room-membership.notification';
+import { RoomNotifyProcessor } from './room-notify.processor';
+import type { RoomNotifyJob } from './room-notify.types';
+import type { Job } from 'bull';
+
+/**
+ * DB integration for the membership-notification dispatch path (Task 12). Mirrors
+ * the Task 10 harness: a real Postgres backs `token` + `room_notification_preference`
+ * + `notification_preferences` in a DEDICATED `tgr12_test` schema
+ * (`synchronize: true`). The processor's dispatch sink (`NotificationService.send`)
+ * + device lookup (`DeviceService.getActiveTokens`) are mocked so the test asserts
+ * the SKIP/dispatch decision over the REAL mute SQL.
+ *
+ * Requires the local Postgres (`DB_HOST`); auto-skips otherwise.
+ */
+const HAS_DB = !!process.env.DB_HOST;
+const d = HAS_DB ? describe : describe.skip;
+
+const SCHEMA = 'tgr12_test';
+const SALE = 'ct_tgr12_sale';
+const TOKEN_ADDR = 'ct_tgr12_token';
+const MEMBER = 'ak_tgr12_member';
+
+d('RoomNotifyProcessor (integration)', () => {
+  let ds: DataSource;
+  let tokenRepo: Repository<Token>;
+  let roomPrefRepo: Repository<RoomNotificationPreference>;
+  let notifPrefRepo: Repository<NotificationPreference>;
+  let roomPreferences: RoomPreferencesService;
+  let processor: RoomNotifyProcessor;
+  let send: jest.Mock;
+  let getActiveTokens: jest.Mock;
+
+  const job = (over: Partial<RoomNotifyJob> = {}): Job<RoomNotifyJob> =>
+    ({
+      data: {
+        saleAddress: SALE,
+        memberAddress: MEMBER,
+        change: 'added',
+        ...over,
+      },
+    }) as Job<RoomNotifyJob>;
+
+  beforeAll(async () => {
+    const boot = new DataSource({
+      ...(DATABASE_CONFIG as any),
+      synchronize: false,
+      entities: [],
+    });
+    await boot.initialize();
+    await boot.query(`DROP SCHEMA IF EXISTS "${SCHEMA}" CASCADE`);
+    await boot.query(`CREATE SCHEMA "${SCHEMA}"`);
+    await boot.destroy();
+
+    ds = new DataSource({
+      ...(DATABASE_CONFIG as any),
+      schema: SCHEMA,
+      synchronize: true,
+      entities: [
+        Token,
+        CommunityRoom,
+        RoomMembership,
+        RoomNotificationPreference,
+        RoomMessageSeen,
+        TokenBalance,
+        RoomBackfillState,
+        NotificationPreference,
+      ],
+    });
+    await ds.initialize();
+
+    tokenRepo = ds.getRepository(Token);
+    roomPrefRepo = ds.getRepository(RoomNotificationPreference);
+    notifPrefRepo = ds.getRepository(NotificationPreference);
+  }, 60_000);
+
+  beforeEach(async () => {
+    await roomPrefRepo.clear();
+    await notifPrefRepo.clear();
+    await tokenRepo.clear();
+
+    await tokenRepo.save(
+      tokenRepo.create({
+        sale_address: SALE,
+        address: TOKEN_ADDR,
+        name: 'TGR12',
+        symbol: 'TGR',
+        owner_address: 'ak_owner',
+      } as Partial<Token>),
+    );
+
+    const notifPrefs = new NotificationPreferencesService(notifPrefRepo);
+    roomPreferences = new RoomPreferencesService(roomPrefRepo, notifPrefs);
+
+    send = jest.fn().mockResolvedValue({ outcome: 'sent' });
+    getActiveTokens = jest.fn().mockResolvedValue(['ExponentPushToken[x]']);
+    processor = new RoomNotifyProcessor(
+      tokenRepo,
+      { getActiveTokens } as any,
+      roomPreferences,
+      { send } as any,
+    );
+  });
+
+  afterAll(async () => {
+    if (ds?.isInitialized) {
+      await ds.destroy();
+    }
+    const cleanup = new DataSource({
+      ...(DATABASE_CONFIG as any),
+      synchronize: false,
+      entities: [],
+    });
+    await cleanup.initialize();
+    await cleanup.query(`DROP SCHEMA IF EXISTS "${SCHEMA}" CASCADE`);
+    await cleanup.destroy();
+  }, 60_000);
+
+  it('dispatches when not muted and a device exists', async () => {
+    await processor.process(job());
+    expect(send).toHaveBeenCalledTimes(1);
+    const [notifiable, notification] = send.mock.calls[0];
+    expect(notifiable).toEqual({ address: MEMBER });
+    expect(notification).toBeInstanceOf(RoomMembershipNotification);
+    expect(notification.toExpo().data).toMatchObject({
+      type: 'room-membership',
+      saleAddress: SALE,
+      change: 'added',
+    });
+  });
+
+  it('does NOT dispatch when per-room muted (room_notification_preference.muted=true)', async () => {
+    await roomPrefRepo.save(
+      roomPrefRepo.create({ address: MEMBER, sale_address: SALE, muted: true }),
+    );
+    await processor.process(job());
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('does NOT dispatch when type-level muted-all (notification_preferences enabled=false)', async () => {
+    await notifPrefRepo.save(
+      notifPrefRepo.create({
+        address: MEMBER,
+        type: RoomMembershipNotification.META.type,
+        enabled: false,
+      }),
+    );
+    await processor.process(job());
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('does NOT dispatch when the member has no registered device', async () => {
+    getActiveTokens.mockResolvedValue([]);
+    await processor.process(job());
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('a per-room mute in one room does not suppress another room', async () => {
+    await roomPrefRepo.save(
+      roomPrefRepo.create({
+        address: MEMBER,
+        sale_address: 'ct_other',
+        muted: true,
+      }),
+    );
+    await processor.process(job());
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/token-gated-rooms/queues/room-notify.integration.spec.ts
+++ b/src/token-gated-rooms/queues/room-notify.integration.spec.ts
@@ -6,6 +6,7 @@ import { NotificationPreference } from '@/notifications/entities/notification-pr
 import { NotificationPreferencesService } from '@/notifications/services/notification-preferences.service';
 import { CommunityRoom } from '../entities/community-room.entity';
 import { RoomMembership } from '../entities/room-membership.entity';
+import { RoomMembershipEvent } from '../entities/room-membership-event.entity';
 import { RoomNotificationPreference } from '../entities/room-notification-preference.entity';
 import { RoomMessageSeen } from '../entities/room-message-seen.entity';
 import { TokenBalance } from '../entities/token-balance.entity';
@@ -73,6 +74,7 @@ d('RoomNotifyProcessor (integration)', () => {
         Token,
         CommunityRoom,
         RoomMembership,
+        RoomMembershipEvent,
         RoomNotificationPreference,
         RoomMessageSeen,
         TokenBalance,
@@ -109,6 +111,7 @@ d('RoomNotifyProcessor (integration)', () => {
     getActiveTokens = jest.fn().mockResolvedValue(['ExponentPushToken[x]']);
     processor = new RoomNotifyProcessor(
       tokenRepo,
+      ds.getRepository(RoomMembershipEvent),
       { getActiveTokens } as any,
       roomPreferences,
       { send } as any,

--- a/src/token-gated-rooms/queues/room-notify.processor.spec.ts
+++ b/src/token-gated-rooms/queues/room-notify.processor.spec.ts
@@ -8,6 +8,7 @@ describe('RoomNotifyProcessor', () => {
   const MEMBER = 'ak_member';
 
   let tokenRepo: { findOne: jest.Mock };
+  let eventRepo: { findOne: jest.Mock; update: jest.Mock };
   let devices: { getActiveTokens: jest.Mock };
   let roomPreferences: { isRoomEnabled: jest.Mock };
   let notifications: { send: jest.Mock };
@@ -25,6 +26,10 @@ describe('RoomNotifyProcessor', () => {
 
   beforeEach(() => {
     tokenRepo = { findOne: jest.fn().mockResolvedValue({ symbol: 'FOO' }) };
+    eventRepo = {
+      findOne: jest.fn().mockResolvedValue(null),
+      update: jest.fn().mockResolvedValue(undefined),
+    };
     devices = {
       getActiveTokens: jest.fn().mockResolvedValue(['ExponentPushToken[x]']),
     };
@@ -32,6 +37,7 @@ describe('RoomNotifyProcessor', () => {
     notifications = { send: jest.fn().mockResolvedValue({ outcome: 'sent' }) };
     processor = new RoomNotifyProcessor(
       tokenRepo as any,
+      eventRepo as any,
       devices as any,
       roomPreferences as any,
       notifications as any,

--- a/src/token-gated-rooms/queues/room-notify.processor.spec.ts
+++ b/src/token-gated-rooms/queues/room-notify.processor.spec.ts
@@ -1,0 +1,91 @@
+import type { Job } from 'bull';
+import { RoomNotifyProcessor } from './room-notify.processor';
+import { RoomMembershipNotification } from '../notifications/room-membership.notification';
+import type { RoomNotifyJob } from './room-notify.types';
+
+describe('RoomNotifyProcessor', () => {
+  const SALE = 'ct_sale';
+  const MEMBER = 'ak_member';
+
+  let tokenRepo: { findOne: jest.Mock };
+  let devices: { getActiveTokens: jest.Mock };
+  let roomPreferences: { isRoomEnabled: jest.Mock };
+  let notifications: { send: jest.Mock };
+  let processor: RoomNotifyProcessor;
+
+  const job = (over: Partial<RoomNotifyJob> = {}): Job<RoomNotifyJob> =>
+    ({
+      data: {
+        saleAddress: SALE,
+        memberAddress: MEMBER,
+        change: 'added',
+        ...over,
+      },
+    }) as Job<RoomNotifyJob>;
+
+  beforeEach(() => {
+    tokenRepo = { findOne: jest.fn().mockResolvedValue({ symbol: 'FOO' }) };
+    devices = {
+      getActiveTokens: jest.fn().mockResolvedValue(['ExponentPushToken[x]']),
+    };
+    roomPreferences = { isRoomEnabled: jest.fn().mockResolvedValue(true) };
+    notifications = { send: jest.fn().mockResolvedValue({ outcome: 'sent' }) };
+    processor = new RoomNotifyProcessor(
+      tokenRepo as any,
+      devices as any,
+      roomPreferences as any,
+      notifications as any,
+    );
+  });
+
+  it('dispatches an added RoomMembershipNotification on the happy path', async () => {
+    await processor.process(job());
+    expect(devices.getActiveTokens).toHaveBeenCalledWith(MEMBER);
+    expect(roomPreferences.isRoomEnabled).toHaveBeenCalledWith(
+      MEMBER,
+      RoomMembershipNotification.META.type,
+      SALE,
+    );
+    expect(notifications.send).toHaveBeenCalledTimes(1);
+    const [notifiable, notification] = notifications.send.mock.calls[0];
+    expect(notifiable).toEqual({ address: MEMBER });
+    expect(notification).toBeInstanceOf(RoomMembershipNotification);
+    expect(notification.toExpo().data).toMatchObject({
+      change: 'added',
+      saleAddress: SALE,
+    });
+  });
+
+  it('SKIPS dispatch when the member has no registered device', async () => {
+    devices.getActiveTokens.mockResolvedValue([]);
+    await processor.process(job());
+    expect(roomPreferences.isRoomEnabled).not.toHaveBeenCalled();
+    expect(notifications.send).not.toHaveBeenCalled();
+  });
+
+  it('SKIPS dispatch when per-room/type muted (isRoomEnabled=false)', async () => {
+    roomPreferences.isRoomEnabled.mockResolvedValue(false);
+    await processor.process(job());
+    expect(notifications.send).not.toHaveBeenCalled();
+  });
+
+  it('resolves and forwards the room symbol into the notification copy', async () => {
+    await processor.process(job());
+    const notification = notifications.send.mock.calls[0][1];
+    expect(notification.toExpo().body).toContain('FOO');
+  });
+
+  it('still dispatches with generic copy when the symbol lookup fails', async () => {
+    tokenRepo.findOne.mockRejectedValue(new Error('db'));
+    await processor.process(job());
+    expect(notifications.send).toHaveBeenCalledTimes(1);
+    expect(notifications.send.mock.calls[0][1].toExpo().body).toContain(
+      'a room',
+    );
+  });
+
+  it('ignores malformed jobs', async () => {
+    await processor.process(job({ memberAddress: '' as any }));
+    expect(notifications.send).not.toHaveBeenCalled();
+  });
+});

--- a/src/token-gated-rooms/queues/room-notify.processor.ts
+++ b/src/token-gated-rooms/queues/room-notify.processor.ts
@@ -87,6 +87,7 @@ export class RoomNotifyProcessor {
         symbol,
         change,
         isFirstGrant,
+        accessEventId,
       }),
     );
     if (outcome.outcome === 'failed') {

--- a/src/token-gated-rooms/queues/room-notify.processor.ts
+++ b/src/token-gated-rooms/queues/room-notify.processor.ts
@@ -1,0 +1,98 @@
+import { Process, Processor } from '@nestjs/bull';
+import { Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Encoded } from '@aeternity/aepp-sdk';
+import { Job } from 'bull';
+import { Repository } from 'typeorm';
+import { Token } from '@/tokens/entities/token.entity';
+import { NotificationService } from '@/notifications/core/notification.service';
+import { DeviceService } from '@/notifications/services/device.service';
+import { RoomMembershipNotification } from '../notifications/room-membership.notification';
+import { RoomPreferencesService } from '../services/room-preferences.service';
+import { ROOM_NOTIFY_QUEUE, type RoomNotifyJob } from './room-notify.types';
+
+/**
+ * Consumer for `worker:room-notify` (Task 12 / plan §7) — **WORKER PROCESS ONLY**.
+ *
+ * The heavy half of the membership-push path: for each enqueued
+ * `(saleAddress, memberAddress, change)` it
+ *   1. resolves the member's device(s) — SKIP if none registered (the holder has
+ *      no app installed; this is a `no-channel` outcome, NOT a failure — only
+ *      device-bearing addresses are reachable, by design);
+ *   2. checks the room-scoped preference — SKIP when the member is per-room muted
+ *      (`room_notification_preference.muted=true` for `(address, saleAddress)`) OR
+ *      the type-level `room-membership` mute-all is off
+ *      (`NotificationPreferencesService.isEnabled` via {@link RoomPreferencesService});
+ *   3. resolves the room symbol (best-effort) for nicer copy;
+ *   4. dispatches via {@link NotificationService} (which re-applies its own
+ *      type-level chokepoint independently).
+ *
+ * It NEVER throws past Bull's retry contract for a benign skip; only genuine
+ * dispatch errors propagate (so Bull retries per the job options).
+ */
+@Processor(ROOM_NOTIFY_QUEUE)
+export class RoomNotifyProcessor {
+  private readonly logger = new Logger(RoomNotifyProcessor.name);
+
+  constructor(
+    @InjectRepository(Token)
+    private readonly tokenRepo: Repository<Token>,
+    private readonly devices: DeviceService,
+    private readonly roomPreferences: RoomPreferencesService,
+    private readonly notifications: NotificationService,
+  ) {}
+
+  @Process()
+  async process(job: Job<RoomNotifyJob>): Promise<void> {
+    const { saleAddress, memberAddress, change } = job.data;
+    if (!saleAddress || !memberAddress || !change) {
+      return;
+    }
+
+    // (1) Device-token reality: only addresses with a registered device are
+    // reachable. No device → no push (not a failure).
+    const tokens = await this.devices.getActiveTokens(memberAddress);
+    if (tokens.length === 0) {
+      return;
+    }
+
+    // (2) Room-scoped mute: per-room muted OR type-level mute-all both suppress.
+    const enabled = await this.roomPreferences.isRoomEnabled(
+      memberAddress,
+      RoomMembershipNotification.META.type,
+      saleAddress,
+    );
+    if (!enabled) {
+      return;
+    }
+
+    // (3) Best-effort room label for copy (re-queried, never trust a stale event).
+    const symbol = await this.resolveSymbol(saleAddress);
+
+    // (4) Dispatch (NotificationService re-applies the type-level chokepoint).
+    const outcome = await this.notifications.send(
+      { address: memberAddress as Encoded.AccountAddress },
+      new RoomMembershipNotification({ saleAddress, symbol, change }),
+    );
+    if (outcome.outcome === 'failed') {
+      this.logger.warn(
+        `room-membership notification failed for ${memberAddress} in ${saleAddress}: ${outcome.error}`,
+      );
+    }
+  }
+
+  /** Resolve the token symbol for nicer copy; undefined when unknown. */
+  private async resolveSymbol(
+    saleAddress: string,
+  ): Promise<string | undefined> {
+    try {
+      const token = await this.tokenRepo.findOne({
+        where: { sale_address: saleAddress },
+        select: ['sale_address', 'symbol'],
+      });
+      return token?.symbol ?? undefined;
+    } catch {
+      return undefined;
+    }
+  }
+}

--- a/src/token-gated-rooms/queues/room-notify.processor.ts
+++ b/src/token-gated-rooms/queues/room-notify.processor.ts
@@ -7,6 +7,7 @@ import { Repository } from 'typeorm';
 import { Token } from '@/tokens/entities/token.entity';
 import { NotificationService } from '@/notifications/core/notification.service';
 import { DeviceService } from '@/notifications/services/device.service';
+import { RoomMembershipEvent } from '../entities/room-membership-event.entity';
 import { RoomMembershipNotification } from '../notifications/room-membership.notification';
 import { RoomPreferencesService } from '../services/room-preferences.service';
 import { ROOM_NOTIFY_QUEUE, type RoomNotifyJob } from './room-notify.types';
@@ -37,6 +38,8 @@ export class RoomNotifyProcessor {
   constructor(
     @InjectRepository(Token)
     private readonly tokenRepo: Repository<Token>,
+    @InjectRepository(RoomMembershipEvent)
+    private readonly eventRepo: Repository<RoomMembershipEvent>,
     private readonly devices: DeviceService,
     private readonly roomPreferences: RoomPreferencesService,
     private readonly notifications: NotificationService,
@@ -44,8 +47,15 @@ export class RoomNotifyProcessor {
 
   @Process()
   async process(job: Job<RoomNotifyJob>): Promise<void> {
-    const { saleAddress, memberAddress, change } = job.data;
+    const { saleAddress, memberAddress, change, accessEventId, isFirstGrant } =
+      job.data;
     if (!saleAddress || !memberAddress || !change) {
+      return;
+    }
+
+    // (0) Durable dedup: if this access-ledger event was already pushed (Bull
+    // retry / redelivery after a restart), do not push it again.
+    if (accessEventId && (await this.alreadyNotified(accessEventId))) {
       return;
     }
 
@@ -72,11 +82,53 @@ export class RoomNotifyProcessor {
     // (4) Dispatch (NotificationService re-applies the type-level chokepoint).
     const outcome = await this.notifications.send(
       { address: memberAddress as Encoded.AccountAddress },
-      new RoomMembershipNotification({ saleAddress, symbol, change }),
+      new RoomMembershipNotification({
+        saleAddress,
+        symbol,
+        change,
+        isFirstGrant,
+      }),
     );
     if (outcome.outcome === 'failed') {
       this.logger.warn(
         `room-membership notification failed for ${memberAddress} in ${saleAddress}: ${outcome.error}`,
+      );
+      return;
+    }
+
+    // (5) Stamp the ledger event dispatched (durable dedup). Best-effort — a stamp
+    // failure must not fail the job (it would only risk a duplicate push).
+    if (accessEventId) {
+      await this.markNotified(accessEventId);
+    }
+  }
+
+  /** True iff the access-ledger event has already been dispatched. */
+  private async alreadyNotified(accessEventId: string): Promise<boolean> {
+    try {
+      const event = await this.eventRepo.findOne({
+        where: { id: accessEventId },
+        select: ['id', 'notified_at'],
+      });
+      return !!event?.notified_at;
+    } catch {
+      // Fail open: a lookup blip should not silently swallow the notification.
+      return false;
+    }
+  }
+
+  /** Stamp `notified_at=now()` on the access-ledger event (best-effort). */
+  private async markNotified(accessEventId: string): Promise<void> {
+    try {
+      await this.eventRepo.update(
+        { id: accessEventId },
+        { notified_at: new Date() },
+      );
+    } catch (error) {
+      this.logger.warn(
+        `failed to stamp notified_at for access event ${accessEventId}: ${
+          (error as Error).message
+        }`,
       );
     }
   }

--- a/src/token-gated-rooms/queues/room-notify.types.ts
+++ b/src/token-gated-rooms/queues/room-notify.types.ts
@@ -1,0 +1,41 @@
+import type { JobOptions } from 'bull';
+import { prefixQueue, TGR_QUEUE_NAMES } from '../config/queue-prefix';
+import type { RoomMembershipChange } from '../notifications/room-membership.notification';
+
+/**
+ * Resolved queue name (`worker:room-notify`) — the membership-notification fan-out
+ * queue. Consumed by the worker process (Task 12 / plan §7). The listener
+ * (`RoomEventListener`) is the only producer in this task.
+ */
+export const ROOM_NOTIFY_QUEUE = prefixQueue(
+  TGR_QUEUE_NAMES.ROOM_NOTIFY,
+  'worker',
+);
+
+/**
+ * Job payload for `worker:room-notify`. Thin by design (mirrors the THIN in-process
+ * events): the processor re-resolves the member's device(s) + room symbol + mute
+ * state from the DB, so a stale snapshot never travels through the queue.
+ */
+export interface RoomNotifyJob {
+  /** `Token.sale_address` — the room key. */
+  saleAddress: string;
+  /** æternity account address to notify. */
+  memberAddress: string;
+  /** Whether the holder was added to or removed from the room. */
+  change: RoomMembershipChange;
+}
+
+/**
+ * Job options for `worker:room-notify`. Membership pushes are low-frequency and
+ * best-effort; a couple of retries cover a transient device-lookup / Redis blip
+ * without spinning. `removeOnComplete` keeps the queue from growing unbounded.
+ */
+export function roomNotifyJobOptions(): JobOptions {
+  return {
+    attempts: 3,
+    backoff: { type: 'fixed', delay: 2000 },
+    removeOnComplete: true,
+    removeOnFail: true,
+  };
+}

--- a/src/token-gated-rooms/queues/room-notify.types.ts
+++ b/src/token-gated-rooms/queues/room-notify.types.ts
@@ -24,6 +24,14 @@ export interface RoomNotifyJob {
   memberAddress: string;
   /** Whether the holder was added to or removed from the room. */
   change: RoomMembershipChange;
+  /**
+   * `room_membership_event.id` for this transition (access-ledger plan). The
+   * processor stamps `notified_at` on dispatch → durable dedup (never re-push the
+   * same access transition on a Bull retry / after a restart).
+   */
+  accessEventId?: string;
+  /** True iff the member's first-ever access grant (drives "Welcome" copy). */
+  isFirstGrant?: boolean;
 }
 
 /**

--- a/src/token-gated-rooms/queues/token-bucket.ts
+++ b/src/token-gated-rooms/queues/token-bucket.ts
@@ -1,0 +1,87 @@
+/**
+ * A simple async token-bucket rate limiter (Task 07 §4).
+ *
+ * One shared bucket per worker caps the publish rate to `ratePerSec` events/sec
+ * across all `TG_PUBLISH_CONCURRENCY` workers — a second line of defence alongside
+ * Bull's queue `limiter`. `take()` resolves immediately when a token is
+ * available and otherwise waits exactly long enough for the bucket to refill,
+ * so a burst of N callers is smoothed to ≤ `ratePerSec` per rolling second.
+ *
+ * Pure of NestJS so it is directly unit-testable; `now`/`sleep` are injectable
+ * for deterministic tests (fake clock).
+ */
+export interface TokenBucketDeps {
+  /** Monotonic-ish clock in ms (default `Date.now`). */
+  now?: () => number;
+  /** Sleep helper (default `setTimeout`). */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+export class TokenBucket {
+  private readonly capacity: number;
+  private readonly refillPerMs: number;
+  private readonly now: () => number;
+  private readonly sleep: (ms: number) => Promise<void>;
+
+  private tokens: number;
+  private last: number;
+  /** Serializes waiters so the refill window is honoured FIFO under burst. */
+  private chain: Promise<void> = Promise.resolve();
+
+  constructor(ratePerSec: number, deps: TokenBucketDeps = {}) {
+    this.capacity = Math.max(1, ratePerSec);
+    this.refillPerMs = this.capacity / 1000;
+    this.now = deps.now ?? Date.now;
+    this.sleep = deps.sleep ?? defaultSleep;
+    this.tokens = this.capacity;
+    this.last = this.now();
+  }
+
+  private refill(): void {
+    const t = this.now();
+    const elapsed = t - this.last;
+    if (elapsed <= 0) {
+      return;
+    }
+    this.tokens = Math.min(
+      this.capacity,
+      this.tokens + elapsed * this.refillPerMs,
+    );
+    this.last = t;
+  }
+
+  /** Acquire one token, waiting (FIFO) until one is available. */
+  async take(): Promise<void> {
+    // Chain so concurrent callers don't all observe the same refill snapshot
+    // and over-spend; each waits for the previous to settle its reservation.
+    const prev = this.chain;
+    let release!: () => void;
+    this.chain = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await prev;
+    try {
+      await this.reserve();
+    } finally {
+      release();
+    }
+  }
+
+  private async reserve(): Promise<void> {
+    // Loop: refill, spend if possible, else sleep the deficit and retry.
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      this.refill();
+      if (this.tokens >= 1) {
+        this.tokens -= 1;
+        return;
+      }
+      const deficit = 1 - this.tokens;
+      const waitMs = Math.ceil(deficit / this.refillPerMs);
+      await this.sleep(Math.max(1, waitMs));
+    }
+  }
+}

--- a/src/token-gated-rooms/queues/token-bucket.ts
+++ b/src/token-gated-rooms/queues/token-bucket.ts
@@ -18,7 +18,10 @@ export interface TokenBucketDeps {
 }
 
 const defaultSleep = (ms: number): Promise<void> =>
-  new Promise((resolve) => setTimeout(resolve, ms));
+  new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    timer.unref?.();
+  });
 
 export class TokenBucket {
   private readonly capacity: number;

--- a/src/token-gated-rooms/room-notifications.module.spec.ts
+++ b/src/token-gated-rooms/room-notifications.module.spec.ts
@@ -1,0 +1,71 @@
+import { getQueueToken } from '@nestjs/bull';
+import { RoomNotificationsModule } from './room-notifications.module';
+import { RoomPreferencesService } from './services/room-preferences.service';
+import { RoomEventListener } from './listeners/room-event.listener';
+import { RoomNotifyProcessor } from './queues/room-notify.processor';
+import { RoomMessageNotifyProcessor } from './queues/room-message-notify.processor';
+import { RelaySubscriberService } from './nostr/relay-subscriber.service';
+import { NotificationRedisService } from '@/notifications/services/notification-redis.service';
+import { ROOM_NOTIFY_QUEUE } from './queues/room-notify.types';
+
+/**
+ * Static-metadata smoke for the Task 12 module after worker mode was removed
+ * (see `deworker-plan.md`). The module is now a plain `@Module` that registers the
+ * full membership-notification fan-out unconditionally in the single always-on
+ * process — there is no `forRoot({ mode })` and no per-mode provider split.
+ *
+ * What used to be "worker/combined mode loads the listener + processors + the
+ * `worker:room-notify` queue, main mode loads only RoomPreferencesService" is now a
+ * single unified wiring: ALL of those providers are present and the queue is
+ * registered exactly once. The relay READ path (RelaySubscriberService) and the
+ * dispatch path self-gate at runtime on `isRelayConfigured` (the injected tgrConfig),
+ * not on process mode, so loading them is boot-safe regardless of relay config.
+ *
+ * We assert the `@Module` metadata directly via `Reflect.getMetadata` rather than a
+ * full Nest bootstrap, so this needs no Postgres/Redis and runs everywhere.
+ */
+describe('RoomNotificationsModule wiring', () => {
+  const providers: any[] =
+    Reflect.getMetadata('providers', RoomNotificationsModule) ?? [];
+  const exportsMeta: any[] =
+    Reflect.getMetadata('exports', RoomNotificationsModule) ?? [];
+  const imports: any[] =
+    Reflect.getMetadata('imports', RoomNotificationsModule) ?? [];
+
+  it('registers the full membership-notification fan-out unconditionally', () => {
+    // Previously worker/combined-only; now always present in the single process.
+    expect(providers).toContain(RoomEventListener);
+    expect(providers).toContain(RoomNotifyProcessor);
+    expect(providers).toContain(RoomMessageNotifyProcessor);
+    expect(providers).toContain(NotificationRedisService);
+  });
+
+  it('registers the relay READ subscriber unconditionally (self-gates at runtime)', () => {
+    // Was a worker-only provider; the subscriber now loads in every process and
+    // only opens a socket when isRelayConfigured(this.config) is true.
+    expect(providers).toContain(RelaySubscriberService);
+  });
+
+  it('registers RoomPreferencesService (the HTTP controller read/write surface)', () => {
+    // This used to be the ONLY provider in main mode; it is still always present.
+    expect(providers).toContain(RoomPreferencesService);
+  });
+
+  it('exports RoomPreferencesService for the client room API controller', () => {
+    expect(exportsMeta).toContain(RoomPreferencesService);
+  });
+
+  it('registers the worker:room-notify queue exactly once', () => {
+    // As a plain @Module singleton the queue is registered once even though both
+    // TokenGatedRoomsModule and ClientRoomApiModule import this module.
+    const queueToken = getQueueToken(ROOM_NOTIFY_QUEUE);
+    const queueRegistrations = imports.filter(
+      (imported) =>
+        imported?.module?.name === 'BullModule' &&
+        (imported.providers ?? []).some(
+          (provider: any) => provider?.provide === queueToken,
+        ),
+    );
+    expect(queueRegistrations).toHaveLength(1);
+  });
+});

--- a/src/token-gated-rooms/room-notifications.module.ts
+++ b/src/token-gated-rooms/room-notifications.module.ts
@@ -1,0 +1,61 @@
+import { BullModule } from '@nestjs/bull';
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Token } from '@/tokens/entities/token.entity';
+import { NotificationsModule } from '@/notifications/notifications.module';
+import notificationsConfig from '@/notifications/notifications.config';
+import { NotificationRedisService } from '@/notifications/services/notification-redis.service';
+import tgrConfig from './config/tgr.config';
+import { CommunityRoom } from './entities/community-room.entity';
+import { RoomMembership } from './entities/room-membership.entity';
+import { RoomMessageSeen } from './entities/room-message-seen.entity';
+import { RoomNotificationPreference } from './entities/room-notification-preference.entity';
+import { RoomPreferencesService } from './services/room-preferences.service';
+import { RoomEventListener } from './listeners/room-event.listener';
+import { RoomNotifyProcessor } from './queues/room-notify.processor';
+import { RoomMessageNotifyProcessor } from './queues/room-message-notify.processor';
+import { RelaySubscriberService } from './nostr/relay-subscriber.service';
+import { ROOM_NOTIFY_QUEUE } from './queues/room-notify.types';
+
+/**
+ * Membership notifications + per-room mute (plan §7.2).
+ *
+ * Plain self-contained `@Module` (worker mode removed — see `deworker-plan.md`).
+ * Everything loads in the single process: `RoomPreferencesService` (the read/write
+ * surface the HTTP controller needs), the membership-push fan-out (listener +
+ * `worker:room-notify` queue + its two processors), and the Task 14 relay READ
+ * subscriber. The subscriber + the dispatch path self-gate at runtime on
+ * `isRelayConfigured` (no relay → no socket, nothing enqueued), so this module is
+ * safe to load unconditionally. As a plain `@Module` it is a NestJS singleton, so
+ * the `worker:room-notify` queue is registered exactly once even though both
+ * `TokenGatedRoomsModule` and `ClientRoomApiModule` import it.
+ *
+ * Boot-safe: nothing schedules work in `onModuleInit`; the listener only enqueues
+ * on an event and the processors only run on jobs.
+ */
+@Module({
+  imports: [
+    ConfigModule.forFeature(tgrConfig),
+    ConfigModule.forFeature(notificationsConfig),
+    TypeOrmModule.forFeature([
+      Token,
+      RoomNotificationPreference,
+      CommunityRoom,
+      RoomMembership,
+      RoomMessageSeen,
+    ]),
+    NotificationsModule,
+    BullModule.registerQueue({ name: ROOM_NOTIFY_QUEUE }),
+  ],
+  providers: [
+    RoomPreferencesService,
+    NotificationRedisService,
+    RoomEventListener,
+    RoomNotifyProcessor,
+    RelaySubscriberService,
+    RoomMessageNotifyProcessor,
+  ],
+  exports: [RoomPreferencesService],
+})
+export class RoomNotificationsModule {}

--- a/src/token-gated-rooms/room-notifications.module.ts
+++ b/src/token-gated-rooms/room-notifications.module.ts
@@ -9,6 +9,7 @@ import { NotificationRedisService } from '@/notifications/services/notification-
 import tgrConfig from './config/tgr.config';
 import { CommunityRoom } from './entities/community-room.entity';
 import { RoomMembership } from './entities/room-membership.entity';
+import { RoomMembershipEvent } from './entities/room-membership-event.entity';
 import { RoomMessageSeen } from './entities/room-message-seen.entity';
 import { RoomNotificationPreference } from './entities/room-notification-preference.entity';
 import { RoomPreferencesService } from './services/room-preferences.service';
@@ -43,6 +44,7 @@ import { ROOM_NOTIFY_QUEUE } from './queues/room-notify.types';
       RoomNotificationPreference,
       CommunityRoom,
       RoomMembership,
+      RoomMembershipEvent,
       RoomMessageSeen,
     ]),
     NotificationsModule,

--- a/src/token-gated-rooms/services/__tests__/group-missing-tracker.service.spec.ts
+++ b/src/token-gated-rooms/services/__tests__/group-missing-tracker.service.spec.ts
@@ -1,0 +1,44 @@
+import { GroupMissingTracker } from '../group-missing-tracker.service';
+
+describe('GroupMissingTracker', () => {
+  let tracker: GroupMissingTracker;
+
+  beforeEach(() => {
+    tracker = new GroupMissingTracker();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('is not missing by default', () => {
+    expect(tracker.isMissing('ct_a')).toBe(false);
+    expect(tracker.size).toBe(0);
+  });
+
+  it('marks a group missing and clears it', () => {
+    tracker.markMissing('ct_a');
+    expect(tracker.isMissing('ct_a')).toBe(true);
+    expect(tracker.size).toBe(1);
+
+    tracker.clear('ct_a');
+    expect(tracker.isMissing('ct_a')).toBe(false);
+    expect(tracker.size).toBe(0);
+  });
+
+  it('debounces: marking is idempotent per sale', () => {
+    tracker.markMissing('ct_a');
+    tracker.markMissing('ct_a');
+    expect(tracker.size).toBe(1);
+  });
+
+  it('expires entries after the TTL (and lazily evicts on read)', () => {
+    jest.useFakeTimers();
+    tracker.markMissing('ct_a', 1000);
+    expect(tracker.isMissing('ct_a')).toBe(true);
+
+    jest.advanceTimersByTime(1001);
+    expect(tracker.isMissing('ct_a')).toBe(false); // expired
+    expect(tracker.size).toBe(0); // lazily evicted by the isMissing read
+  });
+});

--- a/src/token-gated-rooms/services/__tests__/reconciliation-reorg.integration.spec.ts
+++ b/src/token-gated-rooms/services/__tests__/reconciliation-reorg.integration.spec.ts
@@ -1,0 +1,368 @@
+import 'dotenv/config';
+import { DataSource, Repository } from 'typeorm';
+import { Relay } from 'nostr-tools';
+import WebSocket from 'ws';
+import { DATABASE_CONFIG } from '@/configs/database';
+import { Token } from '@/tokens/entities/token.entity';
+import { SyncState } from '@/mdw-sync/entities/sync-state.entity';
+import { CommunityRoom } from '../../entities/community-room.entity';
+import { RoomMembership } from '../../entities/room-membership.entity';
+import { RoomNotificationPreference } from '../../entities/room-notification-preference.entity';
+import { RoomMessageSeen } from '../../entities/room-message-seen.entity';
+import { TokenBalance } from '../../entities/token-balance.entity';
+import { RoomBackfillState } from '../../entities/room-backfill-state.entity';
+import { NIP29_KIND } from '../../nostr/nip29';
+import { ReconciliationService } from '../reconciliation.service';
+import { ReorgEvictionService } from '../reorg-eviction.service';
+
+if (typeof (globalThis as { WebSocket?: unknown }).WebSocket === 'undefined') {
+  (globalThis as { WebSocket?: unknown }).WebSocket = WebSocket;
+}
+
+/**
+ * DB integration for Task 11 (reconciliation diff + reorg buffer/flush). A real
+ * Postgres backs `token` + `community_room` + `room_membership` + `sync_state` in a
+ * DEDICATED `tgr11_test` schema (`synchronize: true`), mirroring the Task 09/10
+ * harness. The relay WRITE path is MOCKED (we assert the enqueued `9000`/`9001`
+ * templates) and the `39002` read-back is fed via a stubbed `fetchGroupMembers` —
+ * the relay socket / read helper is Task 07's contract; here we drive the state
+ * machine. Auto-skips when there is no local Postgres (`DB_HOST`).
+ */
+const HAS_DB = !!process.env.DB_HOST;
+const d = HAS_DB ? describe : describe.skip;
+
+const SCHEMA = 'tgr11_test';
+const SALE = 'ct_tgr11_sale';
+const TOKEN_ADDR = 'ct_tgr11_token';
+const MEMBER = 'ak_tgr11_member';
+const PUBKEY = 'a'.repeat(64);
+const DEPTH = 10;
+
+void Relay; // imported for parity with sibling harnesses (relay section is mocked)
+
+d('Task 11 reconciliation + reorg (integration)', () => {
+  let ds: DataSource;
+  let tokenRepo: Repository<Token>;
+  let roomRepo: Repository<CommunityRoom>;
+  let membershipRepo: Repository<RoomMembership>;
+  let syncStateRepo: Repository<SyncState>;
+
+  let publishQueue: { add: jest.Mock };
+  let relayMembers: Set<string>;
+  let reconciliation: ReconciliationService;
+  let reorg: ReorgEvictionService;
+
+  const config = {
+    reconcileBatchSize: 500,
+    reconcileIntervalSec: 600,
+    reorgConfirmationDepthBlocks: DEPTH,
+    publishMaxRetries: 5,
+  } as any;
+
+  beforeAll(async () => {
+    const boot = new DataSource({
+      ...(DATABASE_CONFIG as any),
+      synchronize: false,
+      entities: [],
+    });
+    await boot.initialize();
+    await boot.query(`DROP SCHEMA IF EXISTS "${SCHEMA}" CASCADE`);
+    await boot.query(`CREATE SCHEMA "${SCHEMA}"`);
+    await boot.destroy();
+
+    ds = new DataSource({
+      ...(DATABASE_CONFIG as any),
+      schema: SCHEMA,
+      synchronize: true,
+      entities: [
+        Token,
+        SyncState,
+        CommunityRoom,
+        RoomMembership,
+        RoomNotificationPreference,
+        RoomMessageSeen,
+        TokenBalance,
+        RoomBackfillState,
+      ],
+    });
+    await ds.initialize();
+
+    tokenRepo = ds.getRepository(Token);
+    roomRepo = ds.getRepository(CommunityRoom);
+    membershipRepo = ds.getRepository(RoomMembership);
+    syncStateRepo = ds.getRepository(SyncState);
+  }, 60_000);
+
+  beforeEach(async () => {
+    await membershipRepo.clear();
+    await roomRepo.clear();
+    await tokenRepo.clear();
+    await syncStateRepo.clear();
+
+    publishQueue = { add: jest.fn().mockResolvedValue({ id: 'p' }) };
+    relayMembers = new Set<string>();
+
+    const relay = {
+      pubkey: 'f'.repeat(64),
+      isHealthy: () => true,
+      publish: jest.fn(),
+      fetchGroupMembers: jest.fn(async () => new Set(relayMembers)),
+    };
+    const roomAdmins = {
+      isConfiguredAdmin: () => false,
+      convergeRoomAdmins: jest.fn().mockResolvedValue(0),
+    };
+
+    reconciliation = new ReconciliationService(
+      membershipRepo,
+      tokenRepo,
+      syncStateRepo,
+      publishQueue as unknown as any,
+      relay as any,
+      roomAdmins as any,
+      config,
+    );
+    reorg = new ReorgEvictionService(
+      membershipRepo,
+      tokenRepo,
+      syncStateRepo,
+      publishQueue as unknown as any,
+      roomAdmins as any,
+      config,
+    );
+  });
+
+  afterAll(async () => {
+    if (ds?.isInitialized) {
+      await ds.destroy();
+    }
+    const cleanup = new DataSource({
+      ...(DATABASE_CONFIG as any),
+      synchronize: false,
+      entities: [],
+    });
+    await cleanup.initialize();
+    await cleanup.query(`DROP SCHEMA IF EXISTS "${SCHEMA}" CASCADE`);
+    await cleanup.destroy();
+  }, 60_000);
+
+  async function seedRoom(): Promise<void> {
+    await tokenRepo.save(
+      tokenRepo.create({
+        sale_address: SALE,
+        address: TOKEN_ADDR,
+        name: 'TGR11',
+        symbol: 'TGR',
+        owner_address: 'ak_owner',
+        nostr_group_id: SALE,
+        nostr_room_state: 'created',
+        has_nostr_room: true,
+      } as Partial<Token>),
+    );
+    await roomRepo.save(
+      roomRepo.create({
+        sale_address: SALE,
+        token_address: TOKEN_ADDR,
+        symbol: 'TGR',
+        owner_address: 'ak_owner',
+        is_private: true,
+        moderators: [],
+        muted: [],
+        is_community: true,
+        deleted: false,
+      }),
+    );
+  }
+
+  async function setHeight(tip: number): Promise<void> {
+    await syncStateRepo.save(
+      syncStateRepo.create({
+        id: 'global',
+        last_synced_height: tip,
+        last_synced_hash: 'mh_x',
+        tip_height: tip,
+      } as Partial<SyncState>),
+    );
+  }
+
+  // ── §A drift heals ──────────────────────────────────────────────────────────
+
+  it('drift heals: eligible+linked member missing from 39002 → republishes 9000, advances last_reconciled_at', async () => {
+    await seedRoom();
+    await setHeight(1000);
+    await membershipRepo.save(
+      membershipRepo.create({
+        sale_address: SALE,
+        member_address: MEMBER,
+        member_pubkey: PUBKEY,
+        eligible: true,
+        relay_state: 'added',
+      }),
+    );
+    relayMembers = new Set(); // 39002 lost the member (dropped publish)
+
+    const before = await membershipRepo.findOneByOrFail({ sale_address: SALE });
+    expect(before.last_reconciled_at).toBeNull();
+
+    const result = await reconciliation.reconcileBatch();
+
+    expect(result.added).toBe(1);
+    expect(publishQueue.add).toHaveBeenCalledTimes(1);
+    expect(publishQueue.add.mock.calls[0][0].template.kind).toBe(
+      NIP29_KIND.PUT_USER,
+    );
+    const after = await membershipRepo.findOneByOrFail({ sale_address: SALE });
+    expect(after.last_reconciled_at).toBeInstanceOf(Date);
+  });
+
+  it('stale-remove heals: ineligible member still in 39002 → republishes 9001', async () => {
+    await seedRoom();
+    await setHeight(1000);
+    await membershipRepo.save(
+      membershipRepo.create({
+        sale_address: SALE,
+        member_address: MEMBER,
+        member_pubkey: PUBKEY,
+        eligible: false,
+        relay_state: 'added',
+      }),
+    );
+    relayMembers = new Set([PUBKEY]); // dropped 9001 → still present
+
+    const result = await reconciliation.reconcileBatch();
+
+    expect(result.removed).toBe(1);
+    expect(publishQueue.add).toHaveBeenCalledTimes(1);
+    expect(publishQueue.add.mock.calls[0][0].template.kind).toBe(
+      NIP29_KIND.REMOVE_USER,
+    );
+  });
+
+  it('no drift → no spurious publishes (idempotent)', async () => {
+    await seedRoom();
+    await setHeight(1000);
+    await membershipRepo.save(
+      membershipRepo.create({
+        sale_address: SALE,
+        member_address: MEMBER,
+        member_pubkey: PUBKEY,
+        eligible: true,
+        relay_state: 'added',
+      }),
+    );
+    relayMembers = new Set([PUBKEY]);
+
+    await reconciliation.reconcileBatch();
+
+    expect(publishQueue.add).not.toHaveBeenCalled();
+  });
+
+  // ── §B reorg buffer + flush ───────────────────────────────────────────────────
+
+  it('reorg within depth does NOT evict: bufferEvictions sets a future hold, flush publishes nothing', async () => {
+    await seedRoom();
+    await setHeight(1000);
+    await membershipRepo.save(
+      membershipRepo.create({
+        sale_address: SALE,
+        member_address: MEMBER,
+        member_pubkey: PUBKEY,
+        eligible: false, // post-reorg recompute made them ineligible
+        relay_state: 'added',
+      }),
+    );
+
+    const buffered = await reorg.bufferEvictions([SALE]);
+    expect(buffered).toBe(1);
+    let row = await membershipRepo.findOneByOrFail({ sale_address: SALE });
+    expect(row.held_until_height).toBe(1000 + DEPTH);
+    expect(row.relay_state).toBe('added');
+
+    // Advance height by < DEPTH → hold not passed → flush is a no-op.
+    await setHeight(1000 + DEPTH - 1);
+    const { published } = await reorg.flushDueEvictions();
+    expect(published).toBe(0);
+    expect(publishQueue.add).not.toHaveBeenCalled();
+    row = await membershipRepo.findOneByOrFail({ sale_address: SALE });
+    expect(row.held_until_height).toBe(1000 + DEPTH);
+    expect(row.relay_state).toBe('added');
+  });
+
+  it('reorg beyond depth evicts: flush publishes 9001, clears hold, sets pending_remove', async () => {
+    await seedRoom();
+    await setHeight(1000);
+    await membershipRepo.save(
+      membershipRepo.create({
+        sale_address: SALE,
+        member_address: MEMBER,
+        member_pubkey: PUBKEY,
+        eligible: false,
+        relay_state: 'added',
+      }),
+    );
+
+    await reorg.bufferEvictions([SALE]);
+    await setHeight(1000 + DEPTH); // hold passed
+
+    const { published } = await reorg.flushDueEvictions();
+    expect(published).toBe(1);
+    expect(publishQueue.add).toHaveBeenCalledTimes(1);
+    expect(publishQueue.add.mock.calls[0][0].template.kind).toBe(
+      NIP29_KIND.REMOVE_USER,
+    );
+    const row = await membershipRepo.findOneByOrFail({ sale_address: SALE });
+    expect(row.held_until_height).toBeNull();
+    expect(row.relay_state).toBe('pending_remove');
+  });
+
+  it('transient fork cancels eviction: eligibility restored before depth → flush cancels, no 9001', async () => {
+    await seedRoom();
+    await setHeight(1000);
+    await membershipRepo.save(
+      membershipRepo.create({
+        sale_address: SALE,
+        member_address: MEMBER,
+        member_pubkey: PUBKEY,
+        eligible: false,
+        relay_state: 'added',
+      }),
+    );
+
+    await reorg.bufferEvictions([SALE]);
+    // A follow-up reorg restores eligibility before depth passes.
+    await membershipRepo.update({ sale_address: SALE }, { eligible: true });
+    await setHeight(1000 + DEPTH);
+
+    const { published, cancelled } = await reorg.flushDueEvictions();
+    // An eligible row is filtered out of the flush select entirely → not published,
+    // and its hold is left for the next recompute to clear (no spurious 9001).
+    expect(published).toBe(0);
+    expect(cancelled).toBe(0);
+    expect(publishQueue.add).not.toHaveBeenCalled();
+    const row = await membershipRepo.findOneByOrFail({ sale_address: SALE });
+    expect(row.relay_state).toBe('added');
+  });
+
+  // ── §A.8 buffer vs reconcile interaction ──────────────────────────────────────
+
+  it('a row inside an unexpired reorg hold (still in 39002) is NOT reconciled as drift-to-remove', async () => {
+    await seedRoom();
+    await setHeight(1000);
+    await membershipRepo.save(
+      membershipRepo.create({
+        sale_address: SALE,
+        member_address: MEMBER,
+        member_pubkey: PUBKEY,
+        eligible: false,
+        relay_state: 'added',
+        held_until_height: 1000 + DEPTH, // unexpired hold
+      }),
+    );
+    relayMembers = new Set([PUBKEY]); // intentionally still in 39002
+
+    const result = await reconciliation.reconcileBatch();
+
+    expect(result.removed).toBe(0);
+    expect(publishQueue.add).not.toHaveBeenCalled();
+  });
+});

--- a/src/token-gated-rooms/services/__tests__/reconciliation.service.spec.ts
+++ b/src/token-gated-rooms/services/__tests__/reconciliation.service.spec.ts
@@ -1,0 +1,332 @@
+import { NIP29_KIND } from '../../nostr/nip29';
+import { RoomMembership } from '../../entities/room-membership.entity';
+import { Token } from '@/tokens/entities/token.entity';
+import { ReconciliationService } from '../reconciliation.service';
+
+/**
+ * Unit coverage for the rotating read-back reconciliation (Task 11 §A). Repos /
+ * relay writer / publish queue / room-admins are stubbed; the focus is the diff
+ * logic, the unlinked + admin exemptions, the reorg-hold skip, idempotency (no
+ * spurious writes), and the SLA-coverage math. No DB, no relay.
+ */
+
+const SALE = 'ct_sale';
+const A = 'a'.repeat(64);
+const B = 'b'.repeat(64);
+
+function membership(over: Partial<RoomMembership> = {}): RoomMembership {
+  return {
+    id: 1,
+    sale_address: SALE,
+    member_address: 'ak_member',
+    member_pubkey: A,
+    role: 'member',
+    eligible: true,
+    relay_state: 'added',
+    held_until_height: null as any,
+    last_published_at: null as any,
+    last_reconciled_at: null as any,
+    updated_at: new Date(),
+    ...over,
+  } as RoomMembership;
+}
+
+function token(over: Partial<Token> = {}): Token {
+  return {
+    sale_address: SALE,
+    nostr_group_id: SALE,
+    nostr_room_state: 'created',
+    ...over,
+  } as unknown as Token;
+}
+
+interface Harness {
+  service: ReconciliationService;
+  queue: { add: jest.Mock };
+  relayMembers: Set<string>;
+  convergeRoomAdmins: jest.Mock;
+  markReconciledFor: string[];
+}
+
+function setup(opts: {
+  rows: RoomMembership[];
+  relayMembers?: string[];
+  tip?: number | null;
+  isConfiguredAdmin?: (pubkey: string) => boolean;
+  isHealthy?: boolean;
+  rooms?: Token[];
+}): Harness {
+  const relayMembers = new Set(opts.relayMembers ?? []);
+  const markReconciledFor: string[] = [];
+
+  const membershipRepo: any = {
+    find: jest.fn(async ({ where }: any) => {
+      return opts.rows.filter(
+        (r) => !where?.sale_address || r.sale_address === where.sale_address,
+      );
+    }),
+    update: jest.fn(async (where: any) => {
+      if (where.sale_address) {
+        markReconciledFor.push(where.sale_address);
+      }
+    }),
+    createQueryBuilder: jest.fn(() => {
+      throw new Error('reconcile unit tests should not hit maxStalenessMs qb');
+    }),
+  };
+
+  const tokenRepo: any = {
+    createQueryBuilder: jest.fn(() => {
+      const qb: any = {
+        where: jest.fn(() => qb),
+        andWhere: jest.fn(() => qb),
+        orderBy: jest.fn(() => qb),
+        limit: jest.fn(() => qb),
+        getMany: jest.fn(async () => opts.rooms ?? []),
+      };
+      return qb;
+    }),
+  };
+
+  const syncStateRepo: any = {
+    findOne: jest.fn(async () =>
+      opts.tip === null || opts.tip === undefined
+        ? { tip_height: 0 }
+        : { tip_height: opts.tip },
+    ),
+  };
+
+  const queue = { add: jest.fn().mockResolvedValue({ id: 'p' }) };
+
+  const relay = {
+    isHealthy: jest.fn().mockReturnValue(opts.isHealthy ?? true),
+    fetchGroupMembers: jest.fn().mockResolvedValue(relayMembers),
+  };
+
+  const convergeRoomAdmins = jest.fn().mockResolvedValue(0);
+  const roomAdmins = {
+    isConfiguredAdmin: jest.fn((pk: string) =>
+      opts.isConfiguredAdmin ? opts.isConfiguredAdmin(pk) : false,
+    ),
+    convergeRoomAdmins,
+  };
+
+  const config = {
+    reconcileBatchSize: 500,
+    reconcileIntervalSec: 600,
+    publishMaxRetries: 5,
+  };
+
+  const service = new ReconciliationService(
+    membershipRepo,
+    tokenRepo,
+    syncStateRepo,
+    queue as any,
+    relay as any,
+    roomAdmins as any,
+    config as any,
+  );
+
+  return {
+    service,
+    queue,
+    relayMembers,
+    convergeRoomAdmins,
+    markReconciledFor,
+  };
+}
+
+describe('ReconciliationService.reconcileRoom diff', () => {
+  it('re-adds (9000) an eligible+linked member missing from 39002', async () => {
+    const { service, queue } = setup({
+      rows: [membership({ id: 1, member_pubkey: A, eligible: true })],
+      relayMembers: [], // 39002 missing A
+    });
+
+    const result = await service.reconcileRoom(token());
+
+    expect(result.added).toBe(1);
+    expect(result.removed).toBe(0);
+    expect(queue.add).toHaveBeenCalledTimes(1);
+    expect(queue.add.mock.calls[0][0].template.kind).toBe(NIP29_KIND.PUT_USER);
+  });
+
+  it('re-removes (9001) a present-but-ineligible non-admin member', async () => {
+    const { service, queue } = setup({
+      rows: [membership({ id: 1, member_pubkey: A, eligible: false })],
+      relayMembers: [A], // present on relay but desired-removed
+    });
+
+    const result = await service.reconcileRoom(token());
+
+    expect(result.removed).toBe(1);
+    expect(queue.add).toHaveBeenCalledTimes(1);
+    expect(queue.add.mock.calls[0][0].template.kind).toBe(
+      NIP29_KIND.REMOVE_USER,
+    );
+  });
+
+  it('39002 == desired → NO publishes (idempotent, no spurious writes)', async () => {
+    const { service, queue } = setup({
+      rows: [membership({ id: 1, member_pubkey: A, eligible: true })],
+      relayMembers: [A], // already matches
+    });
+
+    const result = await service.reconcileRoom(token());
+
+    expect(result.added).toBe(0);
+    expect(result.removed).toBe(0);
+    expect(queue.add).not.toHaveBeenCalled();
+  });
+
+  it('unlinked invariant: eligible+null-pubkey absent from 39002 is NOT drift-to-add', async () => {
+    const { service, queue } = setup({
+      rows: [membership({ id: 1, member_pubkey: null as any, eligible: true })],
+      relayMembers: [],
+    });
+
+    const result = await service.reconcileRoom(token());
+
+    expect(result.added).toBe(0);
+    expect(queue.add).not.toHaveBeenCalled();
+  });
+
+  it('admin exemption: a configured-admin pubkey present in 39002 but ineligible is NOT removed', async () => {
+    const { service, queue } = setup({
+      rows: [
+        membership({
+          id: 1,
+          member_pubkey: A,
+          eligible: false,
+          role: 'member',
+        }),
+      ],
+      relayMembers: [A],
+      isConfiguredAdmin: (pk) => pk === A,
+    });
+
+    const result = await service.reconcileRoom(token());
+
+    expect(result.removed).toBe(0);
+    expect(queue.add).not.toHaveBeenCalled();
+  });
+
+  it('admin exemption: a role=admin row present in 39002 but ineligible is NOT removed', async () => {
+    const { service, queue } = setup({
+      rows: [
+        membership({ id: 1, member_pubkey: A, eligible: false, role: 'admin' }),
+      ],
+      relayMembers: [A],
+    });
+
+    const result = await service.reconcileRoom(token());
+
+    expect(result.removed).toBe(0);
+    expect(queue.add).not.toHaveBeenCalled();
+  });
+
+  it('reorg-hold skip: an unexpired held row still in 39002 is NOT treated as drift-to-remove', async () => {
+    const { service, queue } = setup({
+      rows: [
+        membership({
+          id: 1,
+          member_pubkey: A,
+          eligible: false,
+          relay_state: 'added',
+          held_until_height: 2000, // > tip → unexpired
+        }),
+      ],
+      relayMembers: [A],
+      tip: 1000,
+    });
+
+    const result = await service.reconcileRoom(token());
+
+    expect(result.removed).toBe(0);
+    expect(queue.add).not.toHaveBeenCalled();
+  });
+
+  it('expired hold no longer protects: a held row past depth IS drift-to-remove', async () => {
+    const { service, queue } = setup({
+      rows: [
+        membership({
+          id: 1,
+          member_pubkey: A,
+          eligible: false,
+          relay_state: 'added',
+          held_until_height: 500, // < tip → expired
+        }),
+      ],
+      relayMembers: [A],
+      tip: 1000,
+    });
+
+    const result = await service.reconcileRoom(token());
+
+    expect(result.removed).toBe(1);
+    expect(queue.add).toHaveBeenCalledTimes(1);
+  });
+
+  it('a relay pubkey with no desired-state row is left alone (not this task drift)', async () => {
+    const { service, queue } = setup({
+      rows: [],
+      relayMembers: [B],
+    });
+
+    const result = await service.reconcileRoom(token());
+
+    expect(result.removed).toBe(0);
+    expect(queue.add).not.toHaveBeenCalled();
+  });
+
+  it('stamps last_reconciled_at and runs the admin converge for the room', async () => {
+    const { service, convergeRoomAdmins, markReconciledFor } = setup({
+      rows: [membership({ id: 1, member_pubkey: A, eligible: true })],
+      relayMembers: [A],
+    });
+
+    await service.reconcileRoom(token());
+
+    expect(markReconciledFor).toContain(SALE);
+    expect(convergeRoomAdmins).toHaveBeenCalledWith(SALE);
+  });
+});
+
+describe('ReconciliationService.reconcileBatch rotation + health', () => {
+  it('skips the run when the relay writer is unhealthy (no read-back, no publish)', async () => {
+    const { service, queue } = setup({
+      rows: [],
+      rooms: [token()],
+      isHealthy: false,
+    });
+
+    const result = await service.reconcileBatch();
+
+    expect(result.roomsScanned).toBe(0);
+    expect(queue.add).not.toHaveBeenCalled();
+  });
+
+  it('advances + wraps the rotating cursor when the page is shorter than the batch', async () => {
+    const { service } = setup({
+      rows: [membership({ id: 1, member_pubkey: A, eligible: true })],
+      relayMembers: [A],
+      rooms: [token({ sale_address: SALE })],
+    });
+
+    const result = await service.reconcileBatch();
+
+    expect(result.roomsScanned).toBe(1);
+    // Page < batch → cursor wraps to '' for the next rotation.
+    expect(service.getCursor()).toBe('');
+    expect(result.nextCursor).toBeNull();
+  });
+});
+
+describe('ReconciliationService SLA coverage math', () => {
+  it('default knobs (500 × 144 runs/day) cover ≥ 54,000 rooms/day', () => {
+    const { service } = setup({ rows: [] });
+    // TG_RECONCILE_BATCH_SIZE=500, TG_RECONCILE_INTERVAL=10m → 144 runs/day → 72,000.
+    expect(service.slaCoveragePerDay()).toBe(72000);
+    expect(service.slaCoveragePerDay()).toBeGreaterThanOrEqual(54000);
+  });
+});

--- a/src/token-gated-rooms/services/__tests__/reorg-eviction.service.spec.ts
+++ b/src/token-gated-rooms/services/__tests__/reorg-eviction.service.spec.ts
@@ -1,0 +1,438 @@
+import { NIP29_KIND } from '../../nostr/nip29';
+import { RoomMembership } from '../../entities/room-membership.entity';
+import { ReorgEvictionService } from '../reorg-eviction.service';
+
+/**
+ * Unit coverage for the reorg-buffered eviction (Task 11 §B). Repos / publish
+ * queue / room-admins are stubbed; the focus is the buffer timing, the depth gate,
+ * the cancel-on-restore, and the admin/unlinked exemptions. No DB, no relay.
+ */
+
+const SALE = 'ct_sale';
+const PUBKEY = 'a'.repeat(64);
+const DEPTH = 10;
+const TIP = 1000;
+
+function membership(over: Partial<RoomMembership> = {}): RoomMembership {
+  return {
+    id: 1,
+    sale_address: SALE,
+    member_address: 'ak_member',
+    member_pubkey: PUBKEY,
+    role: 'member',
+    eligible: false,
+    relay_state: 'added',
+    held_until_height: null as any,
+    last_published_at: null as any,
+    last_reconciled_at: null as any,
+    updated_at: new Date(),
+    ...over,
+  } as RoomMembership;
+}
+
+interface Harness {
+  service: ReorgEvictionService;
+  membershipRepo: any;
+  queue: { add: jest.Mock };
+  updates: Array<{ where: any; set: any }>;
+  store: Map<number, RoomMembership>;
+}
+
+function setup(
+  opts: {
+    rows?: RoomMembership[];
+    tip?: number | null;
+    isConfiguredAdmin?: boolean;
+    withQueue?: boolean;
+  } = {},
+): Harness {
+  const tip = opts.tip === undefined ? TIP : opts.tip;
+  const store = new Map<number, RoomMembership>();
+  for (const r of opts.rows ?? []) {
+    store.set(r.id, { ...r });
+  }
+  const updates: Array<{ where: any; set: any }> = [];
+
+  const membershipRepo: any = {
+    find: jest.fn(async ({ where }: any) => {
+      // Used by bufferEvictions: filter on sale_address/eligible/role/relay_state.
+      return [...store.values()].filter((r) => {
+        if (where.sale_address && r.sale_address !== where.sale_address) {
+          return false;
+        }
+        if (where.eligible !== undefined && r.eligible !== where.eligible) {
+          return false;
+        }
+        // role: Not('admin')
+        if (where.role && r.role === 'admin') {
+          return false;
+        }
+        // relay_state: In(['added','pending_remove'])
+        if (
+          where.relay_state &&
+          !['added', 'pending_remove'].includes(r.relay_state)
+        ) {
+          return false;
+        }
+        return true;
+      });
+    }),
+    findOne: jest.fn(async ({ where }: any) => {
+      if (where.id !== undefined) {
+        const r = store.get(where.id);
+        return r ? { ...r } : null;
+      }
+      return null;
+    }),
+    update: jest.fn(async (where: any, set: any) => {
+      updates.push({ where, set });
+      const r = store.get(where.id);
+      if (r) {
+        Object.assign(r, set);
+      }
+    }),
+    createQueryBuilder: jest.fn(() => {
+      const state: any = { cursor: 0, current: tip };
+      const qb: any = {
+        select: jest.fn(() => qb),
+        where: jest.fn((_c: string, p?: any) => {
+          if (p && p.cursor !== undefined) state.cursor = p.cursor;
+          return qb;
+        }),
+        andWhere: jest.fn((_c: string, p?: any) => {
+          if (p && p.current !== undefined) state.current = p.current;
+          return qb;
+        }),
+        orderBy: jest.fn(() => qb),
+        limit: jest.fn(() => qb),
+        getMany: jest.fn(async () => {
+          // Mirrors the flush predicate: held set, <= current, ineligible, non-admin.
+          return [...store.values()].filter(
+            (r) =>
+              r.id > state.cursor &&
+              r.held_until_height !== null &&
+              r.held_until_height !== undefined &&
+              r.held_until_height <= state.current &&
+              r.eligible === false &&
+              r.role !== 'admin',
+          );
+        }),
+        getRawMany: jest.fn(async () => {
+          const sales = new Set<string>();
+          for (const r of store.values()) {
+            if (
+              r.eligible === false &&
+              r.role !== 'admin' &&
+              ['added', 'pending_remove'].includes(r.relay_state) &&
+              (r.held_until_height === null ||
+                r.held_until_height === undefined)
+            ) {
+              sales.add(r.sale_address);
+            }
+          }
+          return [...sales].map((sale_address) => ({ sale_address }));
+        }),
+      };
+      return qb;
+    }),
+  };
+
+  const tokenRepo = {
+    findOne: jest.fn(async () => ({
+      sale_address: SALE,
+      nostr_group_id: SALE,
+    })),
+  };
+  const syncStateRepo = {
+    findOne: jest.fn(async () => (tip === null ? null : { tip_height: tip })),
+  };
+  const queue = { add: jest.fn().mockResolvedValue({ id: 'p' }) };
+  const roomAdmins = {
+    isConfiguredAdmin: jest.fn().mockReturnValue(!!opts.isConfiguredAdmin),
+  };
+  const config = {
+    reorgConfirmationDepthBlocks: DEPTH,
+    reconcileBatchSize: 500,
+    publishMaxRetries: 5,
+  };
+
+  const service = new ReorgEvictionService(
+    membershipRepo,
+    tokenRepo as any,
+    syncStateRepo as any,
+    opts.withQueue === false ? (null as any) : (queue as any),
+    roomAdmins as any,
+    config as any,
+  );
+
+  return { service, membershipRepo, queue, updates, store };
+}
+
+describe('ReorgEvictionService.bufferEvictions', () => {
+  it('sets held_until_height = tip + DEPTH and emits NO 9001; relay_state stays added', async () => {
+    const { service, queue, store } = setup({
+      rows: [membership({ id: 1, eligible: false, relay_state: 'added' })],
+    });
+
+    const buffered = await service.bufferEvictions([SALE]);
+
+    expect(buffered).toBe(1);
+    expect(queue.add).not.toHaveBeenCalled();
+    const row = store.get(1)!;
+    expect(row.held_until_height).toBe(TIP + DEPTH);
+    expect(row.relay_state).toBe('added');
+  });
+
+  it('pins a pending_remove row back to added under the hold (no immediate eviction)', async () => {
+    const { service, store } = setup({
+      rows: [
+        membership({ id: 1, eligible: false, relay_state: 'pending_remove' }),
+      ],
+    });
+
+    await service.bufferEvictions([SALE]);
+
+    const row = store.get(1)!;
+    expect(row.relay_state).toBe('added');
+    expect(row.held_until_height).toBe(TIP + DEPTH);
+  });
+
+  it('does NOT buffer an admin row (admin exemption §6.7)', async () => {
+    const { service, store } = setup({
+      rows: [
+        membership({
+          id: 1,
+          role: 'admin',
+          eligible: false,
+          relay_state: 'added',
+        }),
+      ],
+    });
+
+    const buffered = await service.bufferEvictions([SALE]);
+
+    expect(buffered).toBe(0);
+    expect(store.get(1)!.held_until_height).toBeNull();
+  });
+
+  it('does NOT buffer a still-eligible row (only newly-ineligible are held)', async () => {
+    const { service, store } = setup({
+      rows: [membership({ id: 1, eligible: true, relay_state: 'added' })],
+    });
+
+    const buffered = await service.bufferEvictions([SALE]);
+
+    expect(buffered).toBe(0);
+    expect(store.get(1)!.held_until_height).toBeNull();
+  });
+
+  it('skips buffering when the current height is unknown', async () => {
+    const { service, queue } = setup({
+      rows: [membership({ id: 1, eligible: false })],
+      tip: null,
+    });
+
+    const buffered = await service.bufferEvictions([SALE]);
+
+    expect(buffered).toBe(0);
+    expect(queue.add).not.toHaveBeenCalled();
+  });
+});
+
+describe('ReorgEvictionService.flushDueEvictions (depth gate)', () => {
+  it('publishes nothing when current < held_until_height (hold not passed)', async () => {
+    const { service, queue, store } = setup({
+      rows: [
+        membership({
+          id: 1,
+          eligible: false,
+          relay_state: 'added',
+          held_until_height: TIP + 5,
+        }),
+      ],
+      tip: TIP, // TIP < TIP+5 → not due
+    });
+
+    const { published, cancelled } = await service.flushDueEvictions();
+
+    expect(published).toBe(0);
+    expect(cancelled).toBe(0);
+    expect(queue.add).not.toHaveBeenCalled();
+    expect(store.get(1)!.held_until_height).toBe(TIP + 5);
+  });
+
+  it('publishes 9001 and clears held_until_height when current >= held and still ineligible', async () => {
+    const { service, queue, store } = setup({
+      rows: [
+        membership({
+          id: 1,
+          eligible: false,
+          relay_state: 'added',
+          held_until_height: TIP - 1,
+        }),
+      ],
+      tip: TIP, // TIP >= TIP-1 → due
+    });
+
+    const { published } = await service.flushDueEvictions();
+
+    expect(published).toBe(1);
+    expect(queue.add).toHaveBeenCalledTimes(1);
+    expect(queue.add.mock.calls[0][0].template.kind).toBe(
+      NIP29_KIND.REMOVE_USER,
+    );
+    const row = store.get(1)!;
+    expect(row.held_until_height).toBeNull();
+    expect(row.relay_state).toBe('pending_remove');
+  });
+
+  it('cancels the eviction (clears hold, no publish) when the member is eligible again', async () => {
+    const { service, queue, store } = setup({
+      rows: [
+        membership({
+          id: 1,
+          eligible: true,
+          relay_state: 'added',
+          held_until_height: TIP - 1,
+        }),
+      ],
+      tip: TIP,
+    });
+
+    // Note: the flush SELECT predicate filters eligible=false, so an eligible row
+    // is not even selected — it simply keeps its hold until re-buffered/cleared by
+    // a later recompute. Assert no publish + no clear here (the select skips it).
+    const { published, cancelled } = await service.flushDueEvictions();
+
+    expect(published).toBe(0);
+    expect(cancelled).toBe(0);
+    expect(queue.add).not.toHaveBeenCalled();
+    expect(store.get(1)!.relay_state).toBe('added');
+  });
+
+  it('cancels at flush time when a row flipped eligible between select and re-confirm', async () => {
+    const { service, queue, store } = setup({
+      rows: [
+        membership({
+          id: 1,
+          eligible: false,
+          relay_state: 'added',
+          held_until_height: TIP - 1,
+        }),
+      ],
+      tip: TIP,
+    });
+    // Simulate a follow-up reorg restoring eligibility after the row was selected
+    // but before re-confirm: patch findOne to report eligible=true.
+    const repo: any = (service as any).membershipRepo;
+    const realFindOne = repo.findOne;
+    repo.findOne = jest.fn(async (arg: any) => {
+      const r = await realFindOne(arg);
+      if (r) {
+        return { ...r, eligible: true };
+      }
+      return r;
+    });
+
+    const { published, cancelled } = await service.flushDueEvictions();
+
+    expect(published).toBe(0);
+    expect(cancelled).toBe(1);
+    expect(queue.add).not.toHaveBeenCalled();
+    expect(store.get(1)!.held_until_height).toBeNull();
+  });
+
+  it('cancels (no 9001) for a configured-admin pubkey even if past depth', async () => {
+    const { service, queue, store } = setup({
+      rows: [
+        membership({
+          id: 1,
+          eligible: false,
+          relay_state: 'added',
+          held_until_height: TIP - 1,
+        }),
+      ],
+      tip: TIP,
+      isConfiguredAdmin: true,
+    });
+
+    const { published, cancelled } = await service.flushDueEvictions();
+
+    expect(published).toBe(0);
+    expect(cancelled).toBe(1);
+    expect(queue.add).not.toHaveBeenCalled();
+    expect(store.get(1)!.held_until_height).toBeNull();
+  });
+
+  it('cancels (no 9001) for an unlinked row (null pubkey) — nothing to remove', async () => {
+    const { service, queue, store } = setup({
+      rows: [
+        membership({
+          id: 1,
+          eligible: false,
+          relay_state: 'added',
+          held_until_height: TIP - 1,
+          member_pubkey: null as any,
+        }),
+      ],
+      tip: TIP,
+    });
+
+    const { published, cancelled } = await service.flushDueEvictions();
+
+    expect(published).toBe(0);
+    expect(cancelled).toBe(1);
+    expect(queue.add).not.toHaveBeenCalled();
+    expect(store.get(1)!.held_until_height).toBeNull();
+  });
+
+  it('is a no-op (no publish) when there is no publish queue (main mode)', async () => {
+    const { service } = setup({
+      rows: [
+        membership({ id: 1, eligible: false, held_until_height: TIP - 1 }),
+      ],
+      tip: TIP,
+      withQueue: false,
+    });
+
+    const { published, cancelled } = await service.flushDueEvictions();
+
+    expect(published).toBe(0);
+    expect(cancelled).toBe(0);
+  });
+});
+
+describe('ReorgEvictionService.bufferAllPendingEvictions (aex9 reorg entry)', () => {
+  it('discovers at-risk rooms by their membership rows and buffers them', async () => {
+    const { service, store } = setup({
+      rows: [
+        membership({
+          id: 1,
+          sale_address: 'ct_a',
+          eligible: false,
+          relay_state: 'added',
+        }),
+        membership({
+          id: 2,
+          sale_address: 'ct_b',
+          eligible: true,
+          relay_state: 'added',
+        }),
+      ],
+    });
+
+    const buffered = await service.bufferAllPendingEvictions();
+
+    expect(buffered).toBe(1);
+    expect(store.get(1)!.held_until_height).toBe(TIP + DEPTH);
+    expect(store.get(2)!.held_until_height).toBeNull();
+  });
+
+  it('returns 0 when no rooms have at-risk members', async () => {
+    const { service } = setup({
+      rows: [membership({ id: 1, eligible: true, relay_state: 'added' })],
+    });
+
+    expect(await service.bufferAllPendingEvictions()).toBe(0);
+  });
+});

--- a/src/token-gated-rooms/services/balance-indexer.service.ts
+++ b/src/token-gated-rooms/services/balance-indexer.service.ts
@@ -1,0 +1,256 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { EventEmitter2, OnEvent } from '@nestjs/event-emitter';
+import { ConfigType } from '@nestjs/config';
+import { IsNull, Not, Repository } from 'typeorm';
+import { BigNumber } from 'bignumber.js';
+import { Token } from '@/tokens/entities/token.entity';
+import { LIVE_TX_EVENT, LiveTxEventPayload } from '@/mdw-sync/events';
+import { BCL_FUNCTIONS } from '@/configs/constants';
+import { TokenBalance } from '../entities/token-balance.entity';
+import tgrConfig from '../config/tgr.config';
+import {
+  TGR_BALANCE_CHANGED,
+  TGR_COMMUNITY_UPSERTED,
+  TgrBalanceChangedPayload,
+  TgrCommunityUpsertedPayload,
+} from '../events';
+
+/**
+ * Owns the **community-token allowlist** (the set of AEX9 contract `address`es the
+ * AEX9-transfer plugin indexes) plus the `token_balance` upsert helpers (plan
+ * §5.3/§5.4).
+ *
+ * Allowlist = `Token.address` (the AEX9 contract id, NOT `sale_address`). Held in
+ * an in-memory `Set<string>` with a TTL so a refresh re-reads the DB at most once
+ * per `communityTokenRefreshSec`. Refresh triggers:
+ *  - lazy TTL expiry (any `isCommunityToken` call past the TTL re-loads);
+ *  - the in-process `tgr.community.upserted` event (a token got/changed its room);
+ *  - reactively from `LIVE_TX_EVENT` when a `create_community` tx is seen, so a
+ *    brand-new token's transfers index on its very next call (plan §5.3).
+ *
+ * Balances are stored as **raw integer base units** — never divided by
+ * `10**decimals`. Upserts clamp at 0 (no negative balances, mirroring
+ * `TokenHolderService.calculateNewBalance`) and emit `tgr.balance.changed` only
+ * when the persisted `balance` actually changes.
+ */
+@Injectable()
+export class BalanceIndexerService {
+  private readonly logger = new Logger(BalanceIndexerService.name);
+
+  /** AEX9 contract addresses of community tokens (the indexing allowlist). */
+  private allowlist = new Set<string>();
+  /** Epoch ms when `allowlist` was last loaded from the DB; 0 = never. */
+  private allowlistLoadedAt = 0;
+  /** Guards against concurrent reloads (the refresh is async). */
+  private reloading: Promise<void> | null = null;
+
+  constructor(
+    @InjectRepository(Token)
+    private readonly tokenRepository: Repository<Token>,
+    @InjectRepository(TokenBalance)
+    private readonly tokenBalanceRepository: Repository<TokenBalance>,
+    private readonly eventEmitter: EventEmitter2,
+    @Inject(tgrConfig.KEY)
+    private readonly config: ConfigType<typeof tgrConfig>,
+  ) {}
+
+  private get ttlMs(): number {
+    return this.config.communityTokenRefreshSec * 1000;
+  }
+
+  /**
+   * Synchronous allowlist membership check used by the plugin predicate (the MDW
+   * filter is sync). If the TTL has expired this kicks off a non-blocking reload
+   * for the *next* call but answers from the current snapshot — predicates must
+   * not await. A brand-new token is still caught immediately by the
+   * `create_community` LIVE_TX hook below.
+   */
+  isCommunityToken(address: string | undefined | null): boolean {
+    if (!address) {
+      return false;
+    }
+    if (this.isStale()) {
+      void this.refreshAllowlist();
+    }
+    return this.allowlist.has(address);
+  }
+
+  private isStale(): boolean {
+    return Date.now() - this.allowlistLoadedAt >= this.ttlMs;
+  }
+
+  /** Current allowlist snapshot (read-only copy, for tests/observability). */
+  getAllowlist(): Set<string> {
+    return new Set(this.allowlist);
+  }
+
+  /**
+   * Reload the allowlist from `Token` where `address` is set. Deduped: concurrent
+   * callers await the same in-flight load. Always refreshes the TTL timestamp so a
+   * transient empty DB doesn't cause a hot reload loop.
+   */
+  async refreshAllowlist(): Promise<void> {
+    if (this.reloading) {
+      return this.reloading;
+    }
+    this.reloading = (async () => {
+      try {
+        const rows = await this.tokenRepository.find({
+          where: { address: Not(IsNull()) },
+          select: { address: true },
+        });
+        const next = new Set<string>();
+        for (const row of rows) {
+          if (row.address) {
+            next.add(row.address);
+          }
+        }
+        this.allowlist = next;
+        this.allowlistLoadedAt = Date.now();
+        this.logger.debug(
+          `Allowlist refreshed: ${next.size} community token(s)`,
+        );
+      } catch (error: any) {
+        this.logger.error('Failed to refresh community-token allowlist', error);
+        // Keep the TTL moving so we don't hot-loop on a DB hiccup.
+        this.allowlistLoadedAt = Date.now();
+      } finally {
+        this.reloading = null;
+      }
+    })();
+    return this.reloading;
+  }
+
+  /** Add a single AEX9 address to the live allowlist without a full reload. */
+  addToAllowlist(address: string | undefined | null): void {
+    if (address) {
+      this.allowlist.add(address);
+    }
+  }
+
+  /**
+   * A token got/changed its room (Task 04 emits this). Make sure its AEX9
+   * `address` is indexable immediately. Non-blocking (the emitter does not await).
+   */
+  @OnEvent(TGR_COMMUNITY_UPSERTED, { async: true })
+  async onCommunityUpserted(
+    payload: TgrCommunityUpsertedPayload,
+  ): Promise<void> {
+    try {
+      const token = await this.tokenRepository.findOne({
+        where: { sale_address: payload.saleAddress },
+        select: { address: true },
+      });
+      this.addToAllowlist(token?.address);
+    } catch (error: any) {
+      this.logger.warn(
+        `onCommunityUpserted(${payload.saleAddress}) failed`,
+        error,
+      );
+    }
+  }
+
+  /**
+   * Reactive dynamic subscription (plan §5.3): when a `create_community` tx lands
+   * on the live stream, refresh the allowlist so the new token's AEX9 transfers
+   * are indexed from its very first call. Non-blocking — `LIVE_TX_EVENT` is
+   * emitted without await.
+   */
+  @OnEvent(LIVE_TX_EVENT, { async: true })
+  async onLiveTx(tx: LiveTxEventPayload): Promise<void> {
+    if (
+      tx?.type === 'ContractCallTx' &&
+      tx.function === BCL_FUNCTIONS.create_community
+    ) {
+      await this.refreshAllowlist();
+    }
+  }
+
+  /**
+   * Apply a signed delta to a holder's raw balance for a token, clamping at 0
+   * (never persist negative). Returns the new balance iff it actually changed
+   * (so the caller can emit `tgr.balance.changed`), else `null`. Does NOT emit —
+   * the sync service emits after the whole tx's legs are applied/idempotency-safe.
+   */
+  async applyDelta(
+    tokenAddress: string,
+    holderAddress: string,
+    delta: BigNumber,
+    updatedHeight: number,
+  ): Promise<BigNumber | null> {
+    const existing = await this.tokenBalanceRepository.findOne({
+      where: { token_address: tokenAddress, holder_address: holderAddress },
+    });
+
+    const current = existing?.balance ?? new BigNumber(0);
+    const normalized = current.isNegative() ? new BigNumber(0) : current;
+    let next = normalized.plus(delta);
+    if (next.isNegative()) {
+      next = new BigNumber(0);
+    }
+
+    if (existing && existing.balance.eq(next)) {
+      // No-op (e.g. a clamp that lands on the same value): keep height fresh but
+      // do not signal a change.
+      if (updatedHeight > existing.updated_height) {
+        await this.tokenBalanceRepository.update(
+          { token_address: tokenAddress, holder_address: holderAddress },
+          { updated_height: updatedHeight },
+        );
+      }
+      return null;
+    }
+
+    await this.tokenBalanceRepository.save(
+      this.tokenBalanceRepository.create({
+        token_address: tokenAddress,
+        holder_address: holderAddress,
+        balance: next,
+        updated_height: updatedHeight,
+      }),
+    );
+    return next;
+  }
+
+  /**
+   * Overwrite a holder's raw balance to an authoritative value (reconciliation
+   * self-heal). Returns the value iff it changed, else `null`. Sets
+   * `updated_height` to `tipHeight` and `last_reconciled_at = now`.
+   */
+  async setAuthoritativeBalance(
+    tokenAddress: string,
+    holderAddress: string,
+    authoritative: BigNumber,
+    tipHeight: number,
+  ): Promise<BigNumber | null> {
+    const existing = await this.tokenBalanceRepository.findOne({
+      where: { token_address: tokenAddress, holder_address: holderAddress },
+    });
+    const now = new Date();
+    const changed = !existing || !existing.balance.eq(authoritative);
+
+    await this.tokenBalanceRepository.save(
+      this.tokenBalanceRepository.create({
+        token_address: tokenAddress,
+        holder_address: holderAddress,
+        balance: authoritative,
+        updated_height: changed
+          ? tipHeight
+          : (existing?.updated_height ?? tipHeight),
+        last_reconciled_at: now,
+      }),
+    );
+
+    return changed ? authoritative : null;
+  }
+
+  /** Emit the canonical `tgr.balance.changed` (thin payload, plan §5/Shared). */
+  emitBalanceChanged(tokenAddress: string, holderAddress: string): void {
+    const payload: TgrBalanceChangedPayload = {
+      tokenAddress,
+      holderAddress,
+    };
+    this.eventEmitter.emit(TGR_BALANCE_CHANGED, payload);
+  }
+}

--- a/src/token-gated-rooms/services/balance-indexer.service.ts
+++ b/src/token-gated-rooms/services/balance-indexer.service.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { EventEmitter2, OnEvent } from '@nestjs/event-emitter';
 import { ConfigType } from '@nestjs/config';
-import { IsNull, Not, Repository } from 'typeorm';
+import { EntityManager, IsNull, Not, Repository } from 'typeorm';
 import { BigNumber } from 'bignumber.js';
 import { Token } from '@/tokens/entities/token.entity';
 import { LIVE_TX_EVENT, LiveTxEventPayload } from '@/mdw-sync/events';
@@ -172,14 +172,26 @@ export class BalanceIndexerService {
    * (never persist negative). Returns the new balance iff it actually changed
    * (so the caller can emit `tgr.balance.changed`), else `null`. Does NOT emit —
    * the sync service emits after the whole tx's legs are applied/idempotency-safe.
+   *
+   * `manager` (optional): when the caller is inside an outer DB transaction
+   * (e.g. the BCL buy/sell processor mirroring its delta here), pass the
+   * transactional `EntityManager` so the `token_balance` read+write joins that
+   * transaction and rolls back atomically with it. Without it, the AEX9-transfer
+   * indexer path (which has no surrounding transaction) uses the default
+   * connection unchanged.
    */
   async applyDelta(
     tokenAddress: string,
     holderAddress: string,
     delta: BigNumber,
     updatedHeight: number,
+    manager?: EntityManager,
   ): Promise<BigNumber | null> {
-    const existing = await this.tokenBalanceRepository.findOne({
+    const repo = manager
+      ? manager.getRepository(TokenBalance)
+      : this.tokenBalanceRepository;
+
+    const existing = await repo.findOne({
       where: { token_address: tokenAddress, holder_address: holderAddress },
     });
 
@@ -194,7 +206,7 @@ export class BalanceIndexerService {
       // No-op (e.g. a clamp that lands on the same value): keep height fresh but
       // do not signal a change.
       if (updatedHeight > existing.updated_height) {
-        await this.tokenBalanceRepository.update(
+        await repo.update(
           { token_address: tokenAddress, holder_address: holderAddress },
           { updated_height: updatedHeight },
         );
@@ -202,8 +214,8 @@ export class BalanceIndexerService {
       return null;
     }
 
-    await this.tokenBalanceRepository.save(
-      this.tokenBalanceRepository.create({
+    await repo.save(
+      repo.create({
         token_address: tokenAddress,
         holder_address: holderAddress,
         balance: next,

--- a/src/token-gated-rooms/services/balance-reconciliation.service.ts
+++ b/src/token-gated-rooms/services/balance-reconciliation.service.ts
@@ -1,0 +1,218 @@
+import { Inject, Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { InjectQueue, Process, Processor } from '@nestjs/bull';
+import { InjectRepository } from '@nestjs/typeorm';
+import { ConfigType } from '@nestjs/config';
+import { Repository } from 'typeorm';
+import { Queue } from 'bull';
+import { BigNumber } from 'bignumber.js';
+import { Contract, Encoded } from '@aeternity/aepp-sdk';
+import { AeSdkService } from '@/ae/ae-sdk.service';
+import { TokenBalance } from '../entities/token-balance.entity';
+import { BalanceIndexerService } from './balance-indexer.service';
+import tgrConfig from '../config/tgr.config';
+import {
+  TGR_QUEUE_NAMES,
+  TGR_QUEUE_OWNER,
+  prefixQueue,
+} from '../config/queue-prefix';
+import FungibleTokenFullACI from '../plugins/aci/FungibleTokenFull.aci.json';
+
+/** Prefixed Bull queue name for the AEX9 reconciliation sweep (Shared contracts). */
+export const RECONCILE_BALANCE_QUEUE = prefixQueue(
+  TGR_QUEUE_NAMES.RECONCILE_BALANCE,
+  TGR_QUEUE_OWNER[TGR_QUEUE_NAMES.RECONCILE_BALANCE],
+);
+
+/** Bull job id used for the single repeatable sweep (so re-adds don't dupe it). */
+export const RECONCILE_BALANCE_REPEAT_JOB = 'reconcile-balance-sweep';
+
+/** Cached AEX9 contract instances keyed by token address (reconciliation reads). */
+type ContractInstance = Awaited<ReturnType<typeof Contract.initialize>>;
+
+/**
+ * Repeatable Bull (v4) consumer on the **`reconcile-balance`** queue (consumed by
+ * the indexer/main process per `TGR_QUEUE_OWNER`). Each run sweeps a rotating
+ * batch of `token_balance` rows ordered by oldest `last_reconciled_at` (the
+ * cursor), re-reads the authoritative AEX9 balance from chain for each
+ * `(token_address, holder_address)`, overwrites on drift (self-heal), and emits
+ * `tgr.balance.changed` for corrected rows. `last_reconciled_at` always advances
+ * so the cursor rotates through every holder over time.
+ *
+ * Reorg-safe rollback + reconciliation cost/SLA tuning are Task 11/§11; here we
+ * implement only the rotating-cursor batch + drift correction.
+ */
+@Injectable()
+@Processor(RECONCILE_BALANCE_QUEUE)
+export class BalanceReconciliationService implements OnModuleInit {
+  private readonly logger = new Logger(BalanceReconciliationService.name);
+  private contractCache = new Map<string, ContractInstance>();
+
+  constructor(
+    @InjectRepository(TokenBalance)
+    private readonly tokenBalanceRepository: Repository<TokenBalance>,
+    @InjectQueue(RECONCILE_BALANCE_QUEUE)
+    private readonly reconcileQueue: Queue,
+    private readonly balanceIndexer: BalanceIndexerService,
+    private readonly aeSdkService: AeSdkService,
+    @Inject(tgrConfig.KEY)
+    private readonly config: ConfigType<typeof tgrConfig>,
+  ) {}
+
+  /**
+   * Schedule the single repeatable sweep on boot. Bull dedupes by job id +
+   * repeat-opts, so re-registering on every restart is safe. Interval =
+   * `TG_RECONCILE_INTERVAL` (default 10m).
+   */
+  async onModuleInit(): Promise<void> {
+    // AEX9 balance reconciliation is an INDEXER (chain-read) concern; it runs in
+    // the single always-on process (worker mode removed — see `deworker-plan.md`).
+    const everyMs = this.config.reconcileIntervalSec * 1000;
+    try {
+      await this.reconcileQueue.add(
+        RECONCILE_BALANCE_REPEAT_JOB,
+        {},
+        {
+          jobId: RECONCILE_BALANCE_REPEAT_JOB,
+          repeat: { every: everyMs },
+          removeOnComplete: true,
+          removeOnFail: true,
+        },
+      );
+      this.logger.log(
+        `Scheduled reconcile-balance sweep every ${everyMs}ms on '${RECONCILE_BALANCE_QUEUE}'`,
+      );
+    } catch (error: any) {
+      this.logger.error('Failed to schedule reconcile-balance sweep', error);
+    }
+  }
+
+  @Process(RECONCILE_BALANCE_REPEAT_JOB)
+  async handleSweep(): Promise<void> {
+    await this.runOnce();
+  }
+
+  /**
+   * Run a single reconciliation batch. Selects `TG_RECONCILE_BATCH_SIZE` rows by
+   * oldest `last_reconciled_at` (nulls first), re-reads each authoritative balance
+   * from chain, self-heals drift, and always advances `last_reconciled_at`.
+   * Returns the number of rows whose balance was corrected.
+   */
+  async runOnce(): Promise<number> {
+    const batchSize = this.config.reconcileBatchSize;
+    const rows = await this.tokenBalanceRepository
+      .createQueryBuilder('tb')
+      .orderBy('tb.last_reconciled_at', 'ASC', 'NULLS FIRST')
+      .take(batchSize)
+      .getMany();
+
+    if (rows.length === 0) {
+      return 0;
+    }
+
+    let tipHeight = 0;
+    try {
+      tipHeight = await this.aeSdkService.sdk.getHeight();
+    } catch (error: any) {
+      this.logger.warn(
+        'Failed to read current tip height; using stored heights for corrections',
+        error,
+      );
+    }
+
+    let corrected = 0;
+    for (const row of rows) {
+      try {
+        const authoritative = await this.readAuthoritativeBalance(
+          row.token_address,
+          row.holder_address,
+        );
+        if (authoritative === null) {
+          // Could not read chain: only advance the cursor, don't clobber.
+          await this.tokenBalanceRepository.update(
+            {
+              token_address: row.token_address,
+              holder_address: row.holder_address,
+            },
+            { last_reconciled_at: new Date() },
+          );
+          continue;
+        }
+
+        const changed = await this.balanceIndexer.setAuthoritativeBalance(
+          row.token_address,
+          row.holder_address,
+          authoritative,
+          tipHeight || row.updated_height,
+        );
+        if (changed !== null) {
+          corrected++;
+          this.balanceIndexer.emitBalanceChanged(
+            row.token_address,
+            row.holder_address,
+          );
+        }
+      } catch (error: any) {
+        this.logger.error(
+          `Reconcile failed for ${row.token_address}/${row.holder_address}`,
+          error,
+        );
+        // Still advance the cursor so a single bad row can't wedge the sweep.
+        await this.tokenBalanceRepository
+          .update(
+            {
+              token_address: row.token_address,
+              holder_address: row.holder_address,
+            },
+            { last_reconciled_at: new Date() },
+          )
+          .catch(() => undefined);
+      }
+    }
+
+    this.logger.debug(
+      `Reconcile sweep: scanned ${rows.length}, corrected ${corrected}`,
+    );
+    return corrected;
+  }
+
+  /**
+   * Read the authoritative raw balance for one holder from the AEX9 contract's
+   * `balance(account)` view (returns `Some(int)` / `None`). `None` (no entry) is
+   * treated as 0. Returns `null` only on a read failure so the caller can skip the
+   * overwrite and just advance the cursor.
+   */
+  async readAuthoritativeBalance(
+    tokenAddress: string,
+    holderAddress: string,
+  ): Promise<BigNumber | null> {
+    try {
+      const contract = await this.getContract(tokenAddress);
+      const result = await contract.balance(holderAddress);
+      const decoded = result?.decodedResult;
+      if (decoded === undefined || decoded === null) {
+        return new BigNumber(0);
+      }
+      return new BigNumber(decoded.toString());
+    } catch (error: any) {
+      this.logger.warn(
+        `readAuthoritativeBalance(${tokenAddress}, ${holderAddress}) failed`,
+        error?.message ?? error,
+      );
+      return null;
+    }
+  }
+
+  private async getContract(tokenAddress: string): Promise<ContractInstance> {
+    const cached = this.contractCache.get(tokenAddress);
+    if (cached) {
+      return cached;
+    }
+    const contract = await Contract.initialize({
+      ...this.aeSdkService.sdk.getContext(),
+      aci: FungibleTokenFullACI,
+      address: tokenAddress as Encoded.ContractAddress,
+    });
+    this.contractCache.set(tokenAddress, contract);
+    return contract;
+  }
+}

--- a/src/token-gated-rooms/services/community-room-backfill.service.spec.ts
+++ b/src/token-gated-rooms/services/community-room-backfill.service.spec.ts
@@ -1,0 +1,362 @@
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { SchedulerRegistry } from '@nestjs/schedule';
+import {
+  CommunityRoomBackfillService,
+  ROOM_PROVISION_SCAN_JOB,
+} from './community-room-backfill.service';
+import { TGR_COMMUNITY_UPSERTED } from '../events';
+import type { Token } from '@/tokens/entities/token.entity';
+
+/**
+ * Unit coverage for the resumable backfill loop (Task 04 req §6) + the roomless-
+ * token provisioning cron / buy-listener (room_id source-of-truth).
+ *
+ * We mock the `Token` query builder to hand out batches and the
+ * `RoomStateService.readAndUpsertRoomState` per-token call. Asserts: batching,
+ * per-token error isolation (a failed read does not abort the batch), the
+ * loop-guard against a non-progressing repeated batch, and emission counting.
+ */
+describe('CommunityRoomBackfillService', () => {
+  const makeToken = (sale: string): Token =>
+    ({ sale_address: sale, address: 'ct_' + sale, symbol: sale }) as Token;
+
+  type Harness = {
+    service: CommunityRoomBackfillService;
+    upsert: jest.Mock;
+    emitter: EventEmitter2;
+    emitSpy: jest.SpyInstance;
+    tokenRepo: any;
+    qb: any;
+    scheduler: SchedulerRegistry;
+    setBatches: (batches: Token[][]) => void;
+  };
+
+  /**
+   * Build the service against a mock config. The relay-actuator duties (the
+   * 5-min provisioning cron + the buy-listener) gate on `isRelayConfigured`,
+   * which reads the INJECTED `nostrRelayUrl` + `nostrBotNsec`. Pass
+   * `relayConfigured: true` to set both (gate OPEN → cron scheduled / listener
+   * active); leave it false to keep them unset (gate CLOSED → dormant).
+   */
+  const makeHarness = (
+    upsertImpl?: (t: Token) => any,
+    opts: { relayConfigured?: boolean } = {},
+  ): Harness => {
+    let batches: Token[][] = [];
+    let call = 0;
+
+    // Each createQueryBuilder().…​.getMany() returns the next queued batch.
+    // Methods are jest.fn so tests can assert the worth-gate filters + ordering.
+    const qb: any = {
+      leftJoin: jest.fn(() => qb),
+      where: jest.fn(() => qb),
+      andWhere: jest.fn(() => qb),
+      orderBy: jest.fn(() => qb),
+      addOrderBy: jest.fn(() => qb),
+      limit: jest.fn(() => qb),
+      getMany: jest.fn(async () => batches[call++] ?? []),
+      getCount: jest.fn(async () => 0),
+    };
+    const tokenRepo = {
+      createQueryBuilder: () => qb,
+      find: jest.fn(async () => []),
+      findOne: jest.fn(async () => null),
+    } as any;
+    const communityRoomRepo = {} as any;
+
+    const upsert = jest.fn(
+      upsertImpl ??
+        (async (t: Token) => ({
+          saleAddress: t.sale_address,
+          emitted: true,
+          isCommunity: true,
+          deleted: false,
+        })),
+    );
+    const roomStateService = {
+      readAndUpsertRoomState: upsert,
+    } as any;
+    const config = {
+      backfillBatchSize: 2,
+      roomProvisionBatchSize: 500,
+      // Relay-enable switch (replaces the old TG_WORKER_MODE process mode):
+      // both set → isRelayConfigured(config) === true.
+      nostrRelayUrl: opts.relayConfigured ? 'ws://relay' : undefined,
+      nostrBotNsec: opts.relayConfigured ? 'nsec1abc' : undefined,
+    } as any;
+
+    const emitter = new EventEmitter2();
+    const emitSpy = jest.spyOn(emitter, 'emit');
+    const scheduler = new SchedulerRegistry();
+
+    const service = new CommunityRoomBackfillService(
+      tokenRepo,
+      communityRoomRepo,
+      roomStateService,
+      emitter,
+      scheduler,
+      config,
+    );
+
+    return {
+      service,
+      upsert,
+      emitter,
+      emitSpy,
+      tokenRepo,
+      qb,
+      scheduler,
+      setBatches: (b) => {
+        batches = b;
+      },
+    };
+  };
+
+  it('processes every token across multiple batches until exhausted', async () => {
+    const h = makeHarness();
+    h.setBatches([
+      [makeToken('a'), makeToken('b')],
+      [makeToken('c')],
+      [], // exhausted
+    ]);
+
+    const result = await h.service.run();
+
+    expect(h.upsert).toHaveBeenCalledTimes(3);
+    expect(result.processed).toBe(3);
+    expect(result.emitted).toBe(3);
+    expect(result.failed).toBe(0);
+  });
+
+  it('counts only emitting upserts in `emitted` (idempotent no-diff re-runs)', async () => {
+    const h = makeHarness(async (t: Token) => ({
+      saleAddress: t.sale_address,
+      emitted: t.sale_address === 'a', // only "a" actually changed
+      isCommunity: true,
+      deleted: false,
+    }));
+    h.setBatches([[makeToken('a'), makeToken('b')], []]);
+
+    const result = await h.service.run();
+    expect(result.processed).toBe(2);
+    expect(result.emitted).toBe(1);
+  });
+
+  it('isolates a per-token failure (the batch continues; failed counted)', async () => {
+    const h = makeHarness(async (t: Token) => {
+      if (t.sale_address === 'b') {
+        throw new Error('get_state reverted');
+      }
+      return {
+        saleAddress: t.sale_address,
+        emitted: true,
+        isCommunity: true,
+        deleted: false,
+      };
+    });
+    h.setBatches([[makeToken('a'), makeToken('b'), makeToken('c')], []]);
+
+    const result = await h.service.run();
+    expect(h.upsert).toHaveBeenCalledTimes(3); // b failed but a + c still ran
+    expect(result.processed).toBe(2);
+    expect(result.failed).toBe(1);
+  });
+
+  it('stops on a non-progressing repeated batch (loop-guard)', async () => {
+    // Every read fails → state_synced_at never set → the same batch would repeat
+    // forever. The guard detects the identical set with zero progress and stops.
+    const h = makeHarness(async () => {
+      throw new Error('always fails');
+    });
+    const batch = [makeToken('a'), makeToken('b')];
+    h.setBatches([batch, batch, batch, batch]);
+
+    const result = await h.service.run();
+    // First batch ran (all failed); the repeat of the identical set stops it.
+    expect(result.failed).toBe(4); // two batches of two before the guard trips
+    expect(result.processed).toBe(0);
+  });
+
+  it('honours an explicit batchSize / maxBatches override', async () => {
+    const h = makeHarness();
+    h.setBatches([[makeToken('a')], [makeToken('b')], [makeToken('c')]]);
+
+    const result = await h.service.run({ batchSize: 1, maxBatches: 2 });
+    expect(result.processed).toBe(2); // capped at 2 batches
+  });
+
+  // ── roomless-token provisioning cron (room_id source-of-truth) ──────────────
+  describe('provisionRoomlessTokens', () => {
+    it('calls readAndUpsertRoomState per token and force-emits ONLY when !emitted', async () => {
+      // "a" emits on its own (first creation); "b" does not (community_room exists,
+      // room_id still NULL → retry case) → force-emit fires only for "b".
+      const h = makeHarness(async (t: Token) => ({
+        saleAddress: t.sale_address,
+        emitted: t.sale_address === 'a',
+        isCommunity: true,
+        deleted: false,
+      }));
+      const tokenA = makeToken('a');
+      const tokenB = makeToken('b');
+      // provisionRoomlessTokens now selects via a query builder (market_cap > 0 AND
+      // holders_count >= 2, ORDER BY market_cap DESC) → feed the qb.getMany batch.
+      h.setBatches([[tokenA, tokenB]]);
+
+      const processed = await h.service.provisionRoomlessTokens(500);
+
+      // readAndUpsertRoomState called once per token.
+      expect(h.upsert).toHaveBeenCalledTimes(2);
+      expect(h.upsert).toHaveBeenCalledWith(tokenA);
+      expect(h.upsert).toHaveBeenCalledWith(tokenB);
+      expect(processed).toBe(2);
+
+      // Force-emit fires ONLY for the emitted:false token ("b").
+      const upsertEmits = h.emitSpy.mock.calls.filter(
+        (c) => c[0] === TGR_COMMUNITY_UPSERTED,
+      );
+      expect(upsertEmits).toHaveLength(1);
+      expect(upsertEmits[0][1]).toEqual({ saleAddress: 'b' });
+    });
+
+    it('worth-gates + prioritizes: market_cap > 0 AND holders_count >= 2, ORDER BY market_cap DESC', async () => {
+      const h = makeHarness();
+      h.setBatches([[makeToken('a')]]);
+
+      await h.service.provisionRoomlessTokens(100);
+
+      const andWhereArgs = h.qb.andWhere.mock.calls.map((c: any[]) => c[0]);
+      expect(andWhereArgs).toEqual(
+        expect.arrayContaining([
+          'token.market_cap > 0',
+          'token.holders_count >= 2',
+        ]),
+      );
+      expect(h.qb.orderBy).toHaveBeenCalledWith('token.market_cap', 'DESC');
+      expect(h.qb.limit).toHaveBeenCalledWith(100);
+    });
+
+    it('isolates a per-token failure (the batch continues; count excludes it)', async () => {
+      const h = makeHarness(async (t: Token) => {
+        if (t.sale_address === 'b') {
+          throw new Error('get_state reverted');
+        }
+        return {
+          saleAddress: t.sale_address,
+          emitted: false,
+          isCommunity: true,
+          deleted: false,
+        };
+      });
+      h.setBatches([[makeToken('a'), makeToken('b'), makeToken('c')]]);
+
+      const processed = await h.service.provisionRoomlessTokens(500);
+      expect(h.upsert).toHaveBeenCalledTimes(3); // b failed but a + c still ran
+      expect(processed).toBe(2);
+    });
+  });
+
+  // ── 5-min provisioning cron gate (onModuleInit) ─────────────────────────────
+  describe('onModuleInit (cron gate)', () => {
+    afterEach(() => jest.clearAllMocks());
+
+    it('schedules the 5-min provisioning interval when the relay IS configured', () => {
+      const h = makeHarness(undefined, { relayConfigured: true });
+      const addInterval = jest.spyOn(h.scheduler, 'addInterval');
+
+      h.service.onModuleInit();
+
+      expect(addInterval).toHaveBeenCalledTimes(1);
+      expect(addInterval.mock.calls[0][0]).toBe(ROOM_PROVISION_SCAN_JOB);
+      expect(h.scheduler.doesExist('interval', ROOM_PROVISION_SCAN_JOB)).toBe(
+        true,
+      );
+
+      // Tidy up the registered timer.
+      h.service.onApplicationShutdown();
+    });
+
+    it('does NOT schedule the interval when the relay is NOT configured (dormant)', () => {
+      const h = makeHarness(undefined, { relayConfigured: false });
+      const addInterval = jest.spyOn(h.scheduler, 'addInterval');
+
+      h.service.onModuleInit();
+
+      expect(addInterval).not.toHaveBeenCalled();
+      expect(h.scheduler.doesExist('interval', ROOM_PROVISION_SCAN_JOB)).toBe(
+        false,
+      );
+    });
+  });
+
+  // ── buy → create-if-missing (onBalanceChanged) ──────────────────────────────
+  // The buy-listener is relay-gated: it only provisions when a relay is
+  // configured (`isRelayConfigured(this.config)`), since there is a room to
+  // create. With no relay it returns early (dormant) — replaces the old
+  // pure-main / worker process-mode distinction.
+  describe('onBalanceChanged (buy → create room if missing)', () => {
+    it('provisions a roomless token (room_id NULL): upsert + force-emit', async () => {
+      const h = makeHarness(
+        async (t: Token) => ({
+          saleAddress: t.sale_address,
+          emitted: false, // community_room exists → force-emit path
+          isCommunity: true,
+          deleted: false,
+        }),
+        { relayConfigured: true }, // relay configured → listener active
+      );
+      const token = {
+        sale_address: 'sale_x',
+        address: 'ct_aex9_x',
+        room_id: null,
+      } as unknown as Token;
+      h.tokenRepo.findOne.mockResolvedValue(token);
+
+      await h.service.onBalanceChanged({
+        tokenAddress: 'ct_aex9_x',
+        holderAddress: 'ak_buyer',
+      });
+
+      // Resolved by AEX9 address (NOT sale_address).
+      expect(h.tokenRepo.findOne).toHaveBeenCalledWith({
+        where: { address: 'ct_aex9_x' },
+      });
+      expect(h.upsert).toHaveBeenCalledWith(token);
+      const upsertEmits = h.emitSpy.mock.calls.filter(
+        (c) => c[0] === TGR_COMMUNITY_UPSERTED,
+      );
+      expect(upsertEmits).toEqual([
+        [TGR_COMMUNITY_UPSERTED, { saleAddress: 'sale_x' }],
+      ]);
+    });
+
+    it('is a no-op for a token that already has room_id set', async () => {
+      const h = makeHarness(undefined, { relayConfigured: true });
+      h.tokenRepo.findOne.mockResolvedValue({
+        sale_address: 'sale_y',
+        address: 'ct_aex9_y',
+        room_id: 'sale_y', // already confirmed-created
+      } as unknown as Token);
+
+      await h.service.onBalanceChanged({
+        tokenAddress: 'ct_aex9_y',
+        holderAddress: 'ak_buyer',
+      });
+
+      expect(h.upsert).not.toHaveBeenCalled();
+      const upsertEmits = h.emitSpy.mock.calls.filter(
+        (c) => c[0] === TGR_COMMUNITY_UPSERTED,
+      );
+      expect(upsertEmits).toHaveLength(0);
+    });
+
+    it('is a no-op when the relay is NOT configured (no room to create)', async () => {
+      const h = makeHarness(undefined, { relayConfigured: false });
+      await h.service.onBalanceChanged({
+        tokenAddress: 'ct_aex9_z',
+        holderAddress: 'ak_buyer',
+      });
+      expect(h.tokenRepo.findOne).not.toHaveBeenCalled();
+      expect(h.upsert).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/token-gated-rooms/services/community-room-backfill.service.ts
+++ b/src/token-gated-rooms/services/community-room-backfill.service.ts
@@ -1,0 +1,357 @@
+import {
+  Inject,
+  Injectable,
+  Logger,
+  OnApplicationShutdown,
+  OnModuleInit,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { EventEmitter2, OnEvent } from '@nestjs/event-emitter';
+import { SchedulerRegistry } from '@nestjs/schedule';
+import { Repository } from 'typeorm';
+import { ConfigType } from '@nestjs/config';
+import { Token } from '@/tokens/entities/token.entity';
+import { CommunityRoom } from '../entities/community-room.entity';
+import { RoomStateService } from './room-state.service';
+import tgrConfig, { isRelayConfigured } from '../config/tgr.config';
+import {
+  TGR_BALANCE_CHANGED,
+  TGR_COMMUNITY_UPSERTED,
+  type TgrBalanceChangedPayload,
+} from '../events';
+
+export interface BackfillRunResult {
+  processed: number;
+  emitted: number;
+  failed: number;
+}
+
+/**
+ * Name of the periodic roomless-token provisioning cron registered on the Nest
+ * {@link SchedulerRegistry} (worker-only). Re-derives the `room_id IS NULL`
+ * working set every tick → resumable after a crash; idempotent (a token whose
+ * `room_id` got stamped by an ACK drops out of the selection).
+ */
+export const ROOM_PROVISION_SCAN_JOB = 'tgr-room-provision-scan';
+
+/** How often the roomless-token provisioning cron fires (5 minutes). */
+export const ROOM_PROVISION_INTERVAL_MS = 5 * 60 * 1000;
+
+/**
+ * Resumable per-token backfill of `community_room` desired state (Task 04 req §6).
+ *
+ * Iterates the existing `Token` registry (the DB directly — never `/api/tokens`)
+ * ordered by `community_room.state_synced_at ASC NULLS FIRST`, so never-synced
+ * and stalest rooms are processed first. The per-row `state_synced_at` IS the
+ * cursor (plan §8): every successful `readAndUpsertRoomState` stamps it `now`, so
+ * a re-run naturally resumes where it left off and an interrupted run completes
+ * the remainder. Errors are isolated per token (a single failed `get_state` does
+ * not abort the batch — log + continue, leaving `state_synced_at` unset so the
+ * token is retried on the next pass).
+ *
+ * NOTE: batch size / throughput are LOAD-TUNED with the eager room backfill
+ * (Task 09 owns the 54k load-test); the default here (`backfillBatchSize` ≈ 200)
+ * is conservative.
+ */
+@Injectable()
+export class CommunityRoomBackfillService
+  implements OnModuleInit, OnApplicationShutdown
+{
+  private readonly logger = new Logger(CommunityRoomBackfillService.name);
+
+  /** Single-flight guard so overlapping 5-minute ticks never stack. */
+  private provisionRunning = false;
+
+  constructor(
+    @InjectRepository(Token)
+    private readonly tokenRepository: Repository<Token>,
+    @InjectRepository(CommunityRoom)
+    private readonly communityRoomRepository: Repository<CommunityRoom>,
+    private readonly roomStateService: RoomStateService,
+    private readonly eventEmitter: EventEmitter2,
+    private readonly scheduler: SchedulerRegistry,
+    @Inject(tgrConfig.KEY)
+    private readonly config: ConfigType<typeof tgrConfig>,
+  ) {}
+
+  /**
+   * Schedule the 5-minute roomless-token provisioning cron on the Nest
+   * {@link SchedulerRegistry} — relay-gated (worker mode removed, see
+   * `deworker-plan.md`). Room creation publishes to the relay, so we only schedule
+   * the cron when a relay is configured (`isRelayConfigured`); otherwise this is a
+   * no-op. The interval re-derives the `room_id IS NULL` working set every tick →
+   * resumable after a crash without losing rows.
+   */
+  onModuleInit(): void {
+    if (!isRelayConfigured(this.config)) {
+      return;
+    }
+    try {
+      const interval = setInterval(() => {
+        void this.runProvisionSafely();
+      }, ROOM_PROVISION_INTERVAL_MS);
+      interval.unref?.();
+      this.scheduler.addInterval(ROOM_PROVISION_SCAN_JOB, interval);
+      this.logger.log(
+        `scheduled roomless-token provisioning every ${
+          ROOM_PROVISION_INTERVAL_MS / 1000
+        }s`,
+      );
+    } catch (error: any) {
+      this.logger.warn(
+        `failed to schedule roomless-token provisioning: ${error?.message ?? error}`,
+      );
+    }
+  }
+
+  /** Tear down the interval on shutdown so tests / restarts don't leak timers. */
+  onApplicationShutdown(): void {
+    try {
+      if (this.scheduler.doesExist?.('interval', ROOM_PROVISION_SCAN_JOB)) {
+        this.scheduler.deleteInterval(ROOM_PROVISION_SCAN_JOB);
+      }
+    } catch {
+      // best-effort
+    }
+  }
+
+  /** Run the provisioning scan with single-flight + error isolation (interval cb). */
+  private async runProvisionSafely(): Promise<void> {
+    if (this.provisionRunning) {
+      return;
+    }
+    this.provisionRunning = true;
+    try {
+      await this.provisionRoomlessTokens(this.config.roomProvisionBatchSize);
+    } catch (error: any) {
+      this.logger.error(
+        `roomless-token provisioning scan failed: ${error?.message ?? error}`,
+      );
+    } finally {
+      this.provisionRunning = false;
+    }
+  }
+
+  /**
+   * Provision relay rooms for up to `limit` tokens that still have no confirmed
+   * room (`room_id IS NULL AND sale_address IS NOT NULL`). For each: read+upsert the
+   * on-chain community state (the canonical reactive seed), and if that upsert did
+   * NOT itself emit `tgr.community.upserted` (the retry case — the `community_room`
+   * row already exists but the relay room / `room_id` is still NULL), FORCE-emit it
+   * so the decoupled relay-create (RoomBackfillService) + member-seed
+   * (EligibilityService) chains re-fire. Errors are isolated per token (log +
+   * continue). Idempotent: once `room_id` is stamped on the `9007` ACK the token
+   * drops out of the selection.
+   *
+   * **Worth-gating + priority:** only tokens with a non-zero `market_cap` AND at
+   * least 2 holders get a room — there is no point provisioning a relay group for a
+   * worthless / single-holder token. Highest market cap first, so the most valuable
+   * communities are provisioned ahead of the long tail.
+   *
+   * @returns the number of tokens processed.
+   */
+  async provisionRoomlessTokens(limit: number): Promise<number> {
+    const tokens = await this.tokenRepository
+      .createQueryBuilder('token')
+      .where('token.room_id IS NULL')
+      .andWhere('token.sale_address IS NOT NULL')
+      .andWhere('token.market_cap > 0')
+      .andWhere('token.holders_count >= 2')
+      .orderBy('token.market_cap', 'DESC')
+      .limit(limit)
+      .getMany();
+
+    let processed = 0;
+    for (const token of tokens) {
+      try {
+        const result =
+          await this.roomStateService.readAndUpsertRoomState(token);
+        // readAndUpsertRoomState emits on first creation; force-emit covers the
+        // retry case where community_room already exists but room_id is still NULL.
+        if (!result.emitted) {
+          this.eventEmitter.emit(TGR_COMMUNITY_UPSERTED, {
+            saleAddress: token.sale_address,
+          });
+        }
+        processed += 1;
+      } catch (error: any) {
+        this.logger.error(
+          `[provision] failed to provision room for ${token.sale_address}: ${
+            error?.message ?? error
+          }`,
+        );
+        // Leave room_id NULL → retried on the next tick.
+      }
+    }
+
+    if (processed > 0) {
+      this.logger.log(
+        `[provision] processed ${processed} roomless token(s) (room_id IS NULL)`,
+      );
+    }
+    return processed;
+  }
+
+  /**
+   * Buy → create the room immediately if missing (relay-gated).
+   *
+   * A buy on a roomless token raises `tgr.balance.changed` (Task 03). The payload
+   * carries the AEX9 `Token.address` (NOT `sale_address`), so we resolve the token
+   * by `address`. If found AND it has no confirmed room yet (`room_id IS NULL`), we
+   * provision it right away — read+upsert the community state and force-emit
+   * `tgr.community.upserted` when the upsert was a no-op — so the room is created
+   * without waiting for the 5-minute cron. The existing eligibility chain then adds
+   * the buyer as a member once `community_room` exists. Idempotent: once `room_id`
+   * is stamped on the ACK, subsequent balance changes for the token skip. No relay
+   * configured → no room to create, so we skip.
+   */
+  @OnEvent(TGR_BALANCE_CHANGED, { async: true })
+  async onBalanceChanged(payload: TgrBalanceChangedPayload): Promise<void> {
+    if (!isRelayConfigured(this.config)) {
+      return;
+    }
+    const tokenAddress = payload?.tokenAddress;
+    if (!tokenAddress) {
+      return;
+    }
+    try {
+      const token = await this.tokenRepository.findOne({
+        where: { address: tokenAddress },
+      });
+      if (!token || !token.sale_address) {
+        return;
+      }
+      // Already has a confirmed room → nothing to do (idempotent fast-path).
+      if (token.room_id) {
+        return;
+      }
+      const result = await this.roomStateService.readAndUpsertRoomState(token);
+      if (!result.emitted) {
+        this.eventEmitter.emit(TGR_COMMUNITY_UPSERTED, {
+          saleAddress: token.sale_address,
+        });
+      }
+    } catch (error: any) {
+      this.logger.error(
+        `[provision] buy-triggered room create for token ${tokenAddress} failed: ${
+          error?.message ?? error
+        }`,
+      );
+    }
+  }
+
+  /**
+   * Run the backfill to completion. Repeatedly pulls the next batch of stalest /
+   * never-synced tokens and upserts each room until none remain unsynced.
+   *
+   * @param options.batchSize override the configured batch size (tests).
+   * @param options.maxBatches safety cap on the number of batches per run; when
+   *   omitted the loop runs until a batch yields no progress.
+   */
+  async run(
+    options: {
+      batchSize?: number;
+      maxBatches?: number;
+    } = {},
+  ): Promise<BackfillRunResult> {
+    const batchSize = options.batchSize ?? this.config.backfillBatchSize;
+    const result: BackfillRunResult = { processed: 0, emitted: 0, failed: 0 };
+
+    let batches = 0;
+    let lastSynced = new Set<string>();
+
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      if (options.maxBatches !== undefined && batches >= options.maxBatches) {
+        break;
+      }
+
+      const tokens = await this.nextBatch(batchSize);
+      if (tokens.length === 0) {
+        break;
+      }
+
+      // Loop-guard: if a whole batch failed (state_synced_at stays unset) the
+      // same tokens would be re-selected forever. Track the previous batch's
+      // sale_addresses; if we get the exact same set with zero progress, stop.
+      const currentSet = new Set(tokens.map((t) => t.sale_address));
+      const sameAsLast =
+        currentSet.size === lastSynced.size &&
+        [...currentSet].every((s) => lastSynced.has(s));
+
+      let progressed = 0;
+      for (const token of tokens) {
+        try {
+          const upsert =
+            await this.roomStateService.readAndUpsertRoomState(token);
+          result.processed += 1;
+          progressed += 1;
+          if (upsert.emitted) {
+            result.emitted += 1;
+          }
+        } catch (error: any) {
+          result.failed += 1;
+          this.logger.error(
+            `[backfill] failed to sync room for ${token.sale_address}: ${error?.message ?? error}`,
+          );
+          // Leave state_synced_at unset → retried on the next pass.
+        }
+      }
+
+      batches += 1;
+
+      if (sameAsLast && progressed === 0) {
+        this.logger.warn(
+          `[backfill] no progress on a repeated batch of ${tokens.length}; stopping to avoid a hot loop`,
+        );
+        break;
+      }
+      lastSynced = currentSet;
+    }
+
+    this.logger.log(
+      `[backfill] complete: processed=${result.processed} emitted=${result.emitted} failed=${result.failed} (${batches} batches)`,
+    );
+    return result;
+  }
+
+  /**
+   * Pull the next batch of tokens, stalest-first. `Token LEFT JOIN community_room`
+   * ordered by `community_room.state_synced_at ASC NULLS FIRST` so never-synced
+   * rooms come first, then the oldest.
+   */
+  private async nextBatch(batchSize: number): Promise<Token[]> {
+    return (
+      this.tokenRepository
+        .createQueryBuilder('token')
+        .leftJoin(
+          CommunityRoom,
+          'room',
+          'room.sale_address = token.sale_address',
+        )
+        .where('token.sale_address IS NOT NULL')
+        // Only ever-unsynced rows are candidates: once stamped this run, a row drops
+        // out of the selection, giving natural resumability + a finite loop.
+        .andWhere('room.state_synced_at IS NULL')
+        .orderBy('room.state_synced_at', 'ASC', 'NULLS FIRST')
+        .addOrderBy('token.created_at', 'ASC')
+        // `limit` (raw LIMIT) not `take`: ordering by a non-selected JOINed column
+        // breaks TypeORM's distinct-id pagination wrapper. Safe here — the join is
+        // to-one (community_room PK = token.sale_address), so no row fan-out.
+        .limit(batchSize)
+        .getMany()
+    );
+  }
+
+  /**
+   * Count tokens still awaiting an initial sync — useful for observability/tests.
+   */
+  async pendingCount(): Promise<number> {
+    return this.tokenRepository
+      .createQueryBuilder('token')
+      .leftJoin(CommunityRoom, 'room', 'room.sale_address = token.sale_address')
+      .where('token.sale_address IS NOT NULL')
+      .andWhere('room.state_synced_at IS NULL')
+      .getCount();
+  }
+}

--- a/src/token-gated-rooms/services/community-room-state.integration.spec.ts
+++ b/src/token-gated-rooms/services/community-room-state.integration.spec.ts
@@ -1,0 +1,278 @@
+import 'dotenv/config';
+import { BigNumber } from 'bignumber.js';
+import { DataSource, Repository } from 'typeorm';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { SchedulerRegistry } from '@nestjs/schedule';
+import { DATABASE_CONFIG } from '@/configs/database';
+import { Token } from '@/tokens/entities/token.entity';
+import { CommunityRoom } from '../entities/community-room.entity';
+import { RoomStateService } from './room-state.service';
+import { CommunityRoomBackfillService } from './community-room-backfill.service';
+import { TGR_COMMUNITY_UPSERTED } from '../events';
+
+/**
+ * DB integration (Task 04; harness pattern mirrors Task 02 /
+ * `entities/migrations.integration.spec.ts`): a real Postgres backs the backfill
+ * and a simulated live management change. The chain reads (`get_state` /
+ * `get_community_management`) are stubbed on `RoomStateService.getContract` so the
+ * test is deterministic and offline; only the DB I/O is real.
+ *
+ * Isolation: runs in a DEDICATED `tgr04_test` schema (created/dropped here) with
+ * `synchronize: true`, so `token` + `community_room` contain ONLY the seeds of
+ * this test — the whole-registry backfill is naturally scoped and never touches
+ * the shared `public` schema (which holds 54k real tokens).
+ *
+ * Asserts:
+ *  - backfill populates `community_room` for a mix of community + `[TG]` tokens,
+ *    stamps `state_synced_at`, processes stalest-first, and is resumable after a
+ *    mid-run interruption;
+ *  - re-running over synced rooms is idempotent (no events);
+ *  - a simulated management change re-reads + updates the row and re-emits
+ *    `tgr.community.upserted` with the diff;
+ *  - raw thresholds round-trip through numeric without precision loss.
+ *
+ * Requires the local Postgres (`DB_HOST`); auto-skips otherwise so unit-only runs
+ * stay green.
+ */
+const HAS_DB = !!process.env.DB_HOST;
+const d = HAS_DB ? describe : describe.skip;
+
+const SCHEMA = 'tgr04_test';
+const SALE_COMMUNITY = 'ct_tgr04_sale_community';
+const SALE_TG = 'ct_tgr04_sale_tg';
+const TOKEN_COMMUNITY = 'ct_tgr04_token_community';
+const TOKEN_TG = 'ct_tgr04_token_tg';
+const MGMT = 'ct_tgr04_mgmt';
+
+d('Community-room state indexer (integration)', () => {
+  let ds: DataSource;
+  let tokenRepo: Repository<Token>;
+  let roomRepo: Repository<CommunityRoom>;
+  let emitter: EventEmitter2;
+  let roomState: RoomStateService;
+  let backfill: CommunityRoomBackfillService;
+
+  // Mutable chain state our stubbed contract reads return.
+  let managementBySale: Record<string, string | undefined>;
+  let stateByMgmt: Record<string, any>;
+
+  const installChainStub = (svc: RoomStateService) => {
+    (svc as any).getContract = jest.fn(async (address: string) => {
+      if (address in stateByMgmt) {
+        return {
+          get_state: async () => ({ decodedResult: stateByMgmt[address] }),
+        };
+      }
+      // factory
+      return {
+        get_community_management: async (sale: string) => ({
+          decodedResult: managementBySale[sale],
+        }),
+      };
+    });
+  };
+
+  beforeAll(async () => {
+    // Bootstrap the isolated schema on a throwaway connection.
+    const boot = new DataSource({
+      ...(DATABASE_CONFIG as any),
+      synchronize: false,
+      entities: [],
+    });
+    await boot.initialize();
+    await boot.query(`DROP SCHEMA IF EXISTS "${SCHEMA}" CASCADE`);
+    await boot.query(`CREATE SCHEMA "${SCHEMA}"`);
+    await boot.destroy();
+
+    ds = new DataSource({
+      ...(DATABASE_CONFIG as any),
+      schema: SCHEMA,
+      synchronize: true, // empty schema → entities create token + community_room
+      entities: [Token, CommunityRoom],
+    });
+    await ds.initialize();
+
+    tokenRepo = ds.getRepository(Token);
+    roomRepo = ds.getRepository(CommunityRoom);
+    emitter = new EventEmitter2();
+    roomState = new RoomStateService(
+      roomRepo,
+      { sdk: { getContext: () => ({}) } } as any,
+      emitter,
+    );
+    installChainStub(roomState);
+    backfill = new CommunityRoomBackfillService(
+      tokenRepo,
+      roomRepo,
+      roomState,
+      emitter,
+      new SchedulerRegistry(),
+      { backfillBatchSize: 1, roomProvisionBatchSize: 500 } as any, // tiny batches exercise resumability
+    );
+  }, 60_000);
+
+  beforeEach(async () => {
+    await roomRepo.clear();
+    await tokenRepo.clear();
+
+    await tokenRepo.save([
+      tokenRepo.create({
+        sale_address: SALE_COMMUNITY,
+        address: TOKEN_COMMUNITY,
+        name: 'CommunityToken',
+        symbol: 'COMM',
+        owner_address: 'ak_comm_owner',
+        creator_address: 'ak_comm_creator',
+        last_sync_block_height: 500,
+      }),
+      tokenRepo.create({
+        sale_address: SALE_TG,
+        address: TOKEN_TG,
+        name: 'TgToken',
+        symbol: 'TG',
+        owner_address: 'ak_tg_owner',
+        creator_address: 'ak_tg_creator',
+        last_sync_block_height: 600,
+      }),
+    ]);
+
+    managementBySale = {
+      [SALE_COMMUNITY]: MGMT,
+      [SALE_TG]: undefined, // None → [TG] defaults
+    };
+    stateByMgmt = {
+      [MGMT]: {
+        owner: 'ak_dao_owner',
+        minimum_token_threshold: 1000000000000000000n,
+        is_private: true,
+        moderator_accounts: new Set(['ak_mod_1']),
+        muted_user_ids: new Set(['npub_mute_1']),
+        meta_info: new Map(),
+      },
+    };
+  });
+
+  afterAll(async () => {
+    if (ds?.isInitialized) {
+      await ds.destroy();
+    }
+    const cleanup = new DataSource({
+      ...(DATABASE_CONFIG as any),
+      synchronize: false,
+      entities: [],
+    });
+    await cleanup.initialize();
+    await cleanup.query(`DROP SCHEMA IF EXISTS "${SCHEMA}" CASCADE`);
+    await cleanup.destroy();
+  }, 60_000);
+
+  it('backfill populates community_room for community + [TG] tokens, stamping state_synced_at', async () => {
+    const result = await backfill.run();
+    expect(result.processed).toBe(2);
+
+    const community = await roomRepo.findOneByOrFail({
+      sale_address: SALE_COMMUNITY,
+    });
+    expect(community.is_community).toBe(true);
+    expect(community.is_private).toBe(true);
+    expect(community.owner_address).toBe('ak_dao_owner');
+    expect(community.min_token_threshold.toFixed()).toBe('1000000000000000000');
+    expect(community.moderators).toEqual(['ak_mod_1']);
+    expect(community.muted).toEqual(['npub_mute_1']);
+    expect(community.state_synced_at).toBeInstanceOf(Date);
+    expect(community.created_height).toBe(500);
+
+    const tg = await roomRepo.findOneByOrFail({ sale_address: SALE_TG });
+    expect(tg.is_community).toBe(false);
+    expect(tg.is_private).toBe(false);
+    expect(tg.min_token_threshold.toFixed()).toBe('0');
+    expect(tg.moderators).toEqual([]);
+    expect(tg.muted).toEqual([]);
+    expect(tg.owner_address).toBe('ak_tg_owner');
+    expect(tg.state_synced_at).toBeInstanceOf(Date);
+  });
+
+  it('processes the stalest-first and is resumable after a mid-run interruption', async () => {
+    // Process only the first (stalest / never-synced) token, then "crash".
+    const first = await backfill.run({ maxBatches: 1 });
+    expect(first.processed).toBe(1);
+    expect(await roomRepo.count()).toBe(1); // exactly one room synced so far
+
+    // Re-run: the already-synced row drops out of the NULLS-FIRST selection, so
+    // only the remaining token is processed → run completes the rest.
+    const second = await backfill.run();
+    expect(second.processed).toBe(1);
+    expect(await roomRepo.count()).toBe(2);
+  });
+
+  it('re-running over already-synced rooms emits nothing (idempotent)', async () => {
+    await backfill.run();
+    const events: any[] = [];
+    emitter.on(TGR_COMMUNITY_UPSERTED, (p) => events.push(p));
+
+    // Force a full re-sweep by clearing the cursor (simulate a reconcile pass).
+    await ds.query(
+      `UPDATE "${SCHEMA}"."community_room" SET "state_synced_at" = NULL`,
+    );
+    const result = await backfill.run();
+
+    expect(result.processed).toBe(2);
+    expect(result.emitted).toBe(0); // nothing changed → no events
+    expect(events).toHaveLength(0);
+  });
+
+  it('a live management change updates the row and emits the diff', async () => {
+    await backfill.run(); // seed the community room
+
+    const received: any[] = [];
+    emitter.on(TGR_COMMUNITY_UPSERTED, (p) => received.push(p));
+
+    // Simulate the on-chain change: threshold up, add a moderator, mute someone.
+    stateByMgmt[MGMT] = {
+      owner: 'ak_dao_owner',
+      minimum_token_threshold: 2000000000000000000n,
+      is_private: true,
+      moderator_accounts: new Set(['ak_mod_1', 'ak_mod_2']),
+      muted_user_ids: new Set(['npub_mute_1', 'npub_mute_2']),
+      meta_info: new Map(),
+    };
+
+    const token = await tokenRepo.findOneByOrFail({
+      sale_address: SALE_COMMUNITY,
+    });
+    const upsert = await roomState.readAndUpsertRoomState(token);
+    expect(upsert.emitted).toBe(true);
+
+    const row = await roomRepo.findOneByOrFail({
+      sale_address: SALE_COMMUNITY,
+    });
+    expect(row.min_token_threshold.toFixed()).toBe('2000000000000000000');
+    expect([...row.moderators].sort()).toEqual(['ak_mod_1', 'ak_mod_2']);
+    expect([...row.muted].sort()).toEqual(['npub_mute_1', 'npub_mute_2']);
+
+    expect(received).toHaveLength(1);
+    const payload = received[0];
+    expect(payload.saleAddress).toBe(SALE_COMMUNITY);
+    expect(payload.changed.threshold).toBe(true);
+    expect(payload.changed.moderators).toEqual({
+      added: ['ak_mod_2'],
+      removed: [],
+    });
+    expect(payload.changed.muted).toEqual({
+      added: ['npub_mute_2'],
+      removed: [],
+    });
+    expect(payload.changed.owner).toBeUndefined();
+  });
+
+  it('round-trips a raw 24-digit threshold through numeric (no precision loss)', async () => {
+    const huge = '123456789012345678901234'; // > Number.MAX_SAFE_INTEGER
+    stateByMgmt[MGMT].minimum_token_threshold = BigInt(huge);
+    await backfill.run();
+    const row = await roomRepo.findOneByOrFail({
+      sale_address: SALE_COMMUNITY,
+    });
+    expect(row.min_token_threshold).toBeInstanceOf(BigNumber);
+    expect(row.min_token_threshold.toFixed()).toBe(huge);
+  });
+});

--- a/src/token-gated-rooms/services/eligibility.service.integration.spec.ts
+++ b/src/token-gated-rooms/services/eligibility.service.integration.spec.ts
@@ -7,7 +7,6 @@ import { BigNumber } from 'bignumber.js';
 import { DATABASE_CONFIG } from '@/configs/database';
 import { Account } from '@/account/entities/account.entity';
 import { Token } from '@/tokens/entities/token.entity';
-import { TokenHolder } from '@/tokens/entities/token-holders.entity';
 import { CommunityRoom } from '@/token-gated-rooms/entities/community-room.entity';
 import { RoomMembership } from '@/token-gated-rooms/entities/room-membership.entity';
 import { RoomNotificationPreference } from '@/token-gated-rooms/entities/room-notification-preference.entity';
@@ -81,7 +80,7 @@ d('EligibilityService (integration)', () => {
   let accountRepo: Repository<Account>;
   let roomRepo: Repository<CommunityRoom>;
   let membershipRepo: Repository<RoomMembership>;
-  let holderRepo: Repository<TokenHolder>;
+  let balanceRepo: Repository<TokenBalance>;
   let eventEmitter: EventEmitter2;
 
   beforeAll(async () => {
@@ -90,7 +89,6 @@ d('EligibilityService (integration)', () => {
       synchronize: false,
       entities: [
         Token,
-        TokenHolder,
         Account,
         CommunityRoom,
         RoomMembership,
@@ -117,7 +115,6 @@ d('EligibilityService (integration)', () => {
             CommunityRoom,
             RoomMembership,
             TokenBalance,
-            TokenHolder,
             Token,
           ],
         }),
@@ -125,7 +122,7 @@ d('EligibilityService (integration)', () => {
           Account,
           CommunityRoom,
           RoomMembership,
-          TokenHolder,
+          TokenBalance,
         ]),
       ],
       providers: [
@@ -148,7 +145,7 @@ d('EligibilityService (integration)', () => {
     accountRepo = moduleRef.get(getRepositoryToken(Account));
     roomRepo = moduleRef.get(getRepositoryToken(CommunityRoom));
     membershipRepo = moduleRef.get(getRepositoryToken(RoomMembership));
-    holderRepo = moduleRef.get(getRepositoryToken(TokenHolder));
+    balanceRepo = moduleRef.get(getRepositoryToken(TokenBalance));
     eventEmitter = moduleRef.get(EventEmitter2);
   }, 90_000);
 
@@ -168,7 +165,7 @@ d('EligibilityService (integration)', () => {
 
   async function cleanup(): Promise<void> {
     await membershipRepo.delete({ sale_address: SALE });
-    await holderRepo.delete({ aex9_address: TOKEN });
+    await balanceRepo.delete({ token_address: TOKEN });
     await roomRepo.delete({ sale_address: SALE });
     await accountRepo
       .createQueryBuilder()
@@ -204,12 +201,10 @@ d('EligibilityService (integration)', () => {
     const member = 'ak_int_elig_member';
     await seedRoom();
     await accountRepo.insert({ address: member, links: { [PROVIDER]: HEX } });
-    await holderRepo.insert({
-      id: `${member}_${TOKEN}`,
-      aex9_address: TOKEN,
-      address: member,
+    await balanceRepo.insert({
+      token_address: TOKEN,
+      holder_address: member,
       balance: new BigNumber('5000') as any,
-      block_number: 10,
     });
 
     const seen: any[] = [];
@@ -239,12 +234,10 @@ d('EligibilityService (integration)', () => {
     const member = 'ak_int_elig_member';
     await seedRoom();
     await accountRepo.insert({ address: member, links: { [PROVIDER]: HEX } });
-    await holderRepo.insert({
-      id: `${member}_${TOKEN}`,
-      aex9_address: TOKEN,
-      address: member,
+    await balanceRepo.insert({
+      token_address: TOKEN,
+      holder_address: member,
       balance: new BigNumber('5000') as any,
-      block_number: 10,
     });
     // Start from a published-eligible row.
     await membershipRepo.insert({
@@ -291,12 +284,10 @@ d('EligibilityService (integration)', () => {
     // All linked + all above threshold → all should become eligible.
     for (const m of members) {
       await accountRepo.insert({ address: m, links: { [PROVIDER]: HEX } });
-      await holderRepo.insert({
-        id: `${m}_${TOKEN}`,
-        aex9_address: TOKEN,
-        address: m,
+      await balanceRepo.insert({
+        token_address: TOKEN,
+        holder_address: m,
         balance: new BigNumber('5000') as any,
-        block_number: 10,
       });
       // Pre-create the membership rows (ineligible) so the cursor scan has rows.
       await membershipRepo.insert({
@@ -324,12 +315,10 @@ d('EligibilityService (integration)', () => {
     const member = 'ak_int_elig_member';
     await seedRoom();
     await accountRepo.insert({ address: member, links: { [PROVIDER]: HEX } });
-    await holderRepo.insert({
-      id: `${member}_${TOKEN}`,
-      aex9_address: TOKEN,
-      address: member,
+    await balanceRepo.insert({
+      token_address: TOKEN,
+      holder_address: member,
       balance: new BigNumber('5000') as any,
-      block_number: 10,
     });
 
     const room = await roomRepo.findOneByOrFail({ sale_address: SALE });

--- a/src/token-gated-rooms/services/eligibility.service.integration.spec.ts
+++ b/src/token-gated-rooms/services/eligibility.service.integration.spec.ts
@@ -1,0 +1,359 @@
+import 'dotenv/config';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken, TypeOrmModule } from '@nestjs/typeorm';
+import { EventEmitter2, EventEmitterModule } from '@nestjs/event-emitter';
+import { DataSource, Repository } from 'typeorm';
+import { BigNumber } from 'bignumber.js';
+import { DATABASE_CONFIG } from '@/configs/database';
+import { Account } from '@/account/entities/account.entity';
+import { Token } from '@/tokens/entities/token.entity';
+import { TokenHolder } from '@/tokens/entities/token-holders.entity';
+import { CommunityRoom } from '@/token-gated-rooms/entities/community-room.entity';
+import { RoomMembership } from '@/token-gated-rooms/entities/room-membership.entity';
+import { RoomNotificationPreference } from '@/token-gated-rooms/entities/room-notification-preference.entity';
+import { RoomMessageSeen } from '@/token-gated-rooms/entities/room-message-seen.entity';
+import { TokenBalance } from '@/token-gated-rooms/entities/token-balance.entity';
+import { RoomBackfillState } from '@/token-gated-rooms/entities/room-backfill-state.entity';
+import { IdentityService } from '@/token-gated-rooms/services/identity.service';
+import { EligibilityService } from '@/token-gated-rooms/services/eligibility.service';
+import {
+  TGR_BALANCE_CHANGED,
+  TGR_COMMUNITY_UPSERTED,
+  TGR_ELIGIBILITY_CHANGED,
+} from '@/token-gated-rooms/events';
+import tgrConfig from '@/token-gated-rooms/config/tgr.config';
+
+/**
+ * DB integration for Task 06 eligibility. Applies the TGR migrations on the real
+ * local Postgres (DB_* env / repo .env) via an isolated migrations history table
+ * (mirrors `identity.int-spec.ts` / `migrations.integration.spec.ts`), then drives
+ * the real {@link EligibilityService} through its event triggers and asserts the
+ * desired-state `room_membership` rows + `tgr.eligibility.changed` emissions.
+ *
+ * `nostr-tools/nip19` is mocked (the real module pulls @noble/* ESM that ts-jest
+ * cannot transform) with a fixed hex passthrough so {@link IdentityService}
+ * normalization is real.
+ */
+const HEX = 'a'.repeat(64);
+
+jest.mock('nostr-tools/nip19', () => ({
+  decode: () => {
+    throw new Error('invalid bech32');
+  },
+}));
+
+const HAS_DB = !!process.env.DB_HOST;
+const d = HAS_DB ? describe : describe.skip;
+
+const PROVIDER = 'nostr';
+const SALE = 'ct_int_sale_eligibility';
+const TOKEN = 'ct_int_token_eligibility';
+
+async function dropTgrObjects(ds: DataSource): Promise<void> {
+  const stmts = [
+    `DROP TABLE IF EXISTS "room_backfill_state"`,
+    `DROP TABLE IF EXISTS "token_balance"`,
+    `DROP TABLE IF EXISTS "room_message_seen"`,
+    `DROP TABLE IF EXISTS "room_notification_preference"`,
+    `DROP TABLE IF EXISTS "room_membership"`,
+    `DROP TABLE IF EXISTS "community_room"`,
+    `DROP TYPE IF EXISTS "room_membership_relay_state_enum"`,
+    `DROP TYPE IF EXISTS "room_membership_role_enum"`,
+    `ALTER TABLE "token" DROP COLUMN IF EXISTS "nostr_room_state"`,
+    `ALTER TABLE "token" DROP COLUMN IF EXISTS "nostr_room_created_at"`,
+    `ALTER TABLE "token" DROP COLUMN IF EXISTS "has_nostr_room"`,
+    `ALTER TABLE "token" DROP COLUMN IF EXISTS "nostr_group_id"`,
+    `DROP TYPE IF EXISTS "token_nostr_room_state_enum"`,
+  ];
+  for (const s of stmts) {
+    await ds.query(s);
+  }
+  await ds
+    .query(`DELETE FROM "migrations" WHERE "name" LIKE 'Tgr%'`)
+    .catch(() => undefined);
+}
+
+d('EligibilityService (integration)', () => {
+  let ds: DataSource;
+  let moduleRef: TestingModule;
+  let service: EligibilityService;
+  let identity: IdentityService;
+  let accountRepo: Repository<Account>;
+  let roomRepo: Repository<CommunityRoom>;
+  let membershipRepo: Repository<RoomMembership>;
+  let holderRepo: Repository<TokenHolder>;
+  let eventEmitter: EventEmitter2;
+
+  beforeAll(async () => {
+    ds = new DataSource({
+      ...(DATABASE_CONFIG as any),
+      synchronize: false,
+      entities: [
+        Token,
+        TokenHolder,
+        Account,
+        CommunityRoom,
+        RoomMembership,
+        RoomNotificationPreference,
+        RoomMessageSeen,
+        TokenBalance,
+        RoomBackfillState,
+      ],
+      migrations: [__dirname + '/../../migrations/*{.ts,.js}'],
+      migrationsTableName: 'migrations_tgr_eligibility_test',
+    });
+    await ds.initialize();
+    await dropTgrObjects(ds);
+    await ds.runMigrations();
+
+    moduleRef = await Test.createTestingModule({
+      imports: [
+        EventEmitterModule.forRoot(),
+        TypeOrmModule.forRoot({
+          ...(DATABASE_CONFIG as any),
+          synchronize: false,
+          entities: [
+            Account,
+            CommunityRoom,
+            RoomMembership,
+            TokenBalance,
+            TokenHolder,
+            Token,
+          ],
+        }),
+        TypeOrmModule.forFeature([
+          Account,
+          CommunityRoom,
+          RoomMembership,
+          TokenHolder,
+        ]),
+      ],
+      providers: [
+        IdentityService,
+        EligibilityService,
+        {
+          provide: tgrConfig.KEY,
+          useValue: {
+            nostrLinkProvider: PROVIDER,
+            reconcileBatchSize: 2,
+          },
+        },
+      ],
+    }).compile();
+    // init() so @OnEvent subscriptions register on the event bus.
+    await moduleRef.init();
+
+    service = moduleRef.get(EligibilityService);
+    identity = moduleRef.get(IdentityService);
+    accountRepo = moduleRef.get(getRepositoryToken(Account));
+    roomRepo = moduleRef.get(getRepositoryToken(CommunityRoom));
+    membershipRepo = moduleRef.get(getRepositoryToken(RoomMembership));
+    holderRepo = moduleRef.get(getRepositoryToken(TokenHolder));
+    eventEmitter = moduleRef.get(EventEmitter2);
+  }, 90_000);
+
+  afterAll(async () => {
+    if (moduleRef) {
+      await cleanup();
+      await moduleRef.close();
+    }
+    if (ds?.isInitialized) {
+      for (let i = 0; i < 7; i++) {
+        await ds.undoLastMigration();
+      }
+      await ds.query('DROP TABLE IF EXISTS "migrations_tgr_eligibility_test"');
+      await ds.destroy();
+    }
+  }, 90_000);
+
+  async function cleanup(): Promise<void> {
+    await membershipRepo.delete({ sale_address: SALE });
+    await holderRepo.delete({ aex9_address: TOKEN });
+    await roomRepo.delete({ sale_address: SALE });
+    await accountRepo
+      .createQueryBuilder()
+      .delete()
+      .where('address LIKE :p', { p: 'ak_int_elig_%' })
+      .execute();
+    identity.clearCacheEntry('ak_int_elig_member');
+  }
+
+  async function seedRoom(over: Partial<CommunityRoom> = {}): Promise<void> {
+    await roomRepo.save(
+      roomRepo.create({
+        sale_address: SALE,
+        token_address: TOKEN,
+        symbol: 'TGR',
+        owner_address: 'ak_int_elig_owner',
+        is_private: false,
+        min_token_threshold: new BigNumber('1000'),
+        moderators: [],
+        muted: [],
+        is_community: true,
+        deleted: false,
+        ...over,
+      }),
+    );
+  }
+
+  beforeEach(async () => {
+    await cleanup();
+  });
+
+  it('balance change flips eligibility: creates row eligible=true, pending_add, and emits', async () => {
+    const member = 'ak_int_elig_member';
+    await seedRoom();
+    await accountRepo.insert({ address: member, links: { [PROVIDER]: HEX } });
+    await holderRepo.insert({
+      id: `${member}_${TOKEN}`,
+      aex9_address: TOKEN,
+      address: member,
+      balance: new BigNumber('5000') as any,
+      block_number: 10,
+    });
+
+    const seen: any[] = [];
+    const listener = (p: any) => seen.push(p);
+    eventEmitter.on(TGR_ELIGIBILITY_CHANGED, listener);
+
+    await eventEmitter.emitAsync(TGR_BALANCE_CHANGED, {
+      tokenAddress: TOKEN,
+      holderAddress: member,
+    });
+
+    eventEmitter.off(TGR_ELIGIBILITY_CHANGED, listener);
+
+    const row = await membershipRepo.findOneByOrFail({
+      sale_address: SALE,
+      member_address: member,
+    });
+    expect(row.eligible).toBe(true);
+    expect(row.member_pubkey).toBe(HEX);
+    expect(row.relay_state).toBe('pending_add');
+    expect(seen).toEqual([
+      { saleAddress: SALE, memberAddress: member, eligible: true },
+    ]);
+  });
+
+  it('muted user removed from eligible: flips to false + pending_remove on community upsert', async () => {
+    const member = 'ak_int_elig_member';
+    await seedRoom();
+    await accountRepo.insert({ address: member, links: { [PROVIDER]: HEX } });
+    await holderRepo.insert({
+      id: `${member}_${TOKEN}`,
+      aex9_address: TOKEN,
+      address: member,
+      balance: new BigNumber('5000') as any,
+      block_number: 10,
+    });
+    // Start from a published-eligible row.
+    await membershipRepo.insert({
+      sale_address: SALE,
+      member_address: member,
+      eligible: true,
+      role: 'member',
+      member_pubkey: HEX,
+      relay_state: 'added',
+    });
+
+    // Mute them at the room level, then signal the upsert.
+    await roomRepo.update({ sale_address: SALE }, { muted: [member] });
+
+    const seen: any[] = [];
+    const listener = (p: any) => seen.push(p);
+    eventEmitter.on(TGR_ELIGIBILITY_CHANGED, listener);
+
+    await eventEmitter.emitAsync(TGR_COMMUNITY_UPSERTED, {
+      saleAddress: SALE,
+    });
+
+    eventEmitter.off(TGR_ELIGIBILITY_CHANGED, listener);
+
+    const row = await membershipRepo.findOneByOrFail({
+      sale_address: SALE,
+      member_address: member,
+    });
+    expect(row.eligible).toBe(false);
+    expect(row.relay_state).toBe('pending_remove');
+    expect(seen).toEqual([
+      { saleAddress: SALE, memberAddress: member, eligible: false },
+    ]);
+  });
+
+  it('cursor-batched recompute: every member of a room with > N members is recomputed', async () => {
+    await seedRoom(); // reconcileBatchSize = 2 → forces multiple batches
+    const count = 5;
+    const members = Array.from(
+      { length: count },
+      (_, i) => `ak_int_elig_m${i.toString().padStart(2, '0')}`,
+    );
+
+    // All linked + all above threshold → all should become eligible.
+    for (const m of members) {
+      await accountRepo.insert({ address: m, links: { [PROVIDER]: HEX } });
+      await holderRepo.insert({
+        id: `${m}_${TOKEN}`,
+        aex9_address: TOKEN,
+        address: m,
+        balance: new BigNumber('5000') as any,
+        block_number: 10,
+      });
+      // Pre-create the membership rows (ineligible) so the cursor scan has rows.
+      await membershipRepo.insert({
+        sale_address: SALE,
+        member_address: m,
+        eligible: false,
+        role: 'member',
+        relay_state: 'removed',
+      });
+    }
+
+    const flips = await service.recomputeRoom(SALE);
+    expect(flips).toBe(count);
+
+    const rows = await membershipRepo.find({ where: { sale_address: SALE } });
+    expect(rows).toHaveLength(count);
+    for (const r of rows) {
+      expect(r.eligible).toBe(true);
+      expect(r.relay_state).toBe('pending_add');
+      expect(r.member_pubkey).toBe(HEX);
+    }
+  });
+
+  it('idempotency: a second recompute with unchanged inputs writes nothing and emits nothing', async () => {
+    const member = 'ak_int_elig_member';
+    await seedRoom();
+    await accountRepo.insert({ address: member, links: { [PROVIDER]: HEX } });
+    await holderRepo.insert({
+      id: `${member}_${TOKEN}`,
+      aex9_address: TOKEN,
+      address: member,
+      balance: new BigNumber('5000') as any,
+      block_number: 10,
+    });
+
+    const room = await roomRepo.findOneByOrFail({ sale_address: SALE });
+    // First compute creates the row.
+    await service.recomputeMember(room, member);
+    const before = await membershipRepo.findOneByOrFail({
+      sale_address: SALE,
+      member_address: member,
+    });
+
+    const seen: any[] = [];
+    const listener = (p: any) => seen.push(p);
+    eventEmitter.on(TGR_ELIGIBILITY_CHANGED, listener);
+
+    const flipped = await service.recomputeMember(room, member);
+
+    eventEmitter.off(TGR_ELIGIBILITY_CHANGED, listener);
+
+    expect(flipped).toBe(false);
+    expect(seen).toEqual([]);
+    const after = await membershipRepo.findOneByOrFail({
+      sale_address: SALE,
+      member_address: member,
+    });
+    expect(after.updated_at.getTime()).toBe(before.updated_at.getTime());
+  });
+});

--- a/src/token-gated-rooms/services/eligibility.service.spec.ts
+++ b/src/token-gated-rooms/services/eligibility.service.spec.ts
@@ -1,0 +1,575 @@
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { BigNumber } from 'bignumber.js';
+import { Repository } from 'typeorm';
+import {
+  EligibilityService,
+  isEligible,
+  toShiftedBigNumber,
+} from './eligibility.service';
+import { CommunityRoom } from '../entities/community-room.entity';
+import { RoomMembership } from '../entities/room-membership.entity';
+import { TokenBalance } from '../entities/token-balance.entity';
+import { IdentityService } from './identity.service';
+import { TGR_ELIGIBILITY_CHANGED } from '../events';
+
+const HEX = 'a'.repeat(64);
+
+function makeRoom(over: Partial<CommunityRoom> = {}): CommunityRoom {
+  return {
+    sale_address: 'ct_sale',
+    token_address: 'ct_token',
+    symbol: 'TGR',
+    owner_address: 'ak_owner',
+    is_private: false,
+    min_token_threshold: new BigNumber('1000'),
+    moderators: [],
+    muted: [],
+    is_community: false,
+    state_synced_at: new Date(),
+    created_height: 1,
+    deleted: false,
+    ...over,
+  } as CommunityRoom;
+}
+
+function makeMembership(over: Partial<RoomMembership> = {}): RoomMembership {
+  return {
+    id: 1,
+    sale_address: 'ct_sale',
+    member_address: 'ak_member',
+    member_pubkey: null as any,
+    role: 'member',
+    eligible: false,
+    relay_state: 'removed',
+    held_until_height: null as any,
+    last_published_at: null as any,
+    last_reconciled_at: null as any,
+    updated_at: new Date(),
+    ...over,
+  } as RoomMembership;
+}
+
+describe('isEligible (pure helper)', () => {
+  it('balance exactly == threshold (raw) → eligible', () => {
+    expect(isEligible('1000', '1000', [], 'ak')).toBe(true);
+  });
+
+  it('balance == threshold-1 (raw) → ineligible', () => {
+    expect(isEligible('999', '1000', [], 'ak')).toBe(false);
+  });
+
+  it('balance > threshold → eligible', () => {
+    expect(isEligible('1001', '1000', [], 'ak')).toBe(true);
+  });
+
+  it('null balance treated as zero', () => {
+    expect(isEligible(null, '1', [], 'ak')).toBe(false);
+    expect(isEligible(null, '0', [], 'ak')).toBe(true);
+  });
+
+  it('muted holder above threshold → ineligible', () => {
+    expect(isEligible('5000', '1000', ['ak'], 'ak')).toBe(false);
+    // non-muted member with same balance stays eligible
+    expect(isEligible('5000', '1000', ['someone_else'], 'ak')).toBe(true);
+  });
+
+  it('compares as raw integers far beyond Number precision (no float drift)', () => {
+    const threshold = '1000000000000000000000'; // 1000 @ 18 decimals
+    expect(isEligible('1000000000000000000000', threshold, [], 'ak')).toBe(
+      true,
+    );
+    expect(isEligible('999999999999999999999', threshold, [], 'ak')).toBe(
+      false,
+    );
+  });
+});
+
+describe('decimals correctness (raw-vs-raw, no double-shift)', () => {
+  // Same human amount (100 tokens) across 0/6/18 decimals → raw threshold via
+  // toShiftedBigNumber; a balance shifted the same way compares equal/correct.
+  it.each([
+    ['0 decimals', 0],
+    ['6 decimals', 6],
+    ['18 decimals', 18],
+  ])('%s: human→raw shift then raw compare', (_label, decimals) => {
+    const humanThreshold = '100';
+    const humanBalance = '100';
+    const thresholdRaw = toShiftedBigNumber(humanThreshold, decimals);
+    const balanceRaw = toShiftedBigNumber(humanBalance, decimals);
+
+    // exactly at threshold → eligible
+    expect(isEligible(balanceRaw, thresholdRaw, [], 'ak')).toBe(true);
+
+    // one base-unit below threshold → ineligible (proves no double-shift)
+    const justUnder = balanceRaw.minus(1);
+    expect(isEligible(justUnder, thresholdRaw, [], 'ak')).toBe(false);
+  });
+
+  it('toShiftedBigNumber coerces a string decimals (Token.decimals is a string)', () => {
+    expect(toShiftedBigNumber('1', '18').toFixed()).toBe('1000000000000000000');
+    expect(toShiftedBigNumber('1', '6').toFixed()).toBe('1000000');
+    expect(toShiftedBigNumber('1', '0').toFixed()).toBe('1');
+  });
+});
+
+describe('EligibilityService.nextRelayState (transitions)', () => {
+  let service: EligibilityService;
+  beforeEach(() => {
+    service = new EligibilityService(
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      new EventEmitter2(),
+      { reconcileBatchSize: 500 } as any,
+    );
+  });
+
+  it('eligible + linked + no/removed row → pending_add', () => {
+    expect(
+      service.nextRelayState(true, true, 'member', { prevState: null }),
+    ).toBe('pending_add');
+    expect(
+      service.nextRelayState(true, true, 'member', { prevState: 'removed' }),
+    ).toBe('pending_add');
+    expect(
+      service.nextRelayState(true, true, 'member', {
+        prevState: 'pending_remove',
+      }),
+    ).toBe('pending_add');
+  });
+
+  it('eligible + linked + already added/pending_add → unchanged', () => {
+    expect(
+      service.nextRelayState(true, true, 'member', { prevState: 'added' }),
+    ).toBe('added');
+    expect(
+      service.nextRelayState(true, true, 'member', {
+        prevState: 'pending_add',
+      }),
+    ).toBe('pending_add');
+  });
+
+  it('unlinked invariant: eligible + no pubkey → always pending_add (never added/pending_remove)', () => {
+    expect(
+      service.nextRelayState(true, false, 'member', { prevState: null }),
+    ).toBe('pending_add');
+    expect(
+      service.nextRelayState(true, false, 'member', { prevState: 'added' }),
+    ).toBe('pending_add');
+    expect(
+      service.nextRelayState(true, false, 'member', {
+        prevState: 'pending_remove',
+      }),
+    ).toBe('pending_add');
+  });
+
+  it('ineligible member added/pending_add → pending_remove', () => {
+    expect(
+      service.nextRelayState(false, true, 'member', { prevState: 'added' }),
+    ).toBe('pending_remove');
+    expect(
+      service.nextRelayState(false, true, 'member', {
+        prevState: 'pending_add',
+      }),
+    ).toBe('pending_remove');
+  });
+
+  it('admin exemption: ineligible admin keeps its state (no pending_remove)', () => {
+    expect(
+      service.nextRelayState(false, true, 'admin', { prevState: 'added' }),
+    ).toBe('added');
+    expect(
+      service.nextRelayState(false, true, 'admin', {
+        prevState: 'pending_add',
+      }),
+    ).toBe('pending_add');
+  });
+});
+
+describe('EligibilityService.recomputeMember (mocked repos)', () => {
+  let communityRoomRepo: jest.Mocked<
+    Pick<Repository<CommunityRoom>, 'findOne'>
+  >;
+  let membershipRepo: jest.Mocked<
+    Pick<Repository<RoomMembership>, 'findOne' | 'update' | 'insert'>
+  >;
+  let tokenBalanceRepo: jest.Mocked<Pick<Repository<TokenBalance>, 'findOne'>>;
+  let identity: jest.Mocked<Pick<IdentityService, 'getPubkeyForAddress'>>;
+  let emitter: EventEmitter2;
+  let emitSpy: jest.SpyInstance;
+  let service: EligibilityService;
+
+  beforeEach(() => {
+    communityRoomRepo = { findOne: jest.fn() } as any;
+    membershipRepo = {
+      findOne: jest.fn(),
+      update: jest.fn().mockResolvedValue(undefined),
+      insert: jest.fn().mockResolvedValue(undefined),
+    } as any;
+    tokenBalanceRepo = { findOne: jest.fn() } as any;
+    identity = { getPubkeyForAddress: jest.fn().mockResolvedValue(HEX) } as any;
+    emitter = new EventEmitter2();
+    emitSpy = jest.spyOn(emitter, 'emit');
+    service = new EligibilityService(
+      communityRoomRepo as any,
+      membershipRepo as any,
+      tokenBalanceRepo as any,
+      identity as any,
+      emitter,
+      { reconcileBatchSize: 500 } as any,
+    );
+  });
+
+  it('eligible flip inserts a new row and emits tgr.eligibility.changed', async () => {
+    membershipRepo.findOne.mockResolvedValue(null);
+    tokenBalanceRepo.findOne.mockResolvedValue({
+      balance: new BigNumber('5000'),
+    } as any);
+
+    const flipped = await service.recomputeMember(makeRoom(), 'ak_member');
+
+    expect(flipped).toBe(true);
+    expect(membershipRepo.insert).toHaveBeenCalledTimes(1);
+    const inserted = membershipRepo.insert.mock.calls[0][0] as any;
+    expect(inserted.eligible).toBe(true);
+    expect(inserted.member_pubkey).toBe(HEX);
+    expect(inserted.relay_state).toBe('pending_add');
+    expect(emitSpy).toHaveBeenCalledWith(TGR_ELIGIBILITY_CHANGED, {
+      saleAddress: 'ct_sale',
+      memberAddress: 'ak_member',
+      eligible: true,
+    });
+  });
+
+  it('moderator → role=admin', async () => {
+    membershipRepo.findOne.mockResolvedValue(null);
+    tokenBalanceRepo.findOne.mockResolvedValue({
+      balance: new BigNumber('5000'),
+    } as any);
+
+    await service.recomputeMember(
+      makeRoom({ moderators: ['ak_member'] }),
+      'ak_member',
+    );
+
+    const inserted = membershipRepo.insert.mock.calls[0][0] as any;
+    expect(inserted.role).toBe('admin');
+  });
+
+  it('muted holder above threshold → eligible=false, no insert (never-created ineligible)', async () => {
+    membershipRepo.findOne.mockResolvedValue(null);
+    tokenBalanceRepo.findOne.mockResolvedValue({
+      balance: new BigNumber('5000'),
+    } as any);
+
+    const flipped = await service.recomputeMember(
+      makeRoom({ muted: ['ak_member'] }),
+      'ak_member',
+    );
+
+    expect(flipped).toBe(false);
+    expect(membershipRepo.insert).not.toHaveBeenCalled();
+    expect(emitSpy).not.toHaveBeenCalled();
+  });
+
+  it('muted flips an existing eligible+added row to pending_remove', async () => {
+    membershipRepo.findOne.mockResolvedValue(
+      makeMembership({
+        eligible: true,
+        relay_state: 'added',
+        member_pubkey: HEX as any,
+      }),
+    );
+    tokenBalanceRepo.findOne.mockResolvedValue({
+      balance: new BigNumber('5000'),
+    } as any);
+
+    const flipped = await service.recomputeMember(
+      makeRoom({ muted: ['ak_member'] }),
+      'ak_member',
+    );
+
+    expect(flipped).toBe(true);
+    const update = membershipRepo.update.mock.calls[0][1] as any;
+    expect(update.eligible).toBe(false);
+    expect(update.relay_state).toBe('pending_remove');
+    expect(emitSpy).toHaveBeenCalledWith(TGR_ELIGIBILITY_CHANGED, {
+      saleAddress: 'ct_sale',
+      memberAddress: 'ak_member',
+      eligible: false,
+    });
+  });
+
+  it('unlinked invariant: eligible holder with null pubkey → eligible=true, pending_add, no added/pending_remove, emits the flip', async () => {
+    identity.getPubkeyForAddress.mockResolvedValue(null);
+    membershipRepo.findOne.mockResolvedValue(null);
+    tokenBalanceRepo.findOne.mockResolvedValue({
+      balance: new BigNumber('5000'),
+    } as any);
+
+    const flipped = await service.recomputeMember(makeRoom(), 'ak_member');
+
+    expect(flipped).toBe(true);
+    const inserted = membershipRepo.insert.mock.calls[0][0] as any;
+    expect(inserted.eligible).toBe(true);
+    expect(inserted.member_pubkey).toBeNull();
+    expect(inserted.relay_state).toBe('pending_add');
+    expect(emitSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('unlinked + eligible never flips to pending_remove even if it was added', async () => {
+    identity.getPubkeyForAddress.mockResolvedValue(null);
+    membershipRepo.findOne.mockResolvedValue(
+      makeMembership({
+        eligible: true,
+        relay_state: 'added',
+        member_pubkey: null as any,
+      }),
+    );
+    tokenBalanceRepo.findOne.mockResolvedValue({
+      balance: new BigNumber('5000'),
+    } as any);
+
+    const flipped = await service.recomputeMember(makeRoom(), 'ak_member');
+
+    // eligible flag did not flip (still eligible) but relay_state pulled back.
+    expect(flipped).toBe(false);
+    const update = membershipRepo.update.mock.calls[0][1] as any;
+    expect(update.eligible).toBe(true);
+    expect(update.relay_state).toBe('pending_add');
+  });
+
+  it('admin exemption: admin whose balance drops below threshold is not set to pending_remove', async () => {
+    membershipRepo.findOne.mockResolvedValue(
+      makeMembership({
+        role: 'admin',
+        eligible: true,
+        relay_state: 'added',
+        member_pubkey: HEX as any,
+      }),
+    );
+    // balance below threshold
+    tokenBalanceRepo.findOne.mockResolvedValue({
+      balance: new BigNumber('0'),
+    } as any);
+
+    const flipped = await service.recomputeMember(
+      makeRoom({ moderators: ['ak_member'] }),
+      'ak_member',
+    );
+
+    expect(flipped).toBe(true); // eligible flipped to false
+    const update = membershipRepo.update.mock.calls[0][1] as any;
+    expect(update.eligible).toBe(false);
+    expect(update.role).toBe('admin');
+    expect(update.relay_state).toBe('added'); // NOT pending_remove
+  });
+
+  it('idempotency: re-running with unchanged inputs writes nothing and emits nothing', async () => {
+    membershipRepo.findOne.mockResolvedValue(
+      makeMembership({
+        eligible: true,
+        relay_state: 'added',
+        role: 'member',
+        member_pubkey: HEX as any,
+      }),
+    );
+    tokenBalanceRepo.findOne.mockResolvedValue({
+      balance: new BigNumber('5000'),
+    } as any);
+
+    const flipped = await service.recomputeMember(makeRoom(), 'ak_member');
+
+    expect(flipped).toBe(false);
+    expect(membershipRepo.update).not.toHaveBeenCalled();
+    expect(membershipRepo.insert).not.toHaveBeenCalled();
+    expect(emitSpy).not.toHaveBeenCalled();
+  });
+
+  it('deleted room → existing eligible member desired-removed (eligible=false)', async () => {
+    membershipRepo.findOne.mockResolvedValue(
+      makeMembership({
+        eligible: true,
+        relay_state: 'added',
+        member_pubkey: HEX as any,
+      }),
+    );
+    // balance well above threshold — irrelevant because room.deleted
+    tokenBalanceRepo.findOne.mockResolvedValue({
+      balance: new BigNumber('999999'),
+    } as any);
+
+    const flipped = await service.recomputeMember(
+      makeRoom({ deleted: true }),
+      'ak_member',
+    );
+
+    expect(flipped).toBe(true);
+    expect(tokenBalanceRepo.findOne).not.toHaveBeenCalled(); // short-circuit
+    const update = membershipRepo.update.mock.calls[0][1] as any;
+    expect(update.eligible).toBe(false);
+    expect(update.relay_state).toBe('pending_remove');
+  });
+
+  it('link→invite: an already-eligible UNLINKED row that links emits tgr.eligibility.changed (publishableAdd) with NO eligible-flip', async () => {
+    // The §6.6 case the reactive link→invite fix targets: holder already eligible
+    // (eligible=true) but unpublished (member_pubkey=null, pending_add). They link
+    // their Nostr key → pubkey resolves now. `eligible` does NOT flip, but the row
+    // becomes a publishable pending_add, so membership-sync MUST be notified.
+    identity.getPubkeyForAddress.mockResolvedValue(HEX); // now linked
+    membershipRepo.findOne.mockResolvedValue(
+      makeMembership({
+        eligible: true,
+        relay_state: 'pending_add',
+        member_pubkey: null as any,
+      }),
+    );
+    tokenBalanceRepo.findOne.mockResolvedValue({
+      balance: new BigNumber('5000'),
+    } as any);
+
+    const flipped = await service.recomputeMember(makeRoom(), 'ak_member');
+
+    expect(flipped).toBe(false); // eligible did not flip — it was already eligible
+    // …but the row went unpublishable → publishable, so the emit MUST fire so
+    // membership-sync publishes the 9000 reactively (not only on the periodic scan).
+    expect(emitSpy).toHaveBeenCalledWith(TGR_ELIGIBILITY_CHANGED, {
+      saleAddress: 'ct_sale',
+      memberAddress: 'ak_member',
+      eligible: true,
+    });
+    const update = membershipRepo.update.mock.calls[0][1] as any;
+    expect(update.member_pubkey).toBe(HEX);
+    expect(update.relay_state).toBe('pending_add');
+  });
+
+  it('no spurious emit: a stable already-added linked member recompute emits nothing', async () => {
+    // Guards the publishableAdd condition against over-emitting: an `added` row that
+    // re-computes unchanged must neither write nor emit (Req 10 idempotency).
+    membershipRepo.findOne.mockResolvedValue(
+      makeMembership({
+        eligible: true,
+        relay_state: 'added',
+        role: 'member',
+        member_pubkey: HEX as any,
+      }),
+    );
+    tokenBalanceRepo.findOne.mockResolvedValue({
+      balance: new BigNumber('5000'),
+    } as any);
+
+    const flipped = await service.recomputeMember(makeRoom(), 'ak_member');
+
+    expect(flipped).toBe(false);
+    expect(membershipRepo.update).not.toHaveBeenCalled();
+    expect(emitSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('EligibilityService.recomputeRoom (cursor batching, mocked QB)', () => {
+  it('iterates batches until a short batch and recomputes every member', async () => {
+    const room = makeRoom();
+    const communityRoomRepo = { findOne: jest.fn().mockResolvedValue(room) };
+
+    // 3 members; batchSize 2 → two batches (2 then 1).
+    const members = ['ak_a', 'ak_b', 'ak_c'].map((member_address) =>
+      makeMembership({
+        member_address,
+        eligible: false,
+        relay_state: 'removed',
+      }),
+    );
+
+    const getMany = jest
+      .fn()
+      // batch 1: > '' → first 2
+      .mockResolvedValueOnce([members[0], members[1]])
+      // batch 2: > 'ak_b' → last 1
+      .mockResolvedValueOnce([members[2]]);
+
+    const qb: any = {
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      getMany,
+    };
+    const membershipRepo = {
+      createQueryBuilder: jest.fn().mockReturnValue(qb),
+      update: jest.fn().mockResolvedValue(undefined),
+      insert: jest.fn().mockResolvedValue(undefined),
+    };
+    // all 3 above threshold → all flip to eligible
+    const tokenBalanceRepo = {
+      findOne: jest.fn().mockResolvedValue({ balance: new BigNumber('5000') }),
+    };
+    const identity = {
+      getPubkeyForAddress: jest.fn().mockResolvedValue(HEX),
+    };
+    const emitter = new EventEmitter2();
+    const emitSpy = jest.spyOn(emitter, 'emit');
+
+    const service = new EligibilityService(
+      communityRoomRepo as any,
+      membershipRepo as any,
+      tokenBalanceRepo as any,
+      identity as any,
+      emitter,
+      { reconcileBatchSize: 2 } as any,
+    );
+
+    const flips = await service.recomputeRoom('ct_sale');
+
+    expect(getMany).toHaveBeenCalledTimes(2);
+    expect(flips).toBe(3);
+    expect(membershipRepo.update).toHaveBeenCalledTimes(3);
+    expect(emitSpy).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('EligibilityService.recomputeRoomFromHolders (seed, batched reads)', () => {
+  it('seeds members from the holder ledger with NO per-member token_holder/membership reads', async () => {
+    const room = makeRoom(); // threshold 1000
+    const communityRoomRepo = { findOne: jest.fn().mockResolvedValue(room) };
+    // One positive holder (eligible) + one zero-balance row (not a holder).
+    const tokenHolderRepo = {
+      find: jest.fn().mockResolvedValue([
+        { address: 'ak_holder', balance: new BigNumber('5000') },
+        { address: 'ak_zero', balance: new BigNumber('0') },
+      ]),
+      findOne: jest.fn(), // MUST NOT be called — balances are pre-loaded
+    };
+    const membershipRepo = {
+      find: jest.fn().mockResolvedValue([]), // no existing rows
+      findOne: jest.fn(), // MUST NOT be called — `existing` passed as null
+      update: jest.fn().mockResolvedValue(undefined),
+      insert: jest.fn().mockResolvedValue(undefined),
+    };
+    const identity = { getPubkeyForAddress: jest.fn().mockResolvedValue(HEX) };
+    const emitter = new EventEmitter2();
+    const service = new EligibilityService(
+      communityRoomRepo as any,
+      membershipRepo as any,
+      tokenHolderRepo as any,
+      identity as any,
+      emitter,
+      { reconcileBatchSize: 500 } as any,
+    );
+
+    const flips = await service.recomputeRoomFromHolders('ct_sale');
+
+    // Only the positive holder is in the recompute set and becomes eligible.
+    expect(flips).toBe(1);
+    expect(membershipRepo.insert).toHaveBeenCalledTimes(1);
+    expect(membershipRepo.insert.mock.calls[0][0].member_address).toBe(
+      'ak_holder',
+    );
+    expect(membershipRepo.insert.mock.calls[0][0].eligible).toBe(true);
+    // The whole point: batched — zero per-member reads.
+    expect(tokenHolderRepo.findOne).not.toHaveBeenCalled();
+    expect(membershipRepo.findOne).not.toHaveBeenCalled();
+    expect(tokenHolderRepo.find).toHaveBeenCalledTimes(1);
+    expect(membershipRepo.find).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/token-gated-rooms/services/eligibility.service.spec.ts
+++ b/src/token-gated-rooms/services/eligibility.service.spec.ts
@@ -529,14 +529,14 @@ describe('EligibilityService.recomputeRoom (cursor batching, mocked QB)', () => 
 });
 
 describe('EligibilityService.recomputeRoomFromHolders (seed, batched reads)', () => {
-  it('seeds members from the holder ledger with NO per-member token_holder/membership reads', async () => {
+  it('seeds members from the holder ledger with NO per-member token_balance/membership reads', async () => {
     const room = makeRoom(); // threshold 1000
     const communityRoomRepo = { findOne: jest.fn().mockResolvedValue(room) };
     // One positive holder (eligible) + one zero-balance row (not a holder).
-    const tokenHolderRepo = {
+    const tokenBalanceRepo = {
       find: jest.fn().mockResolvedValue([
-        { address: 'ak_holder', balance: new BigNumber('5000') },
-        { address: 'ak_zero', balance: new BigNumber('0') },
+        { holder_address: 'ak_holder', balance: new BigNumber('5000') },
+        { holder_address: 'ak_zero', balance: new BigNumber('0') },
       ]),
       findOne: jest.fn(), // MUST NOT be called — balances are pre-loaded
     };
@@ -551,7 +551,7 @@ describe('EligibilityService.recomputeRoomFromHolders (seed, batched reads)', ()
     const service = new EligibilityService(
       communityRoomRepo as any,
       membershipRepo as any,
-      tokenHolderRepo as any,
+      tokenBalanceRepo as any,
       identity as any,
       emitter,
       { reconcileBatchSize: 500 } as any,
@@ -567,9 +567,9 @@ describe('EligibilityService.recomputeRoomFromHolders (seed, batched reads)', ()
     );
     expect(membershipRepo.insert.mock.calls[0][0].eligible).toBe(true);
     // The whole point: batched — zero per-member reads.
-    expect(tokenHolderRepo.findOne).not.toHaveBeenCalled();
+    expect(tokenBalanceRepo.findOne).not.toHaveBeenCalled();
     expect(membershipRepo.findOne).not.toHaveBeenCalled();
-    expect(tokenHolderRepo.find).toHaveBeenCalledTimes(1);
+    expect(tokenBalanceRepo.find).toHaveBeenCalledTimes(1);
     expect(membershipRepo.find).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/token-gated-rooms/services/eligibility.service.ts
+++ b/src/token-gated-rooms/services/eligibility.service.ts
@@ -10,7 +10,7 @@ import {
   RoomMembershipRelayState,
   RoomMembershipRole,
 } from '../entities/room-membership.entity';
-import { TokenHolder } from '@/tokens/entities/token-holders.entity';
+import { TokenBalance } from '../entities/token-balance.entity';
 import { IdentityService } from './identity.service';
 import tgrConfig from '../config/tgr.config';
 import {
@@ -102,8 +102,8 @@ export class EligibilityService {
     private readonly communityRoomRepo: Repository<CommunityRoom>,
     @InjectRepository(RoomMembership)
     private readonly membershipRepo: Repository<RoomMembership>,
-    @InjectRepository(TokenHolder)
-    private readonly tokenHolderRepo: Repository<TokenHolder>,
+    @InjectRepository(TokenBalance)
+    private readonly tokenBalanceRepo: Repository<TokenBalance>,
     private readonly identity: IdentityService,
     private readonly eventEmitter: EventEmitter2,
     @Inject(tgrConfig.KEY)
@@ -272,7 +272,7 @@ export class EligibilityService {
    * `room_membership` rows, so it cannot bootstrap a brand-new room whose holders
    * predate it (the common case for the existing 54k-token registry). This walks
    * the union of:
-   *   - current positive holders of the room's AEX9 token (`token_holder`),
+   *   - current positive holders of the room's AEX9 token (`token_balance`),
    *   - existing membership rows (so a holder who dropped to zero is demoted), and
    *   - configured moderators (admins keep a row regardless of balance, §6.7),
    * recomputing each. Returns the number of `eligible` flips.
@@ -290,17 +290,17 @@ export class EligibilityService {
     const addresses = new Set<string>();
 
     // 1) All holders of the room's AEX9 token — load balances ONCE into a map so
-    //    the per-member recompute below never re-reads token_holder (perf).
-    const holders = await this.tokenHolderRepo.find({
-      where: { aex9_address: room.token_address },
-      select: ['address', 'balance'],
+    //    the per-member recompute below never re-reads token_balance (perf).
+    const holders = await this.tokenBalanceRepo.find({
+      where: { token_address: room.token_address },
+      select: ['holder_address', 'balance'],
     });
     const balanceByAddress = new Map<string, BigNumber>();
     for (const holder of holders) {
       const bal = new BigNumber(holder.balance ?? 0);
-      balanceByAddress.set(holder.address, bal);
+      balanceByAddress.set(holder.holder_address, bal);
       if (bal.gt(0)) {
-        addresses.add(holder.address);
+        addresses.add(holder.holder_address);
       }
     }
 
@@ -382,24 +382,25 @@ export class EligibilityService {
     if (room.deleted) {
       eligible = false;
     } else {
-      // Eligibility reads the canonical, already-populated holder ledger
-      // (`token_holder`, maintained by the BCL indexer + MDW reconcile) rather than
-      // a TGR-private balance table. `community_room.token_address` IS the AEX9
-      // contract address (room-state.service sets it from `Token.address`), so it
-      // maps directly to `token_holder.aex9_address`. Raw-vs-raw compare — both are
-      // base units (token_holder stores balance × 10^decimals).
+      // Eligibility reads `token_balance`, the ledger kept current by the AEX9
+      // transfer plugin for EVERY transfer (plain wallet-to-wallet, DEX swap,
+      // airdrop) — not `token_holder`, which only reacts to BCL buy/sell calls
+      // and would go stale on any other transfer. `community_room.token_address`
+      // IS the AEX9 contract address (room-state.service sets it from
+      // `Token.address`), so it maps directly to `token_balance.token_address`.
+      // Raw-vs-raw compare — both are base units.
       // Perf: the seed/batch path (recomputeRoomFromHolders) has ALREADY loaded
       // every holder's balance, so it passes `balanceRaw` to skip a per-member
-      // token_holder read (O(N) reads → 0 for a whole-room recompute). When not
+      // token_balance read (O(N) reads → 0 for a whole-room recompute). When not
       // provided (the single-member reactive paths), read it here.
       const holderBalance =
         balanceRaw !== undefined
           ? balanceRaw
           : ((
-              await this.tokenHolderRepo.findOne({
+              await this.tokenBalanceRepo.findOne({
                 where: {
-                  aex9_address: room.token_address,
-                  address: memberAddress,
+                  token_address: room.token_address,
+                  holder_address: memberAddress,
                 },
               })
             )?.balance ?? null);

--- a/src/token-gated-rooms/services/eligibility.service.ts
+++ b/src/token-gated-rooms/services/eligibility.service.ts
@@ -1,0 +1,581 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { EventEmitter2, OnEvent } from '@nestjs/event-emitter';
+import { ConfigType } from '@nestjs/config';
+import { Repository } from 'typeorm';
+import { BigNumber } from 'bignumber.js';
+import { CommunityRoom } from '../entities/community-room.entity';
+import {
+  RoomMembership,
+  RoomMembershipRelayState,
+  RoomMembershipRole,
+} from '../entities/room-membership.entity';
+import { TokenHolder } from '@/tokens/entities/token-holders.entity';
+import { IdentityService } from './identity.service';
+import tgrConfig from '../config/tgr.config';
+import {
+  TGR_BALANCE_CHANGED,
+  TGR_COMMUNITY_UPSERTED,
+  TGR_ELIGIBILITY_CHANGED,
+  TGR_LINK_CHANGED,
+  TgrBalanceChangedPayload,
+  TgrCommunityUpsertedPayload,
+  TgrEligibilityChangedPayload,
+  TgrLinkChangedPayload,
+} from '../events';
+
+/**
+ * Replicate the bot's `toShiftedBigNumber(value, precision)` (matrix-defi-bot
+ * `src/utils/aeternity.ts` lines 91-96): `new BigNumber(value).shiftedBy(Number(precision))`.
+ *
+ * Used ONLY where a human-unit amount must be converted to raw base units (e.g.
+ * a threshold that ever arrives in human units). The hot eligibility comparison
+ * is RAW-vs-RAW and never shifts (plan §5.4) — `Token.decimals` is a string, so
+ * coerce with `Number(...)` exactly as the bot does.
+ */
+export function toShiftedBigNumber(
+  value: BigNumber.Value,
+  decimals: number | string | bigint,
+): BigNumber {
+  return new BigNumber(value).shiftedBy(Number(decimals));
+}
+
+/**
+ * Pure eligibility predicate (plan §5.1, Task 06 req §2/§3). Decoupled from any
+ * I/O so unit tests can exercise the threshold/decimals/mute edges directly.
+ *
+ * `eligible` iff the holder's **raw** balance meets the room's **raw** threshold
+ * AND the member is not in the room's `muted` set. NO shifting at compare time —
+ * both inputs are already raw integer base units (plan §5.4). A `null`/`undefined`
+ * balance is treated as zero (the holder has no row yet).
+ */
+export function isEligible(
+  balanceRaw: BigNumber.Value | null | undefined,
+  thresholdRaw: BigNumber.Value | null | undefined,
+  muted: readonly string[] | null | undefined,
+  memberAddress: string,
+): boolean {
+  if (muted && muted.includes(memberAddress)) {
+    return false;
+  }
+  const balance = new BigNumber(balanceRaw ?? 0);
+  const threshold = new BigNumber(thresholdRaw ?? 0);
+  return balance.gte(threshold);
+}
+
+/**
+ * The single source of truth for *who should be in which room* (plan §5.1, Task
+ * 06). Computes `eligible` per `(sale_address, member_address)` from raw token
+ * balances vs. the room threshold (minus muted users), writes the **desired-state**
+ * rows into `room_membership` (`eligible`, `role`, `member_pubkey`), applies the
+ * desired `relay_state` transitions, and emits `tgr.eligibility.changed` ONLY on a
+ * real flip. It reacts to balance / community / link changes via cursor-batched
+ * recompute.
+ *
+ * ## Boundaries (out of scope here — owned elsewhere)
+ * - It does **not** talk to the relay. Relay `9000`/`9001` publishing and the
+ *   `relay_state` transitions to `added`/`removed` are Task 10 (membership-sync),
+ *   which consumes `tgr.eligibility.changed`.
+ * - It does **not** produce `tgr.balance.changed` (Task 03) or
+ *   `tgr.community.upserted` (Task 04); it only consumes them.
+ * - It only *reads* the resolved pubkey from {@link IdentityService} (Task 05).
+ *
+ * ## Unlinked-but-eligible invariant (plan §6.6 — VERIFIED)
+ * Private-room access needs BOTH balance AND a Nostr link. An eligible holder with
+ * no resolvable `member_pubkey` is recorded `eligible=true, member_pubkey=null,
+ * relay_state='pending_add'` and is **never** advanced to `added` and **never**
+ * flipped to `pending_remove` purely for the missing link. Task 10 skips such rows.
+ *
+ * ## Room-admin exemption (plan §6.7)
+ * A row whose `role='admin'` is never set to `pending_remove` merely because its
+ * balance dropped below threshold — configured room admins stay published.
+ *
+ * Registered as a MAIN-role provider (indexer concern; loads in `'main'` and
+ * `'combined'`), `export: true`.
+ */
+@Injectable()
+export class EligibilityService {
+  private readonly logger = new Logger(EligibilityService.name);
+
+  constructor(
+    @InjectRepository(CommunityRoom)
+    private readonly communityRoomRepo: Repository<CommunityRoom>,
+    @InjectRepository(RoomMembership)
+    private readonly membershipRepo: Repository<RoomMembership>,
+    @InjectRepository(TokenHolder)
+    private readonly tokenHolderRepo: Repository<TokenHolder>,
+    private readonly identity: IdentityService,
+    private readonly eventEmitter: EventEmitter2,
+    @Inject(tgrConfig.KEY)
+    private readonly config: ConfigType<typeof tgrConfig>,
+  ) {}
+
+  /**
+   * Cursor batch size for room-scoped recompute (plan §5.1). Reuses the existing
+   * `reconcileBatchSize` knob (Task 01, default 500) rather than inventing a new
+   * env var — the goal is short-held locks during Transfer bursts.
+   */
+  private get batchSize(): number {
+    return this.config.reconcileBatchSize;
+  }
+
+  // ── trigger surfaces (req §6) ──────────────────────────────────────────────
+
+  /**
+   * A holder's AEX9 balance changed (Task 03). Recompute their eligibility across
+   * every room backed by that token's AEX9 `address`
+   * (`community_room.token_address`). The payload carries the AEX9 contract
+   * `tokenAddress` + `holderAddress`.
+   */
+  @OnEvent(TGR_BALANCE_CHANGED, { async: true, promisify: true })
+  async onBalanceChanged(payload: TgrBalanceChangedPayload): Promise<void> {
+    const tokenAddress = payload?.tokenAddress;
+    const holderAddress = payload?.holderAddress;
+    if (!tokenAddress || !holderAddress) {
+      return;
+    }
+    try {
+      const rooms = await this.communityRoomRepo.find({
+        where: { token_address: tokenAddress },
+      });
+      for (const room of rooms) {
+        await this.recomputeMember(room, holderAddress);
+      }
+    } catch (error: any) {
+      this.logger.error(
+        `onBalanceChanged(${tokenAddress}, ${holderAddress}) failed`,
+        error,
+      );
+    }
+  }
+
+  /**
+   * A community-room desired-state row was created/updated (Task 04). Its
+   * `min_token_threshold`, `moderators`, `muted`, or `deleted` may have changed →
+   * full cursor-batched recompute of all members of that room (plan §5.1).
+   */
+  @OnEvent(TGR_COMMUNITY_UPSERTED, { async: true, promisify: true })
+  async onCommunityUpserted(
+    payload: TgrCommunityUpsertedPayload,
+  ): Promise<void> {
+    const saleAddress = payload?.saleAddress;
+    if (!saleAddress) {
+      return;
+    }
+    try {
+      // Seed/refresh from the live holder set (not just rows already in
+      // `room_membership`) so a freshly-created room — backfill or live
+      // `create_community` — gets a membership row for every current holder, not
+      // an empty roster. This is the bootstrap path for the existing token
+      // registry (holders predate the room).
+      await this.recomputeRoomFromHolders(saleAddress);
+    } catch (error: any) {
+      this.logger.error(`onCommunityUpserted(${saleAddress}) failed`, error);
+    }
+  }
+
+  /**
+   * An address↔nostr link changed (Task 05). {@link IdentityService} has already
+   * mirrored the new `member_pubkey` onto every `room_membership` row for this
+   * address; we re-evaluate eligibility for that member across its rooms so the
+   * `relay_state` transition + emit fire for the (un)linked holder (e.g. an
+   * eligible-but-unlinked holder linking becomes publishable).
+   *
+   * NOTE: IdentityService also consumes this same event independently; we both
+   * react to the single emit (no re-broadcast loop) — see its class doc.
+   */
+  @OnEvent(TGR_LINK_CHANGED, { async: true, promisify: true })
+  async onLinkChanged(payload: TgrLinkChangedPayload): Promise<void> {
+    const address = payload?.address;
+    if (!address) {
+      return;
+    }
+    try {
+      const rows = await this.membershipRepo.find({
+        where: { member_address: address },
+        select: ['sale_address'],
+      });
+      const saleAddresses = [...new Set(rows.map((r) => r.sale_address))];
+      for (const saleAddress of saleAddresses) {
+        const room = await this.communityRoomRepo.findOne({
+          where: { sale_address: saleAddress },
+        });
+        if (room) {
+          await this.recomputeMember(room, address);
+        }
+      }
+    } catch (error: any) {
+      this.logger.error(`onLinkChanged(${address}) failed`, error);
+    }
+  }
+
+  // ── recompute paths ────────────────────────────────────────────────────────
+
+  /**
+   * Cursor-batched recompute of all members of one room (plan §5.1). Iterates
+   * `WHERE sale_address=:x AND member_address > :cursor ORDER BY member_address
+   * ASC LIMIT :N`, applying the upsert/transition per batch and advancing the
+   * cursor to the last `member_address`, until a batch yields fewer than `N` rows.
+   * Short-held locks avoid contention during Transfer bursts.
+   *
+   * Returns the number of `(sale_address, member_address)` rows whose `eligible`
+   * flag flipped (for tests/observability).
+   */
+  async recomputeRoom(saleAddress: string): Promise<number> {
+    const room = await this.communityRoomRepo.findOne({
+      where: { sale_address: saleAddress },
+    });
+    if (!room) {
+      return 0;
+    }
+
+    const limit = this.batchSize;
+    let cursor = '';
+    let flips = 0;
+
+    for (;;) {
+      const batch = await this.membershipRepo
+        .createQueryBuilder('m')
+        .where('m.sale_address = :sale', { sale: saleAddress })
+        .andWhere('m.member_address > :cursor', { cursor })
+        .orderBy('m.member_address', 'ASC')
+        .limit(limit)
+        .getMany();
+
+      if (batch.length === 0) {
+        break;
+      }
+
+      for (const existing of batch) {
+        const flipped = await this.recomputeMember(
+          room,
+          existing.member_address,
+          existing,
+        );
+        if (flipped) {
+          flips += 1;
+        }
+      }
+
+      cursor = batch[batch.length - 1].member_address;
+      if (batch.length < limit) {
+        break;
+      }
+    }
+
+    return flips;
+  }
+
+  /**
+   * Seed/recompute a room's desired membership from the **live holder set** plus
+   * any rows already tracked. `recomputeRoom` only revisits existing
+   * `room_membership` rows, so it cannot bootstrap a brand-new room whose holders
+   * predate it (the common case for the existing 54k-token registry). This walks
+   * the union of:
+   *   - current positive holders of the room's AEX9 token (`token_holder`),
+   *   - existing membership rows (so a holder who dropped to zero is demoted), and
+   *   - configured moderators (admins keep a row regardless of balance, §6.7),
+   * recomputing each. Returns the number of `eligible` flips.
+   *
+   * MAIN-process bootstrap/seed path; consumed by `onCommunityUpserted`.
+   */
+  async recomputeRoomFromHolders(saleAddress: string): Promise<number> {
+    const room = await this.communityRoomRepo.findOne({
+      where: { sale_address: saleAddress },
+    });
+    if (!room) {
+      return 0;
+    }
+
+    const addresses = new Set<string>();
+
+    // 1) All holders of the room's AEX9 token — load balances ONCE into a map so
+    //    the per-member recompute below never re-reads token_holder (perf).
+    const holders = await this.tokenHolderRepo.find({
+      where: { aex9_address: room.token_address },
+      select: ['address', 'balance'],
+    });
+    const balanceByAddress = new Map<string, BigNumber>();
+    for (const holder of holders) {
+      const bal = new BigNumber(holder.balance ?? 0);
+      balanceByAddress.set(holder.address, bal);
+      if (bal.gt(0)) {
+        addresses.add(holder.address);
+      }
+    }
+
+    // 2) Existing membership rows (handle drops / mutes / unlinks on re-run) —
+    //    load FULL rows ONCE into a map so the recompute passes them as `existing`
+    //    instead of re-reading per member.
+    const existingRows = await this.membershipRepo.find({
+      where: { sale_address: saleAddress },
+    });
+    const membershipByAddress = new Map<string, RoomMembership>();
+    for (const row of existingRows) {
+      membershipByAddress.set(row.member_address, row);
+      addresses.add(row.member_address);
+    }
+
+    // 3) Configured moderators stay published even at zero balance (§6.7).
+    for (const moderator of room.moderators ?? []) {
+      addresses.add(moderator);
+    }
+
+    let flips = 0;
+    for (const address of addresses) {
+      // Pass the pre-loaded membership row + balance (0 for a union member with no
+      // positive holder row) so recomputeMember does no per-member reads here.
+      const flipped = await this.recomputeMember(
+        room,
+        address,
+        membershipByAddress.get(address) ?? null,
+        balanceByAddress.get(address) ?? new BigNumber(0),
+      );
+      if (flipped) {
+        flips += 1;
+      }
+    }
+    return flips;
+  }
+
+  /**
+   * Recompute the desired state for a single `(room, member_address)`. Reads the
+   * raw balance + resolved pubkey, derives `eligible`/`role`/`relay_state`, and
+   * upserts the row ONLY when something actually changed (idempotency, req §9).
+   * Emits `tgr.eligibility.changed` ONLY when the `eligible` flag flipped (req §8).
+   *
+   * @param existing optional already-loaded row (cursor-batch path) to avoid a
+   *   re-read; when omitted we load it by `(sale_address, member_address)`.
+   * @returns `true` iff the `eligible` flag flipped.
+   */
+  async recomputeMember(
+    room: CommunityRoom,
+    memberAddress: string,
+    existing?: RoomMembership | null,
+    balanceRaw?: BigNumber.Value | null,
+  ): Promise<boolean> {
+    // `existing === undefined` ⇒ not provided, load it. `existing === null` ⇒ the
+    // caller already loaded the full room roster and this member has NO row (the
+    // batch/seed path) — skip the per-member read entirely.
+    const current =
+      existing === undefined
+        ? await this.membershipRepo.findOne({
+            where: {
+              sale_address: room.sale_address,
+              member_address: memberAddress,
+            },
+          })
+        : existing;
+
+    // Resolved hex pubkey (or null) for the member — read-only (Task 05).
+    const memberPubkey = await this.identity.getPubkeyForAddress(memberAddress);
+
+    // Role: configured moderator → admin, else member.
+    const role: RoomMembershipRole = (room.moderators ?? []).includes(
+      memberAddress,
+    )
+      ? 'admin'
+      : 'member';
+
+    // A deleted room desired-removes every member (req §2).
+    let eligible: boolean;
+    if (room.deleted) {
+      eligible = false;
+    } else {
+      // Eligibility reads the canonical, already-populated holder ledger
+      // (`token_holder`, maintained by the BCL indexer + MDW reconcile) rather than
+      // a TGR-private balance table. `community_room.token_address` IS the AEX9
+      // contract address (room-state.service sets it from `Token.address`), so it
+      // maps directly to `token_holder.aex9_address`. Raw-vs-raw compare — both are
+      // base units (token_holder stores balance × 10^decimals).
+      // Perf: the seed/batch path (recomputeRoomFromHolders) has ALREADY loaded
+      // every holder's balance, so it passes `balanceRaw` to skip a per-member
+      // token_holder read (O(N) reads → 0 for a whole-room recompute). When not
+      // provided (the single-member reactive paths), read it here.
+      const holderBalance =
+        balanceRaw !== undefined
+          ? balanceRaw
+          : ((
+              await this.tokenHolderRepo.findOne({
+                where: {
+                  aex9_address: room.token_address,
+                  address: memberAddress,
+                },
+              })
+            )?.balance ?? null);
+      eligible = isEligible(
+        holderBalance,
+        room.min_token_threshold,
+        room.muted,
+        memberAddress,
+      );
+    }
+
+    const prevState: RoomMembershipRelayState | null =
+      current?.relay_state ?? null;
+    const relayState = this.nextRelayState(eligible, !!memberPubkey, role, {
+      prevState,
+    });
+
+    const prevEligible = current?.eligible ?? false;
+    const flipped = prevEligible !== eligible;
+
+    // Idempotency (req §9): only write when a tracked field actually changes.
+    const changed =
+      !current ||
+      current.eligible !== eligible ||
+      current.role !== role ||
+      (current.member_pubkey ?? null) !== (memberPubkey ?? null) ||
+      current.relay_state !== relayState;
+
+    if (!changed) {
+      return false;
+    }
+
+    // A row that was never created and is ineligible (e.g. a deleted room with no
+    // prior membership) has nothing to desired-remove — skip creating it.
+    if (!current && !eligible) {
+      return false;
+    }
+
+    await this.upsertMembership({
+      saleAddress: room.sale_address,
+      memberAddress,
+      eligible,
+      role,
+      memberPubkey,
+      relayState,
+      existing: current,
+    });
+
+    // Notify membership-sync (Task 10) whenever there is something to publish, not
+    // only on an eligible-flip. The link→invite case (§6.6): an already-eligible
+    // holder who links their Nostr key does NOT flip `eligible`, but the row goes
+    // from unpublishable (no pubkey) to a publishable `pending_add` — without this
+    // it would only be picked up by the periodic scan (≤reconcileInterval later),
+    // never reactively. Race-safe: keyed off the freshly-computed state (eligible +
+    // resolved pubkey + pending_add), not the prior row's `member_pubkey` (which a
+    // concurrent IdentityService link handler may already have written).
+    const publishableAdd =
+      eligible && !!memberPubkey && relayState === 'pending_add';
+    if (flipped || publishableAdd) {
+      this.emitEligibilityChanged(room.sale_address, memberAddress, eligible);
+    }
+
+    return flipped;
+  }
+
+  // ── desired-state transitions (req §5) ─────────────────────────────────────
+
+  /**
+   * Compute the desired `relay_state` (plan §4.3 — relay `39002` is the real
+   * source of truth; this is desired-state only). This task only makes the
+   * pending_* transitions; Task 10 advances pending → added/removed on ACK.
+   *
+   * - eligible & current ∈ {removed, pending_remove} (or none) → `pending_add`.
+   * - ineligible & current ∈ {added, pending_add} → `pending_remove`.
+   * - **Unlinked invariant (§6.6):** eligible but no pubkey → stay `pending_add`
+   *   (never `added`); never flip an unlinked eligible member to `pending_remove`.
+   * - **Admin exemption (§6.7):** a `role='admin'` row is never set to
+   *   `pending_remove` purely for a balance drop — keep its current state.
+   * - otherwise keep the current state (a pending/added row stays put).
+   */
+  nextRelayState(
+    eligible: boolean,
+    hasPubkey: boolean,
+    role: RoomMembershipRole,
+    opts: { prevState: RoomMembershipRelayState | null },
+  ): RoomMembershipRelayState {
+    const prev = opts.prevState;
+
+    if (eligible) {
+      // Unlinked-but-eligible: must remain unpublished until linked (§6.6).
+      // Never flip an unlinked eligible member to pending_remove; pin to
+      // pending_add regardless of the prior state.
+      if (!hasPubkey) {
+        return 'pending_add';
+      }
+      // Linked + eligible: schedule an add unless already added / pending_add.
+      if (prev === 'added' || prev === 'pending_add') {
+        return prev;
+      }
+      return 'pending_add';
+    }
+
+    // Ineligible. Admins are exempt from balance-gated removal (§6.7): keep state.
+    if (role === 'admin') {
+      return prev ?? 'pending_add';
+    }
+
+    if (prev === 'added' || prev === 'pending_add') {
+      return 'pending_remove';
+    }
+    // Already removed / pending_remove / no row → desired-removed.
+    return prev ?? 'removed';
+  }
+
+  // ── persistence ────────────────────────────────────────────────────────────
+
+  /**
+   * Upsert a single desired-state `room_membership` row. Updates the existing row
+   * in place (preserving id + relay bookkeeping owned by Task 10/11) or inserts a
+   * new one. Always refreshes `updated_at` (req §4).
+   */
+  private async upsertMembership(args: {
+    saleAddress: string;
+    memberAddress: string;
+    eligible: boolean;
+    role: RoomMembershipRole;
+    memberPubkey: string | null;
+    relayState: RoomMembershipRelayState;
+    existing?: RoomMembership | null;
+  }): Promise<void> {
+    const {
+      saleAddress,
+      memberAddress,
+      eligible,
+      role,
+      memberPubkey,
+      relayState,
+      existing,
+    } = args;
+
+    if (existing) {
+      await this.membershipRepo.update(
+        { id: existing.id },
+        {
+          eligible,
+          role,
+          member_pubkey: memberPubkey ?? null,
+          relay_state: relayState,
+          updated_at: new Date(),
+        },
+      );
+      return;
+    }
+
+    await this.membershipRepo.insert({
+      sale_address: saleAddress,
+      member_address: memberAddress,
+      eligible,
+      role,
+      member_pubkey: memberPubkey ?? null,
+      relay_state: relayState,
+      updated_at: new Date(),
+    });
+  }
+
+  /** Emit the canonical `tgr.eligibility.changed` (thin payload, Shared contracts). */
+  private emitEligibilityChanged(
+    saleAddress: string,
+    memberAddress: string,
+    eligible: boolean,
+  ): void {
+    const payload: TgrEligibilityChangedPayload = {
+      saleAddress,
+      memberAddress,
+      eligible,
+    };
+    this.eventEmitter.emit(TGR_ELIGIBILITY_CHANGED, payload);
+  }
+}

--- a/src/token-gated-rooms/services/group-missing-tracker.service.ts
+++ b/src/token-gated-rooms/services/group-missing-tracker.service.ts
@@ -1,0 +1,59 @@
+import { Injectable } from '@nestjs/common';
+
+/**
+ * In-memory registry of groups the relay reported as missing (`"Group not found"`)
+ * and are currently being re-created. Two jobs:
+ *
+ *  1. **Debounce re-creates** — only the FIRST `tgr.group.missing` for a sale
+ *     enqueues a `9007` re-create; the thousands of in-flight member adds that hit
+ *     the same missing group are coalesced ({@link RoomBackfillService.onGroupMissing}).
+ *  2. **Stop adding members to a missing group** — membership-sync skips enqueuing
+ *     `9000` adds for a suppressed sale until the group is confirmed re-created
+ *     (`MembershipSyncService.maybeEnqueueAdd`), so we don't pile adds onto a group
+ *     that doesn't exist.
+ *
+ * Cleared when the re-create's `9007` ok-ACK lands (the group is back). Entries also
+ * auto-expire after a TTL so a group whose re-create never confirms is retried on
+ * the next member-add failure rather than being suppressed forever. Single-process,
+ * so plain in-memory is sufficient (it self-heals on restart — the next member-add
+ * failure re-marks it).
+ */
+@Injectable()
+export class GroupMissingTracker {
+  /** sale_address → expiry epoch ms. */
+  private readonly missing = new Map<string, number>();
+
+  /** Default suppression window — generous enough for a throttled re-create to land. */
+  static readonly DEFAULT_TTL_MS = 10 * 60 * 1000;
+
+  /** Mark a group missing (re-create in flight). Idempotent; refreshes the TTL. */
+  markMissing(
+    saleAddress: string,
+    ttlMs = GroupMissingTracker.DEFAULT_TTL_MS,
+  ): void {
+    this.missing.set(saleAddress, Date.now() + Math.max(1, ttlMs));
+  }
+
+  /** True iff the group is currently flagged missing (and not expired). */
+  isMissing(saleAddress: string): boolean {
+    const expiry = this.missing.get(saleAddress);
+    if (expiry === undefined) {
+      return false;
+    }
+    if (expiry <= Date.now()) {
+      this.missing.delete(saleAddress);
+      return false;
+    }
+    return true;
+  }
+
+  /** Clear the flag — the group was confirmed re-created (resume member adds). */
+  clear(saleAddress: string): void {
+    this.missing.delete(saleAddress);
+  }
+
+  /** Count of currently-suppressed groups (observability / tests). */
+  get size(): number {
+    return this.missing.size;
+  }
+}

--- a/src/token-gated-rooms/services/identity-backfill.service.spec.ts
+++ b/src/token-gated-rooms/services/identity-backfill.service.spec.ts
@@ -1,0 +1,176 @@
+import { Test } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { Account } from '@/account/entities/account.entity';
+import { RoomMembership } from '../entities/room-membership.entity';
+import { IdentityService } from './identity.service';
+import { IdentityBackfillService } from './identity-backfill.service';
+import tgrConfig from '../config/tgr.config';
+
+// nostr-tools/nip19 mocked (see identity.service.spec.ts).
+const HEX = 'a'.repeat(64);
+const NPUB = 'npub1valid';
+
+jest.mock('nostr-tools/nip19', () => ({
+  decode: (value: string) => {
+    if (value === NPUB) return { type: 'npub', data: 'a'.repeat(64) };
+    throw new Error('invalid bech32');
+  },
+}));
+
+const PROVIDER = 'nostr';
+const LINKED_HEX = 'ak_linked_hex';
+const LINKED_NPUB = 'ak_linked_npub';
+const NO_NOSTR = 'ak_no_nostr';
+const MALFORMED = 'ak_malformed';
+
+describe('IdentityBackfillService (Task 05)', () => {
+  let backfill: IdentityBackfillService;
+  let identity: IdentityService;
+  let accountRepo: { find: jest.Mock };
+  let membershipRepo: { update: jest.Mock; createQueryBuilder: jest.Mock };
+  let memberQb: {
+    innerJoin: jest.Mock;
+    select: jest.Mock;
+    where: jest.Mock;
+    groupBy: jest.Mock;
+    orderBy: jest.Mock;
+    limit: jest.Mock;
+    getRawMany: jest.Mock;
+  };
+
+  beforeEach(async () => {
+    memberQb = {
+      innerJoin: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      groupBy: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      getRawMany: jest.fn().mockResolvedValue([]),
+    };
+    accountRepo = { find: jest.fn().mockResolvedValue([]) };
+    membershipRepo = {
+      update: jest.fn().mockResolvedValue(undefined),
+      createQueryBuilder: jest.fn().mockReturnValue(memberQb),
+    };
+
+    // Real IdentityService so setCacheEntry/clearCacheEntry/provider behave for
+    // real; its repos are stubbed (the backfill drives all writes).
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        IdentityBackfillService,
+        IdentityService,
+        { provide: getRepositoryToken(Account), useValue: accountRepo },
+        {
+          provide: getRepositoryToken(RoomMembership),
+          useValue: membershipRepo,
+        },
+        {
+          provide: tgrConfig.KEY,
+          useValue: { nostrLinkProvider: PROVIDER, backfillBatchSize: 200 },
+        },
+        { provide: EventEmitter2, useValue: { emit: jest.fn() } },
+      ],
+    }).compile();
+
+    backfill = moduleRef.get(IdentityBackfillService);
+    identity = moduleRef.get(IdentityService);
+  });
+
+  it('resolves linked holders (hex + npub), leaves unlinked/malformed null', async () => {
+    memberQb.getRawMany.mockResolvedValueOnce([
+      { member_address: LINKED_HEX },
+      { member_address: LINKED_NPUB },
+      { member_address: NO_NOSTR },
+      { member_address: MALFORMED },
+    ]);
+    accountRepo.find.mockResolvedValueOnce([
+      { address: LINKED_HEX, links: { [PROVIDER]: HEX } },
+      { address: LINKED_NPUB, links: { [PROVIDER]: NPUB } },
+      { address: NO_NOSTR, links: { x: 'x:foo' } },
+      { address: MALFORMED, links: { [PROVIDER]: 'deadbeef' } },
+    ]);
+
+    const result = await backfill.run();
+
+    expect(result).toEqual({ scanned: 4, linked: 2, unlinked: 2 });
+
+    // Linked holders get their hex written.
+    expect(membershipRepo.update).toHaveBeenCalledWith(
+      { member_address: LINKED_HEX },
+      { member_pubkey: HEX },
+    );
+    expect(membershipRepo.update).toHaveBeenCalledWith(
+      { member_address: LINKED_NPUB },
+      { member_pubkey: HEX },
+    );
+    // Unlinked & malformed are nulled (invariant), never the malformed value.
+    expect(membershipRepo.update).toHaveBeenCalledWith(
+      { member_address: NO_NOSTR },
+      { member_pubkey: null },
+    );
+    expect(membershipRepo.update).toHaveBeenCalledWith(
+      { member_address: MALFORMED },
+      { member_pubkey: null },
+    );
+    // No update ever carries the malformed value.
+    for (const [, set] of membershipRepo.update.mock.calls) {
+      expect(set.member_pubkey === 'deadbeef').toBe(false);
+    }
+
+    // Cache seeded for the two linked holders.
+    expect(identity.cacheSize).toBe(2);
+    expect(await identity.getPubkeyForAddress(LINKED_HEX)).toBe(HEX);
+  });
+
+  it('is cursor-batched: pages until a short batch and never writes eligibility/relay_state', async () => {
+    // batchSize 2 → two full pages then a short page ends the loop.
+    memberQb.getRawMany
+      .mockResolvedValueOnce([
+        { member_address: 'ak_a' },
+        { member_address: 'ak_b' },
+      ])
+      .mockResolvedValueOnce([
+        { member_address: 'ak_c' },
+        { member_address: 'ak_d' },
+      ])
+      .mockResolvedValueOnce([{ member_address: 'ak_e' }]);
+    accountRepo.find.mockResolvedValue([]); // all unlinked
+
+    const result = await backfill.run({ batchSize: 2 });
+
+    expect(result.scanned).toBe(5);
+    expect(result.unlinked).toBe(5);
+    // 3 page queries (2,2,1) — the short final page stops the loop.
+    expect(memberQb.getRawMany).toHaveBeenCalledTimes(3);
+    // Cursor advanced: the 2nd page query filtered on the last addr of page 1.
+    expect(memberQb.where).toHaveBeenCalledWith('m.member_address > :cursor', {
+      cursor: '',
+    });
+    expect(memberQb.where).toHaveBeenCalledWith('m.member_address > :cursor', {
+      cursor: 'ak_b',
+    });
+    expect(memberQb.where).toHaveBeenCalledWith('m.member_address > :cursor', {
+      cursor: 'ak_d',
+    });
+    // This service only ever writes member_pubkey.
+    for (const [, set] of membershipRepo.update.mock.calls) {
+      expect(Object.keys(set)).toEqual(['member_pubkey']);
+    }
+  });
+
+  it('is idempotent: a second run produces the same writes', async () => {
+    memberQb.getRawMany
+      .mockResolvedValueOnce([{ member_address: LINKED_HEX }])
+      .mockResolvedValueOnce([{ member_address: LINKED_HEX }]);
+    accountRepo.find.mockResolvedValue([
+      { address: LINKED_HEX, links: { [PROVIDER]: HEX } },
+    ]);
+
+    const a = await backfill.run();
+    const b = await backfill.run();
+    expect(a).toEqual(b);
+    expect(a).toEqual({ scanned: 1, linked: 1, unlinked: 0 });
+  });
+});

--- a/src/token-gated-rooms/services/identity-backfill.service.ts
+++ b/src/token-gated-rooms/services/identity-backfill.service.ts
@@ -1,0 +1,165 @@
+import {
+  Inject,
+  Injectable,
+  Logger,
+  OnApplicationBootstrap,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ConfigType } from '@nestjs/config';
+import { Account } from '@/account/entities/account.entity';
+import { RoomMembership } from '../entities/room-membership.entity';
+import tgrConfig from '../config/tgr.config';
+import { normalizePubkey } from '../nostr/pubkey';
+import { IdentityService } from './identity.service';
+
+export interface IdentityBackfillResult {
+  /** distinct member addresses scanned */
+  scanned: number;
+  /** members resolved to a hex pubkey (member_pubkey set) */
+  linked: number;
+  /** members with no parseable nostr link (member_pubkey null — invariant) */
+  unlinked: number;
+}
+
+/**
+ * One-time AE-address → nostr-pubkey backfill at startup (Task 05 req §4).
+ *
+ * Iterates the **relevant holders** — distinct `room_membership.member_address`
+ * values joined to `accounts` — and resolves `Account.links[<provider>]` to a
+ * normalized hex pubkey, seeding {@link IdentityService}'s in-memory cache and
+ * writing `room_membership.member_pubkey` for every linked holder.
+ *
+ * We read `Account.links` **directly** — the reactive link sync already
+ * materialized it — so this is a plain DB scan, NOT an MDW-log replay (unlike the
+ * bot's `NostrVerifiedAccounts.backfillLinks()`).
+ *
+ * **Resumable / bounded / idempotent:** the scan is cursor-paginated by
+ * `member_address` (`WHERE member_address > :cursor ORDER BY member_address ASC
+ * LIMIT :N`) so a large membership table never loads in one query, and re-running
+ * converges to the same state (every write is the normalized value, null for
+ * unlinked — honoring the unlinked-but-eligible invariant §6.6).
+ */
+@Injectable()
+export class IdentityBackfillService implements OnApplicationBootstrap {
+  private readonly logger = new Logger(IdentityBackfillService.name);
+
+  constructor(
+    @InjectRepository(Account)
+    private readonly accountRepo: Repository<Account>,
+    @InjectRepository(RoomMembership)
+    private readonly membershipRepo: Repository<RoomMembership>,
+    private readonly identityService: IdentityService,
+    @Inject(tgrConfig.KEY)
+    private readonly config: ConfigType<typeof tgrConfig>,
+  ) {}
+
+  async onApplicationBootstrap(): Promise<void> {
+    try {
+      const result = await this.run();
+      this.logger.log(
+        `[identity-backfill] complete: scanned=${result.scanned} linked=${result.linked} unlinked=${result.unlinked}`,
+      );
+    } catch (error: any) {
+      // Never crash startup on a backfill error — the reactive path + the
+      // hot-path DB fall-through still keep resolution correct; a later restart
+      // re-runs the backfill (it is idempotent).
+      this.logger.error(
+        `[identity-backfill] failed: ${error?.message ?? error}`,
+      );
+    }
+  }
+
+  /**
+   * Run the backfill to completion. Pages through distinct member addresses,
+   * resolves each link, seeds the cache, and writes `member_pubkey`.
+   *
+   * @param options.batchSize override the configured batch size (tests).
+   */
+  async run(
+    options: { batchSize?: number } = {},
+  ): Promise<IdentityBackfillResult> {
+    const batchSize = options.batchSize ?? this.config.backfillBatchSize;
+    const result: IdentityBackfillResult = {
+      scanned: 0,
+      linked: 0,
+      unlinked: 0,
+    };
+
+    let cursor = '';
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const addresses = await this.nextMemberBatch(cursor, batchSize);
+      if (addresses.length === 0) break;
+
+      // Resolve each address' link from `accounts.links` in this page.
+      const links = await this.loadLinks(addresses);
+
+      for (const address of addresses) {
+        result.scanned += 1;
+        const hex = normalizePubkey(links.get(address));
+        if (hex) {
+          this.identityService.setCacheEntry(address, hex);
+          await this.membershipRepo.update(
+            { member_address: address },
+            { member_pubkey: hex },
+          );
+          result.linked += 1;
+        } else {
+          // Unlinked / unparseable: enforce the §6.6 invariant — member_pubkey
+          // stays null. We never persist a malformed pubkey, and we do NOT touch
+          // eligibility/relay_state (Task 06/10 own those).
+          this.identityService.clearCacheEntry(address);
+          await this.membershipRepo.update(
+            { member_address: address },
+            { member_pubkey: null },
+          );
+          result.unlinked += 1;
+        }
+      }
+
+      cursor = addresses[addresses.length - 1];
+      if (addresses.length < batchSize) break;
+    }
+
+    return result;
+  }
+
+  /**
+   * Next page of distinct `member_address` values present in `room_membership`
+   * AND `accounts`, ordered ascending for a stable cursor. Inner-joining
+   * `accounts` excludes orphan membership rows whose account row was never
+   * created (their links would be unresolvable anyway).
+   */
+  private async nextMemberBatch(
+    cursor: string,
+    batchSize: number,
+  ): Promise<string[]> {
+    const rows = await this.membershipRepo
+      .createQueryBuilder('m')
+      .innerJoin(Account, 'a', 'a.address = m.member_address')
+      .select('m.member_address', 'member_address')
+      .where('m.member_address > :cursor', { cursor })
+      .groupBy('m.member_address')
+      .orderBy('m.member_address', 'ASC')
+      .limit(batchSize)
+      .getRawMany<{ member_address: string }>();
+    return rows.map((r) => r.member_address);
+  }
+
+  /** Bulk-load `links` for a page of addresses → `address → links[provider]`. */
+  private async loadLinks(
+    addresses: string[],
+  ): Promise<Map<string, string | undefined>> {
+    const accounts = await this.accountRepo.find({
+      where: addresses.map((address) => ({ address })),
+      select: ['address', 'links'],
+    });
+    const provider = this.identityService.provider;
+    const map = new Map<string, string | undefined>();
+    for (const account of accounts) {
+      map.set(account.address, account.links?.[provider]);
+    }
+    return map;
+  }
+}

--- a/src/token-gated-rooms/services/identity.service.spec.ts
+++ b/src/token-gated-rooms/services/identity.service.spec.ts
@@ -1,0 +1,250 @@
+import { Test } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { Account } from '@/account/entities/account.entity';
+import { RoomMembership } from '../entities/room-membership.entity';
+import { IdentityService } from './identity.service';
+import { TGR_LINK_CHANGED } from '../events';
+import tgrConfig from '../config/tgr.config';
+
+// nostr-tools/nip19 is mocked (real module pulls in @noble/* ESM, untransformable
+// by ts-jest). Map one known npub ↔ hex so normalization is exercised end-to-end.
+const HEX = 'a'.repeat(64);
+const NPUB = 'npub1valid';
+
+jest.mock('nostr-tools/nip19', () => ({
+  decode: (value: string) => {
+    if (value === NPUB || value === NPUB.toLowerCase()) {
+      return { type: 'npub', data: 'a'.repeat(64) };
+    }
+    throw new Error('invalid bech32');
+  },
+}));
+
+const ADDRESS = 'ak_holder1';
+const ADDRESS2 = 'ak_holder2';
+const PROVIDER = 'nostr';
+
+describe('IdentityService (Task 05)', () => {
+  let service: IdentityService;
+  let accountRepo: {
+    findOne: jest.Mock;
+    find: jest.Mock;
+    createQueryBuilder: jest.Mock;
+  };
+  let membershipRepo: { update: jest.Mock };
+  let eventEmitter: { emit: jest.Mock };
+  let qb: {
+    select: jest.Mock;
+    where: jest.Mock;
+    getMany: jest.Mock;
+  };
+
+  beforeEach(async () => {
+    qb = {
+      select: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      getMany: jest.fn().mockResolvedValue([]),
+    };
+    accountRepo = {
+      findOne: jest.fn().mockResolvedValue(null),
+      find: jest.fn().mockResolvedValue([]),
+      createQueryBuilder: jest.fn().mockReturnValue(qb),
+    };
+    membershipRepo = { update: jest.fn().mockResolvedValue(undefined) };
+    eventEmitter = { emit: jest.fn() };
+
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        IdentityService,
+        { provide: getRepositoryToken(Account), useValue: accountRepo },
+        {
+          provide: getRepositoryToken(RoomMembership),
+          useValue: membershipRepo,
+        },
+        {
+          provide: tgrConfig.KEY,
+          useValue: { nostrLinkProvider: PROVIDER },
+        },
+        { provide: EventEmitter2, useValue: eventEmitter },
+      ],
+    }).compile();
+
+    service = moduleRef.get(IdentityService);
+  });
+
+  describe('getPubkeyForAddress', () => {
+    it('returns hex for a holder linked with a hex pubkey', async () => {
+      accountRepo.findOne.mockResolvedValue({
+        address: ADDRESS,
+        links: { [PROVIDER]: HEX },
+      });
+      expect(await service.getPubkeyForAddress(ADDRESS)).toBe(HEX);
+    });
+
+    it('returns hex for a holder linked with an npub', async () => {
+      accountRepo.findOne.mockResolvedValue({
+        address: ADDRESS,
+        links: { [PROVIDER]: NPUB },
+      });
+      expect(await service.getPubkeyForAddress(ADDRESS)).toBe(HEX);
+    });
+
+    it('returns null for an unlinked holder', async () => {
+      accountRepo.findOne.mockResolvedValue({ address: ADDRESS, links: {} });
+      expect(await service.getPubkeyForAddress(ADDRESS)).toBeNull();
+    });
+
+    it('returns null for a malformed nostr link', async () => {
+      accountRepo.findOne.mockResolvedValue({
+        address: ADDRESS,
+        links: { [PROVIDER]: 'not-a-pubkey' },
+      });
+      expect(await service.getPubkeyForAddress(ADDRESS)).toBeNull();
+    });
+
+    it('serves a second lookup from cache (no second DB read)', async () => {
+      accountRepo.findOne.mockResolvedValue({
+        address: ADDRESS,
+        links: { [PROVIDER]: HEX },
+      });
+      await service.getPubkeyForAddress(ADDRESS);
+      await service.getPubkeyForAddress(ADDRESS);
+      expect(accountRepo.findOne).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getAddressForPubkey', () => {
+    it('resolves a hex input to the linked address', async () => {
+      qb.getMany.mockResolvedValue([
+        { address: ADDRESS, links: { [PROVIDER]: HEX } },
+      ]);
+      expect(await service.getAddressForPubkey(HEX)).toBe(ADDRESS);
+    });
+
+    it('resolves an npub input to the same address as its hex', async () => {
+      qb.getMany.mockResolvedValue([
+        { address: ADDRESS, links: { [PROVIDER]: HEX } },
+      ]);
+      expect(await service.getAddressForPubkey(NPUB)).toBe(ADDRESS);
+    });
+
+    it('matches a candidate stored as npub against a hex query', async () => {
+      qb.getMany.mockResolvedValue([
+        { address: ADDRESS2, links: { [PROVIDER]: NPUB } },
+      ]);
+      expect(await service.getAddressForPubkey(HEX)).toBe(ADDRESS2);
+    });
+
+    it('returns null for an unknown pubkey', async () => {
+      qb.getMany.mockResolvedValue([]);
+      expect(await service.getAddressForPubkey(HEX)).toBeNull();
+    });
+
+    it('returns null for an unparseable pubkey input', async () => {
+      expect(await service.getAddressForPubkey('garbage')).toBeNull();
+      expect(accountRepo.createQueryBuilder).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('onLinkChanged (link handler)', () => {
+    it('sets member_pubkey and does NOT re-emit (avoids handler loop)', async () => {
+      accountRepo.findOne.mockResolvedValue({
+        address: ADDRESS,
+        links: { [PROVIDER]: HEX },
+      });
+      await service.onLinkChanged({ address: ADDRESS });
+
+      expect(membershipRepo.update).toHaveBeenCalledWith(
+        { member_address: ADDRESS },
+        { member_pubkey: HEX },
+      );
+      // The originating event already reached Task 06; re-emitting would loop.
+      expect(eventEmitter.emit).not.toHaveBeenCalled();
+    });
+
+    it('nulls member_pubkey on unlink (links no longer has the provider)', async () => {
+      accountRepo.findOne.mockResolvedValue({ address: ADDRESS, links: {} });
+      await service.onLinkChanged({ address: ADDRESS });
+
+      expect(membershipRepo.update).toHaveBeenCalledWith(
+        { member_address: ADDRESS },
+        { member_pubkey: null },
+      );
+    });
+
+    it('ignores an empty payload', async () => {
+      await service.onLinkChanged({ address: '' });
+      expect(membershipRepo.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('reresolveAddress (direct caller)', () => {
+    it('emits tgr.link.changed when called directly (default emit=true)', async () => {
+      accountRepo.findOne.mockResolvedValue({
+        address: ADDRESS,
+        links: { [PROVIDER]: HEX },
+      });
+      await service.reresolveAddress(ADDRESS);
+
+      expect(membershipRepo.update).toHaveBeenCalledWith(
+        { member_address: ADDRESS },
+        { member_pubkey: HEX },
+      );
+      expect(eventEmitter.emit).toHaveBeenCalledWith(TGR_LINK_CHANGED, {
+        address: ADDRESS,
+      });
+    });
+
+    it('nulls member_pubkey + emits on a direct unlink correction', async () => {
+      accountRepo.findOne.mockResolvedValue({ address: ADDRESS, links: {} });
+      await service.reresolveAddress(ADDRESS);
+
+      expect(membershipRepo.update).toHaveBeenCalledWith(
+        { member_address: ADDRESS },
+        { member_pubkey: null },
+      );
+      expect(eventEmitter.emit).toHaveBeenCalledWith(TGR_LINK_CHANGED, {
+        address: ADDRESS,
+      });
+    });
+  });
+
+  describe('unlinked-but-eligible invariant (§6.6)', () => {
+    it('never writes a malformed pubkey — nulls member_pubkey instead', async () => {
+      accountRepo.findOne.mockResolvedValue({
+        address: ADDRESS,
+        links: { [PROVIDER]: 'deadbeef' }, // wrong length → unparseable
+      });
+      await service.reresolveAddress(ADDRESS, { emit: false });
+
+      // member_pubkey set to null (not the malformed value), eligibility/
+      // relay_state untouched (this service writes neither).
+      expect(membershipRepo.update).toHaveBeenCalledWith(
+        { member_address: ADDRESS },
+        { member_pubkey: null },
+      );
+      const updateArg = membershipRepo.update.mock.calls[0][1];
+      expect(updateArg).not.toHaveProperty('eligible');
+      expect(updateArg).not.toHaveProperty('relay_state');
+    });
+  });
+
+  describe('cache maintenance', () => {
+    it('re-link to a new pubkey drops the stale reverse entry', () => {
+      const HEX2 = 'b'.repeat(64);
+      service.setCacheEntry(ADDRESS, HEX);
+      service.setCacheEntry(ADDRESS, HEX2);
+      // Reverse lookup for the old hex must no longer resolve via cache.
+      expect((service as any).pubkeyToAddress.get(HEX)).toBeUndefined();
+      expect((service as any).pubkeyToAddress.get(HEX2)).toBe(ADDRESS);
+    });
+
+    it('clearCacheEntry removes both directions', () => {
+      service.setCacheEntry(ADDRESS, HEX);
+      service.clearCacheEntry(ADDRESS);
+      expect(service.cacheSize).toBe(0);
+      expect((service as any).pubkeyToAddress.get(HEX)).toBeUndefined();
+    });
+  });
+});

--- a/src/token-gated-rooms/services/identity.service.ts
+++ b/src/token-gated-rooms/services/identity.service.ts
@@ -1,0 +1,224 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ConfigType } from '@nestjs/config';
+import { EventEmitter2, OnEvent } from '@nestjs/event-emitter';
+import { Account } from '@/account/entities/account.entity';
+import { RoomMembership } from '../entities/room-membership.entity';
+import { TGR_LINK_CHANGED, TgrLinkChangedPayload } from '../events';
+import tgrConfig from '../config/tgr.config';
+import { normalizePubkey } from '../nostr/pubkey';
+
+/**
+ * AE-address ↔ nostr-pubkey resolution for token-gated rooms (Task 05).
+ *
+ * The single source of the mapping the eligibility (Task 06) and membership-sync
+ * (Task 10) pipelines need. It reads the **already-materialized**
+ * `Account.links[<provider>]` value (populated reactively + verbatim by
+ * `AddressLinksPluginSyncService` — we do NOT re-scan the chain), normalizes it
+ * strictly to lowercase 64-hex (`npub`→hex via {@link normalizePubkey}), and
+ * keeps an in-memory `address↔pubkey` cache for the hot path.
+ *
+ * ## Unlinked-but-eligible invariant (plan §6.6 — VERIFIED)
+ * Private-room access requires **BOTH** an on-chain balance **AND** a nostr link.
+ * An eligible holder with no parseable nostr link MUST be recorded as
+ * `eligible=true, member_pubkey=null, relay_state='pending_add'` and is **NEVER
+ * published** (no `9000`) and **NEVER removed** (no `9001`). This service owns
+ * *writing* the null-pubkey/`pending_add` state; it never advances such a row.
+ * Eligibility itself is decided by Task 06; publish/skip by Task 10.
+ *
+ * ## Validation discipline
+ * A `member_pubkey` is only ever written when it passes `HEX64`. If
+ * `Account.links[<provider>]` exists but is unparseable, the holder is treated as
+ * **unlinked** (member_pubkey nulled) — we never persist a malformed pubkey.
+ *
+ * Registered `mode: 'shared'`, `export: true` so Tasks 06/10 can inject it.
+ */
+@Injectable()
+export class IdentityService {
+  private readonly logger = new Logger(IdentityService.name);
+
+  /** Hot-path cache: AE address → normalized hex pubkey. */
+  private readonly addressToPubkey = new Map<string, string>();
+  /** Hot-path cache: normalized hex pubkey → AE address. */
+  private readonly pubkeyToAddress = new Map<string, string>();
+
+  constructor(
+    @InjectRepository(Account)
+    private readonly accountRepo: Repository<Account>,
+    @InjectRepository(RoomMembership)
+    private readonly membershipRepo: Repository<RoomMembership>,
+    @Inject(tgrConfig.KEY)
+    private readonly config: ConfigType<typeof tgrConfig>,
+    private readonly eventEmitter: EventEmitter2,
+  ) {}
+
+  /** The `Account.links` key resolved to a nostr pubkey (default `'nostr'`). */
+  get provider(): string {
+    return this.config.nostrLinkProvider;
+  }
+
+  // ── cache maintenance (called by IdentityBackfillService + reactive path) ──
+
+  /**
+   * Seed/update both cache directions for a resolved link. Removes any stale
+   * reverse entry so a re-link to a different pubkey does not leave a dangling
+   * `pubkey→address` mapping. No-op for a malformed pubkey.
+   */
+  setCacheEntry(address: string, pubkey: string): void {
+    const hex = normalizePubkey(pubkey);
+    if (!hex) return;
+    const previous = this.addressToPubkey.get(address);
+    if (previous && previous !== hex) {
+      // Only drop the reverse entry if it still points back at this address.
+      if (this.pubkeyToAddress.get(previous) === address) {
+        this.pubkeyToAddress.delete(previous);
+      }
+    }
+    this.addressToPubkey.set(address, hex);
+    this.pubkeyToAddress.set(hex, address);
+  }
+
+  /** Forget an address (unlink / unparseable). Clears both directions. */
+  clearCacheEntry(address: string): void {
+    const previous = this.addressToPubkey.get(address);
+    this.addressToPubkey.delete(address);
+    if (previous && this.pubkeyToAddress.get(previous) === address) {
+      this.pubkeyToAddress.delete(previous);
+    }
+  }
+
+  /** Test/observability hook: number of cached address→pubkey entries. */
+  get cacheSize(): number {
+    return this.addressToPubkey.size;
+  }
+
+  // ── read API (hot path; cache-first, DB fall-through) ──────────────────────
+
+  /**
+   * Resolve an AE address to its normalized hex nostr pubkey, or `null` if the
+   * account is unlinked / the stored value is unparseable.
+   */
+  async getPubkeyForAddress(address: string): Promise<string | null> {
+    const cached = this.addressToPubkey.get(address);
+    if (cached) return cached;
+
+    const account = await this.accountRepo.findOne({
+      where: { address },
+      select: ['address', 'links'],
+    });
+    const hex = normalizePubkey(account?.links?.[this.provider]);
+    if (!hex) return null;
+    this.setCacheEntry(address, hex);
+    return hex;
+  }
+
+  /**
+   * Reverse lookup: resolve a nostr pubkey (hex or npub) to the AE address whose
+   * link normalizes to the same hex, or `null` if none. The input is normalized
+   * first so an `npub` and its hex form resolve identically.
+   */
+  async getAddressForPubkey(pubkey: string): Promise<string | null> {
+    const hex = normalizePubkey(pubkey);
+    if (!hex) return null;
+
+    const cached = this.pubkeyToAddress.get(hex);
+    if (cached) return cached;
+
+    // Cache miss: `links->>provider` may store the hex OR the npub form, so we
+    // can't match on the raw value with one query. Narrow with a jsonb key
+    // filter (only accounts that linked this provider) then normalize each
+    // candidate in memory and compare to the target hex.
+    const candidates = await this.accountRepo
+      .createQueryBuilder('account')
+      .select(['account.address', 'account.links'])
+      .where(`account.links ? :provider`, { provider: this.provider })
+      .getMany();
+
+    for (const account of candidates) {
+      const candidateHex = normalizePubkey(account.links?.[this.provider]);
+      if (candidateHex === hex) {
+        this.setCacheEntry(account.address, hex);
+        return account.address;
+      }
+    }
+    return null;
+  }
+
+  // ── reactive re-resolution ────────────────────────────────────────────────
+
+  /**
+   * React to an address↔nostr link change. `AddressLinksPluginSyncService` emits
+   * `tgr.link.changed` ({@link TGR_LINK_CHANGED}) from its link/unlink handlers
+   * (the one-line seam in its scope). We re-read `Account.links[<provider>]`,
+   * re-normalize, and update the cache + `room_membership.member_pubkey` for that
+   * address across all its rooms.
+   *
+   * We do NOT re-emit `tgr.link.changed` here: the eligibility service (Task 06,
+   * req §6) consumes the SAME event independently and recomputes eligibility,
+   * re-reading the resolved pubkey through this service — so a single emit fans
+   * out to both consumers. Re-emitting would loop this handler. We also do NOT
+   * publish to the relay (Task 10 owns that).
+   */
+  @OnEvent(TGR_LINK_CHANGED, { async: true, promisify: true })
+  async onLinkChanged(payload: TgrLinkChangedPayload): Promise<void> {
+    const address = payload?.address;
+    if (!address) return;
+    // emit:false — this WAS the link event; Task 06 already received it too.
+    await this.reresolveAddress(address, { emit: false });
+  }
+
+  /**
+   * Re-read the link for `address`, update the cache + every `room_membership`
+   * row for that member, and (optionally) fan out the re-evaluation signal.
+   *
+   * Linked  → set `member_pubkey` to the normalized hex on all rows.
+   * Unlinked / unparseable → null `member_pubkey` (unlinked invariant: nothing
+   * else on the row — eligibility / relay_state — is touched here; Task 06/10
+   * apply the invariant downstream).
+   *
+   * @param options.emit when `true` (default) emit `tgr.link.changed` so the
+   *   eligibility pipeline (Task 06) re-evaluates. The `@OnEvent` handler passes
+   *   `false` because the originating event already reached Task 06; direct
+   *   callers (e.g. a backfill correction) pass the default `true` so the change
+   *   still fans out. This satisfies Task 05 req §5 ("trigger membership re-sync")
+   *   without redefining the canonical `tgr.eligibility.changed` payload (owned by
+   *   Task 06) — see the NOTE in the class doc.
+   */
+  async reresolveAddress(
+    address: string,
+    options: { emit?: boolean } = {},
+  ): Promise<void> {
+    const emit = options.emit ?? true;
+
+    const account = await this.accountRepo.findOne({
+      where: { address },
+      select: ['address', 'links'],
+    });
+    const hex = normalizePubkey(account?.links?.[this.provider]);
+
+    if (hex) {
+      this.setCacheEntry(address, hex);
+    } else {
+      this.clearCacheEntry(address);
+    }
+
+    // Mirror onto the desired-state ledger for this member across all rooms.
+    // Validation discipline: `hex` is HEX64-valid or null — never malformed.
+    await this.membershipRepo.update(
+      { member_address: address },
+      { member_pubkey: hex ?? null },
+    );
+
+    if (hex) {
+      this.logger.log(`Link resolved: ${address} -> ${hex.slice(0, 8)}…`);
+    } else {
+      this.logger.log(`Link cleared (unlinked/unparseable): ${address}`);
+    }
+
+    if (emit) {
+      const payload: TgrLinkChangedPayload = { address };
+      this.eventEmitter.emit(TGR_LINK_CHANGED, payload);
+    }
+  }
+}

--- a/src/token-gated-rooms/services/membership-access.service.spec.ts
+++ b/src/token-gated-rooms/services/membership-access.service.spec.ts
@@ -1,0 +1,201 @@
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { RoomMembership } from '../entities/room-membership.entity';
+import {
+  TGR_MEMBERSHIP_CHANGED,
+  type TgrMembershipChangedPayload,
+} from '../events';
+import { MembershipAccessService } from './membership-access.service';
+
+/**
+ * Unit coverage for the access-transition ledger (access-ledger plan §3.4/§3.5) —
+ * the fix for the ~hourly repeated "You now have access" push. Verifies:
+ *   - a genuine gain records ONE grant + emits (first-ever = `is_first_grant`);
+ *   - a re-add of an already-granted member (reconcile / `39002` regen) is a silent
+ *     no-op — the churn that caused the repeat;
+ *   - a loss ARMS the debounce (no push yet);
+ *   - the finalizer emits ONE revoke past the grace window, but a re-add within the
+ *     window is absorbed (NEITHER push).
+ */
+const SALE = 'ct_sale';
+const MEMBER = 'ak_member';
+
+function makeRow(over: Partial<RoomMembership> = {}): RoomMembership {
+  return {
+    id: 1,
+    sale_address: SALE,
+    member_address: MEMBER,
+    member_pubkey: 'p',
+    role: 'member',
+    eligible: true,
+    relay_state: 'added',
+    access_state: 'none',
+    access_changed_at: null as any,
+    pending_revoke_since: null as any,
+    pending_revoke_reason: null as any,
+    held_until_height: null as any,
+    last_published_at: null as any,
+    last_reconciled_at: null as any,
+    updated_at: new Date(),
+    ...over,
+  } as RoomMembership;
+}
+
+function setup(opts: { grace?: number; priorGrants?: number } = {}) {
+  const membershipRepo = {
+    update: jest.fn().mockResolvedValue(undefined),
+    find: jest.fn().mockResolvedValue([]),
+  };
+  let seq = 1;
+  const eventRepo = {
+    count: jest.fn().mockResolvedValue(opts.priorGrants ?? 0),
+    create: jest.fn((v) => v),
+    save: jest.fn(async (v) => ({ ...v, id: String(seq++) })),
+  };
+  const emitter = new EventEmitter2();
+  const emitted: TgrMembershipChangedPayload[] = [];
+  emitter.on(TGR_MEMBERSHIP_CHANGED, (p) => emitted.push(p));
+  const service = new MembershipAccessService(
+    membershipRepo as any,
+    eventRepo as any,
+    emitter,
+    { accessRevokeGraceSec: opts.grace ?? 180 } as any,
+  );
+  return { service, membershipRepo, eventRepo, emitted };
+}
+
+describe('MembershipAccessService — gains', () => {
+  it('none → granted records a first-grant + emits added(isFirstGrant=true)', async () => {
+    const h = setup({ priorGrants: 0 });
+    const row = makeRow({ access_state: 'none' });
+
+    await h.service.recordAccessTransition(row, true, 'access_gained');
+
+    expect(h.membershipRepo.update).toHaveBeenCalledWith(
+      { id: 1 },
+      expect.objectContaining({ access_state: 'granted' }),
+    );
+    expect(h.eventRepo.save).toHaveBeenCalledWith(
+      expect.objectContaining({ event: 'access_granted', reason: 'join', is_first_grant: true }),
+    );
+    expect(h.emitted).toHaveLength(1);
+    expect(h.emitted[0]).toMatchObject({
+      relayState: 'added',
+      isFirstGrant: true,
+      accessEventId: '1',
+    });
+  });
+
+  it('regained (prior grant exists) → reason regained, isFirstGrant=false', async () => {
+    const h = setup({ priorGrants: 1 });
+    const row = makeRow({ access_state: 'none' });
+
+    await h.service.recordAccessTransition(row, true, 'access_gained');
+
+    expect(h.eventRepo.save).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: 'regained', is_first_grant: false }),
+    );
+    expect(h.emitted[0]).toMatchObject({ isFirstGrant: false });
+  });
+
+  it('re-add of an already-granted member is a SILENT no-op (the flap/reconcile churn)', async () => {
+    const h = setup();
+    const row = makeRow({ access_state: 'granted' });
+
+    await h.service.recordAccessTransition(row, true, 'access_gained');
+
+    expect(h.eventRepo.save).not.toHaveBeenCalled();
+    expect(h.emitted).toHaveLength(0);
+  });
+
+  it('re-add of a granted member with an armed revoke cancels the revoke silently', async () => {
+    const h = setup();
+    const row = makeRow({
+      access_state: 'granted',
+      pending_revoke_since: new Date(),
+      pending_revoke_reason: 'eligibility_lost',
+    });
+
+    await h.service.recordAccessTransition(row, true, 'access_gained');
+
+    expect(h.membershipRepo.update).toHaveBeenCalledWith(
+      { id: 1 },
+      { pending_revoke_since: null, pending_revoke_reason: null },
+    );
+    expect(h.emitted).toHaveLength(0);
+  });
+});
+
+describe('MembershipAccessService — losses (debounced)', () => {
+  it('granted → lost ARMS pending_revoke and does NOT emit', async () => {
+    const h = setup();
+    const row = makeRow({ access_state: 'granted', relay_state: 'removed' });
+
+    await h.service.recordAccessTransition(row, false, 'eligibility_lost');
+
+    expect(h.membershipRepo.update).toHaveBeenCalledWith(
+      { id: 1 },
+      expect.objectContaining({
+        pending_revoke_since: expect.any(Date),
+        pending_revoke_reason: 'eligibility_lost',
+      }),
+    );
+    expect(h.emitted).toHaveLength(0);
+  });
+
+  it('loss on a never-granted (none) row is a no-op', async () => {
+    const h = setup();
+    const row = makeRow({ access_state: 'none', relay_state: 'removed' });
+
+    await h.service.recordAccessTransition(row, false, 'eligibility_lost');
+
+    expect(h.membershipRepo.update).not.toHaveBeenCalled();
+    expect(h.emitted).toHaveLength(0);
+  });
+});
+
+describe('MembershipAccessService — finalizeDueRevokes', () => {
+  it('still-removed past grace → ONE revoke emit + access_state=none', async () => {
+    const h = setup();
+    const armed = makeRow({
+      access_state: 'granted',
+      relay_state: 'removed',
+      pending_revoke_since: new Date(Date.now() - 10 * 60_000),
+      pending_revoke_reason: 'eligibility_lost',
+    });
+    h.membershipRepo.find = jest.fn().mockResolvedValue([armed]);
+
+    const result = await h.service.finalizeDueRevokes();
+
+    expect(result).toEqual({ revoked: 1, cancelled: 0 });
+    expect(h.membershipRepo.update).toHaveBeenCalledWith(
+      { id: 1 },
+      expect.objectContaining({ access_state: 'none' }),
+    );
+    expect(h.eventRepo.save).toHaveBeenCalledWith(
+      expect.objectContaining({ event: 'access_revoked', reason: 'eligibility_lost' }),
+    );
+    expect(h.emitted).toHaveLength(1);
+    expect(h.emitted[0]).toMatchObject({ relayState: 'removed', accessEventId: '1' });
+  });
+
+  it('re-added within grace (relay_state=added) → cancelled silently, NO push', async () => {
+    const h = setup();
+    const readded = makeRow({
+      access_state: 'granted',
+      relay_state: 'added', // came back before the finalizer ran
+      pending_revoke_since: new Date(Date.now() - 10 * 60_000),
+      pending_revoke_reason: 'eligibility_lost',
+    });
+    h.membershipRepo.find = jest.fn().mockResolvedValue([readded]);
+
+    const result = await h.service.finalizeDueRevokes();
+
+    expect(result).toEqual({ revoked: 0, cancelled: 1 });
+    expect(h.membershipRepo.update).toHaveBeenCalledWith(
+      { id: 1 },
+      { pending_revoke_since: null, pending_revoke_reason: null },
+    );
+    expect(h.eventRepo.save).not.toHaveBeenCalled();
+    expect(h.emitted).toHaveLength(0);
+  });
+});

--- a/src/token-gated-rooms/services/membership-access.service.spec.ts
+++ b/src/token-gated-rooms/services/membership-access.service.spec.ts
@@ -42,7 +42,8 @@ function makeRow(over: Partial<RoomMembership> = {}): RoomMembership {
 
 function setup(opts: { grace?: number; priorGrants?: number } = {}) {
   const membershipRepo = {
-    update: jest.fn().mockResolvedValue(undefined),
+    // update() returns an UpdateResult; `affected` drives the compare-and-set guard.
+    update: jest.fn().mockResolvedValue({ affected: 1 }),
     find: jest.fn().mockResolvedValue([]),
   };
   let seq = 1;
@@ -71,7 +72,7 @@ describe('MembershipAccessService — gains', () => {
     await h.service.recordAccessTransition(row, true, 'access_gained');
 
     expect(h.membershipRepo.update).toHaveBeenCalledWith(
-      { id: 1 },
+      { id: 1, access_state: 'none' }, // compare-and-set on the prior state
       expect.objectContaining({ access_state: 'granted' }),
     );
     expect(h.eventRepo.save).toHaveBeenCalledWith(
@@ -104,6 +105,19 @@ describe('MembershipAccessService — gains', () => {
   it('re-add of an already-granted member is a SILENT no-op (the flap/reconcile churn)', async () => {
     const h = setup();
     const row = makeRow({ access_state: 'granted' });
+
+    await h.service.recordAccessTransition(row, true, 'access_gained');
+
+    expect(h.eventRepo.save).not.toHaveBeenCalled();
+    expect(h.emitted).toHaveLength(0);
+  });
+
+  it('lost the none→granted CAS race (affected=0) → no ledger row, no push', async () => {
+    // Two concurrent ACKs both see access_state='none'; the DB compare-and-set only
+    // lets ONE win. The loser's UPDATE matches 0 rows → must not double-emit.
+    const h = setup();
+    h.membershipRepo.update = jest.fn().mockResolvedValue({ affected: 0 });
+    const row = makeRow({ access_state: 'none' });
 
     await h.service.recordAccessTransition(row, true, 'access_gained');
 
@@ -172,7 +186,7 @@ describe('MembershipAccessService — finalizeDueRevokes', () => {
 
     expect(result).toEqual({ revoked: 1, cancelled: 0 });
     expect(h.membershipRepo.update).toHaveBeenCalledWith(
-      { id: 1 },
+      { id: 1, access_state: 'granted' }, // compare-and-set on the prior state
       expect.objectContaining({ access_state: 'none' }),
     );
     expect(h.eventRepo.save).toHaveBeenCalledWith(
@@ -186,6 +200,24 @@ describe('MembershipAccessService — finalizeDueRevokes', () => {
       relayState: 'removed',
       accessEventId: '1',
     });
+  });
+
+  it('lost the revoke CAS race (affected=0) → no revoke row, no push', async () => {
+    const h = setup();
+    const armed = makeRow({
+      access_state: 'granted',
+      relay_state: 'removed',
+      pending_revoke_since: new Date(Date.now() - 10 * 60_000),
+      pending_revoke_reason: 'eligibility_lost',
+    });
+    h.membershipRepo.find = jest.fn().mockResolvedValue([armed]);
+    h.membershipRepo.update = jest.fn().mockResolvedValue({ affected: 0 });
+
+    const result = await h.service.finalizeDueRevokes();
+
+    expect(result).toEqual({ revoked: 0, cancelled: 0 });
+    expect(h.eventRepo.save).not.toHaveBeenCalled();
+    expect(h.emitted).toHaveLength(0);
   });
 
   it('re-added within grace (relay_state=added) → cancelled silently, NO push', async () => {

--- a/src/token-gated-rooms/services/membership-access.service.spec.ts
+++ b/src/token-gated-rooms/services/membership-access.service.spec.ts
@@ -75,7 +75,11 @@ describe('MembershipAccessService — gains', () => {
       expect.objectContaining({ access_state: 'granted' }),
     );
     expect(h.eventRepo.save).toHaveBeenCalledWith(
-      expect.objectContaining({ event: 'access_granted', reason: 'join', is_first_grant: true }),
+      expect.objectContaining({
+        event: 'access_granted',
+        reason: 'join',
+        is_first_grant: true,
+      }),
     );
     expect(h.emitted).toHaveLength(1);
     expect(h.emitted[0]).toMatchObject({
@@ -172,10 +176,16 @@ describe('MembershipAccessService — finalizeDueRevokes', () => {
       expect.objectContaining({ access_state: 'none' }),
     );
     expect(h.eventRepo.save).toHaveBeenCalledWith(
-      expect.objectContaining({ event: 'access_revoked', reason: 'eligibility_lost' }),
+      expect.objectContaining({
+        event: 'access_revoked',
+        reason: 'eligibility_lost',
+      }),
     );
     expect(h.emitted).toHaveLength(1);
-    expect(h.emitted[0]).toMatchObject({ relayState: 'removed', accessEventId: '1' });
+    expect(h.emitted[0]).toMatchObject({
+      relayState: 'removed',
+      accessEventId: '1',
+    });
   });
 
   it('re-added within grace (relay_state=added) → cancelled silently, NO push', async () => {

--- a/src/token-gated-rooms/services/membership-access.service.ts
+++ b/src/token-gated-rooms/services/membership-access.service.ts
@@ -97,7 +97,27 @@ export class MembershipAccessService {
       return;
     }
 
-    // Genuine transition none → granted.
+    // Genuine transition none → granted. **Atomic compare-and-set**: condition the
+    // flip on the prior `access_state='none'` so only ONE handler wins when the same
+    // relay ACK is processed concurrently (publish concurrency ≥ 2 → duplicate 9000
+    // ACKs for one member). A racing/duplicate handler matches 0 rows and returns
+    // WITHOUT inserting a ledger row or emitting — no duplicate event, no duplicate push.
+    const now = new Date();
+    const result = await this.membershipRepo.update(
+      { id: row.id, access_state: 'none' },
+      {
+        access_state: 'granted',
+        access_changed_at: now,
+        pending_revoke_since: null,
+        pending_revoke_reason: null,
+      },
+    );
+    if (!result.affected) {
+      return; // lost the race — another handler already granted this transition
+    }
+
+    // Only the winner counts + inserts (so `priorGrants` never includes this
+    // transition's own row → correct first-grant detection under concurrency).
     const priorGrants = await this.eventRepo.count({
       where: {
         sale_address: row.sale_address,
@@ -106,17 +126,6 @@ export class MembershipAccessService {
       },
     });
     const isFirst = priorGrants === 0;
-    const now = new Date();
-
-    await this.membershipRepo.update(
-      { id: row.id },
-      {
-        access_state: 'granted',
-        access_changed_at: now,
-        pending_revoke_since: null,
-        pending_revoke_reason: null,
-      },
-    );
 
     const event = await this.eventRepo.save(
       this.eventRepo.create({
@@ -191,8 +200,10 @@ export class MembershipAccessService {
 
         const reason = row.pending_revoke_reason || 'access_lost';
         const now = new Date();
-        await this.membershipRepo.update(
-          { id: row.id },
+        // Atomic compare-and-set (mirror the grant path): only flip a still-`granted`
+        // row so overlapping finalizer runs can't emit two `access_revoked` rows/pushes.
+        const result = await this.membershipRepo.update(
+          { id: row.id, access_state: 'granted' },
           {
             access_state: 'none',
             access_changed_at: now,
@@ -200,6 +211,9 @@ export class MembershipAccessService {
             pending_revoke_reason: null,
           },
         );
+        if (!result.affected) {
+          continue; // lost the race — already resolved elsewhere
+        }
         const event = await this.eventRepo.save(
           this.eventRepo.create({
             sale_address: row.sale_address,

--- a/src/token-gated-rooms/services/membership-access.service.ts
+++ b/src/token-gated-rooms/services/membership-access.service.ts
@@ -1,0 +1,248 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { ConfigType } from '@nestjs/config';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { InjectRepository } from '@nestjs/typeorm';
+import { LessThanOrEqual, Repository } from 'typeorm';
+import tgrConfig from '../config/tgr.config';
+import { RoomMembership } from '../entities/room-membership.entity';
+import { RoomMembershipEvent } from '../entities/room-membership-event.entity';
+import {
+  TGR_MEMBERSHIP_CHANGED,
+  type TgrMembershipChangedPayload,
+} from '../events';
+
+/**
+ * Access-transition detector + debounce finalizer (access-ledger plan §3.4/§3.5).
+ *
+ * ## Why this exists
+ * The membership push used to fire off the raw `relay_state: pending_add → added`
+ * ACK — a *relay-sync* signal that churns (reconcile re-adds, `39002`
+ * regeneration, a transient `eligible` flap cycling `added → removed → added`).
+ * Result: "You now have access to X" re-fired ~hourly (thinned only by the 1h
+ * Redis dedup TTL) for every room a holder was in.
+ *
+ * This service makes notifications fire off **effective-access transitions**
+ * (`effective access = relay_state === 'added'`), recorded in a durable ledger
+ * (`room_membership_event`) with a short **debounce** on loss:
+ *  - GAIN (`none → granted`): recorded + pushed immediately (first-ever = "join",
+ *    otherwise "regained").
+ *  - LOSS (`granted → …`): NOT pushed immediately — `pending_revoke_since` is armed;
+ *    a re-add within `TG_ACCESS_REVOKE_GRACE_SEC` cancels it silently (flap absorbed,
+ *    no push either way); otherwise the finalizer emits ONE `access_revoked`.
+ *
+ * Reconcile re-adds / `39002` regeneration never change `access_state`, so they
+ * never notify — the hourly repeat is fixed structurally, independent of whether
+ * the underlying balance flap is also fixed (that's the separate §8 follow-up).
+ *
+ * The emitted event is the existing `tgr.membership.changed`, now enriched with the
+ * ledger `accessEventId` + `isFirstGrant` so the room-notify processor can pick the
+ * copy and stamp `notified_at` (durable dedup across Bull retries / restarts).
+ */
+@Injectable()
+export class MembershipAccessService {
+  private readonly logger = new Logger(MembershipAccessService.name);
+
+  constructor(
+    @InjectRepository(RoomMembership)
+    private readonly membershipRepo: Repository<RoomMembership>,
+    @InjectRepository(RoomMembershipEvent)
+    private readonly eventRepo: Repository<RoomMembershipEvent>,
+    private readonly eventEmitter: EventEmitter2,
+    @Inject(tgrConfig.KEY)
+    private readonly config: ConfigType<typeof tgrConfig>,
+  ) {}
+
+  /**
+   * Fold a relay-state transition into the effective-access ledger. Called from
+   * every seam that writes `relay_state` (membership-sync `applyAck` +
+   * `handleDeletedRoom`).
+   *
+   * @param row       the membership row (pre-write access columns are read from it;
+   *                  `relay_state` has already been written by the caller).
+   * @param effective the NEW effective access (`relay_state === 'added'`).
+   * @param reason    the loss reason to persist through the debounce (grants derive
+   *                  their own `join`/`regained` reason and ignore this).
+   */
+  async recordAccessTransition(
+    row: RoomMembership,
+    effective: boolean,
+    reason: string,
+  ): Promise<void> {
+    try {
+      if (effective) {
+        await this.onAccessGained(row);
+      } else {
+        await this.onAccessLost(row, reason);
+      }
+    } catch (error) {
+      // Access bookkeeping must never break the membership-sync ACK loop.
+      this.logger.error(
+        `recordAccessTransition(${row.sale_address}, ${row.member_address}, effective=${effective}) failed`,
+        error as Error,
+      );
+    }
+  }
+
+  /** relay_state is now 'added' → the member has room access. */
+  private async onAccessGained(row: RoomMembership): Promise<void> {
+    if (row.access_state === 'granted') {
+      // Already granted. If a revoke was armed (a flap: removed then re-added
+      // within the grace window), cancel it silently — no push either way.
+      if (row.pending_revoke_since) {
+        await this.membershipRepo.update(
+          { id: row.id },
+          { pending_revoke_since: null, pending_revoke_reason: null },
+        );
+      }
+      return;
+    }
+
+    // Genuine transition none → granted.
+    const priorGrants = await this.eventRepo.count({
+      where: {
+        sale_address: row.sale_address,
+        member_address: row.member_address,
+        event: 'access_granted',
+      },
+    });
+    const isFirst = priorGrants === 0;
+    const now = new Date();
+
+    await this.membershipRepo.update(
+      { id: row.id },
+      {
+        access_state: 'granted',
+        access_changed_at: now,
+        pending_revoke_since: null,
+        pending_revoke_reason: null,
+      },
+    );
+
+    const event = await this.eventRepo.save(
+      this.eventRepo.create({
+        sale_address: row.sale_address,
+        member_address: row.member_address,
+        event: 'access_granted',
+        reason: isFirst ? 'join' : 'regained',
+        is_first_grant: isFirst,
+      }),
+    );
+
+    this.emit(row, 'added', event.id, isFirst, event.reason);
+  }
+
+  /** relay_state is now removed → arm the revoke debounce (no push yet). */
+  private async onAccessLost(
+    row: RoomMembership,
+    reason: string,
+  ): Promise<void> {
+    if (row.access_state !== 'granted') {
+      // Never had (notified) access — nothing to revoke (e.g. an unlinked member
+      // that was never granted, or an already-revoked row).
+      return;
+    }
+    if (row.pending_revoke_since) {
+      return; // already armed — keep the earliest arm time
+    }
+    await this.membershipRepo.update(
+      { id: row.id },
+      {
+        pending_revoke_since: new Date(),
+        pending_revoke_reason: reason || 'access_lost',
+      },
+    );
+  }
+
+  /**
+   * Finalize armed revokes whose grace window has elapsed (access-ledger plan §3.5).
+   * Pure DB + event-emit — safe to run regardless of relay configuration. Scheduled
+   * as a repeatable job by `ReconcileProcessor`.
+   *
+   * For each row with `pending_revoke_since <= now - grace`:
+   *  - re-added during grace (`relay_state='added'`) → clear the arm, no push (flap
+   *    absorbed);
+   *  - still removed → record ONE `access_revoked` + push, flip `access_state='none'`.
+   */
+  async finalizeDueRevokes(): Promise<{ revoked: number; cancelled: number }> {
+    const graceMs = Math.max(0, this.config.accessRevokeGraceSec) * 1000;
+    const cutoff = new Date(Date.now() - graceMs);
+
+    const due = await this.membershipRepo.find({
+      where: { pending_revoke_since: LessThanOrEqual(cutoff) },
+      take: 500,
+    });
+
+    let revoked = 0;
+    let cancelled = 0;
+    for (const row of due) {
+      try {
+        if (row.relay_state === 'added' || row.access_state !== 'granted') {
+          // Re-added during the grace window, or already resolved elsewhere —
+          // clear the arm silently.
+          await this.membershipRepo.update(
+            { id: row.id },
+            { pending_revoke_since: null, pending_revoke_reason: null },
+          );
+          if (row.relay_state === 'added') {
+            cancelled += 1;
+          }
+          continue;
+        }
+
+        const reason = row.pending_revoke_reason || 'access_lost';
+        const now = new Date();
+        await this.membershipRepo.update(
+          { id: row.id },
+          {
+            access_state: 'none',
+            access_changed_at: now,
+            pending_revoke_since: null,
+            pending_revoke_reason: null,
+          },
+        );
+        const event = await this.eventRepo.save(
+          this.eventRepo.create({
+            sale_address: row.sale_address,
+            member_address: row.member_address,
+            event: 'access_revoked',
+            reason,
+            is_first_grant: false,
+          }),
+        );
+        this.emit(row, 'removed', event.id, false, reason);
+        revoked += 1;
+      } catch (error) {
+        this.logger.error(
+          `finalizeDueRevokes: row ${row.id} (${row.sale_address}/${row.member_address}) failed`,
+          error as Error,
+        );
+      }
+    }
+
+    if (revoked > 0 || cancelled > 0) {
+      this.logger.debug(
+        `finalizeDueRevokes: revoked=${revoked} cancelled=${cancelled}`,
+      );
+    }
+    return { revoked, cancelled };
+  }
+
+  /** Emit the enriched `tgr.membership.changed` for a real access transition. */
+  private emit(
+    row: RoomMembership,
+    relayState: TgrMembershipChangedPayload['relayState'],
+    accessEventId: string,
+    isFirstGrant: boolean,
+    reason: string,
+  ): void {
+    const payload: TgrMembershipChangedPayload = {
+      saleAddress: row.sale_address,
+      memberAddress: row.member_address,
+      relayState,
+      accessEventId,
+      isFirstGrant,
+      reason,
+    };
+    this.eventEmitter.emit(TGR_MEMBERSHIP_CHANGED, payload);
+  }
+}

--- a/src/token-gated-rooms/services/membership-sync.service.integration.spec.ts
+++ b/src/token-gated-rooms/services/membership-sync.service.integration.spec.ts
@@ -1,0 +1,551 @@
+import 'dotenv/config';
+import { DataSource, Repository } from 'typeorm';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { SchedulerRegistry } from '@nestjs/schedule';
+import type { Queue } from 'bull';
+import { BigNumber } from 'bignumber.js';
+import { Relay } from 'nostr-tools';
+import WebSocket from 'ws';
+import { DATABASE_CONFIG } from '@/configs/database';
+import { Token } from '@/tokens/entities/token.entity';
+import { CommunityRoom } from '../entities/community-room.entity';
+import { RoomMembership } from '../entities/room-membership.entity';
+import { RoomNotificationPreference } from '../entities/room-notification-preference.entity';
+import { RoomMessageSeen } from '../entities/room-message-seen.entity';
+import { TokenBalance } from '../entities/token-balance.entity';
+import { RoomBackfillState } from '../entities/room-backfill-state.entity';
+import { NIP29_KIND } from '../nostr/nip29';
+import { RelayWriterService } from '../nostr/relay-writer.service';
+import {
+  TGR_MEMBERSHIP_CHANGED,
+  type TgrMembershipChangedPayload,
+} from '../events';
+import type { PublishNip29Job } from '../queues/publish-nip29.types';
+import { MembershipSyncService } from './membership-sync.service';
+
+if (typeof (globalThis as { WebSocket?: unknown }).WebSocket === 'undefined') {
+  (globalThis as { WebSocket?: unknown }).WebSocket = WebSocket;
+}
+
+/**
+ * DB (+ optional relay) integration for membership-sync (Task 10). Mirrors the
+ * Task 09 backfill harness: a real Postgres backs `token` + `community_room` +
+ * `room_membership` in a DEDICATED `tgr10_test` schema (`synchronize: true`), so
+ * the desired-state ledger is naturally scoped and never touches `public`.
+ *
+ * The relay WRITE path (the `worker:publish-nip29` queue + processor) is the Task
+ * 07 contract; here we MOCK the queue and drive the state machine by replaying the
+ * `tgr.publish.ack` the publish processor would emit — exactly the seam Task 10
+ * consumes. A relay socket is opened ONLY for the flagged relay section, which
+ * publishes the enqueued templates straight through `RelayWriterService` (what the
+ * processor does) and asserts the relay's `39002`/`39001` reflect them; it
+ * auto-skips when no `groups_relay` is reachable.
+ *
+ * Requires the local Postgres (`DB_HOST`); auto-skips otherwise so unit-only runs
+ * stay green.
+ */
+const HAS_DB = !!process.env.DB_HOST;
+const d = HAS_DB ? describe : describe.skip;
+
+const SCHEMA = 'tgr10_test';
+const SALE = 'ct_tgr10_sale';
+const TOKEN_ADDR = 'ct_tgr10_token';
+const MEMBER = 'ak_tgr10_member';
+const PUBKEY = 'a'.repeat(64);
+
+const RELAY_URL = process.env.TG_RELAY_URL || 'ws://localhost:8080';
+const RELAY_ADMIN_NSEC =
+  process.env.TG_BOT_NSEC ||
+  'nsec1dwg3l5mumawgr4xq4kc6klagytkj2w4s4kd2rrthy47g3v5mwx8qwrh7sx';
+
+async function relayReachable(url: string): Promise<boolean> {
+  try {
+    const relay = await Relay.connect(url);
+    relay.close();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+d('MembershipSyncService (integration)', () => {
+  let ds: DataSource;
+  let tokenRepo: Repository<Token>;
+  let roomRepo: Repository<CommunityRoom>;
+  let membershipRepo: Repository<RoomMembership>;
+  let emitter: EventEmitter2;
+  let service: MembershipSyncService;
+  let publishQueue: { add: jest.Mock };
+  let isConfiguredAdmin: jest.Mock;
+
+  /** Replay the ACK the publish processor would emit for one member publish. */
+  const ack = (kind: number, pubkey = PUBKEY, ok = true): Promise<void> =>
+    service.onPublishAck({ saleAddress: SALE, pubkey, kind, ok });
+
+  beforeAll(async () => {
+    const boot = new DataSource({
+      ...(DATABASE_CONFIG as any),
+      synchronize: false,
+      entities: [],
+    });
+    await boot.initialize();
+    await boot.query(`DROP SCHEMA IF EXISTS "${SCHEMA}" CASCADE`);
+    await boot.query(`CREATE SCHEMA "${SCHEMA}"`);
+    await boot.destroy();
+
+    ds = new DataSource({
+      ...(DATABASE_CONFIG as any),
+      schema: SCHEMA,
+      synchronize: true,
+      entities: [
+        Token,
+        CommunityRoom,
+        RoomMembership,
+        RoomNotificationPreference,
+        RoomMessageSeen,
+        TokenBalance,
+        RoomBackfillState,
+      ],
+    });
+    await ds.initialize();
+
+    tokenRepo = ds.getRepository(Token);
+    roomRepo = ds.getRepository(CommunityRoom);
+    membershipRepo = ds.getRepository(RoomMembership);
+  }, 60_000);
+
+  beforeEach(async () => {
+    await membershipRepo.clear();
+    await roomRepo.clear();
+    await tokenRepo.clear();
+
+    emitter = new EventEmitter2();
+    publishQueue = { add: jest.fn().mockResolvedValue({ id: 'p' }) } as any;
+    isConfiguredAdmin = jest.fn().mockReturnValue(false);
+
+    service = new MembershipSyncService(
+      membershipRepo,
+      roomRepo,
+      tokenRepo,
+      publishQueue as unknown as Queue<PublishNip29Job>,
+      { isConfiguredAdmin } as any,
+      emitter,
+      new SchedulerRegistry(),
+      {
+        publishMaxRetries: 5,
+        reconcileBatchSize: 2,
+        reconcileIntervalSec: 600,
+      } as any,
+    );
+  });
+
+  afterAll(async () => {
+    if (ds?.isInitialized) {
+      await ds.destroy();
+    }
+    const cleanup = new DataSource({
+      ...(DATABASE_CONFIG as any),
+      synchronize: false,
+      entities: [],
+    });
+    await cleanup.initialize();
+    await cleanup.query(`DROP SCHEMA IF EXISTS "${SCHEMA}" CASCADE`);
+    await cleanup.destroy();
+  }, 60_000);
+
+  async function seedCreatedRoom(
+    over: Partial<CommunityRoom> = {},
+  ): Promise<void> {
+    await tokenRepo.save(
+      tokenRepo.create({
+        sale_address: SALE,
+        address: TOKEN_ADDR,
+        name: 'TGR10',
+        symbol: 'TGR',
+        owner_address: 'ak_owner',
+        nostr_group_id: SALE,
+        nostr_room_state: 'created',
+        has_nostr_room: true,
+      } as Partial<Token>),
+    );
+    await roomRepo.save(
+      roomRepo.create({
+        sale_address: SALE,
+        token_address: TOKEN_ADDR,
+        symbol: 'TGR',
+        owner_address: 'ak_owner',
+        is_private: true,
+        min_token_threshold: new BigNumber('1000'),
+        moderators: [],
+        muted: [],
+        is_community: true,
+        deleted: false,
+        ...over,
+      }),
+    );
+  }
+
+  it('eligibility flip → 9000 enqueued, ACK → relay_state=added + last_published_at + emits', async () => {
+    await seedCreatedRoom();
+    await membershipRepo.save(
+      membershipRepo.create({
+        sale_address: SALE,
+        member_address: MEMBER,
+        member_pubkey: PUBKEY,
+        role: 'member',
+        eligible: true,
+        relay_state: 'pending_add',
+      }),
+    );
+
+    const seen: TgrMembershipChangedPayload[] = [];
+    emitter.on(TGR_MEMBERSHIP_CHANGED, (p) => seen.push(p));
+
+    await service.onEligibilityChanged({
+      saleAddress: SALE,
+      memberAddress: MEMBER,
+      eligible: true,
+    });
+
+    expect(publishQueue.add).toHaveBeenCalledTimes(1);
+    expect(publishQueue.add.mock.calls[0][0].template.kind).toBe(
+      NIP29_KIND.PUT_USER,
+    );
+
+    // No state change until the ACK arrives.
+    let row = await membershipRepo.findOneByOrFail({
+      sale_address: SALE,
+      member_address: MEMBER,
+    });
+    expect(row.relay_state).toBe('pending_add');
+    expect(row.last_published_at).toBeNull();
+
+    await ack(NIP29_KIND.PUT_USER);
+
+    row = await membershipRepo.findOneByOrFail({
+      sale_address: SALE,
+      member_address: MEMBER,
+    });
+    expect(row.relay_state).toBe('added');
+    expect(row.last_published_at).toBeInstanceOf(Date);
+    expect(seen).toEqual([
+      { saleAddress: SALE, memberAddress: MEMBER, relayState: 'added' },
+    ]);
+  });
+
+  it('eligibility off → 9001 enqueued, ACK → relay_state=removed', async () => {
+    await seedCreatedRoom();
+    await membershipRepo.save(
+      membershipRepo.create({
+        sale_address: SALE,
+        member_address: MEMBER,
+        member_pubkey: PUBKEY,
+        role: 'member',
+        eligible: false,
+        relay_state: 'pending_remove',
+      }),
+    );
+
+    await service.onEligibilityChanged({
+      saleAddress: SALE,
+      memberAddress: MEMBER,
+      eligible: false,
+    });
+    expect(publishQueue.add.mock.calls[0][0].template.kind).toBe(
+      NIP29_KIND.REMOVE_USER,
+    );
+
+    await ack(NIP29_KIND.REMOVE_USER);
+    const row = await membershipRepo.findOneByOrFail({
+      sale_address: SALE,
+      member_address: MEMBER,
+    });
+    expect(row.relay_state).toBe('removed');
+  });
+
+  it('unlinked eligible member (null pubkey) is NEVER published, stays pending_add', async () => {
+    await seedCreatedRoom();
+    await membershipRepo.save(
+      membershipRepo.create({
+        sale_address: SALE,
+        member_address: MEMBER,
+        member_pubkey: null as any,
+        role: 'member',
+        eligible: true,
+        relay_state: 'pending_add',
+      }),
+    );
+
+    await service.onEligibilityChanged({
+      saleAddress: SALE,
+      memberAddress: MEMBER,
+      eligible: true,
+    });
+    // Also exercised by the scan: the SQL predicate excludes null-pubkey pending_add.
+    const scanned = await service.scanAndPublishPending();
+
+    expect(publishQueue.add).not.toHaveBeenCalled();
+    expect(scanned).toBe(0);
+    const row = await membershipRepo.findOneByOrFail({
+      sale_address: SALE,
+      member_address: MEMBER,
+    });
+    expect(row.relay_state).toBe('pending_add');
+  });
+
+  it('scan publishes pending members only for created rooms (and skips null-pubkey adds)', async () => {
+    await seedCreatedRoom();
+    await membershipRepo.save([
+      membershipRepo.create({
+        sale_address: SALE,
+        member_address: 'ak_a',
+        member_pubkey: 'b'.repeat(64),
+        role: 'member',
+        eligible: true,
+        relay_state: 'pending_add',
+      }),
+      membershipRepo.create({
+        sale_address: SALE,
+        member_address: 'ak_b',
+        member_pubkey: null as any,
+        role: 'member',
+        eligible: true,
+        relay_state: 'pending_add',
+      }),
+      membershipRepo.create({
+        sale_address: SALE,
+        member_address: 'ak_c',
+        member_pubkey: 'c'.repeat(64),
+        role: 'member',
+        eligible: false,
+        relay_state: 'pending_remove',
+      }),
+    ]);
+
+    const published = await service.scanAndPublishPending();
+
+    // ak_a (9000) + ak_c (9001); ak_b (null pubkey) skipped (§6.6).
+    expect(published).toBe(2);
+    const kinds = publishQueue.add.mock.calls
+      .map((c) => c[0].template.kind)
+      .sort();
+    expect(kinds).toEqual([NIP29_KIND.PUT_USER, NIP29_KIND.REMOVE_USER].sort());
+  });
+
+  it('onRoomCreated drains all pending members of the now-created room', async () => {
+    await seedCreatedRoom();
+    await membershipRepo.save([
+      membershipRepo.create({
+        sale_address: SALE,
+        member_address: 'ak_a',
+        member_pubkey: 'b'.repeat(64),
+        eligible: true,
+        relay_state: 'pending_add',
+      }),
+      membershipRepo.create({
+        sale_address: SALE,
+        member_address: 'ak_b',
+        member_pubkey: 'c'.repeat(64),
+        eligible: true,
+        relay_state: 'pending_add',
+      }),
+    ]);
+
+    await service.onRoomCreated({ saleAddress: SALE });
+    expect(publishQueue.add).toHaveBeenCalledTimes(2);
+  });
+
+  it('community delete → exactly one 9008, all rows terminal removed, no resurrection', async () => {
+    await seedCreatedRoom();
+    await membershipRepo.save([
+      membershipRepo.create({
+        sale_address: SALE,
+        member_address: 'ak_a',
+        member_pubkey: 'b'.repeat(64),
+        eligible: true,
+        relay_state: 'added',
+      }),
+      membershipRepo.create({
+        sale_address: SALE,
+        member_address: 'ak_b',
+        member_pubkey: 'c'.repeat(64),
+        eligible: true,
+        relay_state: 'pending_add',
+      }),
+    ]);
+    // Flag the community deleted (Task 04 would do this) before the event.
+    await roomRepo.update({ sale_address: SALE }, { deleted: true });
+
+    await service.onCommunityUpserted({ saleAddress: SALE });
+
+    expect(publishQueue.add).toHaveBeenCalledTimes(1);
+    expect(publishQueue.add.mock.calls[0][0].template.kind).toBe(
+      NIP29_KIND.DELETE_GROUP,
+    );
+    const rows = await membershipRepo.find({ where: { sale_address: SALE } });
+    expect(rows.every((r) => r.relay_state === 'removed')).toBe(true);
+
+    // A subsequent add attempt does not resurrect a deleted room.
+    publishQueue.add.mockClear();
+    await service.onEligibilityChanged({
+      saleAddress: SALE,
+      memberAddress: 'ak_a',
+      eligible: true,
+    });
+    expect(publishQueue.add).not.toHaveBeenCalled();
+  });
+
+  it('burst of N eligibility flips produces ≤ N publishes (no duplicate adds)', async () => {
+    await seedCreatedRoom();
+    const N = 6;
+    for (let i = 0; i < N; i++) {
+      await membershipRepo.save(
+        membershipRepo.create({
+          sale_address: SALE,
+          member_address: `ak_burst_${i}`,
+          member_pubkey: `${i}`.repeat(64),
+          eligible: true,
+          relay_state: 'pending_add',
+        }),
+      );
+    }
+    const published = await service.scanAndPublishPending();
+    expect(published).toBe(N);
+    expect(publishQueue.add).toHaveBeenCalledTimes(N);
+
+    // Idempotent re-run: ACK them all, then a second scan enqueues nothing.
+    for (let i = 0; i < N; i++) {
+      await ack(NIP29_KIND.PUT_USER, `${i}`.repeat(64));
+    }
+    publishQueue.add.mockClear();
+    const again = await service.scanAndPublishPending();
+    expect(again).toBe(0);
+    expect(publishQueue.add).not.toHaveBeenCalled();
+  });
+
+  // ── relay-backed section (auto-skips without a reachable groups_relay) ───────
+  describe('relay-backed', () => {
+    let relayAvailable = false;
+    let writer: RelayWriterService;
+
+    beforeAll(async () => {
+      relayAvailable =
+        !!process.env.TG_RELAY_URL || (await relayReachable(RELAY_URL));
+      if (relayAvailable) {
+        writer = new RelayWriterService({
+          nostrRelayUrl: RELAY_URL,
+          nostrBotNsec: RELAY_ADMIN_NSEC,
+          publishAckTimeoutMs: 5000,
+          publishRatePerSec: 100,
+          publishMaxRetries: 5,
+          relayHealthPauseSec: 1,
+        } as any);
+        await writer.onModuleInit();
+      } else {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[membership-sync.integration] relay section skipped — no relay at ${RELAY_URL}`,
+        );
+      }
+    }, 30_000);
+
+    afterAll(() => {
+      writer?.onApplicationShutdown();
+    });
+
+    const itRelay = (name: string, fn: () => Promise<void>, timeout = 20000) =>
+      it(
+        name,
+        async () => {
+          if (!relayAvailable) {
+            return;
+          }
+          await fn();
+        },
+        timeout,
+      );
+
+    itRelay(
+      'enqueued 9000 published to the relay shows in 39002 members; 9001 removes it',
+      async () => {
+        const { createGroup, editMetadata } = await import('../nostr/nip29');
+        const gid = `ct_TgrSync10_${Date.now()}`;
+        await writer.publish(createGroup(gid));
+        await writer.publish(
+          editMetadata(gid, { name: 'SYNC', isPrivate: true }),
+        );
+
+        const { generateSecretKey, getPublicKey } = await import('nostr-tools');
+        const memberPubkey = getPublicKey(generateSecretKey());
+
+        // Seed a created room for this gid + an eligible pending_add member, then
+        // drive the service: it enqueues a 9000 which we publish through the writer
+        // (what the processor does), then assert 39002 reflects the member.
+        await tokenRepo.save(
+          tokenRepo.create({
+            sale_address: gid,
+            address: 'ct_t_' + gid,
+            name: 'SYNC',
+            symbol: 'SYNC',
+            owner_address: 'ak_o',
+            nostr_group_id: gid,
+            nostr_room_state: 'created',
+            has_nostr_room: true,
+          } as Partial<Token>),
+        );
+        await roomRepo.save(
+          roomRepo.create({
+            sale_address: gid,
+            token_address: 'ct_t_' + gid,
+            symbol: 'SYNC',
+            owner_address: 'ak_o',
+            is_private: true,
+            min_token_threshold: new BigNumber('1'),
+            moderators: [],
+            muted: [],
+            is_community: true,
+            deleted: false,
+          }),
+        );
+        await membershipRepo.save(
+          membershipRepo.create({
+            sale_address: gid,
+            member_address: 'ak_relay_member',
+            member_pubkey: memberPubkey,
+            eligible: true,
+            relay_state: 'pending_add',
+          }),
+        );
+
+        await service.onEligibilityChanged({
+          saleAddress: gid,
+          memberAddress: 'ak_relay_member',
+          eligible: true,
+        });
+        const addJob = publishQueue.add.mock.calls.at(-1)![0];
+        expect((await writer.publish(addJob.template)).ok).toBe(true);
+        await new Promise((r) => setTimeout(r, 600));
+
+        let members = await writer.fetchGroupMembers(gid);
+        expect(members.has(memberPubkey)).toBe(true);
+
+        // Flip eligible=false → 9001 → member gone from 39002.
+        await membershipRepo.update(
+          { sale_address: gid, member_address: 'ak_relay_member' },
+          { eligible: false, relay_state: 'pending_remove' },
+        );
+        await service.onEligibilityChanged({
+          saleAddress: gid,
+          memberAddress: 'ak_relay_member',
+          eligible: false,
+        });
+        const removeJob = publishQueue.add.mock.calls.at(-1)![0];
+        expect((await writer.publish(removeJob.template)).ok).toBe(true);
+        await new Promise((r) => setTimeout(r, 600));
+
+        members = await writer.fetchGroupMembers(gid);
+        expect(members.has(memberPubkey)).toBe(false);
+      },
+    );
+  });
+});

--- a/src/token-gated-rooms/services/membership-sync.service.integration.spec.ts
+++ b/src/token-gated-rooms/services/membership-sync.service.integration.spec.ts
@@ -10,6 +10,7 @@ import { DATABASE_CONFIG } from '@/configs/database';
 import { Token } from '@/tokens/entities/token.entity';
 import { CommunityRoom } from '../entities/community-room.entity';
 import { RoomMembership } from '../entities/room-membership.entity';
+import { RoomMembershipEvent } from '../entities/room-membership-event.entity';
 import { RoomNotificationPreference } from '../entities/room-notification-preference.entity';
 import { RoomMessageSeen } from '../entities/room-message-seen.entity';
 import { TokenBalance } from '../entities/token-balance.entity';
@@ -21,6 +22,7 @@ import {
   type TgrMembershipChangedPayload,
 } from '../events';
 import type { PublishNip29Job } from '../queues/publish-nip29.types';
+import { MembershipAccessService } from './membership-access.service';
 import { MembershipSyncService } from './membership-sync.service';
 
 if (typeof (globalThis as { WebSocket?: unknown }).WebSocket === 'undefined') {
@@ -101,6 +103,7 @@ d('MembershipSyncService (integration)', () => {
         Token,
         CommunityRoom,
         RoomMembership,
+        RoomMembershipEvent,
         RoomNotificationPreference,
         RoomMessageSeen,
         TokenBalance,
@@ -123,6 +126,13 @@ d('MembershipSyncService (integration)', () => {
     publishQueue = { add: jest.fn().mockResolvedValue({ id: 'p' }) } as any;
     isConfiguredAdmin = jest.fn().mockReturnValue(false);
 
+    const membershipAccess = new MembershipAccessService(
+      membershipRepo,
+      ds.getRepository(RoomMembershipEvent),
+      emitter,
+      { accessRevokeGraceSec: 180 } as any,
+    );
+
     service = new MembershipSyncService(
       membershipRepo,
       roomRepo,
@@ -136,6 +146,8 @@ d('MembershipSyncService (integration)', () => {
         reconcileBatchSize: 2,
         reconcileIntervalSec: 600,
       } as any,
+      undefined, // groupMissing (optional)
+      membershipAccess,
     );
   });
 
@@ -228,9 +240,18 @@ d('MembershipSyncService (integration)', () => {
     });
     expect(row.relay_state).toBe('added');
     expect(row.last_published_at).toBeInstanceOf(Date);
-    expect(seen).toEqual([
-      { saleAddress: SALE, memberAddress: MEMBER, relayState: 'added' },
-    ]);
+    // The push is now emitted by the access-transition ledger with the enriched
+    // payload (ledger event id + first-grant flag).
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toMatchObject({
+      saleAddress: SALE,
+      memberAddress: MEMBER,
+      relayState: 'added',
+      isFirstGrant: true,
+    });
+    expect(seen[0].accessEventId).toBeDefined();
+    // The row's effective-access state flips to granted.
+    expect(row.access_state).toBe('granted');
   });
 
   it('eligibility off → 9001 enqueued, ACK → relay_state=removed', async () => {

--- a/src/token-gated-rooms/services/membership-sync.service.spec.ts
+++ b/src/token-gated-rooms/services/membership-sync.service.spec.ts
@@ -1,0 +1,611 @@
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { SchedulerRegistry } from '@nestjs/schedule';
+import { Repository } from 'typeorm';
+import { Queue } from 'bull';
+import {
+  MEMBERSHIP_SYNC_SCAN_JOB,
+  MembershipSyncService,
+  roomConfirmedCreated,
+} from './membership-sync.service';
+import { CommunityRoom } from '../entities/community-room.entity';
+import { RoomMembership } from '../entities/room-membership.entity';
+import { Token } from '@/tokens/entities/token.entity';
+import { RoomAdminsService } from './room-admins.service';
+import { NIP29_KIND } from '../nostr/nip29';
+import {
+  TGR_MEMBERSHIP_CHANGED,
+  type TgrMembershipChangedPayload,
+} from '../events';
+
+const SALE = 'ct_sale';
+const GROUP = SALE;
+const PUBKEY = 'a'.repeat(64);
+
+function makeRoom(over: Partial<CommunityRoom> = {}): CommunityRoom {
+  return {
+    sale_address: SALE,
+    token_address: 'ct_token',
+    symbol: 'TGR',
+    owner_address: 'ak_owner',
+    is_private: false,
+    min_token_threshold: undefined as any,
+    moderators: [],
+    muted: [],
+    is_community: true,
+    state_synced_at: new Date(),
+    created_height: 1,
+    deleted: false,
+    ...over,
+  } as CommunityRoom;
+}
+
+function makeMembership(over: Partial<RoomMembership> = {}): RoomMembership {
+  return {
+    id: 1,
+    sale_address: SALE,
+    member_address: 'ak_member',
+    member_pubkey: PUBKEY,
+    role: 'member',
+    eligible: true,
+    relay_state: 'pending_add',
+    held_until_height: null as any,
+    last_published_at: null as any,
+    last_reconciled_at: null as any,
+    updated_at: new Date(),
+    ...over,
+  } as RoomMembership;
+}
+
+function makeToken(over: Partial<Token> = {}): Token {
+  return {
+    sale_address: SALE,
+    nostr_group_id: null,
+    nostr_room_state: 'created',
+    ...over,
+  } as unknown as Token;
+}
+
+interface Harness {
+  service: MembershipSyncService;
+  membershipRepo: jest.Mocked<Repository<RoomMembership>>;
+  communityRoomRepo: jest.Mocked<Repository<CommunityRoom>>;
+  tokenRepo: jest.Mocked<Repository<Token>>;
+  queue: { add: jest.Mock };
+  roomAdmins: { isConfiguredAdmin: jest.Mock };
+  emitter: EventEmitter2;
+  emitted: TgrMembershipChangedPayload[];
+  scheduler: {
+    addInterval: jest.Mock;
+    deleteInterval: jest.Mock;
+    doesExist: jest.Mock;
+  };
+}
+
+function setup(
+  opts: {
+    room?: CommunityRoom | null;
+    token?: Token | null;
+    membership?: RoomMembership | null;
+    isConfiguredAdmin?: boolean;
+    /**
+     * When true, the injected tgrConfig carries a relay url + bot nsec, so
+     * `isRelayConfigured(this.config)` is true and the relay-actuator duties
+     * (the periodic membership-sync scan interval) self-enable. Left false
+     * (default) the config has no relay credentials → the service stays dormant.
+     */
+    relayConfigured?: boolean;
+  } = {},
+): Harness {
+  const queue = { add: jest.fn().mockResolvedValue(undefined) };
+  const membershipRepo = {
+    findOne: jest.fn().mockResolvedValue(opts.membership ?? null),
+    find: jest.fn().mockResolvedValue([]),
+    update: jest.fn().mockResolvedValue(undefined),
+    createQueryBuilder: jest.fn(),
+  } as unknown as jest.Mocked<Repository<RoomMembership>>;
+  const communityRoomRepo = {
+    findOne: jest.fn().mockResolvedValue(opts.room ?? null),
+  } as unknown as jest.Mocked<Repository<CommunityRoom>>;
+  const tokenRepo = {
+    findOne: jest.fn().mockResolvedValue(opts.token ?? makeToken()),
+  } as unknown as jest.Mocked<Repository<Token>>;
+  const roomAdmins = {
+    isConfiguredAdmin: jest
+      .fn()
+      .mockReturnValue(opts.isConfiguredAdmin ?? false),
+  };
+  const emitter = new EventEmitter2();
+  const emitted: TgrMembershipChangedPayload[] = [];
+  emitter.on(TGR_MEMBERSHIP_CHANGED, (p: TgrMembershipChangedPayload) =>
+    emitted.push(p),
+  );
+  const scheduler = {
+    addInterval: jest.fn(),
+    deleteInterval: jest.fn(),
+    doesExist: jest.fn().mockReturnValue(false),
+  };
+
+  const service = new MembershipSyncService(
+    membershipRepo,
+    communityRoomRepo,
+    tokenRepo,
+    queue as unknown as Queue,
+    roomAdmins as unknown as RoomAdminsService,
+    emitter,
+    scheduler as unknown as SchedulerRegistry,
+    {
+      // Relay creds gate the relay-actuator duties via `isRelayConfigured`
+      // (worker mode removed — see deworker-plan.md). Set only when the test
+      // wants the membership-sync scan interval to self-enable.
+      nostrRelayUrl: opts.relayConfigured ? 'ws://relay' : undefined,
+      nostrBotNsec: opts.relayConfigured ? 'nsec1abc' : undefined,
+      publishMaxRetries: 5,
+      reconcileBatchSize: 500,
+      reconcileIntervalSec: 600,
+    } as any,
+  );
+
+  return {
+    service,
+    membershipRepo,
+    communityRoomRepo,
+    tokenRepo,
+    queue,
+    roomAdmins,
+    emitter,
+    emitted,
+    scheduler,
+  };
+}
+
+/** Build a chainable query-builder mock returning `pages` in sequence. */
+function queryBuilderReturning(pages: RoomMembership[][]) {
+  let call = 0;
+  const qb: any = {
+    where: jest.fn(() => qb),
+    andWhere: jest.fn(() => qb),
+    orderBy: jest.fn(() => qb),
+    limit: jest.fn(() => qb),
+    getMany: jest.fn(async () => pages[call++] ?? []),
+  };
+  return qb;
+}
+
+describe('MembershipSyncService — desired→publish mapping', () => {
+  it('pending_add (+pubkey, not muted, not deleted) → one 9000 putUser with correct group/p tag', async () => {
+    const row = makeMembership({ relay_state: 'pending_add', role: 'member' });
+    const h = setup({ room: makeRoom(), membership: row });
+
+    const enqueued = await h.service.publishForRow(row);
+
+    expect(enqueued).toBe(true);
+    expect(h.queue.add).toHaveBeenCalledTimes(1);
+    const job = h.queue.add.mock.calls[0][0];
+    expect(job.template.kind).toBe(NIP29_KIND.PUT_USER);
+    expect(job.groupId).toBe(GROUP);
+    expect(job.template.tags[0]).toEqual(['h', GROUP]);
+    expect(job.template.tags[1]).toEqual(['p', PUBKEY]); // plain member add
+  });
+
+  it('pending_add with admin role → 9000 ["p", pubkey, "admin"]', async () => {
+    const row = makeMembership({ relay_state: 'pending_add', role: 'admin' });
+    const h = setup({ room: makeRoom(), membership: row });
+
+    await h.service.publishForRow(row);
+
+    const job = h.queue.add.mock.calls[0][0];
+    expect(job.template.kind).toBe(NIP29_KIND.PUT_USER);
+    expect(job.template.tags[1]).toEqual(['p', PUBKEY, 'admin']);
+  });
+
+  it('pending_remove (+pubkey, not configured admin) → one 9001 removeUser', async () => {
+    const row = makeMembership({ relay_state: 'pending_remove' });
+    const h = setup({ room: makeRoom(), membership: row });
+
+    const enqueued = await h.service.publishForRow(row);
+
+    expect(enqueued).toBe(true);
+    const job = h.queue.add.mock.calls[0][0];
+    expect(job.template.kind).toBe(NIP29_KIND.REMOVE_USER);
+    expect(job.groupId).toBe(GROUP);
+    expect(job.template.tags[1]).toEqual(['p', PUBKEY]);
+  });
+});
+
+describe('MembershipSyncService — skip unlinked (§6.6)', () => {
+  it('pending_add with member_pubkey=null → no enqueue, no event, stays pending_add', async () => {
+    const row = makeMembership({
+      relay_state: 'pending_add',
+      member_pubkey: null as any,
+    });
+    const h = setup({ room: makeRoom(), membership: row });
+
+    const enqueued = await h.service.publishForRow(row);
+
+    expect(enqueued).toBe(false);
+    expect(h.queue.add).not.toHaveBeenCalled();
+    expect(h.membershipRepo.update).not.toHaveBeenCalled();
+    expect(h.emitted).toHaveLength(0);
+  });
+});
+
+describe('MembershipSyncService — mute (§5.1, never re-add)', () => {
+  it('stale pending_add for a muted member enqueues NO 9000', async () => {
+    const row = makeMembership({ relay_state: 'pending_add' });
+    const h = setup({
+      room: makeRoom({ muted: ['ak_member'] }),
+      membership: row,
+    });
+
+    const enqueued = await h.service.publishForRow(row);
+
+    expect(enqueued).toBe(false);
+    expect(h.queue.add).not.toHaveBeenCalled();
+  });
+
+  it('muted member desired-removed → 9001 still enqueues', async () => {
+    const row = makeMembership({ relay_state: 'pending_remove' });
+    const h = setup({
+      room: makeRoom({ muted: ['ak_member'] }),
+      membership: row,
+    });
+
+    const enqueued = await h.service.publishForRow(row);
+
+    expect(enqueued).toBe(true);
+    expect(h.queue.add.mock.calls[0][0].template.kind).toBe(
+      NIP29_KIND.REMOVE_USER,
+    );
+  });
+});
+
+describe('MembershipSyncService — admin exemption (§6.7)', () => {
+  it('pending_remove whose pubkey isConfiguredAdmin → no 9001 enqueued', async () => {
+    const row = makeMembership({ relay_state: 'pending_remove' });
+    const h = setup({
+      room: makeRoom(),
+      membership: row,
+      isConfiguredAdmin: true,
+    });
+
+    const enqueued = await h.service.publishForRow(row);
+
+    expect(enqueued).toBe(false);
+    expect(h.roomAdmins.isConfiguredAdmin).toHaveBeenCalledWith(PUBKEY);
+    expect(h.queue.add).not.toHaveBeenCalled();
+  });
+});
+
+describe('MembershipSyncService — role transitions (§6.7)', () => {
+  it('member → admin promotion → 9006 setRoles(["admin"])', async () => {
+    const row = makeMembership({ relay_state: 'added', role: 'admin' });
+    const h = setup({ room: makeRoom(), membership: row });
+
+    const enqueued = await h.service.publishRoleChange(SALE, 'ak_member');
+
+    expect(enqueued).toBe(true);
+    const job = h.queue.add.mock.calls[0][0];
+    expect(job.template.kind).toBe(NIP29_KIND.SET_ROLES);
+    expect(job.template.tags[1]).toEqual(['p', PUBKEY, 'admin']);
+  });
+
+  it('admin → member demotion → 9006 setRoles(["member"]), never a 9000 downgrade', async () => {
+    const row = makeMembership({ relay_state: 'added', role: 'member' });
+    const h = setup({ room: makeRoom(), membership: row });
+
+    const enqueued = await h.service.publishRoleChange(SALE, 'ak_member');
+
+    expect(enqueued).toBe(true);
+    const job = h.queue.add.mock.calls[0][0];
+    expect(job.template.kind).toBe(NIP29_KIND.SET_ROLES);
+    expect(job.template.kind).not.toBe(NIP29_KIND.PUT_USER);
+    expect(job.template.tags[1]).toEqual(['p', PUBKEY, 'member']);
+  });
+
+  it('demotion of a configured admin is refused (last-admin guard)', async () => {
+    const row = makeMembership({ relay_state: 'added', role: 'member' });
+    const h = setup({
+      room: makeRoom(),
+      membership: row,
+      isConfiguredAdmin: true,
+    });
+
+    const enqueued = await h.service.publishRoleChange(SALE, 'ak_member');
+
+    expect(enqueued).toBe(false);
+    expect(h.queue.add).not.toHaveBeenCalled();
+  });
+
+  it('role change for a not-yet-added member is a no-op', async () => {
+    const row = makeMembership({ relay_state: 'pending_add', role: 'admin' });
+    const h = setup({ room: makeRoom(), membership: row });
+
+    const enqueued = await h.service.publishRoleChange(SALE, 'ak_member');
+
+    expect(enqueued).toBe(false);
+    expect(h.queue.add).not.toHaveBeenCalled();
+  });
+});
+
+describe('MembershipSyncService — ACK-driven relay_state flips (§6.3)', () => {
+  it('9000 ACK → relay_state="added" + last_published_at + emits added', async () => {
+    const row = makeMembership({ relay_state: 'pending_add' });
+    const h = setup({ membership: row });
+
+    await h.service.onPublishAck({
+      saleAddress: SALE,
+      pubkey: PUBKEY,
+      kind: NIP29_KIND.PUT_USER,
+      ok: true,
+    });
+
+    expect(h.membershipRepo.update).toHaveBeenCalledWith(
+      { id: row.id },
+      expect.objectContaining({
+        relay_state: 'added',
+        last_published_at: expect.any(Date),
+      }),
+    );
+    expect(h.emitted).toEqual([
+      { saleAddress: SALE, memberAddress: 'ak_member', relayState: 'added' },
+    ]);
+  });
+
+  it('9001 ACK → relay_state="removed" + emits removed', async () => {
+    const row = makeMembership({ relay_state: 'pending_remove' });
+    const h = setup({ membership: row });
+
+    await h.service.onPublishAck({
+      saleAddress: SALE,
+      pubkey: PUBKEY,
+      kind: NIP29_KIND.REMOVE_USER,
+      ok: true,
+    });
+
+    expect(h.membershipRepo.update).toHaveBeenCalledWith(
+      { id: row.id },
+      expect.objectContaining({ relay_state: 'removed' }),
+    );
+    expect(h.emitted).toEqual([
+      { saleAddress: SALE, memberAddress: 'ak_member', relayState: 'removed' },
+    ]);
+  });
+
+  it('re-observed 9000 ACK on an already-added row is a no-op (no write, no event)', async () => {
+    const row = makeMembership({ relay_state: 'added' });
+    const h = setup({ membership: row });
+
+    await h.service.onPublishAck({
+      saleAddress: SALE,
+      pubkey: PUBKEY,
+      kind: NIP29_KIND.PUT_USER,
+      ok: true,
+    });
+
+    expect(h.membershipRepo.update).not.toHaveBeenCalled();
+    expect(h.emitted).toHaveLength(0);
+  });
+
+  it('re-observed 9001 ACK on an already-removed row is a no-op', async () => {
+    const row = makeMembership({ relay_state: 'removed' });
+    const h = setup({ membership: row });
+
+    await h.service.onPublishAck({
+      saleAddress: SALE,
+      pubkey: PUBKEY,
+      kind: NIP29_KIND.REMOVE_USER,
+      ok: true,
+    });
+
+    expect(h.membershipRepo.update).not.toHaveBeenCalled();
+    expect(h.emitted).toHaveLength(0);
+  });
+
+  it('failed ACK (ok=false) leaves pending state untouched', async () => {
+    const row = makeMembership({ relay_state: 'pending_add' });
+    const h = setup({ membership: row });
+
+    await h.service.onPublishAck({
+      saleAddress: SALE,
+      pubkey: PUBKEY,
+      kind: NIP29_KIND.PUT_USER,
+      ok: false,
+    });
+
+    expect(h.membershipRepo.findOne).not.toHaveBeenCalled();
+    expect(h.membershipRepo.update).not.toHaveBeenCalled();
+    expect(h.emitted).toHaveLength(0);
+  });
+
+  it('group-level ACK (no pubkey) is ignored (Task 09 concern)', async () => {
+    const h = setup();
+    await h.service.onPublishAck({
+      saleAddress: SALE,
+      kind: NIP29_KIND.CREATE_GROUP,
+      ok: true,
+    });
+    expect(h.membershipRepo.findOne).not.toHaveBeenCalled();
+    expect(h.membershipRepo.update).not.toHaveBeenCalled();
+  });
+});
+
+describe('MembershipSyncService — community deletion → 9008 (§4.7, terminal)', () => {
+  it('deleted room → exactly one 9008 deleteGroup, no per-member 9001, all rows removed', async () => {
+    const rowA = makeMembership({ id: 1, relay_state: 'added' });
+    const rowB = makeMembership({
+      id: 2,
+      member_address: 'ak_other',
+      relay_state: 'pending_add',
+    });
+    const h = setup({ room: makeRoom({ deleted: true }) });
+    h.membershipRepo.find = jest.fn().mockResolvedValue([rowA, rowB]);
+
+    await h.service.onCommunityUpserted({ saleAddress: SALE });
+
+    // exactly one 9008, no 9001/9000
+    expect(h.queue.add).toHaveBeenCalledTimes(1);
+    const job = h.queue.add.mock.calls[0][0];
+    expect(job.template.kind).toBe(NIP29_KIND.DELETE_GROUP);
+    expect(job.template.tags).toEqual([['h', GROUP]]);
+
+    // both rows set terminal removed
+    expect(h.membershipRepo.update).toHaveBeenCalledWith(
+      { id: 1 },
+      expect.objectContaining({ relay_state: 'removed' }),
+    );
+    expect(h.membershipRepo.update).toHaveBeenCalledWith(
+      { id: 2 },
+      expect.objectContaining({ relay_state: 'removed' }),
+    );
+    expect(h.emitted.map((e) => e.relayState)).toEqual(['removed', 'removed']);
+  });
+
+  it('non-deleted community upsert → no delete-group enqueued', async () => {
+    const h = setup({ room: makeRoom({ deleted: false }) });
+    await h.service.onCommunityUpserted({ saleAddress: SALE });
+    expect(h.queue.add).not.toHaveBeenCalled();
+  });
+
+  it('publishForRow on a deleted room never (re)publishes members', async () => {
+    const row = makeMembership({ relay_state: 'pending_add' });
+    const h = setup({ room: makeRoom({ deleted: true }), membership: row });
+
+    const enqueued = await h.service.publishForRow(row);
+
+    expect(enqueued).toBe(false);
+    expect(h.queue.add).not.toHaveBeenCalled();
+  });
+});
+
+describe('MembershipSyncService — idempotency (Req 10)', () => {
+  it('re-delivered unchanged tgr.eligibility.changed for an added row enqueues + emits nothing', async () => {
+    const row = makeMembership({ relay_state: 'added' });
+    const h = setup({ room: makeRoom(), membership: row });
+
+    await h.service.onEligibilityChanged({
+      saleAddress: SALE,
+      memberAddress: 'ak_member',
+      eligible: true,
+    });
+
+    expect(h.queue.add).not.toHaveBeenCalled();
+    expect(h.membershipRepo.update).not.toHaveBeenCalled();
+    expect(h.emitted).toHaveLength(0);
+  });
+
+  it('onEligibilityChanged with no row → no-op', async () => {
+    const h = setup({ membership: null });
+    await h.service.onEligibilityChanged({
+      saleAddress: SALE,
+      memberAddress: 'ak_member',
+      eligible: true,
+    });
+    expect(h.queue.add).not.toHaveBeenCalled();
+  });
+});
+
+describe('MembershipSyncService — scan predicate + idempotency', () => {
+  it('scan selects only created rooms; pending_add(+pubkey)→9000, pending_remove→9001', async () => {
+    const add = makeMembership({ id: 1, relay_state: 'pending_add' });
+    const remove = makeMembership({
+      id: 2,
+      member_address: 'ak_other',
+      member_pubkey: 'b'.repeat(64),
+      relay_state: 'pending_remove',
+    });
+    const h = setup({ room: makeRoom(), token: makeToken() });
+    h.membershipRepo.createQueryBuilder = jest
+      .fn()
+      .mockReturnValue(queryBuilderReturning([[add, remove]]));
+
+    const published = await h.service.scanAndPublishPending();
+
+    expect(published).toBe(2);
+    const kinds = h.queue.add.mock.calls.map((c) => c[0].template.kind);
+    expect(kinds).toEqual([NIP29_KIND.PUT_USER, NIP29_KIND.REMOVE_USER]);
+  });
+
+  it('scan skips rooms whose token nostr_room_state != created', async () => {
+    const add = makeMembership({ id: 1, relay_state: 'pending_add' });
+    const h = setup({
+      room: makeRoom(),
+      token: makeToken({ nostr_room_state: 'pending' } as any),
+    });
+    h.membershipRepo.createQueryBuilder = jest
+      .fn()
+      .mockReturnValue(queryBuilderReturning([[add]]));
+
+    const published = await h.service.scanAndPublishPending();
+
+    expect(published).toBe(0);
+    expect(h.queue.add).not.toHaveBeenCalled();
+  });
+
+  it('scan: a burst of N pending_add rows produces ≤ N publishes (no duplicate adds)', async () => {
+    const rows = Array.from({ length: 5 }, (_, i) =>
+      makeMembership({
+        id: i + 1,
+        member_address: `ak_${i}`,
+        member_pubkey: `${i}`.repeat(64),
+        relay_state: 'pending_add',
+      }),
+    );
+    const h = setup({ room: makeRoom(), token: makeToken() });
+    h.membershipRepo.createQueryBuilder = jest
+      .fn()
+      .mockReturnValue(queryBuilderReturning([rows]));
+
+    const published = await h.service.scanAndPublishPending();
+
+    expect(published).toBe(5);
+    expect(h.queue.add).toHaveBeenCalledTimes(5);
+  });
+});
+
+describe('MembershipSyncService — onModuleInit relay gate', () => {
+  it('relay NOT configured → does NOT register the periodic scan interval', () => {
+    const h = setup(); // no relay creds on the injected config → dormant
+    h.service.onModuleInit();
+    expect(h.scheduler.addInterval).not.toHaveBeenCalled();
+  });
+
+  it('relay configured → registers the periodic scan interval and tears it down', () => {
+    const h = setup({ relayConfigured: true });
+    h.service.onModuleInit();
+    expect(h.scheduler.addInterval).toHaveBeenCalledTimes(1);
+    expect(h.scheduler.addInterval.mock.calls[0][0]).toBe(
+      MEMBERSHIP_SYNC_SCAN_JOB,
+    );
+
+    h.scheduler.doesExist.mockReturnValue(true);
+    h.service.onApplicationShutdown();
+    expect(h.scheduler.deleteInterval).toHaveBeenCalledWith(
+      MEMBERSHIP_SYNC_SCAN_JOB,
+    );
+    // Stop the live timer created by setInterval (unref'd, but clean up anyway).
+    clearInterval(h.scheduler.addInterval.mock.calls[0][1] as NodeJS.Timeout);
+  });
+});
+
+describe('roomConfirmedCreated (room_id is the durable created-marker)', () => {
+  it('true when nostr_room_state === "created"', () => {
+    expect(roomConfirmedCreated({ nostr_room_state: 'created' })).toBe(true);
+  });
+
+  it('true when room_id is set even if nostr_room_state was reset to "none"', () => {
+    // The exact desync we observed: the 9007 ACK stamped room_id (group exists on
+    // the relay), but a re-index / schema synchronize reset nostr_room_state back
+    // to the default. The member must still be publishable.
+    expect(
+      roomConfirmedCreated({ nostr_room_state: 'none', room_id: 'ct_abc' }),
+    ).toBe(true);
+  });
+
+  it('false when neither signal is present (room not created yet)', () => {
+    expect(
+      roomConfirmedCreated({ nostr_room_state: 'none', room_id: null }),
+    ).toBe(false);
+    expect(roomConfirmedCreated({ nostr_room_state: 'pending' })).toBe(false);
+    expect(roomConfirmedCreated(null)).toBe(false);
+  });
+});

--- a/src/token-gated-rooms/services/membership-sync.service.spec.ts
+++ b/src/token-gated-rooms/services/membership-sync.service.spec.ts
@@ -48,6 +48,10 @@ function makeMembership(over: Partial<RoomMembership> = {}): RoomMembership {
     role: 'member',
     eligible: true,
     relay_state: 'pending_add',
+    access_state: 'none',
+    access_changed_at: null as any,
+    pending_revoke_since: null as any,
+    pending_revoke_reason: null as any,
     held_until_height: null as any,
     last_published_at: null as any,
     last_reconciled_at: null as any,
@@ -74,6 +78,7 @@ interface Harness {
   roomAdmins: { isConfiguredAdmin: jest.Mock };
   emitter: EventEmitter2;
   emitted: TgrMembershipChangedPayload[];
+  membershipAccess: { recordAccessTransition: jest.Mock };
   scheduler: {
     addInterval: jest.Mock;
     deleteInterval: jest.Mock;
@@ -125,6 +130,10 @@ function setup(
     doesExist: jest.fn().mockReturnValue(false),
   };
 
+  const membershipAccess = {
+    recordAccessTransition: jest.fn().mockResolvedValue(undefined),
+  };
+
   const service = new MembershipSyncService(
     membershipRepo,
     communityRoomRepo,
@@ -143,6 +152,8 @@ function setup(
       reconcileBatchSize: 500,
       reconcileIntervalSec: 600,
     } as any,
+    undefined, // groupMissing (optional)
+    membershipAccess as any, // access-transition ledger (sole push emitter)
   );
 
   return {
@@ -154,6 +165,7 @@ function setup(
     roomAdmins,
     emitter,
     emitted,
+    membershipAccess,
     scheduler,
   };
 }
@@ -346,9 +358,12 @@ describe('MembershipSyncService — ACK-driven relay_state flips (§6.3)', () =>
         last_published_at: expect.any(Date),
       }),
     );
-    expect(h.emitted).toEqual([
-      { saleAddress: SALE, memberAddress: 'ak_member', relayState: 'added' },
-    ]);
+    // The push is emitted by the access-transition ledger, not applyAck directly.
+    expect(h.membershipAccess.recordAccessTransition).toHaveBeenCalledWith(
+      row,
+      true,
+      'access_gained',
+    );
   });
 
   it('9001 ACK → relay_state="removed" + emits removed', async () => {
@@ -366,9 +381,12 @@ describe('MembershipSyncService — ACK-driven relay_state flips (§6.3)', () =>
       { id: row.id },
       expect.objectContaining({ relay_state: 'removed' }),
     );
-    expect(h.emitted).toEqual([
-      { saleAddress: SALE, memberAddress: 'ak_member', relayState: 'removed' },
-    ]);
+    // Access loss folds into the ledger (which arms the debounced revoke).
+    expect(h.membershipAccess.recordAccessTransition).toHaveBeenCalledWith(
+      row,
+      false,
+      'eligibility_lost',
+    );
   });
 
   it('re-observed 9000 ACK on an already-added row is a no-op (no write, no event)', async () => {
@@ -384,6 +402,7 @@ describe('MembershipSyncService — ACK-driven relay_state flips (§6.3)', () =>
 
     expect(h.membershipRepo.update).not.toHaveBeenCalled();
     expect(h.emitted).toHaveLength(0);
+    expect(h.membershipAccess.recordAccessTransition).not.toHaveBeenCalled();
   });
 
   it('re-observed 9001 ACK on an already-removed row is a no-op', async () => {
@@ -399,6 +418,7 @@ describe('MembershipSyncService — ACK-driven relay_state flips (§6.3)', () =>
 
     expect(h.membershipRepo.update).not.toHaveBeenCalled();
     expect(h.emitted).toHaveLength(0);
+    expect(h.membershipAccess.recordAccessTransition).not.toHaveBeenCalled();
   });
 
   it('failed ACK (ok=false) leaves pending state untouched', async () => {
@@ -457,7 +477,17 @@ describe('MembershipSyncService — community deletion → 9008 (§4.7, terminal
       { id: 2 },
       expect.objectContaining({ relay_state: 'removed' }),
     );
-    expect(h.emitted.map((e) => e.relayState)).toEqual(['removed', 'removed']);
+    // Both rows fold into the access ledger as a room_deleted access loss.
+    expect(h.membershipAccess.recordAccessTransition).toHaveBeenCalledWith(
+      rowA,
+      false,
+      'room_deleted',
+    );
+    expect(h.membershipAccess.recordAccessTransition).toHaveBeenCalledWith(
+      rowB,
+      false,
+      'room_deleted',
+    );
   });
 
   it('non-deleted community upsert → no delete-group enqueued', async () => {

--- a/src/token-gated-rooms/services/membership-sync.service.ts
+++ b/src/token-gated-rooms/services/membership-sync.service.ts
@@ -1,0 +1,769 @@
+import { InjectQueue } from '@nestjs/bull';
+import {
+  Inject,
+  Injectable,
+  Logger,
+  OnApplicationShutdown,
+  OnModuleInit,
+  Optional,
+} from '@nestjs/common';
+import { ConfigType } from '@nestjs/config';
+import { EventEmitter2, OnEvent } from '@nestjs/event-emitter';
+import { SchedulerRegistry } from '@nestjs/schedule';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Queue } from 'bull';
+import { In, Repository } from 'typeorm';
+import { Token } from '@/tokens/entities/token.entity';
+import tgrConfig, { isRelayConfigured } from '../config/tgr.config';
+import { CommunityRoom } from '../entities/community-room.entity';
+import { RoomMembership } from '../entities/room-membership.entity';
+import {
+  TGR_COMMUNITY_UPSERTED,
+  TGR_ELIGIBILITY_CHANGED,
+  TGR_MEMBERSHIP_CHANGED,
+  TGR_PUBLISH_ACK,
+  TGR_ROOM_CREATED,
+  type TgrCommunityUpsertedPayload,
+  type TgrEligibilityChangedPayload,
+  type TgrMembershipChangedPayload,
+  type TgrPublishAckPayload,
+  type TgrRoomCreatedPayload,
+} from '../events';
+import {
+  deleteGroup,
+  NIP29_KIND,
+  putUser,
+  removeUser,
+  setRoles,
+} from '../nostr/nip29';
+import { groupIdFor } from '../nostr/group-id';
+import { publishNip29JobOptions } from '../queues/publish-nip29.job-options';
+import { PUBLISH_NIP29_QUEUE } from '../queues/publish-nip29.processor';
+import type { PublishNip29Job } from '../queues/publish-nip29.types';
+import { RoomAdminsService } from './room-admins.service';
+import { GroupMissingTracker } from './group-missing-tracker.service';
+
+/** NIP-29 relay role tokens (mirrors `room-admins.service.ts`). */
+const NIP29_ROLE_ADMIN = 'admin';
+const NIP29_ROLE_MEMBER = 'member';
+
+/**
+ * Name of the periodic publish-pending scan registered on the Nest
+ * {@link SchedulerRegistry} (worker-only). The scan re-derives the pending working
+ * set from `room_membership` every tick → resumable after a crash without losing
+ * rows (idempotent at the relay; the `relay_state` ledger avoids redundant adds).
+ */
+export const MEMBERSHIP_SYNC_SCAN_JOB = 'tgr-membership-sync-scan';
+
+/**
+ * Whether a token's NIP-29 group is confirmed-created on the relay, i.e. it is
+ * safe to publish members into it.
+ *
+ * `room_id` is the **durable** created-marker: it is stamped (= `sale_address`)
+ * ONLY on the `9007` ok ACK (`RoomBackfillService.onPublishAck`) and has no column
+ * default, so — unlike `nostr_room_state` — it survives a token re-index / schema
+ * `synchronize` that resets defaulted columns back to `'none'`. We observed rooms
+ * with `room_id` set but `nostr_room_state='none'` (the group exists on the relay,
+ * but the state column was reset); gating membership promotion on `nostr_room_state`
+ * alone left those members stuck at `pending_add` forever. Accept EITHER signal so
+ * a desynced state column can never strand a holder who already has a real group.
+ */
+export function roomConfirmedCreated(
+  token: { nostr_room_state?: string | null; room_id?: string | null } | null,
+): boolean {
+  if (!token) {
+    return false;
+  }
+  return token.nostr_room_state === 'created' || token.room_id != null;
+}
+
+/**
+ * Turn desired membership (Task 06's `room_membership` ledger) into actual relay
+ * state — WORKER PROCESS ONLY (Task 10, plan §6.3 / §6.6 / §6.7 / §4.7).
+ *
+ * ## Role split (this task is the PUBLISHER; Task 06 is the DECIDER)
+ * Task 06 computes `eligible`/`role`/`member_pubkey` and sets the *desired*
+ * `relay_state` (`pending_add`/`pending_remove`), emitting the THIN
+ * `tgr.eligibility.changed` (`{ saleAddress, memberAddress, eligible }`). This
+ * service re-queries the row (events are thin by design — see `events.ts`),
+ * enqueues the matching `9000`/`9001`/`9006`/`9008` onto Task 07's
+ * `worker:publish-nip29` queue, and on the relay ACK seam (`tgr.publish.ack`)
+ * flips the *pending* state to its terminal published value (`added`/`removed`).
+ * It never recomputes eligibility, never opens a relay socket, never waits on ACK
+ * transport (Task 07 owns rate/backoff/ACK/"already exists").
+ *
+ * ## Invariants enforced here
+ * - **Unlinked-but-eligible (§6.6):** a `pending_add` row with `member_pubkey=null`
+ *   is NEVER published — there is no pubkey to put-user. It stays `pending_add`
+ *   until Task 05/06 fills the pubkey (which re-emits `tgr.eligibility.changed`).
+ * - **Configured admins never balance-removed (§6.7):** before any `9001`,
+ *   {@link RoomAdminsService.isConfiguredAdmin} gates the removal.
+ * - **Never re-add a muted member (§5.1):** a member in `community_room.muted` is
+ *   desired-removed; a stale `pending_add` for it enqueues NO `9000`.
+ * - **Community deletion is terminal (§4.7):** one `9008` delete-group, no
+ *   per-member `9001` fan-out; all rows set terminal `removed`.
+ * - **Relay-owned idempotency (§6.3):** the `relay_state` ledger only avoids
+ *   *redundant* publishes; there is NO process-local membership cache.
+ *
+ * Registered as a WORKER-role provider (loads in `'worker'` and `'combined'`),
+ * `export: false`.
+ */
+@Injectable()
+export class MembershipSyncService
+  implements OnModuleInit, OnApplicationShutdown
+{
+  private readonly logger = new Logger(MembershipSyncService.name);
+  private scanRunning = false;
+
+  constructor(
+    @InjectRepository(RoomMembership)
+    private readonly membershipRepo: Repository<RoomMembership>,
+    @InjectRepository(CommunityRoom)
+    private readonly communityRoomRepo: Repository<CommunityRoom>,
+    @InjectRepository(Token)
+    private readonly tokenRepo: Repository<Token>,
+    @InjectQueue(PUBLISH_NIP29_QUEUE)
+    private readonly publishQueue: Queue<PublishNip29Job>,
+    private readonly roomAdmins: RoomAdminsService,
+    private readonly eventEmitter: EventEmitter2,
+    private readonly scheduler: SchedulerRegistry,
+    @Inject(tgrConfig.KEY)
+    private readonly config: ConfigType<typeof tgrConfig>,
+    // Optional so the existing positional-construction unit tests keep working; the
+    // DI container always provides it in the running app.
+    @Optional()
+    private readonly groupMissing?: GroupMissingTracker,
+  ) {}
+
+  /**
+   * Schedule the periodic publish-pending scan on the Nest {@link SchedulerRegistry}
+   * — relay-gated (worker mode removed, see `deworker-plan.md`). The scan publishes
+   * NIP-29 membership events, so we only schedule it when a relay is configured
+   * (`isRelayConfigured`); otherwise this is a no-op. The interval re-derives the
+   * pending set every tick → resumable after a crash without losing rows
+   * (relay-owned idempotency, §6.3).
+   *
+   * The scan is NOT enqueued onto `worker:publish-nip29` (that queue's processor
+   * only understands publish jobs); it is a local interval that ENQUEUES publishes,
+   * exactly like the eligibility-driven path.
+   */
+  onModuleInit(): void {
+    if (!isRelayConfigured(this.config)) {
+      return;
+    }
+    const everyMs = Math.max(1, this.config.reconcileIntervalSec) * 1000;
+    try {
+      const interval = setInterval(() => {
+        void this.runScanSafely();
+      }, everyMs);
+      interval.unref?.();
+      this.scheduler.addInterval(MEMBERSHIP_SYNC_SCAN_JOB, interval);
+      this.logger.log(
+        `scheduled membership-sync scan every ${everyMs / 1000}s`,
+      );
+    } catch (error: any) {
+      this.logger.warn(
+        `failed to schedule membership-sync scan: ${error?.message ?? error}`,
+      );
+    }
+  }
+
+  /** Tear down the interval on shutdown so tests / restarts don't leak timers. */
+  onApplicationShutdown(): void {
+    try {
+      if (this.scheduler.doesExist?.('interval', MEMBERSHIP_SYNC_SCAN_JOB)) {
+        this.scheduler.deleteInterval(MEMBERSHIP_SYNC_SCAN_JOB);
+      }
+    } catch {
+      // best-effort
+    }
+  }
+
+  /** Run the scan with single-flight + error isolation (interval callback). */
+  private async runScanSafely(): Promise<void> {
+    if (this.scanRunning) {
+      return;
+    }
+    this.scanRunning = true;
+    try {
+      await this.scanAndPublishPending();
+    } catch (error: any) {
+      this.logger.error(
+        `membership-sync scan failed: ${error?.message ?? error}`,
+      );
+    } finally {
+      this.scanRunning = false;
+    }
+  }
+
+  // ── event surfaces ──────────────────────────────────────────────────────────
+
+  /**
+   * A member's eligibility flipped (Task 06). Re-query the desired-state row (the
+   * event is thin by design) and publish the matching add/remove/role change. Task
+   * 06 has already written `eligible`/`role`/`member_pubkey`/`relay_state`; we only
+   * drive the *published* side.
+   */
+  @OnEvent(TGR_ELIGIBILITY_CHANGED, { async: true, promisify: true })
+  async onEligibilityChanged(
+    payload: TgrEligibilityChangedPayload,
+  ): Promise<void> {
+    const saleAddress = payload?.saleAddress;
+    const memberAddress = payload?.memberAddress;
+    if (!saleAddress || !memberAddress) {
+      return;
+    }
+    try {
+      const row = await this.membershipRepo.findOne({
+        where: { sale_address: saleAddress, member_address: memberAddress },
+      });
+      if (!row) {
+        return;
+      }
+      await this.publishForRow(row);
+    } catch (error: any) {
+      this.logger.error(
+        `onEligibilityChanged(${saleAddress}, ${memberAddress}) failed`,
+        error,
+      );
+    }
+  }
+
+  /**
+   * A NIP-29 group was created + ACKed on the relay (Task 09). Now that the group
+   * exists, publish every still-pending member of that room (rooms are eager-created
+   * by Task 09 BEFORE their members are published — this drains the backlog).
+   */
+  @OnEvent(TGR_ROOM_CREATED, { async: true, promisify: true })
+  async onRoomCreated(payload: TgrRoomCreatedPayload): Promise<void> {
+    const saleAddress = payload?.saleAddress;
+    if (!saleAddress) {
+      return;
+    }
+    try {
+      await this.publishPendingForRoom(saleAddress);
+    } catch (error: any) {
+      this.logger.error(`onRoomCreated(${saleAddress}) failed`, error);
+    }
+  }
+
+  /**
+   * A community-room desired-state row was upserted (Task 04). The ONLY delete
+   * trigger (§4.7): when the room is now `deleted`, enqueue exactly one `9008`
+   * delete-group (terminal at the relay) and mark every membership row terminal
+   * `removed` — do NOT fan out per-member `9001`s. The payload is thin/typed; we
+   * re-query `community_room.deleted` so we act on the persisted truth.
+   */
+  @OnEvent(TGR_COMMUNITY_UPSERTED, { async: true, promisify: true })
+  async onCommunityUpserted(
+    payload: TgrCommunityUpsertedPayload,
+  ): Promise<void> {
+    const saleAddress = payload?.saleAddress;
+    if (!saleAddress) {
+      return;
+    }
+    try {
+      const room = await this.communityRoomRepo.findOne({
+        where: { sale_address: saleAddress },
+      });
+      if (room?.deleted) {
+        await this.handleDeletedRoom(saleAddress);
+      }
+    } catch (error: any) {
+      this.logger.error(`onCommunityUpserted(${saleAddress}) failed`, error);
+    }
+  }
+
+  /**
+   * Drive `relay_state` on the relay ACK seam (§6.3). Task 07's publish processor
+   * is the SOLE emitter of `tgr.publish.ack`; this service consumes it and flips
+   * the *pending* state to its terminal published value. It never observes the Bull
+   * job result directly and never polls the relay (Task 11 owns read-back).
+   *
+   *   - `9000` add ok  → `relay_state='added'`,  set `last_published_at`.
+   *   - `9001` remove ok → `relay_state='removed'`, set `last_published_at`.
+   *   - `9006` role ok → confirm the published role (idempotent).
+   *   - `ok=false` → leave `pending_*` untouched for Task 07 retry / Task 11.
+   *   - re-observing an ACK for a row already terminal is a no-op (no write/event).
+   */
+  @OnEvent(TGR_PUBLISH_ACK, { async: true, promisify: true })
+  async onPublishAck(payload: TgrPublishAckPayload): Promise<void> {
+    if (!payload?.saleAddress || !payload.pubkey) {
+      // Group-level publishes (no member pubkey) are Task 09's concern.
+      return;
+    }
+    if (!payload.ok) {
+      // Failed ACK: leave the pending state for retry / reconcile (Task 11).
+      return;
+    }
+    const { saleAddress, pubkey, kind } = payload;
+    if (
+      kind !== NIP29_KIND.PUT_USER &&
+      kind !== NIP29_KIND.REMOVE_USER &&
+      kind !== NIP29_KIND.SET_ROLES
+    ) {
+      return;
+    }
+    try {
+      const row = await this.membershipRepo.findOne({
+        where: { sale_address: saleAddress, member_pubkey: pubkey },
+      });
+      if (!row) {
+        return;
+      }
+      await this.applyAck(row, kind);
+    } catch (error: any) {
+      this.logger.error(
+        `onPublishAck(${saleAddress}, kind=${payload.kind}) failed`,
+        error,
+      );
+    }
+  }
+
+  // ── publish decisions ───────────────────────────────────────────────────────
+
+  /**
+   * Map one desired-state row → at most one publish. Idempotency (Req 10) is the
+   * `relay_state` ledger: an `added` row (same role) or a `removed` row enqueues
+   * nothing. The mute / unlinked / admin-exemption guards are the publish-side
+   * belt-and-braces over Task 06's decisions.
+   *
+   * @returns true iff a publish was enqueued.
+   */
+  async publishForRow(row: RoomMembership): Promise<boolean> {
+    const groupId = await this.resolveGroupId(row.sale_address);
+
+    // A `deleted` room is terminal — never (re)publish members into it (§4.7).
+    const room = await this.communityRoomRepo.findOne({
+      where: { sale_address: row.sale_address },
+    });
+    if (room?.deleted) {
+      return false;
+    }
+
+    if (row.relay_state === 'pending_add') {
+      return this.maybeEnqueueAdd(row, room, groupId);
+    }
+    if (row.relay_state === 'pending_remove') {
+      return this.maybeEnqueueRemove(row, groupId);
+    }
+    // `added` / `removed` are terminal published states: a re-delivered, unchanged
+    // `tgr.eligibility.changed` for one of these enqueues NOTHING (Req 10
+    // idempotency). Role transitions are NOT inferable from the thin eligibility
+    // event (the on-disk eligibility service emits only on an `eligible` flip and
+    // there is no published-role column to diff against), so they are driven
+    // through the explicit {@link publishRoleChange} seam instead.
+    return false;
+  }
+
+  /**
+   * `pending_add`: enqueue `9000` put-user UNLESS the row is unlinked (§6.6) or
+   * the member is currently muted (§5.1, never re-add while muted). An `admin`
+   * role adds with `["p", pubkey, "admin"]` (mirrors the bot promote).
+   */
+  private async maybeEnqueueAdd(
+    row: RoomMembership,
+    room: CommunityRoom | null,
+    groupId: string,
+  ): Promise<boolean> {
+    // §6.6: never publish an unlinked member (no pubkey → no valid `["p", …]`).
+    if (!row.member_pubkey) {
+      return false;
+    }
+    // The relay has no such group right now (a member add failed `"Group not found"`
+    // and a re-create is in flight) — STOP piling adds onto a missing group. The
+    // suppression clears on the re-create's `9007` ok-ACK, which re-fires
+    // `tgr.room.created` → this scan re-runs and re-adds the members.
+    if (this.groupMissing?.isMissing(row.sale_address)) {
+      return false;
+    }
+    // §5.1: never re-add a member currently in the room's muted set.
+    if (room?.muted && room.muted.includes(row.member_address)) {
+      this.logger.debug(
+        `skip 9000 for muted member ${row.member_address} in ${row.sale_address}`,
+      );
+      return false;
+    }
+    const role = row.role === 'admin' ? NIP29_ROLE_ADMIN : undefined;
+    await this.enqueue(
+      putUser(groupId, row.member_pubkey, role),
+      groupId,
+      row.sale_address,
+      'membership-add',
+    );
+    return true;
+  }
+
+  /**
+   * `pending_remove`: enqueue `9001` remove-user UNLESS the member is a configured
+   * admin (§6.7 — admins are never balance-removed) or is unlinked (no pubkey to
+   * remove). Configured-admin exemption is the publish-side guard over Task 06.
+   */
+  private async maybeEnqueueRemove(
+    row: RoomMembership,
+    groupId: string,
+  ): Promise<boolean> {
+    if (!row.member_pubkey) {
+      // Nothing to remove on the relay (was never published).
+      return false;
+    }
+    if (this.roomAdmins.isConfiguredAdmin(row.member_pubkey)) {
+      this.logger.debug(
+        `skip 9001 for configured admin ${row.member_pubkey} in ${row.sale_address}`,
+      );
+      return false;
+    }
+    await this.enqueue(
+      removeUser(groupId, row.member_pubkey),
+      groupId,
+      row.sale_address,
+      'membership-remove',
+    );
+    return true;
+  }
+
+  /**
+   * Explicit role transition for an already-present member (Req 4, §6.7) — invoked
+   * when a moderator-list change flips a member's desired `role` (member↔admin).
+   * BOTH directions go through `9006` set-roles:
+   *   - member → admin: `setRoles(['admin'])` (the relay also accepts a `9000`
+   *     role=admin, but `9006` is symmetric and idempotent);
+   *   - admin → member: `setRoles(['member'])` — NOT a `9000`, because the relay's
+   *     `9000` never downgrades an existing admin (bot line 176-187 / relay
+   *     last-admin guard).
+   *
+   * Respects the relay last-admin guard: a demotion of a configured admin is
+   * refused (configured admins always stay admin, §6.7/§10) and logged — the bot
+   * key always remains admin so this is not hit in normal operation. A no-op
+   * (`fromRole === toRole`) enqueues nothing (idempotency).
+   *
+   * @returns true iff a `9006` was enqueued.
+   */
+  async publishRoleChange(
+    saleAddress: string,
+    memberAddress: string,
+  ): Promise<boolean> {
+    const row = await this.membershipRepo.findOne({
+      where: { sale_address: saleAddress, member_address: memberAddress },
+    });
+    if (!row || !row.member_pubkey) {
+      return false;
+    }
+    // Only an already-present member has a role to transition on the relay.
+    if (row.relay_state !== 'added') {
+      return false;
+    }
+    const groupId = await this.resolveGroupId(saleAddress);
+
+    if (row.role === 'member') {
+      // admin → member demotion: refuse to demote a configured admin (§6.7/§10).
+      if (this.roomAdmins.isConfiguredAdmin(row.member_pubkey)) {
+        this.logger.warn(
+          `refusing to demote configured admin ${row.member_pubkey} in ` +
+            `${saleAddress} (last-admin guard, §6.7)`,
+        );
+        return false;
+      }
+      await this.enqueue(
+        setRoles(groupId, row.member_pubkey, [NIP29_ROLE_MEMBER]),
+        groupId,
+        saleAddress,
+        'role-demote',
+      );
+      return true;
+    }
+
+    // member → admin promotion.
+    await this.enqueue(
+      setRoles(groupId, row.member_pubkey, [NIP29_ROLE_ADMIN]),
+      groupId,
+      saleAddress,
+      'role-promote',
+    );
+    return true;
+  }
+
+  // ── ACK-driven state transitions (§6.3) ─────────────────────────────────────
+
+  /**
+   * Flip `relay_state` on a successful publish ACK (§6.3). Idempotent: a row
+   * already at the terminal state for the ACKed kind is a no-op (no write, no
+   * event). Emits `tgr.membership.changed` once per real transition (Req 9).
+   */
+  private async applyAck(row: RoomMembership, kind: number): Promise<void> {
+    const now = new Date();
+
+    if (kind === NIP29_KIND.PUT_USER) {
+      if (row.relay_state === 'added') {
+        return; // idempotent re-observed ACK
+      }
+      await this.membershipRepo.update(
+        { id: row.id },
+        { relay_state: 'added', last_published_at: now },
+      );
+      this.emitMembershipChanged(row, 'added');
+      return;
+    }
+
+    if (kind === NIP29_KIND.REMOVE_USER) {
+      if (row.relay_state === 'removed') {
+        return; // idempotent re-observed ACK
+      }
+      await this.membershipRepo.update(
+        { id: row.id },
+        { relay_state: 'removed', last_published_at: now },
+      );
+      this.emitMembershipChanged(row, 'removed');
+      return;
+    }
+
+    if (kind === NIP29_KIND.SET_ROLES) {
+      // Role publish confirmed — stamp the publish time + emit a role transition.
+      await this.membershipRepo.update(
+        { id: row.id },
+        { last_published_at: now },
+      );
+      this.emitMembershipChanged(row, 'role');
+      return;
+    }
+  }
+
+  // ── room-scoped scans (§6.3, resumable) ─────────────────────────────────────
+
+  /**
+   * Publish every still-pending member of a freshly-created room (`tgr.room.created`).
+   * Cursor-batched by id to keep locks short under a large member set.
+   */
+  async publishPendingForRoom(saleAddress: string): Promise<number> {
+    const token = await this.tokenRepo.findOne({
+      where: { sale_address: saleAddress },
+    });
+    if (!roomConfirmedCreated(token)) {
+      // The group does not exist yet — wait for the next `tgr.room.created`.
+      return 0;
+    }
+    const groupId = groupIdFor({
+      sale_address: saleAddress,
+      nostr_group_id: token?.nostr_group_id,
+    });
+    const room = await this.communityRoomRepo.findOne({
+      where: { sale_address: saleAddress },
+    });
+    if (room?.deleted) {
+      return 0;
+    }
+
+    const limit = this.config.reconcileBatchSize;
+    let cursorId = 0;
+    let published = 0;
+
+    for (;;) {
+      const batch = await this.membershipRepo
+        .createQueryBuilder('m')
+        .where('m.sale_address = :sale', { sale: saleAddress })
+        .andWhere('m.id > :cursor', { cursor: cursorId })
+        .andWhere('m.relay_state IN (:...states)', {
+          states: ['pending_add', 'pending_remove'],
+        })
+        .orderBy('m.id', 'ASC')
+        .limit(limit)
+        .getMany();
+
+      if (batch.length === 0) {
+        break;
+      }
+      for (const row of batch) {
+        if (row.relay_state === 'pending_add') {
+          if (await this.maybeEnqueueAdd(row, room, groupId)) {
+            published += 1;
+          }
+        } else if (row.relay_state === 'pending_remove') {
+          if (await this.maybeEnqueueRemove(row, groupId)) {
+            published += 1;
+          }
+        }
+      }
+      cursorId = batch[batch.length - 1].id;
+      if (batch.length < limit) {
+        break;
+      }
+    }
+    return published;
+  }
+
+  /**
+   * Periodic / triggered resume scan (§6.3, idempotent + resumable). Selects
+   * `room_membership WHERE relay_state IN ('pending_add','pending_remove')` for
+   * rooms whose `Token.nostr_room_state='created'`, skipping unlinked
+   * `pending_add` rows (NULL pubkey can never be published, §6.6). The
+   * `pending_*` ledger + relay idempotency mean a re-run never double-adds. Called
+   * by the repeatable {@link MEMBERSHIP_SYNC_SCAN_JOB} and exercised directly in
+   * tests.
+   *
+   * @returns the number of publishes enqueued.
+   */
+  async scanAndPublishPending(): Promise<number> {
+    const limit = this.config.reconcileBatchSize;
+    let cursorId = 0;
+    let published = 0;
+    // Cache created-group + deleted lookups per room within a single scan.
+    const roomReady = new Map<string, boolean>();
+    const rooms = new Map<string, CommunityRoom | null>();
+    const groupIds = new Map<string, string>();
+
+    for (;;) {
+      // §6.6 predicate: only rows that CAN be published —
+      //   pending_add must have a non-null pubkey; pending_remove always qualifies.
+      const batch = await this.membershipRepo
+        .createQueryBuilder('m')
+        .where('m.id > :cursor', { cursor: cursorId })
+        .andWhere('m.relay_state IN (:...states)', {
+          states: ['pending_add', 'pending_remove'],
+        })
+        .andWhere('(m.member_pubkey IS NOT NULL OR m.relay_state = :rm)', {
+          rm: 'pending_remove',
+        })
+        .orderBy('m.id', 'ASC')
+        .limit(limit)
+        .getMany();
+
+      if (batch.length === 0) {
+        break;
+      }
+
+      for (const row of batch) {
+        const sale = row.sale_address;
+        let ready = roomReady.get(sale);
+        if (ready === undefined) {
+          const token = await this.tokenRepo.findOne({
+            where: { sale_address: sale },
+          });
+          const room = await this.communityRoomRepo.findOne({
+            where: { sale_address: sale },
+          });
+          ready = roomConfirmedCreated(token) && !room?.deleted;
+          roomReady.set(sale, ready);
+          rooms.set(sale, room ?? null);
+          groupIds.set(
+            sale,
+            groupIdFor({
+              sale_address: sale,
+              nostr_group_id: token?.nostr_group_id,
+            }),
+          );
+        }
+        if (!ready) {
+          continue;
+        }
+        const groupId = groupIds.get(sale) as string;
+        const room = rooms.get(sale) ?? null;
+        if (row.relay_state === 'pending_add') {
+          if (await this.maybeEnqueueAdd(row, room, groupId)) {
+            published += 1;
+          }
+        } else if (row.relay_state === 'pending_remove') {
+          if (await this.maybeEnqueueRemove(row, groupId)) {
+            published += 1;
+          }
+        }
+      }
+
+      cursorId = batch[batch.length - 1].id;
+      if (batch.length < limit) {
+        break;
+      }
+    }
+
+    if (published > 0) {
+      this.logger.log(
+        `membership-sync scan enqueued ${published} pending publish(es)`,
+      );
+    }
+    return published;
+  }
+
+  // ── community deletion (§4.7, terminal) ─────────────────────────────────────
+
+  /**
+   * Community deleted: enqueue exactly ONE `9008` delete-group (terminal at the
+   * relay) and mark every membership row terminal `removed` — no per-member `9001`
+   * fan-out. Idempotent: re-observing a delete on a room whose rows are already
+   * `removed` enqueues a (relay no-op) `9008` once but writes nothing further.
+   */
+  private async handleDeletedRoom(saleAddress: string): Promise<void> {
+    const groupId = await this.resolveGroupId(saleAddress);
+    await this.enqueue(
+      deleteGroup(groupId),
+      groupId,
+      saleAddress,
+      'community-deleted',
+    );
+
+    // Mark all non-terminal rows removed (single bulk update; no per-member 9001).
+    const rows = await this.membershipRepo.find({
+      where: {
+        sale_address: saleAddress,
+        relay_state: In(['pending_add', 'added', 'pending_remove']),
+      },
+    });
+    for (const row of rows) {
+      await this.membershipRepo.update(
+        { id: row.id },
+        { relay_state: 'removed', last_published_at: new Date() },
+      );
+      this.emitMembershipChanged(row, 'removed');
+    }
+    this.logger.log(
+      `community ${saleAddress} deleted: enqueued 9008 and removed ${rows.length} membership row(s)`,
+    );
+  }
+
+  // ── helpers ─────────────────────────────────────────────────────────────────
+
+  /** Resolve the NIP-29 group id for a sale (D3: `nostr_group_id ?? sale_address`). */
+  private async resolveGroupId(saleAddress: string): Promise<string> {
+    const token = await this.tokenRepo.findOne({
+      where: { sale_address: saleAddress },
+    });
+    return groupIdFor({
+      sale_address: saleAddress,
+      nostr_group_id: token?.nostr_group_id,
+    });
+  }
+
+  /** Enqueue one publish onto `worker:publish-nip29` with the §18 job options. */
+  private async enqueue(
+    template: PublishNip29Job['template'],
+    groupId: string,
+    saleAddress: string,
+    reason: string,
+  ): Promise<void> {
+    await this.publishQueue.add(
+      {
+        template,
+        groupId,
+        meta: { saleAddress, reason: `membership:${reason}` },
+      },
+      publishNip29JobOptions(this.config.publishMaxRetries),
+    );
+  }
+
+  /** Emit `tgr.membership.changed` (non-blocking; mirror `live-indexer.service.ts:93`). */
+  private emitMembershipChanged(
+    row: RoomMembership,
+    change: 'added' | 'removed' | 'role',
+  ): void {
+    const relayState: TgrMembershipChangedPayload['relayState'] =
+      change === 'added'
+        ? 'added'
+        : change === 'removed'
+          ? 'removed'
+          : row.relay_state;
+    const payload: TgrMembershipChangedPayload = {
+      saleAddress: row.sale_address,
+      memberAddress: row.member_address,
+      relayState,
+    };
+    this.eventEmitter.emit(TGR_MEMBERSHIP_CHANGED, payload);
+  }
+}

--- a/src/token-gated-rooms/services/membership-sync.service.ts
+++ b/src/token-gated-rooms/services/membership-sync.service.ts
@@ -551,7 +551,11 @@ export class MembershipSyncService
     reason: string,
   ): Promise<void> {
     if (this.membershipAccess) {
-      await this.membershipAccess.recordAccessTransition(row, effective, reason);
+      await this.membershipAccess.recordAccessTransition(
+        row,
+        effective,
+        reason,
+      );
     }
   }
 

--- a/src/token-gated-rooms/services/membership-sync.service.ts
+++ b/src/token-gated-rooms/services/membership-sync.service.ts
@@ -20,12 +20,10 @@ import { RoomMembership } from '../entities/room-membership.entity';
 import {
   TGR_COMMUNITY_UPSERTED,
   TGR_ELIGIBILITY_CHANGED,
-  TGR_MEMBERSHIP_CHANGED,
   TGR_PUBLISH_ACK,
   TGR_ROOM_CREATED,
   type TgrCommunityUpsertedPayload,
   type TgrEligibilityChangedPayload,
-  type TgrMembershipChangedPayload,
   type TgrPublishAckPayload,
   type TgrRoomCreatedPayload,
 } from '../events';
@@ -42,6 +40,7 @@ import { PUBLISH_NIP29_QUEUE } from '../queues/publish-nip29.processor';
 import type { PublishNip29Job } from '../queues/publish-nip29.types';
 import { RoomAdminsService } from './room-admins.service';
 import { GroupMissingTracker } from './group-missing-tracker.service';
+import { MembershipAccessService } from './membership-access.service';
 
 /** NIP-29 relay role tokens (mirrors `room-admins.service.ts`). */
 const NIP29_ROLE_ADMIN = 'admin';
@@ -133,6 +132,13 @@ export class MembershipSyncService
     // DI container always provides it in the running app.
     @Optional()
     private readonly groupMissing?: GroupMissingTracker,
+    // Access-transition ledger (access-ledger plan): the sole emitter of the
+    // membership push. `applyAck`/`handleDeletedRoom` fold relay-state transitions
+    // into it instead of emitting `tgr.membership.changed` directly — so relay-sync
+    // churn (reconcile re-adds, `39002` regen, flaps) no longer re-notifies. Optional
+    // for the same positional-construction test reason; always DI-provided in-app.
+    @Optional()
+    private readonly membershipAccess?: MembershipAccessService,
   ) {}
 
   /**
@@ -501,7 +507,8 @@ export class MembershipSyncService
         { id: row.id },
         { relay_state: 'added', last_published_at: now },
       );
-      this.emitMembershipChanged(row, 'added');
+      // Effective access GAINED — the ledger emits the (deduped) push.
+      await this.recordAccess(row, true, 'access_gained');
       return;
     }
 
@@ -513,18 +520,38 @@ export class MembershipSyncService
         { id: row.id },
         { relay_state: 'removed', last_published_at: now },
       );
-      this.emitMembershipChanged(row, 'removed');
+      // Effective access LOST — the ledger arms the debounce (no push yet; a
+      // re-add within the grace window cancels it, absorbing a flap).
+      await this.recordAccess(row, false, 'eligibility_lost');
       return;
     }
 
     if (kind === NIP29_KIND.SET_ROLES) {
-      // Role publish confirmed — stamp the publish time + emit a role transition.
+      // Role publish confirmed — stamp the publish time. A role change does NOT
+      // change effective access (the member stays 'added'), so folding it into the
+      // ledger is a no-op that will never produce a spurious "you now have access"
+      // push (the old direct `emitMembershipChanged(row, 'role')` did).
       await this.membershipRepo.update(
         { id: row.id },
         { last_published_at: now },
       );
-      this.emitMembershipChanged(row, 'role');
+      await this.recordAccess(row, row.relay_state === 'added', 'role');
       return;
+    }
+  }
+
+  /**
+   * Fold a relay-state transition into the access-transition ledger (the sole
+   * emitter of the membership push). No-op when the ledger service is absent (the
+   * positional-construction unit tests) so relay_state bookkeeping still runs.
+   */
+  private async recordAccess(
+    row: RoomMembership,
+    effective: boolean,
+    reason: string,
+  ): Promise<void> {
+    if (this.membershipAccess) {
+      await this.membershipAccess.recordAccessTransition(row, effective, reason);
     }
   }
 
@@ -711,7 +738,9 @@ export class MembershipSyncService
         { id: row.id },
         { relay_state: 'removed', last_published_at: new Date() },
       );
-      this.emitMembershipChanged(row, 'removed');
+      // Fold into the access ledger — arms the debounced revoke (reason
+      // room_deleted) for members who currently have access.
+      await this.recordAccess(row, false, 'room_deleted');
     }
     this.logger.log(
       `community ${saleAddress} deleted: enqueued 9008 and removed ${rows.length} membership row(s)`,
@@ -746,24 +775,5 @@ export class MembershipSyncService
       },
       publishNip29JobOptions(this.config.publishMaxRetries),
     );
-  }
-
-  /** Emit `tgr.membership.changed` (non-blocking; mirror `live-indexer.service.ts:93`). */
-  private emitMembershipChanged(
-    row: RoomMembership,
-    change: 'added' | 'removed' | 'role',
-  ): void {
-    const relayState: TgrMembershipChangedPayload['relayState'] =
-      change === 'added'
-        ? 'added'
-        : change === 'removed'
-          ? 'removed'
-          : row.relay_state;
-    const payload: TgrMembershipChangedPayload = {
-      saleAddress: row.sale_address,
-      memberAddress: row.member_address,
-      relayState,
-    };
-    this.eventEmitter.emit(TGR_MEMBERSHIP_CHANGED, payload);
   }
 }

--- a/src/token-gated-rooms/services/reconciliation.service.ts
+++ b/src/token-gated-rooms/services/reconciliation.service.ts
@@ -1,0 +1,410 @@
+import { InjectQueue } from '@nestjs/bull';
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { ConfigType } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Queue } from 'bull';
+import { Repository } from 'typeorm';
+import { Token } from '@/tokens/entities/token.entity';
+import { SyncState } from '@/mdw-sync/entities/sync-state.entity';
+import tgrConfig from '../config/tgr.config';
+import { RoomMembership } from '../entities/room-membership.entity';
+import { groupIdFor } from '../nostr/group-id';
+import { putUser, removeUser } from '../nostr/nip29';
+import { RELAY_WRITER, type RelayWriter } from '../nostr/relay-writer.contract';
+import { publishNip29JobOptions } from '../queues/publish-nip29.job-options';
+import { PUBLISH_NIP29_QUEUE } from '../queues/publish-nip29.processor';
+import type { PublishNip29Job } from '../queues/publish-nip29.types';
+import { RoomAdminsService } from './room-admins.service';
+
+/** Hours/day, for the SLA-coverage math (req §4/§9). */
+const HOURS_PER_DAY = 24;
+const SECONDS_PER_DAY = HOURS_PER_DAY * 60 * 60;
+
+/**
+ * Result of reconciling one room against its relay `39002` (for tests/observability).
+ */
+export interface RoomReconcileResult {
+  saleAddress: string;
+  /** `9000` re-adds enqueued (eligible+linked members missing from `39002`). */
+  added: number;
+  /** `9001` re-removes enqueued (present-but-desired-removed non-admin members). */
+  removed: number;
+}
+
+/**
+ * Aggregate of one rotating reconcile batch run.
+ */
+export interface ReconcileBatchResult {
+  /** Rooms actually read back this run. */
+  roomsScanned: number;
+  /** Total corrective `9000`s enqueued. */
+  added: number;
+  /** Total corrective `9001`s enqueued. */
+  removed: number;
+  /** The sale_address cursor advanced to (for the next run); null = wrapped. */
+  nextCursor: string | null;
+}
+
+/**
+ * Membership reconciliation (Task 11, plan §11 / §6.3) — WORKER process.
+ *
+ * The relay's kind-`39002` member list is the source of truth (`room_membership`
+ * is desired-state + cache, §4.3); dropped publishes / same-`created_at` `39002`
+ * regeneration races / transient drift are expected, so this is the periodic
+ * safety net that makes membership *converge* to the desired-eligibility ledger.
+ *
+ * Per room it: (1) reads the authoritative `39002` set via Task 07's
+ * {@link RelayWriter.fetchGroupMembers} on the existing authed connection (we
+ * NEVER open a second socket); (2) diffs it against `room_membership`; (3)
+ * self-heals drift by enqueuing corrective `9000`/`9001` through Task 07's
+ * `worker:publish-nip29` queue. It also self-heals the admin set via
+ * {@link RoomAdminsService.convergeRoomAdmins}.
+ *
+ * ## Coverage / SLA math (req §4/§9 — verbatim §18 defaults)
+ *   TG_RECONCILE_BATCH_SIZE = 500 rooms/run, TG_RECONCILE_INTERVAL = 10m.
+ *   runs/day  = 24h / 10m = 144
+ *   coverage  = 500 × 144 = 72,000 room-reads/day
+ *   rooms     ≈ 54,000  ⇒  every member's room is verified ≤ 24h (the §11 SLA),
+ *               with ~33% headroom. If room count grows past ~72k, raise
+ *               TG_RECONCILE_BATCH_SIZE or shorten TG_RECONCILE_INTERVAL so that
+ *               batch × runs/day ≥ room_count (see {@link slaCoveragePerDay}).
+ *
+ * ## Drift rules (req §A.2)
+ *   - should-be-added  = `eligible=true AND member_pubkey IS NOT NULL` rows whose
+ *     pubkey is ABSENT from `39002`. Unlinked rows (`member_pubkey IS NULL`) are
+ *     SKIPPED (§6.6 — they cannot be in `39002`, not drift).
+ *   - should-be-removed = pubkeys PRESENT in `39002` whose row is `eligible=false`
+ *     AND `role <> 'admin'` (§6.7 admin exemption) AND NOT within an unexpired
+ *     reorg hold (`held_until_height` in the future, req §8 — intentionally still
+ *     in `39002`).
+ *   - `39002` == desired ⇒ NO publishes (idempotent, no spurious writes).
+ *
+ * Mode-gated: scheduling lives on the worker (see the reconcile processor);
+ * methods here are pure DB+relay+queue so they unit-test without a process mode.
+ */
+@Injectable()
+export class ReconciliationService {
+  private readonly logger = new Logger(ReconciliationService.name);
+
+  /**
+   * Rotating cursor: the last `sale_address` reconciled. The next run starts at
+   * `sale_address > cursor` (stable ascending order) and wraps to the start when a
+   * page returns fewer than the batch size — so the rotation walks the whole room
+   * set across runs (req §4). In-memory is sufficient: a worker restart simply
+   * re-starts the rotation from the top (idempotent — relay-owned).
+   */
+  private cursor = '';
+
+  constructor(
+    @InjectRepository(RoomMembership)
+    private readonly membershipRepo: Repository<RoomMembership>,
+    @InjectRepository(Token)
+    private readonly tokenRepo: Repository<Token>,
+    @InjectRepository(SyncState)
+    private readonly syncStateRepo: Repository<SyncState>,
+    @InjectQueue(PUBLISH_NIP29_QUEUE)
+    private readonly publishQueue: Queue<PublishNip29Job>,
+    @Inject(RELAY_WRITER)
+    private readonly relay: RelayWriter,
+    private readonly roomAdmins: RoomAdminsService,
+    @Inject(tgrConfig.KEY)
+    private readonly config: ConfigType<typeof tgrConfig>,
+  ) {}
+
+  /** Reset the rotating cursor (tests). */
+  resetCursor(): void {
+    this.cursor = '';
+  }
+
+  /** Current rotating cursor value (tests/observability). */
+  getCursor(): string {
+    return this.cursor;
+  }
+
+  /**
+   * SLA coverage in room-reads/day for the configured knobs (req §9). Task 15
+   * asserts this is ≥ active-room-count; the unit test asserts the default
+   * (500 × 144 = 72,000 ≥ 54,000).
+   */
+  slaCoveragePerDay(): number {
+    const interval = Math.max(1, this.config.reconcileIntervalSec);
+    const runsPerDay = SECONDS_PER_DAY / interval;
+    return this.config.reconcileBatchSize * runsPerDay;
+  }
+
+  /**
+   * Run one rotating, batched reconcile pass (req §4) — the body of the repeatable
+   * `worker:reconcile-membership` job. Selects the next `TG_RECONCILE_BATCH_SIZE`
+   * CREATED rooms (`Token.nostr_room_state='created'`, ordered by `sale_address`)
+   * after the rotating cursor, reconciles each against its `39002`, advances the
+   * cursor, and wraps at the end.
+   *
+   * Self-bounds load: rotating + batched, never a full scan (§8/§11). Backs off
+   * entirely when the relay writer reports unhealthy (req §5 — do not burn
+   * corrective publishes during an outage; the next run picks up where it left).
+   */
+  async reconcileBatch(): Promise<ReconcileBatchResult> {
+    const empty: ReconcileBatchResult = {
+      roomsScanned: 0,
+      added: 0,
+      removed: 0,
+      nextCursor: this.cursor || null,
+    };
+
+    // Pause on relay outage (req §5): a `39002` read or a corrective publish would
+    // both fail/queue uselessly — skip this run and retry next interval.
+    if (typeof this.relay.isHealthy === 'function' && !this.relay.isHealthy()) {
+      this.logger.warn('reconcileBatch: relay unhealthy — skipping this run');
+      return empty;
+    }
+
+    const limit = this.config.reconcileBatchSize;
+    const rooms = await this.tokenRepo
+      .createQueryBuilder('t')
+      .where('t.nostr_room_state = :created', { created: 'created' })
+      .andWhere('t.sale_address > :cursor', { cursor: this.cursor })
+      .orderBy('t.sale_address', 'ASC')
+      .limit(limit)
+      .getMany();
+
+    if (rooms.length === 0) {
+      // Wrap the rotation back to the start so the next run re-covers from the top.
+      this.cursor = '';
+      return { ...empty, nextCursor: null };
+    }
+
+    let added = 0;
+    let removed = 0;
+    for (const token of rooms) {
+      try {
+        const result = await this.reconcileRoom(token);
+        added += result.added;
+        removed += result.removed;
+      } catch (error: any) {
+        this.logger.error(
+          `reconcileRoom(${token.sale_address}) failed: ${error?.message ?? error}`,
+        );
+      }
+      // Advance the cursor even on a per-room failure so one bad room cannot wedge
+      // the rotation (mirrors the balance-reconciliation cursor discipline).
+      this.cursor = token.sale_address;
+    }
+
+    if (rooms.length < limit) {
+      // Reached the end of the room set this run → wrap for the next one.
+      this.cursor = '';
+    }
+
+    this.logger.debug(
+      `reconcile batch: ${rooms.length} room(s), +${added} re-add, -${removed} re-remove`,
+    );
+    return {
+      roomsScanned: rooms.length,
+      added,
+      removed,
+      nextCursor: this.cursor || null,
+    };
+  }
+
+  /**
+   * Reconcile ONE room against its relay `39002` (req §A.1–§A.3). Reads the
+   * authoritative member set once, diffs against the desired ledger, enqueues only
+   * the corrective deltas (no spurious writes when `39002` already matches), then
+   * self-heals the admin set via the relay's served admin list (Task 08 owns the
+   * converge logic). Stamps `last_reconciled_at` on every row touched (req §5).
+   */
+  async reconcileRoom(token: Token): Promise<RoomReconcileResult> {
+    const saleAddress = token.sale_address;
+    const groupId = groupIdFor({
+      sale_address: saleAddress,
+      nostr_group_id: token.nostr_group_id,
+    });
+
+    // Authoritative `39002` set (hex pubkeys) on Task 07's authed connection. We
+    // do NOT open a second socket; the read helper is owned by Task 07.
+    const relayMembers = await this.relay.fetchGroupMembers(groupId);
+
+    // Desired ledger for this room.
+    const rows = await this.membershipRepo.find({
+      where: { sale_address: saleAddress },
+    });
+
+    const current = await this.currentHeightSafe();
+
+    const toAdd: RoomMembership[] = [];
+    const toRemove: RoomMembership[] = [];
+
+    // ── should-be-added: eligible + linked rows ABSENT from 39002 ──────────────
+    for (const row of rows) {
+      if (!row.eligible) {
+        continue;
+      }
+      if (!row.member_pubkey) {
+        // §6.6 unlinked invariant: cannot be in 39002, NOT drift-to-add.
+        continue;
+      }
+      if (!relayMembers.has(row.member_pubkey)) {
+        toAdd.push(row);
+      }
+    }
+
+    // ── should-be-removed: pubkeys PRESENT in 39002 whose row is desired-removed ─
+    // Index rows by pubkey for an O(1) lookup against the relay set.
+    const byPubkey = new Map<string, RoomMembership>();
+    for (const row of rows) {
+      if (row.member_pubkey) {
+        byPubkey.set(row.member_pubkey, row);
+      }
+    }
+    for (const pubkey of relayMembers) {
+      // Never auto-remove a configured admin (§6.7 / Task 08 owns admin converge).
+      if (this.roomAdmins.isConfiguredAdmin(pubkey)) {
+        continue;
+      }
+      const row = byPubkey.get(pubkey);
+      if (!row) {
+        // Present on the relay but no desired-state row: not THIS task's drift
+        // (could be a configured admin seeded by Task 08, or stale). Leave it —
+        // Task 08's admin converge / Task 10's ledger own those.
+        continue;
+      }
+      if (row.role === 'admin') {
+        continue; // §6.7 admin exemption
+      }
+      if (!row.eligible) {
+        // Within an unexpired reorg hold → intentionally still in 39002 (req §8).
+        if (this.isWithinReorgHold(row, current)) {
+          continue;
+        }
+        toRemove.push(row);
+      }
+    }
+
+    // ── emit corrective publishes (self-heal) ──────────────────────────────────
+    for (const row of toAdd) {
+      const role = row.role === 'admin' ? 'admin' : undefined;
+      await this.enqueue(
+        putUser(groupId, row.member_pubkey, role),
+        groupId,
+        saleAddress,
+        'reconcile-readd',
+      );
+    }
+    for (const row of toRemove) {
+      await this.enqueue(
+        removeUser(groupId, row.member_pubkey),
+        groupId,
+        saleAddress,
+        'reconcile-reremove',
+      );
+    }
+
+    // Admin-set self-heal (Task 08 converge). The relay's authoritative roles are
+    // served on `39001`; this task does not read `39001` separately, so we let the
+    // converge fall back to its own admin-aware diff (it filters non-admin pubkeys
+    // and never demotes the bot). Idempotent: equal sets enqueue nothing.
+    try {
+      await this.roomAdmins.convergeRoomAdmins(saleAddress);
+    } catch (error: any) {
+      this.logger.warn(
+        `convergeRoomAdmins(${saleAddress}) failed: ${error?.message ?? error}`,
+      );
+    }
+
+    // Freshness (req §5): stamp every row of this room reconciled-now.
+    await this.markReconciled(saleAddress);
+
+    return { saleAddress, added: toAdd.length, removed: toRemove.length };
+  }
+
+  /**
+   * Max staleness across active (created-room) memberships, in milliseconds — the
+   * age of the OLDEST `last_reconciled_at` (req §5). Task 15 alerts when this
+   * exceeds the SLA (e.g. > 24h ⇒ the rotation is starving). A `null`
+   * `last_reconciled_at` (never reconciled) is treated as maximally stale and
+   * returned as `Infinity`. Returns `0` when there are no rows.
+   */
+  async maxStalenessMs(): Promise<number> {
+    const oldest = await this.membershipRepo
+      .createQueryBuilder('m')
+      .select('MIN(m.last_reconciled_at)', 'oldest')
+      .addSelect(
+        'COUNT(*) FILTER (WHERE m.last_reconciled_at IS NULL)',
+        'never',
+      )
+      .addSelect('COUNT(*)', 'total')
+      .getRawOne<{ oldest: Date | null; never: string; total: string }>();
+
+    const total = Number(oldest?.total ?? 0);
+    if (total === 0) {
+      return 0;
+    }
+    if (Number(oldest?.never ?? 0) > 0) {
+      // At least one membership has never been reconciled → maximally stale.
+      return Number.POSITIVE_INFINITY;
+    }
+    if (!oldest?.oldest) {
+      return Number.POSITIVE_INFINITY;
+    }
+    return Date.now() - new Date(oldest.oldest).getTime();
+  }
+
+  // ── helpers ─────────────────────────────────────────────────────────────────
+
+  /**
+   * True iff a desired-removed row is inside an unexpired reorg eviction hold
+   * (`held_until_height` set and still in the future), so reconciliation must NOT
+   * treat it as drift-to-remove (req §8). When the current height is unknown we
+   * conservatively treat any set hold as unexpired (skip removal).
+   */
+  private isWithinReorgHold(
+    row: RoomMembership,
+    current: number | null,
+  ): boolean {
+    if (row.held_until_height === null || row.held_until_height === undefined) {
+      return false;
+    }
+    if (current === null) {
+      return true; // unknown height → be conservative, keep the member
+    }
+    return row.held_until_height > current;
+  }
+
+  /** Read tip height via SyncState (`id='global'`); `null` on any failure. */
+  private async currentHeightSafe(): Promise<number | null> {
+    try {
+      const state = await this.syncStateRepo.findOne({
+        where: { id: 'global' },
+      });
+      const tip = state?.tip_height;
+      return typeof tip === 'number' && Number.isFinite(tip) ? tip : null;
+    } catch {
+      return null;
+    }
+  }
+
+  /** Stamp `last_reconciled_at=now()` on every membership row of a room (req §5). */
+  private async markReconciled(saleAddress: string): Promise<void> {
+    await this.membershipRepo.update(
+      { sale_address: saleAddress },
+      { last_reconciled_at: new Date() },
+    );
+  }
+
+  /** Enqueue one corrective publish onto `worker:publish-nip29` (Task 07 path). */
+  private async enqueue(
+    template: PublishNip29Job['template'],
+    groupId: string,
+    saleAddress: string,
+    reason: string,
+  ): Promise<void> {
+    await this.publishQueue.add(
+      {
+        template,
+        groupId,
+        meta: { saleAddress, reason: `reconcile:${reason}` },
+      },
+      publishNip29JobOptions(this.config.publishMaxRetries),
+    );
+  }
+}

--- a/src/token-gated-rooms/services/reorg-eviction.service.ts
+++ b/src/token-gated-rooms/services/reorg-eviction.service.ts
@@ -1,0 +1,375 @@
+import { InjectQueue } from '@nestjs/bull';
+import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
+import { ConfigType } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Queue } from 'bull';
+import { In, Not, Repository } from 'typeorm';
+import { Token } from '@/tokens/entities/token.entity';
+import { SyncState } from '@/mdw-sync/entities/sync-state.entity';
+import tgrConfig from '../config/tgr.config';
+import { RoomMembership } from '../entities/room-membership.entity';
+import { groupIdFor } from '../nostr/group-id';
+import { removeUser } from '../nostr/nip29';
+import { publishNip29JobOptions } from '../queues/publish-nip29.job-options';
+import { PUBLISH_NIP29_QUEUE } from '../queues/publish-nip29.processor';
+import type { PublishNip29Job } from '../queues/publish-nip29.types';
+import { RoomAdminsService } from './room-admins.service';
+
+/**
+ * The single `SyncState` row id (PK `id='global'`) carrying the chain tip height
+ * (mirrors `sync-state.entity.ts`). We read `tip_height` as the single agreed
+ * "current height" for both the buffer math (`bufferEvictions`) and the flush
+ * gate (`flushDueEvictions`) — req §6/§7.
+ */
+const SYNC_STATE_ID = 'global';
+
+/**
+ * Reorg-gated membership eviction (Task 11, plan §6.5). Splits the eviction of a
+ * member who *became ineligible because of a reorg* into two phases so a transient
+ * fork never flaps a member out of `39002`:
+ *
+ *  1. {@link bufferEvictions} — called from the indexer-side plugins' `onReorg`
+ *     (Tasks 03/04, MAIN process). After the plugin recomputes desired
+ *     eligibility, the newly-ineligible non-admin members are *buffered*: we stamp
+ *     `room_membership.held_until_height = tip_height + TG_REORG_CONFIRMATION_DEPTH_BLOCKS`
+ *     and leave `relay_state='added'` (still in `39002`). NO `9001` is enqueued
+ *     here (req §6) — `onReorg` fires synchronously in main and must only do cheap
+ *     Postgres writes (plan §6.5 / task Context).
+ *  2. {@link flushDueEvictions} — a scheduled WORKER job (req §7). It selects rows
+ *     whose hold has passed (`held_until_height <= tip_height`) and, for each that
+ *     is *still* ineligible, enqueues the `9001` `removeUser` via the Task 07
+ *     `worker:publish-nip29` queue (flipping the row to `pending_remove` +
+ *     clearing the hold so the existing ACK seam — Task 10 `onPublishAck` — drives
+ *     it to `removed`). A row that became `eligible=true` again before the hold
+ *     passed has its eviction CANCELLED (clear hold, stay `added`, no publish).
+ *
+ * ## Cost (req §10 — stated for §11)
+ * Depth `TG_REORG_CONFIRMATION_DEPTH_BLOCKS` (default `10`) ≈ the reorg-confirmation
+ * window: an eviction is delayed at most ~10 blocks of chain time. A transient
+ * fork that reverts within depth costs **zero** relay publishes (the eviction is
+ * cancelled at flush). The only relay load is the (rare) genuine evictions.
+ *
+ * Registered `mode: 'shared'` (`bufferEvictions` runs in main from the plugins;
+ * the flush + its scheduling are worker-gated internally via the owning
+ * {@link ReconciliationService}). Holds NO relay socket; the publish transport is
+ * Task 07's queue.
+ */
+@Injectable()
+export class ReorgEvictionService {
+  private readonly logger = new Logger(ReorgEvictionService.name);
+
+  constructor(
+    @InjectRepository(RoomMembership)
+    private readonly membershipRepo: Repository<RoomMembership>,
+    @InjectRepository(Token)
+    private readonly tokenRepo: Repository<Token>,
+    @InjectRepository(SyncState)
+    private readonly syncStateRepo: Repository<SyncState>,
+    // The publish queue + RoomAdminsService are WORKER-only collaborators used by
+    // {@link flushDueEvictions}. `bufferEvictions` (called from the indexer/main
+    // plugins) needs NEITHER, so both are `@Optional()` — the service constructs in
+    // main (plugin modules) without the worker-only relay/admin wiring present.
+    @Optional()
+    @InjectQueue(PUBLISH_NIP29_QUEUE)
+    private readonly publishQueue: Queue<PublishNip29Job> | null,
+    @Optional()
+    private readonly roomAdmins: RoomAdminsService | null,
+    @Inject(tgrConfig.KEY)
+    private readonly config: ConfigType<typeof tgrConfig>,
+  ) {}
+
+  /**
+   * Current chain height = `SyncState.tip_height` (single agreed source, req §6).
+   * Returns `null` when the sync-state row is missing/unreadable so callers can
+   * skip rather than evict against a bogus height.
+   */
+  async currentHeight(): Promise<number | null> {
+    try {
+      const state = await this.syncStateRepo.findOne({
+        where: { id: SYNC_STATE_ID },
+      });
+      const tip = state?.tip_height;
+      return typeof tip === 'number' && Number.isFinite(tip) ? tip : null;
+    } catch (error: any) {
+      this.logger.warn(
+        `currentHeight: failed to read SyncState: ${error?.message ?? error}`,
+      );
+      return null;
+    }
+  }
+
+  /**
+   * Buffer (do NOT publish) the eviction of every member who became ineligible due
+   * to a reorg in one of `saleAddresses` (req §6). Called from the plugins'
+   * `onReorg` AFTER they recompute desired eligibility (so `room_membership.eligible`
+   * already reflects the post-reorg truth).
+   *
+   * For each affected room, the buffered set = rows that are currently published
+   * (`relay_state IN ('added','pending_remove')`) AND now `eligible=false` AND
+   * `role <> 'admin'` (admins are never balance-evicted, §6.7). We stamp
+   * `held_until_height = currentHeight + TG_REORG_CONFIRMATION_DEPTH_BLOCKS` and pin
+   * `relay_state='added'` — the member stays in `39002` (so reconciliation does NOT
+   * see it as drift-to-remove, req §8) until the hold passes and the flush confirms
+   * the ineligibility. ADDS are never buffered (they flow promptly through Task 10).
+   *
+   * @returns the number of membership rows buffered for eviction.
+   */
+  async bufferEvictions(saleAddresses: readonly string[]): Promise<number> {
+    const sales = [...new Set((saleAddresses ?? []).filter(Boolean))];
+    if (sales.length === 0) {
+      return 0;
+    }
+    const current = await this.currentHeight();
+    if (current === null) {
+      this.logger.warn(
+        'bufferEvictions: no current height (SyncState); skipping buffer',
+      );
+      return 0;
+    }
+    const heldUntil = current + this.config.reorgConfirmationDepthBlocks;
+
+    let buffered = 0;
+    for (const saleAddress of sales) {
+      try {
+        // Candidates: published, now-ineligible, non-admin. (An admin row is
+        // exempt from balance eviction, §6.7 — Task 08 owns admin convergence.)
+        const candidates = await this.membershipRepo.find({
+          where: {
+            sale_address: saleAddress,
+            eligible: false,
+            role: Not('admin'),
+            relay_state: In(['added', 'pending_remove']),
+          },
+        });
+        for (const row of candidates) {
+          await this.membershipRepo.update(
+            { id: row.id },
+            // Pin back to `added`: the member must remain in `39002` for the whole
+            // hold window (a `pending_remove` would otherwise be picked up by the
+            // Task 10 publish-pending scan and evicted immediately — the buffer is
+            // the whole point). The hold gates the flush, not the relay_state.
+            { held_until_height: heldUntil, relay_state: 'added' },
+          );
+          buffered += 1;
+        }
+      } catch (error: any) {
+        this.logger.error(
+          `bufferEvictions(${saleAddress}) failed: ${error?.message ?? error}`,
+        );
+      }
+    }
+
+    if (buffered > 0) {
+      this.logger.log(
+        `reorg: buffered ${buffered} eviction(s) across ${sales.length} room(s) ` +
+          `held_until_height=${heldUntil} (current=${current}, depth=${this.config.reorgConfirmationDepthBlocks})`,
+      );
+    }
+    return buffered;
+  }
+
+  /**
+   * Buffer evictions for EVERY room that currently has an at-risk member (a
+   * published, now-ineligible, non-admin row with no hold yet) — the entry point
+   * for the AEX9-transfer plugin's reorg (req §6, modify note). A balance reorg
+   * cannot cheaply name the affected sale_addresses (the reverted txs are already
+   * deleted and balances were applied additively), so we select the affected rooms
+   * by the at-risk membership rows themselves. This is **drift-bounded**, not
+   * room-count-bounded: it touches only rows whose `eligible` flipped false and are
+   * still published — typically a handful after a reorg, not the ~54k registry. A
+   * subsequent balance reconciliation (Task 03) + eligibility recompute (Task 06)
+   * keeps the set correct; here we only protect already-ineligible published members
+   * from premature eviction during the reorg window.
+   *
+   * @returns the number of membership rows buffered.
+   */
+  async bufferAllPendingEvictions(): Promise<number> {
+    const rows = await this.membershipRepo
+      .createQueryBuilder('m')
+      .select('DISTINCT m.sale_address', 'sale_address')
+      .where('m.eligible = false')
+      .andWhere("m.role <> 'admin'")
+      .andWhere("m.relay_state IN ('added','pending_remove')")
+      .andWhere('m.held_until_height IS NULL')
+      .getRawMany<{ sale_address: string }>();
+
+    const sales = rows.map((r) => r.sale_address).filter(Boolean);
+    if (sales.length === 0) {
+      return 0;
+    }
+    return this.bufferEvictions(sales);
+  }
+
+  /**
+   * Flush evictions whose reorg hold has passed (req §7) — WORKER process (it
+   * publishes). Selects `room_membership WHERE held_until_height IS NOT NULL AND
+   * held_until_height <= currentHeight AND eligible=false AND role <> 'admin'`; for
+   * each due row:
+   *   - if it is `eligible=true` again (a follow-up reorg restored it) → CANCEL:
+   *     clear `held_until_height`, leave `relay_state` (`added`), publish nothing;
+   *   - else enqueue `9001` `removeUser` via `worker:publish-nip29`, flip the row
+   *     to `pending_remove`, and clear `held_until_height`. The ACK seam (Task 10
+   *     `onPublishAck`) then drives `pending_remove → removed`.
+   *
+   * The depth gate is enforced by the `held_until_height <= currentHeight`
+   * predicate: a removal whose hold has NOT passed is simply not selected (req §7).
+   * Adds are never held by this gate.
+   *
+   * @returns counts of `{ published, cancelled }` for tests/observability.
+   */
+  async flushDueEvictions(): Promise<{ published: number; cancelled: number }> {
+    if (!this.publishQueue) {
+      // The flush publishes; it must only run in the worker (where the queue is
+      // injected). A main-side caller is a no-op.
+      this.logger.warn(
+        'flushDueEvictions: no publish queue (not worker mode) — skipping',
+      );
+      return { published: 0, cancelled: 0 };
+    }
+    const current = await this.currentHeight();
+    if (current === null) {
+      this.logger.warn('flushDueEvictions: no current height; skipping flush');
+      return { published: 0, cancelled: 0 };
+    }
+
+    const limit = this.config.reconcileBatchSize;
+    let cursorId = 0;
+    let published = 0;
+    let cancelled = 0;
+    const groupIds = new Map<string, string>();
+
+    for (;;) {
+      const due = await this.membershipRepo
+        .createQueryBuilder('m')
+        .where('m.id > :cursor', { cursor: cursorId })
+        .andWhere('m.held_until_height IS NOT NULL')
+        .andWhere('m.held_until_height <= :current', { current })
+        .andWhere('m.eligible = false')
+        .andWhere("m.role <> 'admin'")
+        .orderBy('m.id', 'ASC')
+        .limit(limit)
+        .getMany();
+
+      if (due.length === 0) {
+        break;
+      }
+
+      for (const row of due) {
+        cursorId = Math.max(cursorId, row.id);
+        try {
+          // Re-confirm at flush time (a reorg may have re-org'd back, req §7).
+          const fresh = await this.membershipRepo.findOne({
+            where: { id: row.id },
+          });
+          if (!fresh || fresh.held_until_height === null) {
+            continue; // raced with another flush / a cancel
+          }
+          if (fresh.eligible) {
+            // Eligibility restored before the hold passed → cancel the eviction.
+            await this.membershipRepo.update(
+              { id: fresh.id },
+              { held_until_height: null },
+            );
+            cancelled += 1;
+            continue;
+          }
+          // Still ineligible. A configured admin is never balance-evicted (§6.7) —
+          // belt-and-braces over the `role` predicate (handles a moderator whose
+          // pubkey is in TG_ROOM_ADMINS but role row not yet promoted).
+          if (this.roomAdmins?.isConfiguredAdmin(fresh.member_pubkey)) {
+            await this.membershipRepo.update(
+              { id: fresh.id },
+              { held_until_height: null },
+            );
+            cancelled += 1;
+            continue;
+          }
+          if (!fresh.member_pubkey) {
+            // Nothing to remove on the relay (never published) — just clear hold.
+            await this.membershipRepo.update(
+              { id: fresh.id },
+              { held_until_height: null },
+            );
+            cancelled += 1;
+            continue;
+          }
+
+          const groupId = await this.resolveGroupId(
+            fresh.sale_address,
+            groupIds,
+          );
+          await this.enqueueRemove(
+            groupId,
+            fresh.sale_address,
+            fresh.member_pubkey,
+          );
+          // Flip to pending_remove + clear the hold so it is not re-flushed; the
+          // Task 10 ACK seam drives pending_remove → removed on the relay ACK.
+          await this.membershipRepo.update(
+            { id: fresh.id },
+            { relay_state: 'pending_remove', held_until_height: null },
+          );
+          published += 1;
+        } catch (error: any) {
+          this.logger.error(
+            `flushDueEvictions: row ${row.id} (${row.sale_address}) failed: ` +
+              `${error?.message ?? error}`,
+          );
+        }
+      }
+
+      if (due.length < limit) {
+        break;
+      }
+    }
+
+    if (published > 0 || cancelled > 0) {
+      this.logger.log(
+        `reorg flush @${current}: ${published} eviction(s) published, ` +
+          `${cancelled} cancelled`,
+      );
+    }
+    return { published, cancelled };
+  }
+
+  // ── helpers ─────────────────────────────────────────────────────────────────
+
+  /** Resolve + memoize the NIP-29 group id for a sale (D3 verbatim). */
+  private async resolveGroupId(
+    saleAddress: string,
+    cache: Map<string, string>,
+  ): Promise<string> {
+    const cached = cache.get(saleAddress);
+    if (cached) {
+      return cached;
+    }
+    const token = await this.tokenRepo.findOne({
+      where: { sale_address: saleAddress },
+    });
+    const groupId = groupIdFor({
+      sale_address: saleAddress,
+      nostr_group_id: token?.nostr_group_id,
+    });
+    cache.set(saleAddress, groupId);
+    return groupId;
+  }
+
+  /** Enqueue one `9001` remove-user onto `worker:publish-nip29` (Task 07 path). */
+  private async enqueueRemove(
+    groupId: string,
+    saleAddress: string,
+    pubkey: string,
+  ): Promise<void> {
+    if (!this.publishQueue) {
+      return;
+    }
+    await this.publishQueue.add(
+      {
+        template: removeUser(groupId, pubkey),
+        groupId,
+        meta: { saleAddress, reason: 'reorg-evict' },
+      },
+      publishNip29JobOptions(this.config.publishMaxRetries),
+    );
+  }
+}

--- a/src/token-gated-rooms/services/room-admins.service.spec.ts
+++ b/src/token-gated-rooms/services/room-admins.service.spec.ts
@@ -1,0 +1,193 @@
+import type { JobOptions, Queue } from 'bull';
+import type { RelayWriter } from '../nostr/relay-writer.contract';
+import { TGR_CAPPED_BACKOFF } from '../queues/publish-nip29.job-options';
+import type { PublishNip29Job } from '../queues/publish-nip29.types';
+import {
+  NIP29_ROLE_ADMIN,
+  NIP29_ROLE_MEMBER,
+  RoomAdminsService,
+} from './room-admins.service';
+
+/** The (job, opts) tuple the service passes to `queue.add(job, opts)`. */
+type AddCall = [PublishNip29Job, JobOptions];
+
+/** Read the n-th `queue.add` call as a typed (job, opts) tuple. */
+function addCall(queue: jest.Mocked<Pick<Queue, 'add'>>, n = 0): AddCall {
+  return queue.add.mock.calls[n] as unknown as AddCall;
+}
+
+/** A deterministic 64-hex pubkey for index `n`. */
+const hex = (n: number): string =>
+  (n.toString(16).padStart(2, '0') + 'a'.repeat(62)).slice(0, 64);
+
+const BOT = hex(0);
+const SALE = 'ct_RoomAdminsSvc1';
+
+function makeConfig(admins: string[]): any {
+  return {
+    nostrRoomAdmins: admins,
+    publishMaxRetries: 5,
+  };
+}
+
+function makeQueue(): jest.Mocked<Pick<Queue, 'add'>> {
+  return { add: jest.fn().mockResolvedValue({ id: 'job1' }) } as any;
+}
+
+function makeRelay(
+  members: string[] = [],
+): jest.Mocked<Pick<RelayWriter, 'pubkey' | 'fetchGroupMembers'>> {
+  return {
+    pubkey: BOT,
+    fetchGroupMembers: jest.fn().mockResolvedValue(new Set(members)),
+  } as any;
+}
+
+function build(
+  admins: string[],
+  queue = makeQueue(),
+  relay = makeRelay(),
+): RoomAdminsService {
+  return new RoomAdminsService(
+    makeConfig(admins),
+    queue as unknown as Queue,
+    relay as unknown as RelayWriter,
+  );
+}
+
+describe('RoomAdminsService', () => {
+  describe('construction / parse', () => {
+    it('throws on a malformed configured admin (fail fast at construct)', () => {
+      expect(() => build(['not-a-pubkey'])).toThrow(/unparseable/i);
+    });
+
+    it('de-dups + normalizes the configured set', () => {
+      const svc = build([hex(1), hex(1).toUpperCase()]);
+      expect(svc.admins).toEqual([hex(1)]);
+    });
+  });
+
+  describe('isConfiguredAdmin (exemption predicate)', () => {
+    it('true for a configured admin, false otherwise', () => {
+      const svc = build([hex(1)]);
+      expect(svc.isConfiguredAdmin(hex(1))).toBe(true);
+      expect(svc.isConfiguredAdmin(hex(2))).toBe(false);
+      expect(svc.isConfiguredAdmin(null)).toBe(false);
+    });
+  });
+
+  describe('seedRoomAdmins', () => {
+    it('enqueues one 9000 role=admin per configured admin with the §18 job options', async () => {
+      const queue = makeQueue();
+      const svc = build([hex(1), hex(2)], queue);
+
+      const count = await svc.seedRoomAdmins(SALE);
+
+      expect(count).toBe(2);
+      expect(queue.add).toHaveBeenCalledTimes(2);
+      const [job, opts] = addCall(queue);
+      expect(job.groupId).toBe(SALE);
+      expect(job.meta.saleAddress).toBe(SALE);
+      expect(job.template.kind).toBe(9000);
+      expect(job.template.tags[0]).toEqual(['h', SALE]);
+      expect(job.template.tags[1]).toEqual(['p', hex(1), NIP29_ROLE_ADMIN]);
+      // §18 retry/backoff contract: attempts = maxRetries + 1, capped backoff.
+      expect(opts.attempts).toBe(6);
+      expect(opts.backoff).toEqual({ type: TGR_CAPPED_BACKOFF });
+    });
+
+    it('no configured admins → no enqueue (returns 0)', async () => {
+      const queue = makeQueue();
+      const svc = build([], queue);
+      expect(await svc.seedRoomAdmins(SALE)).toBe(0);
+      expect(queue.add).not.toHaveBeenCalled();
+    });
+
+    it('missing saleAddress → no enqueue', async () => {
+      const queue = makeQueue();
+      const svc = build([hex(1)], queue);
+      expect(await svc.seedRoomAdmins('')).toBe(0);
+      expect(queue.add).not.toHaveBeenCalled();
+    });
+
+    it('idempotency: calling twice enqueues the same publishes again (relay no-op)', async () => {
+      const queue = makeQueue();
+      const svc = build([hex(1)], queue);
+      await svc.seedRoomAdmins(SALE);
+      await svc.seedRoomAdmins(SALE);
+      // The relay collapses replays of the same 9000; the producer simply
+      // re-enqueues — no dedupe ledger here.
+      expect(queue.add).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('onRoomCreated', () => {
+    it('seeds admins on tgr.room.created', async () => {
+      const queue = makeQueue();
+      const svc = build([hex(1)], queue);
+      await svc.onRoomCreated({ saleAddress: SALE });
+      expect(queue.add).toHaveBeenCalledTimes(1);
+    });
+
+    it('ignores a payload without a saleAddress', async () => {
+      const queue = makeQueue();
+      const svc = build([hex(1)], queue);
+      await svc.onRoomCreated({} as any);
+      expect(queue.add).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('convergeRoomAdmins', () => {
+    it('promotes configured-not-yet-admin (9000 role=admin)', async () => {
+      const queue = makeQueue();
+      const svc = build([hex(1), hex(2)], queue);
+
+      const n = await svc.convergeRoomAdmins(SALE, [hex(1), BOT]);
+
+      expect(n).toBe(1);
+      const [job] = addCall(queue);
+      expect(job.template.kind).toBe(9000);
+      expect(job.template.tags[1]).toEqual(['p', hex(2), NIP29_ROLE_ADMIN]);
+    });
+
+    it('demotes admin-no-longer-configured (9006 set-roles=member)', async () => {
+      const queue = makeQueue();
+      const svc = build([hex(1)], queue);
+
+      const n = await svc.convergeRoomAdmins(SALE, [hex(1), hex(2), BOT]);
+
+      expect(n).toBe(1);
+      const [job] = addCall(queue);
+      expect(job.template.kind).toBe(9006);
+      expect(job.template.tags[1]).toEqual(['p', hex(2), NIP29_ROLE_MEMBER]);
+    });
+
+    it('equal sets → no publishes', async () => {
+      const queue = makeQueue();
+      const svc = build([hex(1)], queue);
+      const n = await svc.convergeRoomAdmins(SALE, [hex(1), BOT]);
+      expect(n).toBe(0);
+      expect(queue.add).not.toHaveBeenCalled();
+    });
+
+    it('never demotes the bot key (last-admin guard respected)', async () => {
+      const queue = makeQueue();
+      // No configured admins; bot is the sole current admin.
+      const svc = build([], queue);
+      const n = await svc.convergeRoomAdmins(SALE, [BOT]);
+      expect(n).toBe(0);
+      expect(queue.add).not.toHaveBeenCalled();
+    });
+
+    it('falls back to fetchGroupMembers when no current set is supplied', async () => {
+      const queue = makeQueue();
+      const relay = makeRelay([hex(1), BOT]);
+      const svc = build([hex(1), hex(2)], queue, relay);
+
+      const n = await svc.convergeRoomAdmins(SALE);
+
+      expect(relay.fetchGroupMembers).toHaveBeenCalledWith(SALE);
+      expect(n).toBe(1); // promote hex(2)
+    });
+  });
+});

--- a/src/token-gated-rooms/services/room-admins.service.ts
+++ b/src/token-gated-rooms/services/room-admins.service.ts
@@ -1,0 +1,251 @@
+import { InjectQueue } from '@nestjs/bull';
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { ConfigType } from '@nestjs/config';
+import { OnEvent } from '@nestjs/event-emitter';
+import { Queue } from 'bull';
+import tgrConfig from '../config/tgr.config';
+import { prefixQueue } from '../config/queue-prefix';
+import { TGR_ROOM_CREATED, type TgrRoomCreatedPayload } from '../events';
+import { putUser, setRoles } from '../nostr/nip29';
+import {
+  diffRoomAdmins,
+  isConfiguredAdmin as isConfiguredAdminPure,
+  parseRoomAdmins,
+} from '../nostr/room-admins';
+import { RELAY_WRITER, type RelayWriter } from '../nostr/relay-writer.contract';
+import { publishNip29JobOptions } from '../queues/publish-nip29.job-options';
+import type { PublishNip29Job } from '../queues/publish-nip29.types';
+
+/** Resolved queue name (`worker:publish-nip29`) — the Task 07 durable publish path. */
+export const PUBLISH_NIP29_QUEUE = prefixQueue('publish-nip29', 'worker');
+
+/** NIP-29 relay role token for an admin member (`group.rs` `GroupRole::from_str`). */
+export const NIP29_ROLE_ADMIN = 'admin';
+/** NIP-29 relay role token for a plain member (demotion target in converge). */
+export const NIP29_ROLE_MEMBER = 'member';
+
+/**
+ * Seeds and maintains the configured `TG_ROOM_ADMINS` set as room admins
+ * (`9000` role=admin) in every token-gated room — WORKER PROCESS ONLY (Task 08,
+ * D9, plan §6.7).
+ *
+ * Why a separate provider (not inside the relay writer): the writer is the SOLE
+ * consumer of `worker:publish-nip29`; admin seeds are PRODUCED here and flow
+ * through that same queue so they inherit the §18 rate-limit / capped-backoff /
+ * ACK-timeout discipline (we never call the writer directly to publish). This
+ * service composes Task 07's `nip29.ts` builders + the publish queue; it opens NO
+ * relay socket of its own.
+ *
+ * Responsibilities:
+ *  - {@link onRoomCreated}: react to `tgr.room.created` (Task 09 ACKs a fresh
+ *    group) and seed every configured admin.
+ *  - {@link seedRoomAdmins}: idempotent seed (enqueue one `9000` role=admin per
+ *    configured admin). Safe to call on create AND on backfill (Task 09) AND on
+ *    reconcile — `9000` is relay-replaceable so a re-seed is a relay no-op.
+ *  - {@link convergeRoomAdmins}: read-diff-publish for reconciliation (Task 11):
+ *    promote configured-not-yet-admin, demote admin-no-longer-configured, never
+ *    demoting the bot key (relay last-admin guard, §10).
+ *  - {@link isConfiguredAdmin}: the balance-gating exemption predicate Task 10
+ *    consumes (a configured admin is never `9001`-removed on balance loss).
+ *
+ * The configured set is parsed ONCE (fail-fast on a malformed entry) from
+ * `config.nostrRoomAdmins`. Empty/unset → rooms get only the bot/creator admin.
+ */
+@Injectable()
+export class RoomAdminsService {
+  private readonly logger = new Logger(RoomAdminsService.name);
+
+  /** Configured admins normalized to lowercase 64-hex, parsed once at construct. */
+  private readonly configuredAdmins: string[];
+
+  constructor(
+    @Inject(tgrConfig.KEY)
+    private readonly config: ConfigType<typeof tgrConfig>,
+    @InjectQueue(PUBLISH_NIP29_QUEUE)
+    private readonly publishQueue: Queue<PublishNip29Job>,
+    @Inject(RELAY_WRITER)
+    private readonly relay: RelayWriter,
+  ) {
+    // Parse + normalize + de-dup once. THROWS on a malformed entry (config error,
+    // not a per-room failure) — fail fast at boot.
+    this.configuredAdmins = parseRoomAdmins(this.config.nostrRoomAdmins);
+    if (this.configuredAdmins.length > 0) {
+      this.logger.log(
+        `configured room admins: ${this.configuredAdmins.length} pubkey(s)`,
+      );
+    } else {
+      this.logger.log(
+        'no TG_ROOM_ADMINS configured; rooms get only the bot/creator admin',
+      );
+    }
+  }
+
+  /** The normalized configured admin hex list (read-only copy). */
+  get admins(): readonly string[] {
+    return this.configuredAdmins;
+  }
+
+  /**
+   * Exemption predicate for Task 10: `true` iff `pubkey` (hex/npub) is a
+   * configured room admin. Format-insensitive. Owned by this task.
+   */
+  isConfiguredAdmin(pubkey: string | null | undefined): boolean {
+    return isConfiguredAdminPure(pubkey, this.configuredAdmins);
+  }
+
+  /**
+   * React to a freshly-created/ACKed room (Task 09 emits `tgr.room.created` after
+   * the `9007`/`9002` land) and seed the configured admins. Idempotent — a
+   * re-emit (e.g. backfill resume) re-enqueues the same `9000`s which the relay
+   * treats as no-ops.
+   */
+  @OnEvent(TGR_ROOM_CREATED, { async: true, promisify: true })
+  async onRoomCreated(payload: TgrRoomCreatedPayload): Promise<void> {
+    const saleAddress = payload?.saleAddress;
+    if (!saleAddress) {
+      return;
+    }
+    await this.seedRoomAdmins(saleAddress);
+  }
+
+  /**
+   * Enqueue one `9000` put-user (role=admin) per configured admin for
+   * `saleAddress`'s group, through `worker:publish-nip29`. Returns the number of
+   * publishes enqueued (= configured admin count). No-op (returns 0) when no
+   * admins are configured.
+   *
+   * Idempotent at the relay (`9000` is replaceable) so this is safe to call on
+   * create, on Task 09 backfill seeding, and on every reconcile pass.
+   */
+  async seedRoomAdmins(saleAddress: string): Promise<number> {
+    if (!saleAddress || this.configuredAdmins.length === 0) {
+      return 0;
+    }
+    const groupId = this.groupId(saleAddress);
+    for (const adminHex of this.configuredAdmins) {
+      await this.enqueuePut(groupId, saleAddress, adminHex, 'seed-room-admin');
+    }
+    this.logger.log(
+      `seeded ${this.configuredAdmins.length} admin(s) for room ${saleAddress}`,
+    );
+    return this.configuredAdmins.length;
+  }
+
+  /**
+   * Reconcile the relay's CURRENT admin set against the configured set for one
+   * room (called by Task 11 every reconciliation pass):
+   *  - promote configured-not-yet-admin → `9000` role=admin;
+   *  - demote admin-no-longer-configured → `9006` set-roles=member;
+   *  - NEVER demote the bot key (creator + relay admin, §10) — keeping it admin
+   *    means the relay last-admin guard is not tripped. If a diff would target
+   *    the bot key it is filtered out by {@link diffRoomAdmins}; we assert/log if
+   *    the converge would otherwise empty the admin set.
+   *
+   * `currentAdmins` is the relay-served `39001` admin list (hex). Task 11 reads
+   * it (it owns the `39001`/`39002` read-back scheduling) and passes it in; when
+   * omitted we conservatively fall back to the `39002` member set via the writer
+   * (a member present there but not configured is still only DEMOTED, never the
+   * bot). Idempotent: equal sets emit no publishes. Returns the enqueued count.
+   */
+  async convergeRoomAdmins(
+    saleAddress: string,
+    currentAdmins?: readonly string[],
+  ): Promise<number> {
+    if (!saleAddress) {
+      return 0;
+    }
+    const groupId = this.groupId(saleAddress);
+
+    // Default to a direct `39002` read via the writer when the caller does not
+    // supply the relay's `39001` admin set (Task 11 supplies the real admin list).
+    const current =
+      currentAdmins ?? Array.from(await this.relay.fetchGroupMembers(groupId));
+
+    const { toPromote, toDemote } = diffRoomAdmins(
+      this.configuredAdmins,
+      current,
+      this.relay.pubkey,
+    );
+
+    // Safety: the bot key is always retained admin (§10); a converge that would
+    // demote every admin should never happen. Log loudly if it would.
+    if (toDemote.length > 0 && toPromote.length === 0) {
+      const remaining = new Set(current.map((c) => c.toLowerCase()));
+      for (const hex of toDemote) {
+        remaining.delete(hex);
+      }
+      remaining.add((this.relay.pubkey || '').toLowerCase());
+      if (remaining.size === 0) {
+        this.logger.error(
+          `convergeRoomAdmins(${saleAddress}) would remove the sole remaining ` +
+            `admin — refusing the demotion set to respect the relay last-admin guard`,
+        );
+        return 0;
+      }
+    }
+
+    let enqueued = 0;
+    for (const adminHex of toPromote) {
+      await this.enqueuePut(groupId, saleAddress, adminHex, 'converge-promote');
+      enqueued += 1;
+    }
+    for (const adminHex of toDemote) {
+      await this.enqueueDemote(groupId, saleAddress, adminHex);
+      enqueued += 1;
+    }
+
+    if (enqueued > 0) {
+      this.logger.log(
+        `converge room ${saleAddress}: +${toPromote.length} promote, ` +
+          `-${toDemote.length} demote`,
+      );
+    }
+    return enqueued;
+  }
+
+  // ── publish helpers (enqueue onto worker:publish-nip29) ───────────────────
+
+  /** Enqueue a `9000` put-user role=admin (add/promote). */
+  private async enqueuePut(
+    groupId: string,
+    saleAddress: string,
+    adminHex: string,
+    reason: string,
+  ): Promise<void> {
+    const template = putUser(groupId, adminHex, NIP29_ROLE_ADMIN);
+    await this.publishQueue.add(
+      {
+        template,
+        groupId,
+        meta: { saleAddress, reason },
+      },
+      publishNip29JobOptions(this.config.publishMaxRetries),
+    );
+  }
+
+  /** Enqueue a `9006` set-roles=member (demote a no-longer-configured admin). */
+  private async enqueueDemote(
+    groupId: string,
+    saleAddress: string,
+    adminHex: string,
+  ): Promise<void> {
+    const template = setRoles(groupId, adminHex, [NIP29_ROLE_MEMBER]);
+    await this.publishQueue.add(
+      {
+        template,
+        groupId,
+        meta: { saleAddress, reason: 'converge-demote' },
+      },
+      publishNip29JobOptions(this.config.publishMaxRetries),
+    );
+  }
+
+  /**
+   * The NIP-29 group id for a room. D3: the group id is `sale_address` verbatim
+   * (stored once in `Token.nostr_group_id`); the `tgr.room.created` payload
+   * carries only `saleAddress`, so it IS the group id here.
+   */
+  private groupId(saleAddress: string): string {
+    return saleAddress;
+  }
+}

--- a/src/token-gated-rooms/services/room-backfill.integration.spec.ts
+++ b/src/token-gated-rooms/services/room-backfill.integration.spec.ts
@@ -1,0 +1,327 @@
+import 'dotenv/config';
+import { DataSource, Repository } from 'typeorm';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import type { Queue } from 'bull';
+import { DATABASE_CONFIG } from '@/configs/database';
+import { Token } from '@/tokens/entities/token.entity';
+import { CommunityRoom } from '../entities/community-room.entity';
+import { RoomBackfillState } from '../entities/room-backfill-state.entity';
+import { NIP29_KIND } from '../nostr/nip29';
+import { TGR_ROOM_CREATED } from '../events';
+import type { PublishNip29Job } from '../queues/publish-nip29.types';
+import { RoomBackfillService } from './room-backfill.service';
+
+/**
+ * DB integration for the eager room backfill (Task 09). Mirrors the Task 04
+ * isolated-schema harness (`community-room-state.integration.spec.ts`): a real
+ * Postgres backs `token` + `community_room` + `room_backfill_state` in a DEDICATED
+ * `tgr09_test` schema (created/dropped here, `synchronize: true`), so the
+ * whole-registry backfill is naturally scoped and never touches the shared
+ * `public` schema (54k real tokens).
+ *
+ * The relay WRITE path (the `worker:publish-nip29` queue) is the Task 07 contract;
+ * here we mock the queue + the Task 08 `RoomAdminsService` and drive the state
+ * machine by replaying the `tgr.publish.ack` the publish processor would emit. No
+ * relay socket is opened — the relay-backed throughput run is the flagged load
+ * test (§6.2), not this DB test. Asserts:
+ *  - the working-set predicate + deterministic page ordering;
+ *  - request → pending, ack → created (has_nostr_room=true, room.created emitted);
+ *  - IDEMPOTENT re-run: re-deriving the working set yields no created tokens to
+ *    re-request and re-requesting a still-pending token does not double-create;
+ *  - RESUME after a mid-batch interrupt: the predicate completes the remainder.
+ *
+ * Requires the local Postgres (`DB_HOST`); auto-skips otherwise so unit-only runs
+ * stay green.
+ */
+const HAS_DB = !!process.env.DB_HOST;
+const d = HAS_DB ? describe : describe.skip;
+
+const SCHEMA = 'tgr09_test';
+
+d('Eager room backfill (integration)', () => {
+  let ds: DataSource;
+  let tokenRepo: Repository<Token>;
+  let roomRepo: Repository<CommunityRoom>;
+  let stateRepo: Repository<RoomBackfillState>;
+  let emitter: EventEmitter2;
+  let service: RoomBackfillService;
+  let publishQueue: jest.Mocked<Pick<Queue, 'add'>>;
+  let backfillQueue: jest.Mocked<Pick<Queue, 'add'>>;
+  let seedRoomAdmins: jest.Mock;
+
+  const makeTokenRow = (sale: string, symbol: string): Partial<Token> => ({
+    sale_address: sale,
+    address: 'ct_token_' + sale,
+    name: symbol + 'Name',
+    symbol,
+    owner_address: 'ak_owner_' + sale,
+    creator_address: 'ak_creator_' + sale,
+  });
+
+  /** Replay the ACK the publish processor would emit for one publish job. */
+  const ack = (saleAddress: string, kind: number, ok = true): Promise<void> =>
+    service.onPublishAck({ saleAddress, kind, ok });
+
+  beforeAll(async () => {
+    const boot = new DataSource({
+      ...(DATABASE_CONFIG as any),
+      synchronize: false,
+      entities: [],
+    });
+    await boot.initialize();
+    await boot.query(`DROP SCHEMA IF EXISTS "${SCHEMA}" CASCADE`);
+    await boot.query(`CREATE SCHEMA "${SCHEMA}"`);
+    await boot.destroy();
+
+    ds = new DataSource({
+      ...(DATABASE_CONFIG as any),
+      schema: SCHEMA,
+      synchronize: true,
+      entities: [Token, CommunityRoom, RoomBackfillState],
+    });
+    await ds.initialize();
+
+    tokenRepo = ds.getRepository(Token);
+    roomRepo = ds.getRepository(CommunityRoom);
+    stateRepo = ds.getRepository(RoomBackfillState);
+  }, 60_000);
+
+  beforeEach(async () => {
+    await roomRepo.clear();
+    await tokenRepo.clear();
+    await stateRepo.clear();
+
+    emitter = new EventEmitter2();
+    publishQueue = { add: jest.fn().mockResolvedValue({ id: 'p' }) } as any;
+    backfillQueue = { add: jest.fn().mockResolvedValue({ id: 'b' }) } as any;
+    seedRoomAdmins = jest.fn().mockResolvedValue(1);
+
+    service = new RoomBackfillService(
+      tokenRepo,
+      roomRepo,
+      stateRepo,
+      publishQueue as unknown as Queue<PublishNip29Job>,
+      backfillQueue as unknown as Queue,
+      { seedRoomAdmins } as any,
+      emitter,
+      { backfillBatchSize: 2, publishMaxRetries: 5 } as any,
+    );
+  });
+
+  afterAll(async () => {
+    if (ds?.isInitialized) {
+      await ds.destroy();
+    }
+    const cleanup = new DataSource({
+      ...(DATABASE_CONFIG as any),
+      synchronize: false,
+      entities: [],
+    });
+    await cleanup.initialize();
+    await cleanup.query(`DROP SCHEMA IF EXISTS "${SCHEMA}" CASCADE`);
+    await cleanup.destroy();
+  }, 60_000);
+
+  it('creates N rooms for N tokens and converges all to created / has_nostr_room=true', async () => {
+    await tokenRepo.save([
+      tokenRepo.create(makeTokenRow('ct_a', 'AAA')),
+      tokenRepo.create(makeTokenRow('ct_b', 'BBB')),
+      tokenRepo.create(makeTokenRow('ct_c', 'CCC')),
+    ]);
+
+    const created: string[] = [];
+    emitter.on(TGR_ROOM_CREATED, (p: { saleAddress: string }) =>
+      created.push(p.saleAddress),
+    );
+
+    // Walk the pages (batchSize=2 → page1: a,b ; page2: c).
+    const p1 = await service.processPage();
+    expect(p1.requested).toBe(2);
+    expect(p1.hasMore).toBe(true);
+    const p2 = await service.processPage(p1.nextCursor);
+    expect(p2.requested).toBe(1);
+    expect(p2.hasMore).toBe(false);
+
+    // All three requested → pending, group id stamped, 2 publishes + 1 seed each.
+    for (const sale of ['ct_a', 'ct_b', 'ct_c']) {
+      const t = await tokenRepo.findOneByOrFail({ sale_address: sale });
+      expect(t.nostr_room_state).toBe('pending');
+      expect(t.nostr_group_id).toBe(sale);
+      expect(t.has_nostr_room).toBe(false);
+    }
+    expect(publishQueue.add).toHaveBeenCalledTimes(6); // 3 tokens × (9007+9002)
+    expect(seedRoomAdmins).toHaveBeenCalledTimes(3);
+
+    // Replay the relay 9007 ok ack for each → created.
+    for (const sale of ['ct_a', 'ct_b', 'ct_c']) {
+      await ack(sale, NIP29_KIND.CREATE_GROUP, true);
+    }
+
+    for (const sale of ['ct_a', 'ct_b', 'ct_c']) {
+      const t = await tokenRepo.findOneByOrFail({ sale_address: sale });
+      expect(t.nostr_room_state).toBe('created');
+      expect(t.has_nostr_room).toBe(true);
+      expect(t.nostr_room_created_at).toBeInstanceOf(Date);
+    }
+    expect(created.sort()).toEqual(['ct_a', 'ct_b', 'ct_c']);
+
+    // Working set is now empty.
+    expect(await service.pendingCount()).toBe(0);
+  });
+
+  it('is idempotent: re-running after created produces no new requests', async () => {
+    await tokenRepo.save([tokenRepo.create(makeTokenRow('ct_a', 'AAA'))]);
+
+    await service.processPage();
+    await ack('ct_a', NIP29_KIND.CREATE_GROUP, true);
+    const callsAfterFirst = publishQueue.add.mock.calls.length;
+
+    // A second sweep re-derives the working set from the predicate — the created
+    // token drops out, so nothing is re-requested.
+    const again = await service.processPage();
+    expect(again.requested).toBe(0);
+    expect(publishQueue.add.mock.calls.length).toBe(callsAfterFirst);
+
+    const t = await tokenRepo.findOneByOrFail({ sale_address: 'ct_a' });
+    expect(t.nostr_room_state).toBe('created');
+  });
+
+  it('re-requesting a still-pending token does not double-create (re-publish in place)', async () => {
+    await tokenRepo.save([tokenRepo.create(makeTokenRow('ct_a', 'AAA'))]);
+
+    // First pass: pending (no ack yet).
+    await service.processPage();
+    let t = await tokenRepo.findOneByOrFail({ sale_address: 'ct_a' });
+    expect(t.nostr_room_state).toBe('pending');
+
+    // Interrupt + resume: the predicate still selects the pending token (not yet
+    // created) → re-request re-publishes in place, state stays pending.
+    const resume = await service.processPage();
+    expect(resume.requested).toBe(1);
+    t = await tokenRepo.findOneByOrFail({ sale_address: 'ct_a' });
+    expect(t.nostr_room_state).toBe('pending');
+    expect(t.has_nostr_room).toBe(false);
+
+    // A single create ack now converges it to created exactly once.
+    await ack('ct_a', NIP29_KIND.CREATE_GROUP, true);
+    t = await tokenRepo.findOneByOrFail({ sale_address: 'ct_a' });
+    expect(t.nostr_room_state).toBe('created');
+    expect(t.has_nostr_room).toBe(true);
+  });
+
+  it('resume after a mid-batch interrupt: the full set converges to created', async () => {
+    await tokenRepo.save([
+      tokenRepo.create(makeTokenRow('ct_a', 'AAA')),
+      tokenRepo.create(makeTokenRow('ct_b', 'BBB')),
+      tokenRepo.create(makeTokenRow('ct_c', 'CCC')),
+      tokenRepo.create(makeTokenRow('ct_d', 'DDD')),
+    ]);
+
+    // "Crash" after the first page only (a, b requested + acked).
+    const p1 = await service.processPage();
+    expect(p1.requested).toBe(2);
+    await ack('ct_a', NIP29_KIND.CREATE_GROUP, true);
+    await ack('ct_b', NIP29_KIND.CREATE_GROUP, true);
+
+    // Restart: working set re-derives → only c, d remain.
+    expect(await service.pendingCount()).toBe(2);
+    let next = await service.processPage();
+    expect(next.requested).toBe(2);
+    expect(next.hasMore).toBe(true);
+    // (a short final empty page would report !hasMore; with exactly 2 remaining
+    // and batchSize 2 the page is full, so a follow-up page is checked.)
+    next = await service.processPage(next.nextCursor);
+    expect(next.requested).toBe(0);
+
+    await ack('ct_c', NIP29_KIND.CREATE_GROUP, true);
+    await ack('ct_d', NIP29_KIND.CREATE_GROUP, true);
+
+    for (const sale of ['ct_a', 'ct_b', 'ct_c', 'ct_d']) {
+      const t = await tokenRepo.findOneByOrFail({ sale_address: sale });
+      expect(t.nostr_room_state).toBe('created');
+      expect(t.has_nostr_room).toBe(true);
+    }
+    expect(await service.pendingCount()).toBe(0);
+  });
+
+  it('a 9007 failure ack drives pending → failed; a retry re-requests it', async () => {
+    await tokenRepo.save([tokenRepo.create(makeTokenRow('ct_a', 'AAA'))]);
+
+    await service.processPage();
+    await ack('ct_a', NIP29_KIND.CREATE_GROUP, false); // retries exhausted
+
+    let t = await tokenRepo.findOneByOrFail({ sale_address: 'ct_a' });
+    expect(t.nostr_room_state).toBe('failed');
+    expect(t.has_nostr_room).toBe(false);
+
+    // failed is still in the working set (NOT IN created,deleted) → retried.
+    expect(await service.pendingCount()).toBe(1);
+    const retry = await service.processPage();
+    expect(retry.requested).toBe(1);
+    t = await tokenRepo.findOneByOrFail({ sale_address: 'ct_a' });
+    expect(t.nostr_room_state).toBe('pending');
+
+    await ack('ct_a', NIP29_KIND.CREATE_GROUP, true);
+    t = await tokenRepo.findOneByOrFail({ sale_address: 'ct_a' });
+    expect(t.nostr_room_state).toBe('created');
+  });
+
+  it('derives 9002 visibility from community_room.is_private (private) and default public', async () => {
+    await tokenRepo.save([
+      tokenRepo.create(makeTokenRow('ct_priv', 'PRV')),
+      tokenRepo.create(makeTokenRow('ct_pub', 'PUB')),
+    ]);
+    // Only the private one has a community_room row.
+    await roomRepo.save(
+      roomRepo.create({
+        sale_address: 'ct_priv',
+        token_address: 'ct_token_ct_priv',
+        symbol: 'PRV',
+        owner_address: 'ak_o',
+        is_private: true,
+        is_community: true,
+      }),
+    );
+
+    await service.requestRoom(
+      await tokenRepo.findOneByOrFail({ sale_address: 'ct_priv' }),
+    );
+    await service.requestRoom(
+      await tokenRepo.findOneByOrFail({ sale_address: 'ct_pub' }),
+    );
+
+    // Find the 9002 edit-metadata jobs and check their visibility tag.
+    const editJobs = publishQueue.add.mock.calls
+      .map((c) => c[0] as unknown as PublishNip29Job)
+      .filter((j) => j.template.kind === NIP29_KIND.EDIT_METADATA);
+
+    const privJob = editJobs.find((j) => j.groupId === 'ct_priv');
+    const pubJob = editJobs.find((j) => j.groupId === 'ct_pub');
+    expect(privJob.template.tags.map((t) => t[0])).toContain('private');
+    expect(pubJob.template.tags.map((t) => t[0])).toContain('public');
+  });
+
+  it('deleted is terminal: never re-requested by the working set', async () => {
+    await tokenRepo.save([
+      tokenRepo.create({
+        ...makeTokenRow('ct_del', 'DEL'),
+        nostr_room_state: 'deleted',
+      }),
+    ]);
+    expect(await service.pendingCount()).toBe(0);
+    const page = await service.processPage();
+    expect(page.requested).toBe(0);
+    expect(publishQueue.add).not.toHaveBeenCalled();
+  });
+
+  it('persists the resume cursor in room_backfill_state', async () => {
+    await tokenRepo.save([
+      tokenRepo.create(makeTokenRow('ct_a', 'AAA')),
+      tokenRepo.create(makeTokenRow('ct_b', 'BBB')),
+    ]);
+    await service.processPage();
+    expect(await service.cursorOffset()).toBe(2);
+    const row = await stateRepo.findOneByOrFail({ id: 'global' });
+    expect(row.batch_offset).toBe(2);
+  });
+});

--- a/src/token-gated-rooms/services/room-backfill.service.spec.ts
+++ b/src/token-gated-rooms/services/room-backfill.service.spec.ts
@@ -1,0 +1,670 @@
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import type { JobOptions, Queue } from 'bull';
+import { BigNumber } from 'bignumber.js';
+import type { Token } from '@/tokens/entities/token.entity';
+import { NIP29_KIND } from '../nostr/nip29';
+import { TGR_ROOM_CREATED } from '../events';
+import type { NostrRoomState } from '../enums/nostr-room-state.enum';
+import { TGR_CAPPED_BACKOFF } from '../queues/publish-nip29.job-options';
+import type { PublishNip29Job } from '../queues/publish-nip29.types';
+import { nextStateForAck, RoomBackfillService } from './room-backfill.service';
+import { GroupMissingTracker } from './group-missing-tracker.service';
+
+/**
+ * Unit coverage for the eager room backfill (Task 09):
+ *  - the `nostr_room_state` machine (every Req 3 transition), driven by the
+ *    `tgr.publish.ack` seam + the pure {@link nextStateForAck} decision;
+ *  - the batch cursor: deterministic `sale_address` ordering, page-size honors
+ *    `backfillBatchSize`, the `has_nostr_room=false AND state NOT IN
+ *    (created,deleted)` predicate, and cursor advance;
+ *  - private-flag derivation for `9002` (private when `community_room.is_private`,
+ *    public when the row is absent);
+ *  - admin seeding is DELEGATED to the Task 08 helper (invoked once per room).
+ *
+ * All collaborators are mocked — no DB, no relay. Boot-safety (no auto-run) is
+ * asserted via `onApplicationBootstrap` with the flag unset.
+ */
+describe('RoomBackfillService (unit)', () => {
+  const SALE = 'ct_tgr09_sale_1';
+
+  type Mocks = {
+    service: RoomBackfillService;
+    tokenRepo: any;
+    communityRoomRepo: any;
+    backfillStateRepo: any;
+    publishQueue: jest.Mocked<Pick<Queue, 'add'>>;
+    backfillQueue: jest.Mocked<Pick<Queue, 'add'>>;
+    roomAdmins: { seedRoomAdmins: jest.Mock };
+    emitter: EventEmitter2;
+    groupMissing: GroupMissingTracker;
+    update: jest.Mock;
+  };
+
+  const makeToken = (overrides: Partial<Token> = {}): Token =>
+    ({
+      sale_address: SALE,
+      symbol: 'TG',
+      has_nostr_room: false,
+      nostr_room_state: 'none',
+      ...overrides,
+    }) as Token;
+
+  const build = (
+    opts: {
+      page?: Token[];
+      findToken?: Token | null;
+      isPrivateRow?: { is_private: boolean } | null;
+      batchSize?: number;
+      /**
+       * When true, the injected tgrConfig carries a relay URL + bot nsec so
+       * `isRelayConfigured(this.config)` is satisfied — this is the new switch
+       * that arms the relay-actuator duties (eager boot backfill, the reactive
+       * `onCommunityUpserted` create). Default false keeps the service dormant.
+       */
+      relayConfigured?: boolean;
+    } = {},
+  ): Mocks => {
+    const update = jest.fn().mockResolvedValue({ affected: 1 });
+
+    // Query builder used by workingSetPage / pendingCount.
+    const qb: any = {
+      where: jest.fn(() => qb),
+      andWhere: jest.fn(() => qb),
+      orderBy: jest.fn(() => qb),
+      limit: jest.fn(() => qb),
+      getMany: jest.fn(async () => opts.page ?? []),
+      getCount: jest.fn(async () => (opts.page ?? []).length),
+    };
+
+    const tokenRepo: any = {
+      createQueryBuilder: jest.fn(() => qb),
+      update,
+      findOne: jest.fn(async () =>
+        opts.findToken === undefined ? null : opts.findToken,
+      ),
+      find: jest.fn(async () => opts.page ?? []),
+    };
+    const communityRoomRepo: any = {
+      findOne: jest.fn(async () =>
+        opts.isPrivateRow === undefined ? null : opts.isPrivateRow,
+      ),
+    };
+    const backfillStateRepo: any = {
+      upsert: jest.fn().mockResolvedValue(undefined),
+      findOne: jest.fn(async () => ({ batch_offset: 0 })),
+    };
+    const publishQueue = {
+      add: jest.fn().mockResolvedValue({ id: 'pub1' }),
+    } as any;
+    const backfillQueue = {
+      add: jest.fn().mockResolvedValue({ id: 'bf1' }),
+    } as any;
+    const roomAdmins = { seedRoomAdmins: jest.fn().mockResolvedValue(1) };
+    const emitter = new EventEmitter2();
+    const config: any = {
+      backfillBatchSize: opts.batchSize ?? 200,
+      publishMaxRetries: 5,
+      // Relay-enable switch (DW2): both present + non-blank ⟺
+      // `isRelayConfigured(this.config)` is true. Unset → dormant.
+      nostrRelayUrl: opts.relayConfigured ? 'ws://relay.test' : undefined,
+      nostrBotNsec: opts.relayConfigured ? 'nsec1abc' : undefined,
+    };
+
+    const groupMissing = new GroupMissingTracker();
+
+    const service = new RoomBackfillService(
+      tokenRepo,
+      communityRoomRepo,
+      backfillStateRepo,
+      publishQueue,
+      backfillQueue,
+      roomAdmins as any,
+      emitter,
+      config,
+      groupMissing,
+    );
+
+    return {
+      service,
+      tokenRepo,
+      communityRoomRepo,
+      backfillStateRepo,
+      publishQueue,
+      backfillQueue,
+      roomAdmins,
+      emitter,
+      groupMissing,
+      update,
+    };
+  };
+
+  /** Read the n-th publishQueue.add as (job, opts). */
+  const pub = (
+    q: jest.Mocked<Pick<Queue, 'add'>>,
+    n = 0,
+  ): [PublishNip29Job, JobOptions] =>
+    q.add.mock.calls[n] as unknown as [PublishNip29Job, JobOptions];
+
+  // ── pure transition decision ────────────────────────────────────────────────
+  describe('nextStateForAck (state machine, §4.7)', () => {
+    it('none/failed → created on a 9007 ok ACK', () => {
+      expect(nextStateForAck('pending', NIP29_KIND.CREATE_GROUP, true)).toBe(
+        'created',
+      );
+    });
+
+    it('"Group already exists" surfaces as a 9007 ok → created', () => {
+      // The processor maps already-exists to ok:true, so it reaches us as ok.
+      expect(nextStateForAck('pending', NIP29_KIND.CREATE_GROUP, true)).toBe(
+        'created',
+      );
+    });
+
+    it('pending → failed on a 9007 failure ACK (retries exhausted)', () => {
+      expect(nextStateForAck('pending', NIP29_KIND.CREATE_GROUP, false)).toBe(
+        'failed',
+      );
+    });
+
+    it('pending → failed on a 9002 failure ACK', () => {
+      expect(nextStateForAck('pending', NIP29_KIND.EDIT_METADATA, false)).toBe(
+        'failed',
+      );
+    });
+
+    it('9002 ok ACK is non-authoritative for existence → no change', () => {
+      expect(
+        nextStateForAck('pending', NIP29_KIND.EDIT_METADATA, true),
+      ).toBeUndefined();
+    });
+
+    it('created never regresses on a re-publish ACK (idempotent re-run)', () => {
+      expect(
+        nextStateForAck('created', NIP29_KIND.CREATE_GROUP, true),
+      ).toBeUndefined();
+      expect(
+        nextStateForAck('created', NIP29_KIND.CREATE_GROUP, false),
+      ).toBeUndefined();
+    });
+
+    it('deleted is terminal — no ACK moves it', () => {
+      expect(
+        nextStateForAck('deleted', NIP29_KIND.CREATE_GROUP, true),
+      ).toBeUndefined();
+      expect(
+        nextStateForAck('deleted', NIP29_KIND.EDIT_METADATA, false),
+      ).toBeUndefined();
+    });
+  });
+
+  // ── requestRoom: none → pending + publish sequence ──────────────────────────
+  describe('requestRoom (none → pending; publish sequence)', () => {
+    it('transitions none → pending, stamps group id, enqueues 9007 then 9002, seeds admins', async () => {
+      const m = build({ isPrivateRow: null });
+      const token = makeToken({ nostr_room_state: 'none' });
+
+      const result = await m.service.requestRoom(token);
+
+      expect(result.requested).toBe(true);
+      expect(result.state).toBe('pending');
+
+      // none → pending with group id stamped (conditional on the from-state).
+      expect(m.update).toHaveBeenCalledWith(
+        { sale_address: SALE, nostr_room_state: 'none' },
+        { nostr_room_state: 'pending', nostr_group_id: SALE },
+      );
+
+      // Two group-level publishes in order: 9007 then 9002.
+      expect(m.publishQueue.add).toHaveBeenCalledTimes(2);
+      const [createJob, createOpts] = pub(m.publishQueue, 0);
+      expect(createJob.template.kind).toBe(NIP29_KIND.CREATE_GROUP);
+      expect(createJob.template.tags[0]).toEqual(['h', SALE]);
+      expect(createJob.groupId).toBe(SALE);
+      expect(createJob.meta?.saleAddress).toBe(SALE);
+      // §18 retry/backoff contract spread.
+      expect(createOpts.attempts).toBe(6);
+      expect(createOpts.backoff).toEqual({ type: TGR_CAPPED_BACKOFF });
+
+      const [editJob] = pub(m.publishQueue, 1);
+      expect(editJob.template.kind).toBe(NIP29_KIND.EDIT_METADATA);
+      const tagKeys = editJob.template.tags.map((t) => t[0]);
+      expect(tagKeys).toContain('name');
+      expect(tagKeys).toContain('public');
+      expect(tagKeys).toContain('closed');
+
+      // Admin seeding delegated to Task 08 (NOT reimplemented), once per room.
+      expect(m.roomAdmins.seedRoomAdmins).toHaveBeenCalledTimes(1);
+      expect(m.roomAdmins.seedRoomAdmins).toHaveBeenCalledWith(SALE);
+    });
+
+    it('retries a failed token: failed → pending', async () => {
+      const m = build({ isPrivateRow: null });
+      const token = makeToken({ nostr_room_state: 'failed' });
+
+      const result = await m.service.requestRoom(token);
+
+      expect(result.state).toBe('pending');
+      expect(m.update).toHaveBeenCalledWith(
+        { sale_address: SALE, nostr_room_state: 'failed' },
+        { nostr_room_state: 'pending', nostr_group_id: SALE },
+      );
+    });
+
+    it('re-publishes a pending token in place (no state change)', async () => {
+      const m = build({ isPrivateRow: null });
+      const token = makeToken({ nostr_room_state: 'pending' });
+
+      const result = await m.service.requestRoom(token);
+
+      expect(result.requested).toBe(true);
+      expect(result.state).toBe('pending');
+      // No transition update for an already-pending row …
+      expect(m.update).not.toHaveBeenCalled();
+      // … but the publishes are re-enqueued (relay collapses them).
+      expect(m.publishQueue.add).toHaveBeenCalledTimes(2);
+    });
+
+    it('skips a created token — terminal/done, never re-enqueues', async () => {
+      const m = build();
+      const token = makeToken({
+        nostr_room_state: 'created',
+        has_nostr_room: true,
+      });
+      const result = await m.service.requestRoom(token);
+      expect(result.requested).toBe(false);
+      expect(result.state).toBe('created');
+      expect(m.publishQueue.add).not.toHaveBeenCalled();
+      expect(m.roomAdmins.seedRoomAdmins).not.toHaveBeenCalled();
+    });
+
+    it('skips a deleted token (9008 terminal) — never re-enqueues', async () => {
+      const m = build();
+      const token = makeToken({ nostr_room_state: 'deleted' });
+      const result = await m.service.requestRoom(token);
+      expect(result.requested).toBe(false);
+      expect(result.state).toBe('deleted');
+      expect(m.publishQueue.add).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── private flag derivation (§Req 2.2) ──────────────────────────────────────
+  describe('private flag on 9002', () => {
+    it('private when community_room.is_private = true', async () => {
+      const m = build({ isPrivateRow: { is_private: true } });
+      await m.service.requestRoom(makeToken());
+      const [editJob] = pub(m.publishQueue, 1);
+      const tagKeys = editJob.template.tags.map((t) => t[0]);
+      expect(tagKeys).toContain('private');
+      expect(tagKeys).not.toContain('public');
+    });
+
+    it('public when no community_room row exists (plain [TG] token, D8)', async () => {
+      const m = build({ isPrivateRow: null });
+      await m.service.requestRoom(makeToken());
+      const [editJob] = pub(m.publishQueue, 1);
+      const tagKeys = editJob.template.tags.map((t) => t[0]);
+      expect(tagKeys).toContain('public');
+      expect(tagKeys).not.toContain('private');
+    });
+  });
+
+  // ── batch cursor / working-set predicate (§Req 1, §5) ───────────────────────
+  describe('processPage (batch cursor)', () => {
+    it('selects with the predicate, deterministic sale_address order, page-size = batchSize', async () => {
+      const m = build({
+        page: [makeToken({ sale_address: 'ct_a' })],
+        batchSize: 50,
+        isPrivateRow: null,
+      });
+
+      await m.service.processPage();
+
+      const qb = m.tokenRepo.createQueryBuilder.mock.results[0].value;
+      expect(qb.where).toHaveBeenCalledWith('token.has_nostr_room = :flag', {
+        flag: false,
+      });
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        'token.nostr_room_state NOT IN (:...done)',
+        { done: ['created', 'deleted'] },
+      );
+      expect(qb.orderBy).toHaveBeenCalledWith('token.sale_address', 'ASC');
+      expect(qb.limit).toHaveBeenCalledWith(50);
+    });
+
+    it('reports hasMore + the keyset cursor (last sale_address) when the page is full, and advances the count', async () => {
+      const page = [
+        makeToken({ sale_address: 'ct_a' }),
+        makeToken({ sale_address: 'ct_b' }),
+      ];
+      const m = build({ page, batchSize: 2, isPrivateRow: null });
+      m.backfillStateRepo.findOne.mockResolvedValue({ batch_offset: 0 });
+
+      const result = await m.service.processPage();
+
+      expect(result.requested).toBe(2);
+      expect(result.hasMore).toBe(true); // page filled the batch size
+      expect(result.nextCursor).toBe('ct_b'); // keyset cursor = last sale_address
+      // cumulative requested count persisted for observability
+      expect(m.backfillStateRepo.upsert).toHaveBeenCalledWith(
+        { id: 'global', batch_offset: 2 },
+        { conflictPaths: ['id'] },
+      );
+    });
+
+    it('keyset-pages after the supplied cursor', async () => {
+      const m = build({
+        page: [makeToken({ sale_address: 'ct_z' })],
+        batchSize: 2,
+        isPrivateRow: null,
+      });
+      await m.service.processPage('ct_m');
+      const qb = m.tokenRepo.createQueryBuilder.mock.results[0].value;
+      expect(qb.andWhere).toHaveBeenCalledWith('token.sale_address > :after', {
+        after: 'ct_m',
+      });
+    });
+
+    it('reports !hasMore on a short final page', async () => {
+      const m = build({
+        page: [makeToken({ sale_address: 'ct_a' })],
+        batchSize: 200,
+        isPrivateRow: null,
+      });
+      const result = await m.service.processPage();
+      expect(result.hasMore).toBe(false);
+    });
+
+    it('isolates a per-token failure: the page continues', async () => {
+      const page = [
+        makeToken({ sale_address: 'ct_a' }),
+        makeToken({ sale_address: 'ct_b' }),
+      ];
+      const m = build({ page, batchSize: 5, isPrivateRow: null });
+      // First requestRoom throws (e.g. transient publish enqueue error).
+      const spy = jest
+        .spyOn(m.service, 'requestRoom')
+        .mockRejectedValueOnce(new Error('boom'))
+        .mockResolvedValueOnce({
+          saleAddress: 'ct_b',
+          requested: true,
+          state: 'pending' as NostrRoomState,
+        });
+
+      const result = await m.service.processPage();
+      expect(spy).toHaveBeenCalledTimes(2);
+      expect(result.requested).toBe(1); // only ct_b counted
+    });
+  });
+
+  // ── ACK-driven transitions (§Req 3) ─────────────────────────────────────────
+  describe('onPublishAck (drive state on the ack seam)', () => {
+    it('9007 ok → created: sets has_nostr_room + created_at, emits tgr.room.created', async () => {
+      const m = build({
+        findToken: makeToken({ nostr_room_state: 'pending' }),
+      });
+      const created: string[] = [];
+      m.emitter.on(TGR_ROOM_CREATED, (p: { saleAddress: string }) =>
+        created.push(p.saleAddress),
+      );
+
+      await m.service.onPublishAck({
+        saleAddress: SALE,
+        kind: NIP29_KIND.CREATE_GROUP,
+        ok: true,
+      });
+
+      expect(m.update).toHaveBeenCalledWith(
+        { sale_address: SALE, nostr_room_state: 'pending' },
+        expect.objectContaining({
+          nostr_room_state: 'created',
+          has_nostr_room: true,
+          nostr_room_created_at: expect.any(Date),
+          // room_id is the confirmed-created marker (= the NIP-29 group id = sale).
+          room_id: SALE,
+        }),
+      );
+      expect(created).toEqual([SALE]);
+    });
+
+    it('9007 failure → failed (no room.created emit)', async () => {
+      const m = build({
+        findToken: makeToken({ nostr_room_state: 'pending' }),
+      });
+      const created: string[] = [];
+      m.emitter.on(TGR_ROOM_CREATED, (p: { saleAddress: string }) =>
+        created.push(p.saleAddress),
+      );
+
+      await m.service.onPublishAck({
+        saleAddress: SALE,
+        kind: NIP29_KIND.CREATE_GROUP,
+        ok: false,
+      });
+
+      expect(m.update).toHaveBeenCalledWith(
+        { sale_address: SALE, nostr_room_state: 'pending' },
+        { nostr_room_state: 'failed' },
+      );
+      expect(created).toEqual([]);
+    });
+
+    it('ignores member-level acks (9000/9001 carry a pubkey → Task 10)', async () => {
+      const m = build({
+        findToken: makeToken({ nostr_room_state: 'pending' }),
+      });
+      await m.service.onPublishAck({
+        saleAddress: SALE,
+        kind: NIP29_KIND.PUT_USER,
+        pubkey: 'a'.repeat(64),
+        ok: true,
+      });
+      expect(m.update).not.toHaveBeenCalled();
+    });
+
+    it('no-op when the token is missing / already created', async () => {
+      const m = build({
+        findToken: makeToken({ nostr_room_state: 'created' }),
+      });
+      await m.service.onPublishAck({
+        saleAddress: SALE,
+        kind: NIP29_KIND.CREATE_GROUP,
+        ok: true,
+      });
+      expect(m.update).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── boot safety ─────────────────────────────────────────────────────────────
+  describe('onApplicationBootstrap boot safety', () => {
+    // Eager boot backfill arms ONLY when BOTH (a) a relay is configured on the
+    // injected tgrConfig (`isRelayConfigured(this.config)`) AND (b) the
+    // `TG_BACKFILL_ON_BOOT=true` env flag is set — `shouldBackfillOnBoot()` is the
+    // conjunction. The relay-config half replaces the old worker-mode gate; the
+    // env flag is unchanged (boot-safe default off, so we still toggle it here).
+    const saved = process.env.TG_BACKFILL_ON_BOOT;
+    afterEach(() => {
+      if (saved === undefined) delete process.env.TG_BACKFILL_ON_BOOT;
+      else process.env.TG_BACKFILL_ON_BOOT = saved;
+    });
+
+    it('does NOT enqueue anything on init by default (no relay, flag unset)', async () => {
+      delete process.env.TG_BACKFILL_ON_BOOT;
+      const m = build();
+      await m.service.onApplicationBootstrap();
+      expect(m.backfillQueue.add).not.toHaveBeenCalled();
+    });
+
+    it('does NOT enqueue with a relay configured when TG_BACKFILL_ON_BOOT is off', async () => {
+      delete process.env.TG_BACKFILL_ON_BOOT;
+      const m = build({ relayConfigured: true });
+      await m.service.onApplicationBootstrap();
+      expect(m.backfillQueue.add).not.toHaveBeenCalled();
+    });
+
+    it('does NOT enqueue when TG_BACKFILL_ON_BOOT=true but no relay is configured', async () => {
+      process.env.TG_BACKFILL_ON_BOOT = 'true';
+      const m = build(); // relay NOT configured
+      await m.service.onApplicationBootstrap();
+      expect(m.backfillQueue.add).not.toHaveBeenCalled();
+    });
+
+    it('enqueues kickoff + stale-sweep only when a relay is configured AND TG_BACKFILL_ON_BOOT=true', async () => {
+      process.env.TG_BACKFILL_ON_BOOT = 'true';
+      const m = build({ relayConfigured: true });
+      await m.service.onApplicationBootstrap();
+      expect(m.backfillQueue.add).toHaveBeenCalledTimes(2);
+      const names = m.backfillQueue.add.mock.calls.map((c) => c[0]);
+      expect(names).toContain('backfill-kickoff');
+      expect(names).toContain('backfill-stale-sweep');
+    });
+  });
+
+  // ── reactive auto-create on token launch (tgr.community.upserted) ───────────
+  describe('onCommunityUpserted (reactive room create)', () => {
+    it('requests the room for the token when a relay is configured', async () => {
+      const token = makeToken();
+      const m = build({ findToken: token, relayConfigured: true });
+      const spy = jest.spyOn(m.service, 'requestRoom').mockResolvedValue({
+        saleAddress: token.sale_address,
+        requested: true,
+        state: 'pending',
+      } as any);
+
+      await m.service.onCommunityUpserted({ saleAddress: token.sale_address });
+
+      expect(m.tokenRepo.findOne).toHaveBeenCalled();
+      expect(spy).toHaveBeenCalledWith(token);
+    });
+
+    it('is a no-op when no relay is configured (nothing to create)', async () => {
+      const m = build({ findToken: makeToken() }); // relay NOT configured
+      const spy = jest.spyOn(m.service, 'requestRoom');
+      await m.service.onCommunityUpserted({ saleAddress: 'ct_x' });
+      expect(spy).not.toHaveBeenCalled();
+      // Gated BEFORE the lookup — the token is never even fetched.
+      expect(m.tokenRepo.findOne).not.toHaveBeenCalled();
+    });
+
+    it('no-ops when the token row is not found', async () => {
+      const m = build({ findToken: undefined, relayConfigured: true }); // tokenRepo.findOne → null
+      const spy = jest.spyOn(m.service, 'requestRoom');
+      await m.service.onCommunityUpserted({ saleAddress: 'ct_missing' });
+      expect(spy).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── startBackfill is idempotent (fixed jobId) ───────────────────────────────
+  describe('startBackfill', () => {
+    it('enqueues a fixed-id kickoff + stale-sweep (collapsed by jobId)', async () => {
+      const m = build();
+      await m.service.startBackfill();
+      expect(m.backfillQueue.add).toHaveBeenCalledTimes(2);
+      const [name, , opts] = m.backfillQueue.add.mock.calls[0] as any[];
+      expect(name).toBe('backfill-kickoff');
+      expect(opts.jobId).toBe('backfill-kickoff');
+    });
+  });
+
+  // ── group-not-found recovery (relay↔DB desync; relay group vanished) ─────────
+  describe('onGroupMissing → recreateRoomGroup', () => {
+    const worthyToken = () =>
+      makeToken({
+        sale_address: SALE,
+        symbol: 'TG',
+        market_cap: new BigNumber(100),
+        holders_count: 5,
+      });
+
+    it('re-publishes 9007 + 9002 and marks the group missing (debounced)', async () => {
+      const m = build({
+        relayConfigured: true,
+        findToken: worthyToken(),
+        isPrivateRow: null,
+      });
+
+      await m.service.onGroupMissing({ saleAddress: SALE });
+
+      // 9007 create + 9002 metadata re-published onto the publish queue.
+      expect(m.publishQueue.add).toHaveBeenCalledTimes(2);
+      const kinds = m.publishQueue.add.mock.calls.map(
+        (c: any[]) => c[0].template.kind,
+      );
+      expect(kinds).toEqual([
+        NIP29_KIND.CREATE_GROUP,
+        NIP29_KIND.EDIT_METADATA,
+      ]);
+      // Suppressed so membership-sync stops adding members until it is re-created.
+      expect(m.groupMissing.isMissing(SALE)).toBe(true);
+    });
+
+    it('debounces: a second event while a re-create is in flight does nothing', async () => {
+      const m = build({
+        relayConfigured: true,
+        findToken: worthyToken(),
+        isPrivateRow: null,
+      });
+
+      await m.service.onGroupMissing({ saleAddress: SALE });
+      m.publishQueue.add.mockClear();
+      await m.service.onGroupMissing({ saleAddress: SALE });
+
+      expect(m.publishQueue.add).not.toHaveBeenCalled(); // coalesced
+    });
+
+    it('worth-gate: a 0-market-cap / <2-holder token is NOT re-created', async () => {
+      const m = build({
+        relayConfigured: true,
+        findToken: makeToken({
+          sale_address: SALE,
+          symbol: 'TG',
+          market_cap: new BigNumber(0),
+          holders_count: 1,
+        }),
+        isPrivateRow: null,
+      });
+
+      await m.service.onGroupMissing({ saleAddress: SALE });
+
+      expect(m.publishQueue.add).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op when no relay is configured', async () => {
+      const m = build({ findToken: makeToken({ sale_address: SALE }) });
+      await m.service.onGroupMissing({ saleAddress: SALE });
+      expect(m.publishQueue.add).not.toHaveBeenCalled();
+      expect(m.groupMissing.isMissing(SALE)).toBe(false);
+    });
+  });
+
+  describe('onPublishAck: 9007 ok for a missing group → clear + re-fire tgr.room.created', () => {
+    it('clears the suppression and re-emits tgr.room.created so members re-add', async () => {
+      const m = build({ relayConfigured: true });
+      m.groupMissing.markMissing(SALE);
+      const roomCreated: any[] = [];
+      m.emitter.on(TGR_ROOM_CREATED, (p) => roomCreated.push(p));
+
+      await m.service.onPublishAck({
+        saleAddress: SALE,
+        kind: NIP29_KIND.CREATE_GROUP,
+        ok: true,
+      });
+
+      expect(m.groupMissing.isMissing(SALE)).toBe(false);
+      expect(roomCreated).toEqual([{ saleAddress: SALE }]);
+    });
+
+    it('does nothing for a group that was not flagged missing', async () => {
+      const m = build({ relayConfigured: true });
+      const roomCreated: any[] = [];
+      m.emitter.on(TGR_ROOM_CREATED, (p) => roomCreated.push(p));
+
+      await m.service.onPublishAck({
+        saleAddress: SALE,
+        kind: NIP29_KIND.CREATE_GROUP,
+        ok: true,
+      });
+
+      expect(roomCreated).toHaveLength(0);
+    });
+  });
+});

--- a/src/token-gated-rooms/services/room-backfill.service.ts
+++ b/src/token-gated-rooms/services/room-backfill.service.ts
@@ -1,0 +1,731 @@
+import { InjectQueue } from '@nestjs/bull';
+import {
+  Inject,
+  Injectable,
+  Logger,
+  OnApplicationBootstrap,
+  Optional,
+} from '@nestjs/common';
+import { ConfigType } from '@nestjs/config';
+import { EventEmitter2, OnEvent } from '@nestjs/event-emitter';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Queue } from 'bull';
+import { IsNull, Repository } from 'typeorm';
+import { Token } from '@/tokens/entities/token.entity';
+import tgrConfig, { isRelayConfigured } from '../config/tgr.config';
+import { CommunityRoom } from '../entities/community-room.entity';
+import { RoomBackfillState } from '../entities/room-backfill-state.entity';
+import { createGroup, editMetadata, NIP29_KIND } from '../nostr/nip29';
+import {
+  TGR_COMMUNITY_UPSERTED,
+  TGR_GROUP_MISSING,
+  TGR_PUBLISH_ACK,
+  TGR_ROOM_CREATED,
+  type TgrCommunityUpsertedPayload,
+  type TgrGroupMissingPayload,
+  type TgrPublishAckPayload,
+  type TgrRoomCreatedPayload,
+} from '../events';
+import {
+  isLegalNostrRoomStateTransition,
+  type NostrRoomState,
+} from '../enums/nostr-room-state.enum';
+import { publishNip29JobOptions } from '../queues/publish-nip29.job-options';
+import { PUBLISH_NIP29_QUEUE } from '../queues/publish-nip29.processor';
+import type { PublishNip29Job } from '../queues/publish-nip29.types';
+import { RoomAdminsService } from './room-admins.service';
+import {
+  BACKFILL_KICKOFF_JOB,
+  BACKFILL_ON_BOOT_ENV,
+  BACKFILL_STALE_SWEEP_JOB,
+  parseBool,
+  ROOM_BACKFILL_QUEUE,
+  ROOM_BACKFILL_STATE_ID,
+} from '../queues/room-backfill.constants';
+import { GroupMissingTracker } from './group-missing-tracker.service';
+
+/** Outcome of requesting a room for a single token. */
+export interface RoomRequestResult {
+  saleAddress: string;
+  /** Whether `9007`/`9002` were enqueued (a `none|failed → pending` happened). */
+  requested: boolean;
+  /** The state the token is in after this call. */
+  state: NostrRoomState;
+}
+
+/** Outcome of one driver page. */
+export interface PageResult {
+  /** Tokens requested in this page. */
+  requested: number;
+  /**
+   * Keyset cursor to resume from: the last `sale_address` seen in this page. Pass
+   * it back to {@link RoomBackfillService.processPage} for the following page.
+   * `undefined` when the page was empty.
+   */
+  nextCursor?: string;
+  /** Whether another page may exist (page was full). */
+  hasMore: boolean;
+}
+
+/**
+ * Pure transition decision for a relay publish ACK (§4.7). Given the current
+ * state and an ACK for the group-create / edit-metadata publish, returns the next
+ * state, or `undefined` for "no change" (e.g. an ACK that doesn't apply).
+ *
+ * - A `9007` ok ACK (incl. relay `"Group already exists"`, which the processor
+ *   maps to ok) is the authoritative "group exists" signal: `pending → created`.
+ * - A `9007`/`9002` failure ACK (writer retries exhausted) drives `pending →
+ *   failed`.
+ * - `created`/`deleted` are not moved by an ACK (idempotent re-publish on a
+ *   re-run lands here harmlessly).
+ */
+export function nextStateForAck(
+  from: NostrRoomState,
+  kind: number,
+  ok: boolean,
+): NostrRoomState | undefined {
+  if (from === 'deleted' || from === 'created') {
+    // Terminal / already-created: a re-publish ACK never regresses these.
+    return undefined;
+  }
+  if (kind === NIP29_KIND.CREATE_GROUP) {
+    if (ok && isLegalNostrRoomStateTransition(from, 'created')) {
+      return 'created';
+    }
+    if (!ok && isLegalNostrRoomStateTransition(from, 'failed')) {
+      return 'failed';
+    }
+    return undefined;
+  }
+  if (kind === NIP29_KIND.EDIT_METADATA) {
+    // Metadata is non-authoritative for existence; only a failure (with retries
+    // exhausted) demotes a not-yet-created room to `failed`.
+    if (
+      !ok &&
+      from === 'pending' &&
+      isLegalNostrRoomStateTransition(from, 'failed')
+    ) {
+      return 'failed';
+    }
+    return undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Eager room backfill (Task 09, plan §6.2 / §4.7 / §9) — WORKER PROCESS ONLY.
+ *
+ * Drives a resumable, rate-limited creation of a NIP-29 room for EVERY BCL
+ * factory token (D8). It does NOT open a relay socket or publish directly: it
+ * enqueues `9007` create-group + `9002` edit-metadata onto the Task 07
+ * `worker:publish-nip29` queue, seeds the configured admins via Task 08's
+ * {@link RoomAdminsService.seedRoomAdmins}, and advances each token through the
+ * `nostr_room_state` machine on the `tgr.publish.ack` seam emitted by the publish
+ * processor. The `worker:room-backfill` queue runs under the worker prefix so it
+ * never steals `main:` indexer jobs (§9).
+ *
+ * BOOT SAFETY: the kickoff runs in `onApplicationBootstrap` — the NestJS hook that
+ * fires only AFTER every module has finished initializing (DB, queues and the
+ * relay writer are all ready), not mid-init like `onModuleInit`. It is still gated
+ * behind `TG_BACKFILL_ON_BOOT === 'true'` (default off) so the boot smoke / a
+ * relay-less process never start the sweep; otherwise it is triggered explicitly
+ * via {@link startBackfill}. Enqueuing ~54k jobs only happens behind that flag.
+ *
+ * RESUMABILITY: `Token.has_nostr_room` is the per-token source of truth. The
+ * working set is re-derived every page from
+ * `has_nostr_room = false AND nostr_room_state NOT IN ('created','deleted')`,
+ * ordered by `sale_address`, so a restart re-runs at most the in-flight page and
+ * no token is double-created (the flag guard + relay `"Group already exists"`
+ * make re-runs idempotent). The cursor in `room_backfill_state.batch_offset` is a
+ * best-effort progress marker; correctness comes from the predicate, not it.
+ */
+@Injectable()
+export class RoomBackfillService implements OnApplicationBootstrap {
+  private readonly logger = new Logger(RoomBackfillService.name);
+
+  /** About string applied to every backfilled room's `9002` edit-metadata. */
+  static readonly ROOM_ABOUT = 'Token-gated chat on Superhero.';
+
+  constructor(
+    @InjectRepository(Token)
+    private readonly tokenRepository: Repository<Token>,
+    @InjectRepository(CommunityRoom)
+    private readonly communityRoomRepository: Repository<CommunityRoom>,
+    @InjectRepository(RoomBackfillState)
+    private readonly backfillStateRepository: Repository<RoomBackfillState>,
+    @InjectQueue(PUBLISH_NIP29_QUEUE)
+    private readonly publishQueue: Queue<PublishNip29Job>,
+    @InjectQueue(ROOM_BACKFILL_QUEUE)
+    private readonly backfillQueue: Queue,
+    private readonly roomAdmins: RoomAdminsService,
+    private readonly eventEmitter: EventEmitter2,
+    @Inject(tgrConfig.KEY)
+    private readonly config: ConfigType<typeof tgrConfig>,
+    // Optional so the many positional-construction unit tests keep working; the DI
+    // container always provides it in the running app.
+    @Optional()
+    private readonly groupMissing?: GroupMissingTracker,
+  ) {}
+
+  /**
+   * BOOT-SAFE gate (Task 09): schedule the kickoff ONLY behind
+   * `TG_BACKFILL_ON_BOOT=true` (and only when a relay is configured). Runs in
+   * `onApplicationBootstrap` (not `onModuleInit`) so the whole app — DB pool,
+   * queues, relay writer — is fully up before the sweep enqueues anything. When the
+   * flag is off (the default) this is a no-op: nothing is enqueued, so the boot
+   * smoke / a relay-less process never start a 54k sweep.
+   */
+  async onApplicationBootstrap(): Promise<void> {
+    if (!this.shouldBackfillOnBoot()) {
+      return;
+    }
+    this.logger.log(
+      `${BACKFILL_ON_BOOT_ENV}=true — scheduling eager room backfill`,
+    );
+    await this.startBackfill();
+  }
+
+  /**
+   * True iff a relay is configured (`isRelayConfigured`) AND
+   * `TG_BACKFILL_ON_BOOT === 'true'`. The eager 54k sweep publishes relay creates,
+   * so it requires a relay; it stays opt-in behind the env flag (default off).
+   */
+  private shouldBackfillOnBoot(): boolean {
+    const onBoot = parseBool(process.env[BACKFILL_ON_BOOT_ENV], false);
+    return isRelayConfigured(this.config) && onBoot;
+  }
+
+  /**
+   * Explicit, idempotent kickoff entry point. Enqueues a single
+   * {@link BACKFILL_KICKOFF_JOB} (the processor then walks pages, re-enqueueing
+   * itself) plus the stale-pending sweep. Safe to call repeatedly — Bull collapses
+   * duplicate kickoffs onto an existing run via the fixed `jobId`.
+   */
+  async startBackfill(): Promise<void> {
+    await this.backfillQueue.add(
+      BACKFILL_KICKOFF_JOB,
+      { afterSaleAddress: undefined },
+      {
+        jobId: BACKFILL_KICKOFF_JOB,
+        removeOnComplete: true,
+        removeOnFail: true,
+      },
+    );
+    await this.backfillQueue.add(
+      BACKFILL_STALE_SWEEP_JOB,
+      {},
+      {
+        jobId: BACKFILL_STALE_SWEEP_JOB,
+        removeOnComplete: true,
+        removeOnFail: true,
+      },
+    );
+  }
+
+  /**
+   * Process one page of the working set and request a room for each token. Used by
+   * the processor's kickoff loop. KEYSET pagination by `sale_address` (not numeric
+   * OFFSET): each page starts strictly after the previous page's last
+   * `sale_address`, so a token already requested THIS pass (now `pending`, still in
+   * the working set) is not re-selected, while finished tokens (`created`/`deleted`)
+   * simply drop out of the predicate. This is stable under the set shrinking as
+   * ACKs land asynchronously — no skipped or duplicated rows within a sweep.
+   *
+   * @param afterSaleAddress keyset cursor — process tokens with
+   *   `sale_address > afterSaleAddress` (omit / empty for the first page).
+   */
+  async processPage(
+    afterSaleAddress?: string,
+    batchSize?: number,
+  ): Promise<PageResult> {
+    const size = batchSize ?? this.config.backfillBatchSize;
+    const tokens = await this.workingSetPage(size, afterSaleAddress);
+
+    let requested = 0;
+    for (const token of tokens) {
+      try {
+        const result = await this.requestRoom(token);
+        if (result.requested) {
+          requested += 1;
+        }
+      } catch (error: any) {
+        this.logger.error(
+          `[room-backfill] failed to request room for ${token.sale_address}: ${
+            error?.message ?? error
+          }`,
+        );
+        // Leave the token at its current state → re-selected on a later sweep.
+      }
+    }
+
+    const nextCursor =
+      tokens.length > 0 ? tokens[tokens.length - 1].sale_address : undefined;
+    const hasMore = tokens.length === size;
+    await this.advanceCursor(requested);
+    return { requested, nextCursor, hasMore };
+  }
+
+  /**
+   * The next page of the working set: tokens that still need a room, keyset-paged
+   * by `sale_address` after `afterSaleAddress` (§Req 1, deterministic order). The
+   * predicate (`has_nostr_room=false AND nostr_room_state NOT IN
+   * ('created','deleted')`) is re-derived every page → naturally resumable +
+   * idempotent (a restart re-runs at most the in-flight page).
+   */
+  private async workingSetPage(
+    size: number,
+    afterSaleAddress?: string,
+  ): Promise<Token[]> {
+    const qb = this.tokenRepository
+      .createQueryBuilder('token')
+      .where('token.has_nostr_room = :flag', { flag: false })
+      .andWhere('token.nostr_room_state NOT IN (:...done)', {
+        done: ['created', 'deleted'],
+      })
+      // Worth-gate: only tokens with a non-zero market cap AND ≥2 holders are worth
+      // a relay room (skip worthless / single-holder tokens).
+      .andWhere('token.market_cap > 0')
+      .andWhere('token.holders_count >= 2');
+    if (afterSaleAddress) {
+      qb.andWhere('token.sale_address > :after', { after: afterSaleAddress });
+    }
+    // Keyset-paginated by `sale_address` for resumability (the eager bulk sweep,
+    // off by default). The active, market-cap-prioritized creator is the 5-minute
+    // provisioning cron (`provisionRoomlessTokens`, ORDER BY market_cap DESC).
+    return qb.orderBy('token.sale_address', 'ASC').limit(size).getMany();
+  }
+
+  /** Count of tokens still needing a room (observability / tests). Mirrors the
+   * worth-gated working set: non-zero market cap AND ≥2 holders. */
+  async pendingCount(): Promise<number> {
+    return this.tokenRepository
+      .createQueryBuilder('token')
+      .where('token.has_nostr_room = :flag', { flag: false })
+      .andWhere('token.nostr_room_state NOT IN (:...done)', {
+        done: ['created', 'deleted'],
+      })
+      .andWhere('token.market_cap > 0')
+      .andWhere('token.holders_count >= 2')
+      .getCount();
+  }
+
+  /**
+   * Request a NIP-29 room for one token (§Req 2):
+   *   1) move `none|failed → pending` (legal-transition guarded), stamp
+   *      `nostr_group_id = sale_address` (D3);
+   *   2) enqueue `9007` create-group then `9002` edit-metadata (visibility from
+   *      `community_room.is_private`, default public when no row — plain `[TG]`);
+   *   3) seed the configured admins via Task 08 (do NOT reimplement).
+   *
+   * Idempotent: a token already `created`/`deleted` is skipped; a re-run of a
+   * `pending` token re-enqueues the same publishes (relay collapses them).
+   */
+  async requestRoom(token: Token): Promise<RoomRequestResult> {
+    const saleAddress = token.sale_address;
+    if (!saleAddress) {
+      throw new Error('requestRoom: token.sale_address is required');
+    }
+
+    const from = token.nostr_room_state ?? 'none';
+    if (from === 'created' || from === 'deleted') {
+      // Terminal / done — never re-enqueue (9008-deleted is terminal at the relay).
+      return { saleAddress, requested: false, state: from };
+    }
+    if (from !== 'none' && from !== 'failed' && from !== 'pending') {
+      return { saleAddress, requested: false, state: from };
+    }
+
+    // `none|failed → pending`. A `pending` token is re-published in place (no
+    // state change) — relay idempotency makes the duplicate `9007`/`9002` a no-op.
+    if (from === 'none' || from === 'failed') {
+      await this.transition(saleAddress, from, 'pending', {
+        nostr_group_id: saleAddress,
+      });
+    }
+
+    const isPrivate = await this.resolveIsPrivate(saleAddress);
+
+    // 1) create-group (9007) — `h` = sale_address verbatim (D3).
+    await this.enqueuePublish(
+      createGroup(saleAddress),
+      saleAddress,
+      'backfill-create-group',
+    );
+    // 2) edit-metadata (9002) — name=$SYMBOL, about, public|private + closed.
+    await this.enqueuePublish(
+      editMetadata(saleAddress, {
+        name: token.symbol,
+        about: RoomBackfillService.ROOM_ABOUT,
+        isPrivate,
+      }),
+      saleAddress,
+      'backfill-edit-metadata',
+    );
+    // 3) seed configured admins (Task 08; idempotent at the relay).
+    await this.roomAdmins.seedRoomAdmins(saleAddress);
+
+    return { saleAddress, requested: true, state: 'pending' };
+  }
+
+  /**
+   * REACTIVE auto-create (token launch). `community-room-state` (main) upserts the
+   * `community_room` desired state on a `create_community` tx and emits
+   * `tgr.community.upserted`; here (worker responsibilities) we react by requesting
+   * the relay room for that token so a NEW token gets its NIP-29 group WITHOUT
+   * waiting for the next eager-backfill sweep. `requestRoom` is fully idempotent (a
+   * token already `created`/`deleted` is skipped; the relay collapses a duplicate
+   * `9007` as "Group already exists"), so this is also safe to fire during the bulk
+   * `CommunityRoomBackfillService` pass — every upsert drives its room create.
+   *
+   * In-process only (EventEmitter2): emitter + this listener share the single
+   * process, so a `tgr.community.upserted` reliably drives its `9007` create.
+   * Relay-gated: with no relay configured there is nothing to create, so we skip.
+   */
+  @OnEvent(TGR_COMMUNITY_UPSERTED, { async: true, promisify: true })
+  async onCommunityUpserted(
+    payload: TgrCommunityUpsertedPayload,
+  ): Promise<void> {
+    if (!isRelayConfigured(this.config)) {
+      return;
+    }
+    const saleAddress = payload?.saleAddress;
+    if (!saleAddress) {
+      return;
+    }
+    try {
+      const token = await this.tokenRepository.findOne({
+        where: { sale_address: saleAddress },
+      });
+      if (!token) {
+        return;
+      }
+      await this.requestRoom(token);
+    } catch (error: any) {
+      const msg = String(error?.message ?? error);
+      // The reactive create is a best-effort fast-path; the 5-minute provisioning
+      // cron (`CommunityRoomBackfillService`, `room_id IS NULL`) is the reliable
+      // backstop. A transient infra blip (Redis "Connection is closed", relay
+      // socket reconnecting) is therefore NOT an error here — it self-heals on the
+      // next cron tick — so log it at debug to avoid flooding the logs.
+      const transient =
+        /connection is closed|connection closed|enableofflinequeue|econnrefused|socket closed|not connected|relay (unhealthy|not connected)/i.test(
+          msg,
+        );
+      const line = `[room-backfill] reactive create for ${saleAddress} deferred to cron: ${msg}`;
+      if (transient) {
+        this.logger.debug(line);
+      } else {
+        this.logger.error(line);
+      }
+    }
+  }
+
+  /**
+   * RECOVER from a relay↔DB desync: the publish processor reported a member/metadata
+   * publish failed with `"Group not found"` (the relay has no such group though the
+   * DB marks the room created — e.g. the relay's data was reset). Re-create the group
+   * so the deferred member adds can resume.
+   *
+   * Debounced per sale via {@link GroupMissingTracker}: a missing group triggers
+   * thousands of failing member adds (one per pending holder), but only the FIRST
+   * enqueues the re-create; the rest are coalesced. The `9007`+`9002` go onto the
+   * throttled `worker:publish-nip29` queue (no relay I/O on this in-process handler),
+   * and admins re-seed via `tgr.room.created` once the `9007` ok-ACKs
+   * ({@link onPublishAck}). Relay-gated; a `deleted` room is never re-created.
+   */
+  @OnEvent(TGR_GROUP_MISSING, { async: true, promisify: true })
+  async onGroupMissing(payload: TgrGroupMissingPayload): Promise<void> {
+    if (!isRelayConfigured(this.config)) {
+      return;
+    }
+    const saleAddress = payload?.saleAddress;
+    if (!saleAddress) {
+      return;
+    }
+    // Debounce: a re-create is already in flight for this group (or it was recently
+    // re-created) — coalesce the storm of per-member failures into one re-create.
+    if (this.groupMissing?.isMissing(saleAddress)) {
+      return;
+    }
+    this.groupMissing?.markMissing(saleAddress);
+    try {
+      await this.recreateRoomGroup(saleAddress);
+    } catch (error: any) {
+      // Allow a retry on the next member-add failure rather than suppressing forever.
+      this.groupMissing?.clear(saleAddress);
+      this.logger.warn(
+        `[room-backfill] re-create for missing group ${saleAddress} failed: ${
+          error?.message ?? error
+        }`,
+      );
+    }
+  }
+
+  /**
+   * Re-publish the `9007` create (+ `9002` metadata) for a room whose relay group
+   * vanished. The relay create is idempotent (`"Group already exists"` is a no-op),
+   * so this is safe even if the group actually still exists. The DB `nostr_room_state`
+   * is left `created` (it should be) — the `9007` ok-ACK re-fires `tgr.room.created`
+   * which re-seeds admins + re-adds members.
+   */
+  async recreateRoomGroup(saleAddress: string): Promise<void> {
+    const token = await this.tokenRepository.findOne({
+      where: { sale_address: saleAddress },
+    });
+    if (!token) {
+      return;
+    }
+    // Worth-gate (mirrors the provisioning selection): only re-create a room for a
+    // token that still has a non-zero market cap AND ≥2 holders — after a relay wipe
+    // we don't want to re-create rooms for tokens that are no longer worth one.
+    const hasMarketCap = token.market_cap != null && token.market_cap.gt(0);
+    if (!hasMarketCap || (token.holders_count ?? 0) < 2) {
+      this.logger.debug(
+        `[room-backfill] skip re-create for ${saleAddress}: below worth-gate (market_cap/holders)`,
+      );
+      return;
+    }
+    const room = await this.communityRoomRepository.findOne({
+      where: { sale_address: saleAddress },
+    });
+    if (room?.deleted) {
+      return;
+    }
+    const isPrivate = await this.resolveIsPrivate(saleAddress);
+    await this.enqueuePublish(
+      createGroup(saleAddress),
+      saleAddress,
+      'recreate-missing-group',
+    );
+    await this.enqueuePublish(
+      editMetadata(saleAddress, {
+        name: token.symbol,
+        about: RoomBackfillService.ROOM_ABOUT,
+        isPrivate,
+      }),
+      saleAddress,
+      'recreate-missing-edit',
+    );
+    this.logger.log(
+      `[room-backfill] group ${saleAddress} missing on relay — re-creating (9007+9002)`,
+    );
+  }
+
+  /**
+   * Drive the state machine on the publish ACK seam (§4.7). The publish processor
+   * is the sole ACK emitter; this is the sole consumer that moves
+   * `Token.nostr_room_state` for the group-level (`9007`/`9002`) publishes.
+   *
+   *   - `9007` ok (incl. `"Group already exists"`) → `pending → created`, set
+   *     `has_nostr_room=true` + `nostr_room_created_at=now()`, emit
+   *     `tgr.room.created`.
+   *   - `9007`/`9002` failure (retries exhausted) → `pending → failed`.
+   *
+   * Member-level ACKs (`9000`/`9001`, which carry a `pubkey`) are NOT this task's
+   * concern (Task 10) — ignored here.
+   */
+  @OnEvent(TGR_PUBLISH_ACK, { async: true, promisify: true })
+  async onPublishAck(payload: TgrPublishAckPayload): Promise<void> {
+    if (!payload?.saleAddress) {
+      return;
+    }
+    // Group-level publishes only (no member pubkey). 9000/9001 are Task 10.
+    if (payload.pubkey) {
+      return;
+    }
+    const kind = payload.kind;
+    if (kind !== NIP29_KIND.CREATE_GROUP && kind !== NIP29_KIND.EDIT_METADATA) {
+      return;
+    }
+
+    // Re-create recovery: a `9007` ok-ACK for a group we flagged missing means the
+    // relay re-created it. Clear the suppression and re-fire `tgr.room.created` so
+    // members re-add (publishPendingForRoom), admins re-seed, and the subscriber
+    // re-subscribes — the room is already `created` in the DB, so the transition
+    // logic below is a no-op for it (it never regresses `created`).
+    if (
+      kind === NIP29_KIND.CREATE_GROUP &&
+      payload.ok &&
+      this.groupMissing?.isMissing(payload.saleAddress)
+    ) {
+      this.groupMissing.clear(payload.saleAddress);
+      this.emitRoomCreated(payload.saleAddress);
+      this.logger.log(
+        `[room-backfill] group ${payload.saleAddress} re-created on relay — resuming member adds`,
+      );
+    }
+
+    const token = await this.tokenRepository.findOne({
+      where: { sale_address: payload.saleAddress },
+    });
+    if (!token) {
+      return;
+    }
+
+    const from = token.nostr_room_state ?? 'none';
+    const to = nextStateForAck(from, kind, payload.ok);
+    if (!to || to === from) {
+      return;
+    }
+
+    if (to === 'created') {
+      await this.transition(payload.saleAddress, from, 'created', {
+        has_nostr_room: true,
+        nostr_room_created_at: new Date(),
+        // `room_id` is the CONFIRMED-created marker (= the NIP-29 group id =
+        // sale_address). Setting it here makes `room_id IS NULL` ⟺ not-yet-created,
+        // the predicate the provisioning cron + buy-listener gate on.
+        room_id: payload.saleAddress,
+      });
+      this.emitRoomCreated(payload.saleAddress);
+    } else {
+      await this.transition(payload.saleAddress, from, to);
+    }
+  }
+
+  /**
+   * Re-publish `pending` rooms with no ACK for > 24h (§4.7). The relay collapses
+   * the duplicate `9007`/`9002` (`"Group already exists"`) so this is safe; the
+   * row STAYS `pending` (re-publish is not a state change). Driven by the
+   * {@link BACKFILL_STALE_SWEEP_JOB}.
+   */
+  async sweepStalePending(batchSize?: number): Promise<number> {
+    const size = batchSize ?? this.config.backfillBatchSize;
+
+    // A `pending` room that never reached `created` has `nostr_room_created_at`
+    // unset. The Token entity has no per-row updated-at, so we re-publish every
+    // not-yet-created `pending` row; the relay collapses the duplicate `9007`/
+    // `9002` (`"Group already exists"`), so the cost is bounded by that no-op and
+    // re-publish is safe (the row STAYS `pending` — not a state change, §4.7).
+    const stale = await this.tokenRepository.find({
+      where: {
+        nostr_room_state: 'pending',
+        has_nostr_room: false,
+        nostr_room_created_at: IsNull(),
+      },
+      order: { sale_address: 'ASC' },
+      take: size,
+    });
+
+    let republished = 0;
+    for (const token of stale) {
+      try {
+        const isPrivate = await this.resolveIsPrivate(token.sale_address);
+        await this.enqueuePublish(
+          createGroup(token.sale_address),
+          token.sale_address,
+          'backfill-stale-republish-create',
+        );
+        await this.enqueuePublish(
+          editMetadata(token.sale_address, {
+            name: token.symbol,
+            about: RoomBackfillService.ROOM_ABOUT,
+            isPrivate,
+          }),
+          token.sale_address,
+          'backfill-stale-republish-edit',
+        );
+        republished += 1;
+      } catch (error: any) {
+        this.logger.warn(
+          `[room-backfill] stale re-publish failed for ${token.sale_address}: ${
+            error?.message ?? error
+          }`,
+        );
+      }
+    }
+    if (republished > 0) {
+      this.logger.log(
+        `[room-backfill] re-published ${republished} stale pending room(s) (>24h, no ACK)`,
+      );
+    }
+    return republished;
+  }
+
+  // ── helpers ────────────────────────────────────────────────────────────────
+
+  /**
+   * Resolve `9002` visibility from `community_room.is_private` for the sale.
+   * Default PUBLIC when no `community_room` row exists yet (plain `[TG]` token, D8).
+   */
+  private async resolveIsPrivate(saleAddress: string): Promise<boolean> {
+    const room = await this.communityRoomRepository.findOne({
+      where: { sale_address: saleAddress },
+    });
+    return !!room?.is_private;
+  }
+
+  /** Enqueue one publish onto `worker:publish-nip29` with the §18 job options. */
+  private async enqueuePublish(
+    template: PublishNip29Job['template'],
+    saleAddress: string,
+    reason: string,
+  ): Promise<void> {
+    await this.publishQueue.add(
+      { template, groupId: saleAddress, meta: { saleAddress, reason } },
+      publishNip29JobOptions(this.config.publishMaxRetries),
+    );
+  }
+
+  /**
+   * Apply a legal `nostr_room_state` transition with an optional column patch. A
+   * conditional UPDATE (`WHERE nostr_room_state = from`) makes the write a no-op
+   * if another worker already advanced the row — no double-create. An illegal
+   * transition is rejected loudly (the machine is enforced HERE, Task 09).
+   */
+  private async transition(
+    saleAddress: string,
+    from: NostrRoomState,
+    to: NostrRoomState,
+    patch: Partial<Token> = {},
+  ): Promise<void> {
+    if (!isLegalNostrRoomStateTransition(from, to)) {
+      throw new Error(
+        `illegal nostr_room_state transition ${from} → ${to} for ${saleAddress}`,
+      );
+    }
+    await this.tokenRepository.update(
+      { sale_address: saleAddress, nostr_room_state: from },
+      { nostr_room_state: to, ...patch },
+    );
+  }
+
+  /** Emit `tgr.room.created` (non-blocking, like `live-indexer.service.ts:93`). */
+  private emitRoomCreated(saleAddress: string): void {
+    const payload: TgrRoomCreatedPayload = { saleAddress };
+    this.eventEmitter.emit(TGR_ROOM_CREATED, payload);
+  }
+
+  /**
+   * Best-effort advance of the single-row progress cursor (§8). Resumability is
+   * predicate-driven (a restart re-derives the working set from
+   * `has_nostr_room=false …`), so `room_backfill_state.batch_offset` is a
+   * cumulative count of requested rooms for OBSERVABILITY only — not a correctness
+   * input. (The entity has no string column to persist the keyset `sale_address`
+   * cursor; that lives in-flight on the Bull job. Adding such a column is Task 00.)
+   */
+  private async advanceCursor(requestedThisPage: number): Promise<void> {
+    if (requestedThisPage <= 0) {
+      return;
+    }
+    try {
+      const prior = await this.cursorOffset();
+      await this.backfillStateRepository.upsert(
+        { id: ROOM_BACKFILL_STATE_ID, batch_offset: prior + requestedThisPage },
+        { conflictPaths: ['id'] },
+      );
+    } catch (error: any) {
+      this.logger.warn(
+        `[room-backfill] failed to persist cursor: ${error?.message ?? error}`,
+      );
+    }
+  }
+
+  /** Read the cumulative requested count (0 when unset). Test/observability helper. */
+  async cursorOffset(): Promise<number> {
+    const row = await this.backfillStateRepository.findOne({
+      where: { id: ROOM_BACKFILL_STATE_ID },
+    });
+    return row?.batch_offset ?? 0;
+  }
+}

--- a/src/token-gated-rooms/services/room-mute.service.spec.ts
+++ b/src/token-gated-rooms/services/room-mute.service.spec.ts
@@ -1,0 +1,84 @@
+import { NotificationPreferencesService } from '@/notifications/services/notification-preferences.service';
+import { RoomPreferencesService } from './room-preferences.service';
+import { RoomMuteService, ROOM_MESSAGES_TYPE } from './room-mute.service';
+
+const ADDR = 'ak_member';
+const SALE = 'ct_sale';
+
+describe('RoomMuteService', () => {
+  let roomPrefs: jest.Mocked<
+    Pick<RoomPreferencesService, 'setMuted' | 'isMuted'>
+  >;
+  let prefs: jest.Mocked<
+    Pick<NotificationPreferencesService, 'applyPartial' | 'isEnabled'>
+  >;
+  let service: RoomMuteService;
+
+  beforeEach(() => {
+    roomPrefs = { setMuted: jest.fn(), isMuted: jest.fn() } as any;
+    prefs = { applyPartial: jest.fn(), isEnabled: jest.fn() } as any;
+    service = new RoomMuteService(roomPrefs as any, prefs as any);
+  });
+
+  describe('setMute', () => {
+    it('upserts the per-room mute row', async () => {
+      roomPrefs.isMuted.mockResolvedValue(true);
+      prefs.isEnabled.mockResolvedValue(true);
+      await service.setMute(ADDR, SALE, true);
+      expect(roomPrefs.setMuted).toHaveBeenCalledWith(ADDR, SALE, true);
+    });
+
+    it('leaves the type-level switch untouched when mute_all is omitted', async () => {
+      roomPrefs.isMuted.mockResolvedValue(true);
+      prefs.isEnabled.mockResolvedValue(true);
+      await service.setMute(ADDR, SALE, true);
+      expect(prefs.applyPartial).not.toHaveBeenCalled();
+    });
+
+    it('delegates mute-all=true to applyPartial with enabled=false (opt-out)', async () => {
+      roomPrefs.isMuted.mockResolvedValue(true);
+      prefs.isEnabled.mockResolvedValue(false);
+      await service.setMute(ADDR, SALE, true, true);
+      expect(prefs.applyPartial).toHaveBeenCalledWith(ADDR, [
+        { type: ROOM_MESSAGES_TYPE, enabled: false },
+      ]);
+    });
+
+    it('delegates mute-all=false to applyPartial with enabled=true', async () => {
+      roomPrefs.isMuted.mockResolvedValue(false);
+      prefs.isEnabled.mockResolvedValue(true);
+      await service.setMute(ADDR, SALE, false, false);
+      expect(prefs.applyPartial).toHaveBeenCalledWith(ADDR, [
+        { type: ROOM_MESSAGES_TYPE, enabled: true },
+      ]);
+    });
+
+    it('returns the resulting state', async () => {
+      roomPrefs.isMuted.mockResolvedValue(true);
+      prefs.isEnabled.mockResolvedValue(false);
+      const result = await service.setMute(ADDR, SALE, true, true);
+      expect(result).toEqual({ muted: true, mute_all: true });
+    });
+  });
+
+  describe('getMute', () => {
+    it('defaults both flags to false when no rows exist', async () => {
+      roomPrefs.isMuted.mockResolvedValue(false);
+      prefs.isEnabled.mockResolvedValue(true); // type-level enabled => not mute_all
+      expect(await service.getMute(ADDR, SALE)).toEqual({
+        muted: false,
+        mute_all: false,
+      });
+    });
+
+    it('mute_all reflects the inverse of the type-level enabled flag', async () => {
+      roomPrefs.isMuted.mockResolvedValue(false);
+      prefs.isEnabled.mockResolvedValue(false); // type disabled => mute_all true
+      expect(await service.getMute(ADDR, SALE)).toEqual({
+        muted: false,
+        mute_all: true,
+      });
+      expect(prefs.isEnabled).toHaveBeenCalledWith(ADDR, ROOM_MESSAGES_TYPE);
+    });
+  });
+});

--- a/src/token-gated-rooms/services/room-mute.service.ts
+++ b/src/token-gated-rooms/services/room-mute.service.ts
@@ -1,0 +1,66 @@
+import { Injectable } from '@nestjs/common';
+import { NotificationPreferencesService } from '@/notifications/services/notification-preferences.service';
+import { RoomPreferencesService } from './room-preferences.service';
+import { RoomMuteViewDto } from '../dto/room-mute.view.dto';
+
+/** The type-level switch used for "mute-all room messages" (Task 12 catalog). */
+export const ROOM_MESSAGES_TYPE = 'room-messages';
+
+/**
+ * Client-facing room-mute read/write (Task 13). Thin orchestration over the two
+ * mute layers so the controller stays trivial:
+ *   - **per-room mute** → Task 12's {@link RoomPreferencesService} (writes
+ *     `room_notification_preference (address, sale_address) muted`, the exact row
+ *     Task 12 reads at dispatch via `isRoomEnabled`);
+ *   - **mute-all** → the type-level `room-messages` switch, via the existing
+ *     {@link NotificationPreferencesService} (opt-out model: `enabled=false` ⇒ muted).
+ *
+ * No relay I/O, no queue enqueue, no notification send — mute is enforced at
+ * dispatch time by Task 12. This service only persists the preference rows.
+ */
+@Injectable()
+export class RoomMuteService {
+  constructor(
+    private readonly roomPreferences: RoomPreferencesService,
+    private readonly preferences: NotificationPreferencesService,
+  ) {}
+
+  /**
+   * Persist the per-room mute and, if `muteAll` was provided, toggle the
+   * type-level `room-messages` switch through the existing prefs service. Returns
+   * the resulting state. `muteAll === undefined` leaves the type-level switch
+   * untouched.
+   */
+  async setMute(
+    address: string,
+    saleAddress: string,
+    muted: boolean,
+    muteAll?: boolean,
+  ): Promise<RoomMuteViewDto> {
+    await this.roomPreferences.setMuted(address, saleAddress, muted);
+    if (muteAll !== undefined) {
+      // opt-out model: enabled = !muted. Delegates to Task 12's catalog type.
+      await this.preferences.applyPartial(address, [
+        { type: ROOM_MESSAGES_TYPE, enabled: !muteAll },
+      ]);
+    }
+    return this.getMute(address, saleAddress);
+  }
+
+  /**
+   * Current `{ muted, mute_all }` for `(address, saleAddress)`. Both default to
+   * `false` when no row exists (opt-out, mirroring `isEnabled`/`isMuted` defaults):
+   *   - `muted`    = `room_notification_preference.muted` (default false);
+   *   - `mute_all` = NOT `room-messages` enabled (default enabled ⇒ mute_all false).
+   */
+  async getMute(
+    address: string,
+    saleAddress: string,
+  ): Promise<RoomMuteViewDto> {
+    const [muted, typeEnabled] = await Promise.all([
+      this.roomPreferences.isMuted(address, saleAddress),
+      this.preferences.isEnabled(address, ROOM_MESSAGES_TYPE),
+    ]);
+    return { muted, mute_all: !typeEnabled };
+  }
+}

--- a/src/token-gated-rooms/services/room-preferences.service.spec.ts
+++ b/src/token-gated-rooms/services/room-preferences.service.spec.ts
@@ -1,0 +1,85 @@
+import { Repository } from 'typeorm';
+import { NotificationPreferencesService } from '@/notifications/services/notification-preferences.service';
+import { RoomNotificationPreference } from '../entities/room-notification-preference.entity';
+import { RoomPreferencesService } from './room-preferences.service';
+
+describe('RoomPreferencesService', () => {
+  const ADDR = 'ak_member';
+  const SALE = 'ct_sale';
+  const TYPE = 'room-membership';
+
+  let repo: jest.Mocked<
+    Pick<Repository<RoomNotificationPreference>, 'findOne' | 'upsert'>
+  >;
+  let prefs: jest.Mocked<Pick<NotificationPreferencesService, 'isEnabled'>>;
+  let service: RoomPreferencesService;
+
+  beforeEach(() => {
+    repo = { findOne: jest.fn(), upsert: jest.fn() } as any;
+    prefs = { isEnabled: jest.fn() } as any;
+    service = new RoomPreferencesService(repo as any, prefs as any);
+  });
+
+  describe('isRoomEnabled', () => {
+    it('returns false when the room is muted (per-room row muted=true)', async () => {
+      repo.findOne.mockResolvedValue({
+        muted: true,
+      } as RoomNotificationPreference);
+      expect(await service.isRoomEnabled(ADDR, TYPE, SALE)).toBe(false);
+      // short-circuits before the type-level check
+      expect(prefs.isEnabled).not.toHaveBeenCalled();
+    });
+
+    it('returns false when the type-level mute-all is off (even if not per-room muted)', async () => {
+      repo.findOne.mockResolvedValue(null);
+      prefs.isEnabled.mockResolvedValue(false);
+      expect(await service.isRoomEnabled(ADDR, TYPE, SALE)).toBe(false);
+      expect(prefs.isEnabled).toHaveBeenCalledWith(ADDR, TYPE);
+    });
+
+    it('returns true when neither per-room muted nor type-level muted', async () => {
+      repo.findOne.mockResolvedValue({
+        muted: false,
+      } as RoomNotificationPreference);
+      prefs.isEnabled.mockResolvedValue(true);
+      expect(await service.isRoomEnabled(ADDR, TYPE, SALE)).toBe(true);
+    });
+
+    it('defaults to enabled when no rows exist anywhere', async () => {
+      repo.findOne.mockResolvedValue(null);
+      prefs.isEnabled.mockResolvedValue(true);
+      expect(await service.isRoomEnabled(ADDR, TYPE, SALE)).toBe(true);
+    });
+
+    it('type-level mute-all suppresses ALL rooms', async () => {
+      repo.findOne.mockResolvedValue(null); // not per-room muted in any room
+      prefs.isEnabled.mockResolvedValue(false);
+      expect(await service.isRoomEnabled(ADDR, TYPE, 'ct_a')).toBe(false);
+      expect(await service.isRoomEnabled(ADDR, TYPE, 'ct_b')).toBe(false);
+    });
+  });
+
+  describe('isMuted', () => {
+    it('is false when no row exists (opt-out default)', async () => {
+      repo.findOne.mockResolvedValue(null);
+      expect(await service.isMuted(ADDR, SALE)).toBe(false);
+    });
+
+    it('reflects the row muted flag', async () => {
+      repo.findOne.mockResolvedValue({
+        muted: true,
+      } as RoomNotificationPreference);
+      expect(await service.isMuted(ADDR, SALE)).toBe(true);
+    });
+  });
+
+  describe('setMuted', () => {
+    it('upserts on the composite PK', async () => {
+      await service.setMuted(ADDR, SALE, true);
+      expect(repo.upsert).toHaveBeenCalledWith(
+        { address: ADDR, sale_address: SALE, muted: true },
+        { conflictPaths: ['address', 'sale_address'] },
+      );
+    });
+  });
+});

--- a/src/token-gated-rooms/services/room-preferences.service.ts
+++ b/src/token-gated-rooms/services/room-preferences.service.ts
@@ -1,0 +1,72 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { NotificationPreferencesService } from '@/notifications/services/notification-preferences.service';
+import { RoomNotificationPreference } from '../entities/room-notification-preference.entity';
+
+/**
+ * Room-scoped notification preferences (Task 12, plan §7.2 / §4.4).
+ *
+ * Two distinct mute layers must BOTH be honored before a room push is sent:
+ *   - **per-room mute** — a `room_notification_preference` row with `muted=true`
+ *     for `(address, sale_address)` (default: no row = NOT muted, opt-out model);
+ *   - **mute-all (type-level)** — the existing `NotificationPreference` switch for
+ *     the notification's own type (`room-membership` for membership pushes,
+ *     `room-messages` for message pushes), via {@link NotificationPreferencesService}.
+ *
+ * Chosen approach (R3a): a dedicated service so the shared 2-arg
+ * `NotificationPreferencesService.isEnabled(address, type)` signature stays
+ * untouched. The dispatch path (room-notify processor) calls
+ * {@link isRoomEnabled} *before* `NotificationService.send`, which still applies
+ * its own type-level chokepoint independently.
+ *
+ * Also owns the **write path** used by Task 13's HTTP controller (this task only
+ * exposes {@link setMuted} / {@link isMuted}; it adds NO controller).
+ */
+@Injectable()
+export class RoomPreferencesService {
+  constructor(
+    @InjectRepository(RoomNotificationPreference)
+    private readonly repo: Repository<RoomNotificationPreference>,
+    private readonly preferences: NotificationPreferencesService,
+  ) {}
+
+  /**
+   * Room-scoped enabled check used at the dispatch chokepoint: enabled iff the
+   * member is NOT per-room muted for `(address, saleAddress)` AND the type-level
+   * mute-all switch for `type` is on. Mute-all suppresses EVERY room for that type.
+   */
+  async isRoomEnabled(
+    address: string,
+    type: string,
+    saleAddress: string,
+  ): Promise<boolean> {
+    if (await this.isMuted(address, saleAddress)) {
+      return false;
+    }
+    return this.preferences.isEnabled(address, type);
+  }
+
+  /** True iff a `room_notification_preference` row exists with `muted=true`. */
+  async isMuted(address: string, saleAddress: string): Promise<boolean> {
+    const row = await this.repo.findOne({
+      where: { address, sale_address: saleAddress },
+    });
+    return row ? row.muted : false;
+  }
+
+  /**
+   * Upsert the per-room mute flag for `(address, saleAddress)`. The write path the
+   * Task 13 controller calls; idempotent on the composite PK.
+   */
+  async setMuted(
+    address: string,
+    saleAddress: string,
+    muted: boolean,
+  ): Promise<void> {
+    await this.repo.upsert(
+      { address, sale_address: saleAddress, muted },
+      { conflictPaths: ['address', 'sale_address'] },
+    );
+  }
+}

--- a/src/token-gated-rooms/services/room-recheck.service.spec.ts
+++ b/src/token-gated-rooms/services/room-recheck.service.spec.ts
@@ -1,0 +1,206 @@
+import { RoomRecheckService } from './room-recheck.service';
+
+/**
+ * Unit tests for the on-demand recheck heal paths. The service composes
+ * eligibility recompute + a relay `39002` read + DB heal / publish; here we mock
+ * each collaborator and assert the convergence decisions.
+ */
+describe('RoomRecheckService', () => {
+  const SALE = 'ct_sophia';
+  const ADDR = 'ak_caller';
+  const PUBKEY = 'df8b0d3ehexpubkey';
+  const RELAY_CONFIG = { nostrRelayUrl: 'ws://r', nostrBotNsec: 'nsec1x' };
+
+  const makeHarness = (opts: {
+    token?: any;
+    room?: any;
+    membership?: any;
+    relayMembers?: Set<string>;
+    relayHealthy?: boolean;
+    config?: any;
+  }) => {
+    const tokenRow = {
+      sale_address: SALE,
+      nostr_group_id: SALE,
+      ...opts.token,
+    };
+    const tokenRepo = {
+      findOne: jest.fn(async () => ({ ...tokenRow })),
+      update: jest.fn(async () => ({})),
+    } as any;
+    const communityRoomRepo = {
+      findOne: jest.fn(async () =>
+        opts.room === null
+          ? null
+          : {
+              sale_address: SALE,
+              token_address: 'ct_aex9',
+              symbol: 'SOPHIA',
+              is_private: false,
+              min_token_threshold: '1',
+              is_community: false,
+              ...opts.room,
+            },
+      ),
+    } as any;
+    const membershipRepo = {
+      findOne: jest.fn(async () =>
+        opts.membership === null ? null : { ...opts.membership },
+      ),
+      update: jest.fn(async () => ({})),
+    } as any;
+    const publishQueue = { add: jest.fn(async () => ({})) } as any;
+    const relay = {
+      isHealthy: jest.fn(() => opts.relayHealthy ?? true),
+      fetchGroupMembers: jest.fn(async () => opts.relayMembers ?? new Set()),
+    } as any;
+    const eligibility = { recomputeMember: jest.fn(async () => false) } as any;
+    const roomBackfill = { requestRoom: jest.fn(async () => ({})) } as any;
+    const config = opts.config ?? RELAY_CONFIG;
+
+    const service = new RoomRecheckService(
+      tokenRepo,
+      communityRoomRepo,
+      membershipRepo,
+      publishQueue,
+      relay,
+      eligibility,
+      roomBackfill,
+      config,
+    );
+    return {
+      service,
+      tokenRepo,
+      membershipRepo,
+      publishQueue,
+      relay,
+      eligibility,
+      roomBackfill,
+    };
+  };
+
+  it('returns null when the sale address is not a gated room', async () => {
+    const h = makeHarness({ room: null });
+    expect(await h.service.recheck(ADDR, SALE)).toBeNull();
+  });
+
+  it('recomputes the caller eligibility before reconciling', async () => {
+    const h = makeHarness({
+      membership: {
+        id: 1,
+        member_address: ADDR,
+        member_pubkey: PUBKEY,
+        eligible: true,
+        relay_state: 'added',
+        role: 'member',
+      },
+      relayMembers: new Set([PUBKEY]),
+    });
+    await h.service.recheck(ADDR, SALE);
+    expect(h.eligibility.recomputeMember).toHaveBeenCalledTimes(1);
+  });
+
+  it('relay-ahead heal: group exists on relay but DB lost the created marker → stamps created/room_id', async () => {
+    const h = makeHarness({
+      token: { nostr_room_state: 'pending', room_id: null },
+      membership: {
+        id: 1,
+        member_address: ADDR,
+        member_pubkey: PUBKEY,
+        eligible: true,
+        relay_state: 'added',
+        role: 'member',
+      },
+      relayMembers: new Set([PUBKEY]),
+    });
+    await h.service.recheck(ADDR, SALE);
+    expect(h.tokenRepo.update).toHaveBeenCalledWith(
+      { sale_address: SALE },
+      expect.objectContaining({
+        nostr_room_state: 'created',
+        has_nostr_room: true,
+        room_id: SALE,
+      }),
+    );
+  });
+
+  it('caller-present heal: caller in 39002 but DB pending_add → flips to added', async () => {
+    const h = makeHarness({
+      token: { nostr_room_state: 'created', room_id: SALE },
+      membership: {
+        id: 7,
+        member_address: ADDR,
+        member_pubkey: PUBKEY,
+        eligible: true,
+        relay_state: 'pending_add',
+        role: 'member',
+      },
+      relayMembers: new Set([PUBKEY]),
+    });
+    await h.service.recheck(ADDR, SALE);
+    expect(h.membershipRepo.update).toHaveBeenCalledWith(
+      { id: 7 },
+      expect.objectContaining({ relay_state: 'added' }),
+    );
+    expect(h.publishQueue.add).not.toHaveBeenCalled();
+  });
+
+  it('caller-missing publish: eligible+linked but absent from 39002 → enqueues a 9000 put-user', async () => {
+    const h = makeHarness({
+      token: { nostr_room_state: 'created', room_id: SALE },
+      membership: {
+        id: 9,
+        member_address: ADDR,
+        member_pubkey: PUBKEY,
+        eligible: true,
+        relay_state: 'pending_add',
+        role: 'member',
+      },
+      relayMembers: new Set(['someoneelse']),
+    });
+    await h.service.recheck(ADDR, SALE);
+    expect(h.publishQueue.add).toHaveBeenCalledTimes(1);
+    // room already created → no re-request
+    expect(h.roomBackfill.requestRoom).not.toHaveBeenCalled();
+  });
+
+  it('skips the relay read entirely when no relay is configured', async () => {
+    const h = makeHarness({
+      config: { nostrRelayUrl: '', nostrBotNsec: '' },
+      membership: {
+        id: 1,
+        member_address: ADDR,
+        member_pubkey: PUBKEY,
+        eligible: true,
+        relay_state: 'pending_add',
+        role: 'member',
+      },
+    });
+    const view = await h.service.recheck(ADDR, SALE);
+    expect(h.relay.fetchGroupMembers).not.toHaveBeenCalled();
+    // still returns the (recomputed) DB view
+    expect(view?.relay_state).toBe('pending_add');
+  });
+
+  it('returns the refreshed caller view with derived readable', async () => {
+    const h = makeHarness({
+      token: { nostr_room_state: 'created', room_id: SALE },
+      membership: {
+        id: 1,
+        member_address: ADDR,
+        member_pubkey: PUBKEY,
+        eligible: true,
+        relay_state: 'added',
+        role: 'member',
+      },
+      relayMembers: new Set([PUBKEY]),
+    });
+    const view = await h.service.recheck(ADDR, SALE);
+    expect(view).toMatchObject({
+      sale_address: SALE,
+      relay_state: 'added',
+      member_pubkey: PUBKEY,
+      readable: true,
+    });
+  });
+});

--- a/src/token-gated-rooms/services/room-recheck.service.ts
+++ b/src/token-gated-rooms/services/room-recheck.service.ts
@@ -27,7 +27,7 @@ import { RoomBackfillService } from './room-backfill.service';
  * service is the ACTIVE path the client calls to force a recheck. For the caller +
  * room it:
  *
- *  1. **Recomputes eligibility** from the live `token_holder` ledger
+ *  1. **Recomputes eligibility** from the live `token_balance` ledger
  *     ({@link EligibilityService.recomputeMember}) — picks up a just-settled buy +
  *     resolves the Nostr pubkey, so a fresh holder gets a desired-state row.
  *  2. **Reconciles against the relay** (the authoritative member set, when a relay

--- a/src/token-gated-rooms/services/room-recheck.service.ts
+++ b/src/token-gated-rooms/services/room-recheck.service.ts
@@ -1,0 +1,226 @@
+import { InjectQueue } from '@nestjs/bull';
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { ConfigType } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Queue } from 'bull';
+import { Repository } from 'typeorm';
+import { Token } from '@/tokens/entities/token.entity';
+import tgrConfig, { isRelayConfigured } from '../config/tgr.config';
+import { CommunityRoom } from '../entities/community-room.entity';
+import { RoomMembership } from '../entities/room-membership.entity';
+import { RoomViewDto } from '../dto/room.view.dto';
+import { groupIdFor } from '../nostr/group-id';
+import { putUser } from '../nostr/nip29';
+import { RELAY_WRITER, type RelayWriter } from '../nostr/relay-writer.contract';
+import { publishNip29JobOptions } from '../queues/publish-nip29.job-options';
+import { PUBLISH_NIP29_QUEUE } from '../queues/publish-nip29.processor';
+import type { PublishNip29Job } from '../queues/publish-nip29.types';
+import { EligibilityService } from './eligibility.service';
+import { roomConfirmedCreated } from './membership-sync.service';
+import { RoomBackfillService } from './room-backfill.service';
+
+/**
+ * On-demand, per-caller room access recheck — backs `POST /rooms/:saleAddress/recheck`.
+ *
+ * The read API (`GET /rooms`) is a passive, cached DB read: when a holder is stuck
+ * on "Setting up your access…", re-reading it just returns the same stale row. This
+ * service is the ACTIVE path the client calls to force a recheck. For the caller +
+ * room it:
+ *
+ *  1. **Recomputes eligibility** from the live `token_holder` ledger
+ *     ({@link EligibilityService.recomputeMember}) — picks up a just-settled buy +
+ *     resolves the Nostr pubkey, so a fresh holder gets a desired-state row.
+ *  2. **Reconciles against the relay** (the authoritative member set, when a relay
+ *     is configured + healthy):
+ *     - **relay-ahead heal:** if the NIP-29 group already exists on the relay
+ *       (`39002` non-empty) but the DB never recorded it (`room_id` NULL — e.g. a
+ *       group created out-of-band, or a `synchronize` wipe), stamp the token
+ *       `created`/`room_id`. This is the desync that strands holders forever (the
+ *       normal pipeline only reconciles rooms the DB already thinks are created).
+ *     - **caller-present heal:** if the caller's pubkey is already in `39002` but
+ *       the DB says `pending_add`, flip it to `added` — they can already post.
+ *     - **caller-missing publish:** if the caller is eligible + linked but absent
+ *       from `39002`, (re)request the room create if needed and enqueue a `9000`
+ *       put-user so the worker adds them.
+ *  3. Returns the **refreshed** {@link RoomViewDto} for the caller so the client
+ *     unlocks immediately (and should also invalidate its rooms query).
+ *
+ * Idempotent + safe to spam (rate-limited at the controller): every write is a
+ * convergence the system would eventually perform anyway; relay idempotency
+ * collapses duplicate `9007`/`9000`.
+ */
+@Injectable()
+export class RoomRecheckService {
+  private readonly logger = new Logger(RoomRecheckService.name);
+
+  constructor(
+    @InjectRepository(Token)
+    private readonly tokenRepo: Repository<Token>,
+    @InjectRepository(CommunityRoom)
+    private readonly communityRoomRepo: Repository<CommunityRoom>,
+    @InjectRepository(RoomMembership)
+    private readonly membershipRepo: Repository<RoomMembership>,
+    @InjectQueue(PUBLISH_NIP29_QUEUE)
+    private readonly publishQueue: Queue<PublishNip29Job>,
+    @Inject(RELAY_WRITER)
+    private readonly relay: RelayWriter,
+    private readonly eligibility: EligibilityService,
+    private readonly roomBackfill: RoomBackfillService,
+    @Inject(tgrConfig.KEY)
+    private readonly config: ConfigType<typeof tgrConfig>,
+  ) {}
+
+  /**
+   * Recheck + heal `(address, saleAddress)`. Returns the refreshed caller view, or
+   * `null` when the sale address is not a gated room (no `community_room` / token).
+   */
+  async recheck(
+    address: string,
+    saleAddress: string,
+  ): Promise<RoomViewDto | null> {
+    const room = await this.communityRoomRepo.findOne({
+      where: { sale_address: saleAddress },
+    });
+    const token = await this.tokenRepo.findOne({
+      where: { sale_address: saleAddress },
+    });
+    if (!room || !token) {
+      return null;
+    }
+
+    // 1) Refresh the caller's desired state from current holders (fresh buy + pubkey).
+    try {
+      await this.eligibility.recomputeMember(room, address);
+    } catch (error: any) {
+      this.logger.warn(
+        `recheck recomputeMember(${saleAddress}, ${address}) failed: ${
+          error?.message ?? error
+        }`,
+      );
+    }
+
+    // 2) Relay reconcile — only when a relay is configured AND the writer is
+    //    connected (otherwise fetchGroupMembers would fail; we still return the
+    //    recomputed DB state below).
+    const relayHealthy =
+      isRelayConfigured(this.config) &&
+      (typeof this.relay.isHealthy !== 'function' || this.relay.isHealthy());
+    if (relayHealthy) {
+      try {
+        await this.reconcileAgainstRelay(token, saleAddress, address);
+      } catch (error: any) {
+        this.logger.warn(
+          `recheck relay reconcile(${saleAddress}, ${address}) failed: ${
+            error?.message ?? error
+          }`,
+        );
+      }
+    }
+
+    // 3) Return the refreshed caller view.
+    const fresh = await this.membershipRepo.findOne({
+      where: { sale_address: saleAddress, member_address: address },
+    });
+    if (!fresh) {
+      // Not eligible (no desired-state row) → the client treats this like a room
+      // absent from the list (the "acquire the token" gate).
+      return null;
+    }
+    return this.toView(room, fresh);
+  }
+
+  /** §2 of {@link recheck}: read the relay member set + converge DB / publish. */
+  private async reconcileAgainstRelay(
+    token: Token,
+    saleAddress: string,
+    address: string,
+  ): Promise<void> {
+    const groupId = groupIdFor({
+      sale_address: saleAddress,
+      nostr_group_id: token.nostr_group_id,
+    });
+    const relayMembers = await this.relay.fetchGroupMembers(groupId);
+
+    // relay-ahead heal: group exists on the relay but the DB lost the created marker.
+    if (relayMembers.size > 0 && !roomConfirmedCreated(token)) {
+      await this.tokenRepo.update(
+        { sale_address: saleAddress },
+        {
+          nostr_room_state: 'created',
+          has_nostr_room: true,
+          room_id: saleAddress,
+          nostr_group_id: token.nostr_group_id ?? saleAddress,
+          nostr_room_created_at: token.nostr_room_created_at ?? new Date(),
+        },
+      );
+      this.logger.log(
+        `recheck: healed ${saleAddress} → created (group present on relay, DB was behind)`,
+      );
+    }
+
+    const membership = await this.membershipRepo.findOne({
+      where: { sale_address: saleAddress, member_address: address },
+    });
+    if (!membership?.eligible || !membership.member_pubkey) {
+      // Not eligible, or not linked yet → nothing to converge on the relay (the
+      // unlinked-but-eligible holder must link first; §6.6).
+      return;
+    }
+
+    if (relayMembers.has(membership.member_pubkey)) {
+      // caller-present heal: already a relay member, DB just hadn't caught up.
+      if (membership.relay_state !== 'added') {
+        await this.membershipRepo.update(
+          { id: membership.id },
+          { relay_state: 'added', last_published_at: new Date() },
+        );
+        this.logger.log(
+          `recheck: healed membership ${saleAddress}/${address} → added (present in 39002)`,
+        );
+      }
+      return;
+    }
+
+    // caller-missing publish: eligible + linked but absent from the relay → make
+    // sure the room exists, then enqueue the put-user. Relay idempotency collapses
+    // a duplicate 9007/9000, so this is safe to repeat.
+    const fresh = await this.tokenRepo.findOne({
+      where: { sale_address: saleAddress },
+    });
+    if (!roomConfirmedCreated(fresh)) {
+      await this.roomBackfill.requestRoom(token);
+    }
+    await this.publishQueue.add(
+      {
+        template: putUser(
+          groupId,
+          membership.member_pubkey,
+          membership.role === 'admin' ? 'admin' : undefined,
+        ),
+        groupId,
+        meta: { saleAddress, reason: 'recheck-add' },
+      },
+      publishNip29JobOptions(this.config.publishMaxRetries),
+    );
+    this.logger.log(
+      `recheck: enqueued 9000 add for ${saleAddress}/${address} (absent from 39002)`,
+    );
+  }
+
+  /** Map a `community_room` + the caller's membership row to the client DTO. */
+  private toView(room: CommunityRoom, m: RoomMembership): RoomViewDto {
+    const readable = m.relay_state === 'added' && m.member_pubkey != null;
+    return {
+      sale_address: room.sale_address,
+      token_address: room.token_address,
+      symbol: room.symbol,
+      is_private: room.is_private,
+      min_token_threshold: String(room.min_token_threshold ?? '0'),
+      is_community: room.is_community,
+      role: m.role,
+      relay_state: m.relay_state,
+      member_pubkey: m.member_pubkey ?? null,
+      readable,
+    };
+  }
+}

--- a/src/token-gated-rooms/services/room-state.service.spec.ts
+++ b/src/token-gated-rooms/services/room-state.service.spec.ts
@@ -1,0 +1,442 @@
+import { BigNumber } from 'bignumber.js';
+import { RoomStateService } from './room-state.service';
+import { TGR_COMMUNITY_UPSERTED, TgrCommunityUpsertedPayload } from '../events';
+import type { Token } from '@/tokens/entities/token.entity';
+import type { CommunityRoom } from '../entities/community-room.entity';
+
+/**
+ * Unit coverage for the canonical read/map/diff/emit path (Task 04 req §2–§5).
+ *
+ * The SDK + cached `getContract` are fully mocked: `resolveManagement` and
+ * `readManagementState` are stubbed per test by replacing the contract instances
+ * the cache returns. We assert the raw mapping (no decimal shift), the
+ * moderator/muted set-diffs, `[TG]` defaults, deletion, and emission gating.
+ */
+describe('RoomStateService', () => {
+  const SALE = 'ct_sale_1';
+  const TOKEN_ADDR = 'ct_token_1';
+  const MGMT = 'ct_mgmt_1';
+
+  const makeToken = (overrides: Partial<Token> = {}): Token =>
+    ({
+      sale_address: SALE,
+      address: TOKEN_ADDR,
+      symbol: 'COMMUNITY',
+      owner_address: 'ak_owner',
+      creator_address: 'ak_creator',
+      last_sync_block_height: 1234,
+      ...overrides,
+    }) as Token;
+
+  type Harness = {
+    service: RoomStateService;
+    repo: { findOne: jest.Mock; upsert: jest.Mock };
+    emit: jest.Mock;
+    setManagement: (addr: string | undefined) => void;
+    setState: (state: any) => void;
+  };
+
+  const makeHarness = (existing: CommunityRoom | null = null): Harness => {
+    const repo = {
+      findOne: jest.fn().mockResolvedValue(existing),
+      upsert: jest.fn().mockResolvedValue(undefined),
+    };
+    const emit = jest.fn();
+    const eventEmitter = { emit } as any;
+    const aeSdkService = {
+      sdk: { getContext: () => ({}) },
+    } as any;
+
+    const service = new RoomStateService(
+      repo as any,
+      aeSdkService,
+      eventEmitter,
+    );
+
+    let managementAddr: string | undefined;
+    let stateResult: any;
+
+    // Stub the private getContract so resolveManagement / readManagementState
+    // hit our fakes without touching the SDK.
+    (service as any).getContract = jest.fn(async (address: string) => {
+      if (address === MGMT) {
+        return { get_state: async () => ({ decodedResult: stateResult }) };
+      }
+      // Factory contract: get_community_management(sale)
+      return {
+        get_community_management: async () => ({
+          decodedResult: managementAddr,
+        }),
+      };
+    });
+
+    return {
+      service,
+      repo,
+      emit,
+      setManagement: (addr) => {
+        managementAddr = addr;
+      },
+      setState: (state) => {
+        stateResult = state;
+      },
+    };
+  };
+
+  const communityState = (overrides: Partial<any> = {}) => ({
+    owner: 'ak_dao_owner',
+    minimum_token_threshold: 1000n,
+    is_private: false,
+    moderator_accounts: new Set<string>(['ak_mod_a']),
+    muted_user_ids: new Set<string>(['npub_muted_1']),
+    meta_info: new Map(),
+    ...overrides,
+  });
+
+  const lastPayload = (emit: jest.Mock) =>
+    emit.mock.calls.find((c) => c[0] === TGR_COMMUNITY_UPSERTED)?.[1];
+
+  it('maps get_state() onto community_room (Set→array, threshold raw)', async () => {
+    const h = makeHarness(null);
+    h.setManagement(MGMT);
+    h.setState(communityState());
+
+    const result = await h.service.readAndUpsertRoomState(makeToken());
+
+    expect(result.isCommunity).toBe(true);
+    expect(h.repo.upsert).toHaveBeenCalledTimes(1);
+    const [row, opts] = h.repo.upsert.mock.calls[0];
+    expect(opts).toEqual({ conflictPaths: ['sale_address'] });
+    expect(row.sale_address).toBe(SALE);
+    expect(row.token_address).toBe(TOKEN_ADDR);
+    expect(row.symbol).toBe('COMMUNITY');
+    expect(row.owner_address).toBe('ak_dao_owner');
+    expect(row.is_private).toBe(false);
+    expect(row.is_community).toBe(true);
+    expect(row.moderators).toEqual(['ak_mod_a']);
+    expect(row.muted).toEqual(['npub_muted_1']);
+    expect(BigNumber.isBigNumber(row.min_token_threshold)).toBe(true);
+    expect(row.min_token_threshold.toFixed()).toBe('1000');
+    expect(row.created_height).toBe(1234); // set on first insert
+    expect(row.state_synced_at).toBeInstanceOf(Date);
+  });
+
+  it.each([
+    ['0-decimal', '0'],
+    ['6-decimal', '6000000'],
+    ['18-decimal', '5000000000000000000'],
+    ['zero', '0'],
+  ])(
+    'stores minimum_token_threshold raw for %s tokens',
+    async (_label, raw) => {
+      const h = makeHarness(null);
+      h.setManagement(MGMT);
+      h.setState(communityState({ minimum_token_threshold: BigInt(raw) }));
+
+      await h.service.readAndUpsertRoomState(makeToken());
+
+      const [row] = h.repo.upsert.mock.calls[0];
+      expect(row.min_token_threshold.toFixed()).toBe(raw); // no decimal shifting
+    },
+  );
+
+  it('emits a rich tgr.community.upserted on first insert (canonical saleAddress key)', async () => {
+    const h = makeHarness(null);
+    h.setManagement(MGMT);
+    h.setState(communityState());
+
+    await h.service.readAndUpsertRoomState(makeToken());
+
+    expect(h.emit).toHaveBeenCalledWith(
+      TGR_COMMUNITY_UPSERTED,
+      expect.objectContaining({ saleAddress: SALE }),
+    );
+    const payload = lastPayload(h.emit) as TgrCommunityUpsertedPayload & any;
+    expect(payload.saleAddress).toBe(SALE);
+    expect(payload.is_community).toBe(true);
+    expect(payload.min_token_threshold).toBe('1000');
+    expect(payload.moderators).toEqual(['ak_mod_a']);
+    expect(payload.muted).toEqual(['npub_muted_1']);
+    expect(payload.deleted).toBe(false);
+    // On a fresh insert the full sets are reported as added.
+    expect(payload.changed.moderators).toEqual({
+      added: ['ak_mod_a'],
+      removed: [],
+    });
+    expect(payload.changed.muted).toEqual({
+      added: ['npub_muted_1'],
+      removed: [],
+    });
+  });
+
+  it('does NOT emit on an idempotent re-run (no diff)', async () => {
+    const existing: CommunityRoom = {
+      sale_address: SALE,
+      token_address: TOKEN_ADDR,
+      symbol: 'COMMUNITY',
+      owner_address: 'ak_dao_owner',
+      is_private: false,
+      min_token_threshold: new BigNumber('1000'),
+      moderators: ['ak_mod_a'],
+      muted: ['npub_muted_1'],
+      is_community: true,
+      state_synced_at: new Date(0),
+      created_height: 1234,
+      deleted: false,
+    } as CommunityRoom;
+
+    const h = makeHarness(existing);
+    h.setManagement(MGMT);
+    h.setState(communityState());
+
+    const result = await h.service.readAndUpsertRoomState(makeToken());
+
+    expect(result.emitted).toBe(false);
+    expect(h.emit).not.toHaveBeenCalled();
+    // Still upserts (re-stamps state_synced_at) but never overwrites created_height.
+    expect(h.repo.upsert).toHaveBeenCalledTimes(1);
+    const [row] = h.repo.upsert.mock.calls[0];
+    expect(row.created_height).toBeUndefined();
+  });
+
+  it('computes moderator added/removed across an upsert and emits changed.moderators only on change', async () => {
+    const existing: CommunityRoom = {
+      sale_address: SALE,
+      token_address: TOKEN_ADDR,
+      symbol: 'COMMUNITY',
+      owner_address: 'ak_dao_owner',
+      is_private: false,
+      min_token_threshold: new BigNumber('1000'),
+      moderators: ['ak_mod_a', 'ak_mod_b'],
+      muted: [],
+      is_community: true,
+      state_synced_at: new Date(0),
+      created_height: 1,
+      deleted: false,
+    } as CommunityRoom;
+
+    const h = makeHarness(existing);
+    h.setManagement(MGMT);
+    // mod_b removed, mod_c added; muted unchanged (empty)
+    h.setState(
+      communityState({
+        moderator_accounts: new Set(['ak_mod_a', 'ak_mod_c']),
+        muted_user_ids: new Set<string>(),
+      }),
+    );
+
+    await h.service.readAndUpsertRoomState(makeToken());
+
+    const payload = lastPayload(h.emit);
+    expect(payload.changed.moderators).toEqual({
+      added: ['ak_mod_c'],
+      removed: ['ak_mod_b'],
+    });
+    expect(payload.changed.muted).toBeUndefined(); // muted did not change
+  });
+
+  it('preserves muted string ids verbatim and diffs added/removed', async () => {
+    const existing: CommunityRoom = {
+      sale_address: SALE,
+      token_address: TOKEN_ADDR,
+      symbol: 'COMMUNITY',
+      owner_address: 'ak_dao_owner',
+      is_private: false,
+      min_token_threshold: new BigNumber('1000'),
+      moderators: ['ak_mod_a'],
+      muted: ['npub_keep', 'npub_gone'],
+      is_community: true,
+      state_synced_at: new Date(0),
+      created_height: 1,
+      deleted: false,
+    } as CommunityRoom;
+
+    const h = makeHarness(existing);
+    h.setManagement(MGMT);
+    h.setState(
+      communityState({
+        moderator_accounts: new Set(['ak_mod_a']),
+        muted_user_ids: new Set(['npub_keep', 'npub_new']),
+      }),
+    );
+
+    await h.service.readAndUpsertRoomState(makeToken());
+
+    const [row] = h.repo.upsert.mock.calls[0];
+    expect(row.muted).toEqual(['npub_keep', 'npub_new']); // verbatim, not resolved
+    const payload = lastPayload(h.emit);
+    expect(payload.changed.muted).toEqual({
+      added: ['npub_new'],
+      removed: ['npub_gone'],
+    });
+    expect(payload.changed.moderators).toBeUndefined();
+  });
+
+  it('flags threshold / owner / is_private changes individually', async () => {
+    const existing: CommunityRoom = {
+      sale_address: SALE,
+      token_address: TOKEN_ADDR,
+      symbol: 'COMMUNITY',
+      owner_address: 'ak_old_owner',
+      is_private: false,
+      min_token_threshold: new BigNumber('1000'),
+      moderators: [],
+      muted: [],
+      is_community: true,
+      state_synced_at: new Date(0),
+      created_height: 1,
+      deleted: false,
+    } as CommunityRoom;
+
+    const h = makeHarness(existing);
+    h.setManagement(MGMT);
+    h.setState(
+      communityState({
+        owner: 'ak_new_owner',
+        is_private: true,
+        minimum_token_threshold: 2000n,
+        moderator_accounts: new Set<string>(),
+        muted_user_ids: new Set<string>(),
+      }),
+    );
+
+    await h.service.readAndUpsertRoomState(makeToken());
+
+    const payload = lastPayload(h.emit);
+    expect(payload.changed.threshold).toBe(true);
+    expect(payload.changed.owner).toBe(true);
+    expect(payload.changed.is_private).toBe(true);
+    expect(payload.changed.moderators).toBeUndefined();
+  });
+
+  it('applies [TG] defaults when get_community_management returns None', async () => {
+    const h = makeHarness(null);
+    h.setManagement(undefined); // None
+
+    const result = await h.service.readAndUpsertRoomState(
+      makeToken({ owner_address: 'ak_tg_owner' }),
+    );
+
+    expect(result.isCommunity).toBe(false);
+    const [row] = h.repo.upsert.mock.calls[0];
+    expect(row.is_community).toBe(false);
+    expect(row.is_private).toBe(false);
+    expect(row.min_token_threshold.toFixed()).toBe('0');
+    expect(row.moderators).toEqual([]);
+    expect(row.muted).toEqual([]);
+    expect(row.owner_address).toBe('ak_tg_owner');
+    // Emits on first insert.
+    expect(h.emit).toHaveBeenCalledWith(
+      TGR_COMMUNITY_UPSERTED,
+      expect.objectContaining({ saleAddress: SALE, is_community: false }),
+    );
+  });
+
+  it('[TG] defaults fall back to creator_address when owner_address is absent', async () => {
+    const h = makeHarness(null);
+    h.setManagement(undefined);
+
+    await h.service.readAndUpsertRoomState(
+      makeToken({
+        owner_address: undefined as any,
+        creator_address: 'ak_fallback',
+      }),
+    );
+
+    const [row] = h.repo.upsert.mock.calls[0];
+    expect(row.owner_address).toBe('ak_fallback');
+  });
+
+  it('marks an existing community deleted when management becomes None (row retained)', async () => {
+    const existing: CommunityRoom = {
+      sale_address: SALE,
+      token_address: TOKEN_ADDR,
+      symbol: 'COMMUNITY',
+      owner_address: 'ak_dao_owner',
+      is_private: false,
+      min_token_threshold: new BigNumber('1000'),
+      moderators: ['ak_mod_a'],
+      muted: [],
+      is_community: true,
+      state_synced_at: new Date(0),
+      created_height: 1,
+      deleted: false,
+    } as CommunityRoom;
+
+    const h = makeHarness(existing);
+    h.setManagement(undefined); // None now → community gone
+
+    const result = await h.service.readAndUpsertRoomState(makeToken());
+
+    expect(result.deleted).toBe(true);
+    const [row] = h.repo.upsert.mock.calls[0];
+    expect(row.deleted).toBe(true);
+    expect(row.is_community).toBe(true); // retained, not downgraded
+    // upsert (not delete) — the row is never destroyed.
+    expect(h.repo.upsert).toHaveBeenCalledTimes(1);
+    const payload = lastPayload(h.emit);
+    expect(payload.deleted).toBe(true);
+  });
+
+  it('marks deleted when get_state reverts for a known community', async () => {
+    const existing: CommunityRoom = {
+      sale_address: SALE,
+      token_address: TOKEN_ADDR,
+      symbol: 'COMMUNITY',
+      owner_address: 'ak_dao_owner',
+      is_private: false,
+      min_token_threshold: new BigNumber('1000'),
+      moderators: [],
+      muted: [],
+      is_community: true,
+      state_synced_at: new Date(0),
+      created_height: 1,
+      deleted: false,
+    } as CommunityRoom;
+
+    const h = makeHarness(existing);
+    h.setManagement(MGMT);
+    // get_state throws (DAO gone)
+    (h.service as any).getContract = jest.fn(async (address: string) => {
+      if (address === MGMT) {
+        return {
+          get_state: async () => {
+            throw new Error('reverted');
+          },
+        };
+      }
+      return {
+        get_community_management: async () => ({ decodedResult: MGMT }),
+      };
+    });
+
+    const result = await h.service.readAndUpsertRoomState(makeToken());
+    expect(result.deleted).toBe(true);
+    const payload = lastPayload(h.emit);
+    expect(payload.deleted).toBe(true);
+  });
+
+  it('does not re-emit deleted once already flagged', async () => {
+    const existing: CommunityRoom = {
+      sale_address: SALE,
+      token_address: TOKEN_ADDR,
+      symbol: 'COMMUNITY',
+      owner_address: 'ak_dao_owner',
+      is_private: false,
+      min_token_threshold: new BigNumber('1000'),
+      moderators: [],
+      muted: [],
+      is_community: true,
+      state_synced_at: new Date(0),
+      created_height: 1,
+      deleted: true, // already deleted
+    } as CommunityRoom;
+
+    const h = makeHarness(existing);
+    h.setManagement(undefined);
+
+    const result = await h.service.readAndUpsertRoomState(makeToken());
+    expect(result.emitted).toBe(false);
+    expect(h.emit).not.toHaveBeenCalled();
+  });
+});

--- a/src/token-gated-rooms/services/room-state.service.ts
+++ b/src/token-gated-rooms/services/room-state.service.ts
@@ -1,0 +1,507 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { Repository } from 'typeorm';
+import { BigNumber } from 'bignumber.js';
+import { Contract, Encoded } from '@aeternity/aepp-sdk';
+import { AeSdkService } from '@/ae/ae-sdk.service';
+import { Token } from '@/tokens/entities/token.entity';
+import { CommunityRoom } from '../entities/community-room.entity';
+import { TGR_COMMUNITY_UPSERTED, TgrCommunityUpsertedPayload } from '../events';
+import CommunityFactoryACI from '@/plugins/bcl/contract/aci/CommunityFactory.aci.json';
+import CommunityManagementACI from '@/plugins/bcl/contract/aci/CommunityManagement.aci.json';
+import { BCL_CONTRACT } from '@/plugins/bcl/config/bcl.config';
+
+type ContractInstance = Awaited<ReturnType<typeof Contract.initialize>>;
+
+type CachedContract = {
+  instance: ContractInstance;
+  lastUsedAt: number;
+};
+
+/**
+ * Raw on-chain `CommunityManagement.get_state()` record (verified against
+ * `CommunityManagement.aci.json` state record + the bot's
+ * `RoomManagementContractState`). `minimum_token_threshold` is a raw base-unit
+ * `int`; `moderator_accounts` / `muted_user_ids` decode as JS `Set`s.
+ */
+export interface CommunityManagementState {
+  owner: Encoded.AccountAddress;
+  minimum_token_threshold: bigint | number | string;
+  is_private: boolean;
+  moderator_accounts: Set<string> | string[];
+  muted_user_ids: Set<string> | string[];
+  meta_info?: unknown;
+}
+
+/**
+ * Set-diff of two address/string lists: which entries were added vs removed.
+ */
+export interface SetDiff {
+  added: string[];
+  removed: string[];
+}
+
+/**
+ * Rich, self-contained `tgr.community.upserted` payload (plan §5.2, Task 04 req
+ * §4). Extends the canonical thin payload from `../events` (which carries only
+ * `saleAddress`) with the mapped fields + the computed diff so consumers
+ * (eligibility 06, membership-sync 10) never have to re-read the row. The
+ * canonical event NAME/key (`saleAddress`) is preserved verbatim; this is a
+ * superset, not a redefinition.
+ */
+export interface TgrCommunityUpsertedDetail extends TgrCommunityUpsertedPayload {
+  is_community: boolean;
+  is_private: boolean;
+  /** Raw base-unit integer, serialized as a decimal string (jsonb-safe). */
+  min_token_threshold: string;
+  owner_address: string;
+  moderators: string[];
+  muted: string[];
+  deleted: boolean;
+  changed: {
+    moderators?: SetDiff;
+    muted?: SetDiff;
+    threshold?: boolean;
+    owner?: boolean;
+    is_private?: boolean;
+  };
+}
+
+/**
+ * Outcome of a single `readAndUpsertRoomState` call — useful for the backfill
+ * service's accounting and for tests.
+ */
+export interface RoomStateUpsertResult {
+  saleAddress: string;
+  /** Whether a `tgr.community.upserted` event was emitted (i.e. something changed). */
+  emitted: boolean;
+  isCommunity: boolean;
+  deleted: boolean;
+}
+
+/**
+ * Canonical read-and-persist path for `community_room` desired state (Task 04).
+ *
+ * Used by BOTH the reactive plugin (`community-room-state.plugin.ts`, driven by
+ * `LIVE_TX_EVENT`) and the resumable backfill. It resolves a token's
+ * `CommunityManagement` via the cheap per-key
+ * `CommunityFactory.get_community_management(sale)` entrypoint (NEVER the
+ * whole-registry getter — it runs out of gas, verified in the bot's
+ * `CommunityRoomScanner`), reads `CommunityManagement.get_state()`, maps it onto
+ * `community_room`, diffs against the existing row, upserts, and emits
+ * `tgr.community.upserted` only when something changed.
+ *
+ * Contract instances are cached per-address (LRU, max 150) mirroring
+ * `BasePluginSyncService.getContract` — the management ACI is shared, only the
+ * address varies, so a 54k backfill relies on LRU eviction (no pre-warm).
+ */
+@Injectable()
+export class RoomStateService {
+  private readonly logger = new Logger(RoomStateService.name);
+
+  static readonly MAX_CACHED_CONTRACTS = 150;
+
+  private contractCache: Record<string, CachedContract> = {};
+
+  constructor(
+    @InjectRepository(CommunityRoom)
+    private readonly communityRoomRepository: Repository<CommunityRoom>,
+    private readonly aeSdkService: AeSdkService,
+    private readonly eventEmitter: EventEmitter2,
+  ) {}
+
+  /**
+   * Resolve management → read state → map → diff → upsert → emit. Single source
+   * of truth used by the plugin and the backfill. Returns whether it emitted.
+   */
+  async readAndUpsertRoomState(token: Token): Promise<RoomStateUpsertResult> {
+    if (!token?.sale_address) {
+      throw new Error('readAndUpsertRoomState: token.sale_address is required');
+    }
+
+    const existing = await this.communityRoomRepository.findOne({
+      where: { sale_address: token.sale_address },
+    });
+
+    // A community we have ALREADY flagged deleted is terminal (relay 9008
+    // recreate is impossible — task 10). If management is still gone we no-op.
+    const alreadyDeletedCommunity =
+      !!existing?.is_community && !!existing.deleted;
+
+    let managementAddress: Encoded.ContractAddress | undefined;
+    try {
+      managementAddress = await this.resolveManagement(token.sale_address);
+    } catch (error: any) {
+      // A revert here typically means the community/DAO is gone. If we already
+      // tracked it as a live community, mark it deleted; if already deleted,
+      // no-op; otherwise treat as not-a-community and fall through to defaults.
+      this.logger.warn(
+        `get_community_management reverted for ${token.sale_address}: ${error?.message ?? error}`,
+      );
+      if (alreadyDeletedCommunity) {
+        return this.terminalNoop(token, existing as CommunityRoom);
+      }
+      if (existing?.is_community) {
+        return this.markDeleted(token, existing);
+      }
+      managementAddress = undefined;
+    }
+
+    // Not a community ([TG] token) — apply defaults. But if we *previously* knew
+    // it as a community, this is a deletion (DAO removed), not a downgrade.
+    if (!managementAddress) {
+      if (alreadyDeletedCommunity) {
+        return this.terminalNoop(token, existing as CommunityRoom);
+      }
+      if (existing?.is_community) {
+        return this.markDeleted(token, existing);
+      }
+      return this.applyDefaults(token, existing);
+    }
+
+    let state: CommunityManagementState;
+    try {
+      state = await this.readManagementState(managementAddress);
+    } catch (error: any) {
+      // get_state reverted: the community/DAO is gone.
+      this.logger.warn(
+        `CommunityManagement.get_state reverted for ${managementAddress} (${token.sale_address}): ${error?.message ?? error}`,
+      );
+      if (alreadyDeletedCommunity) {
+        return this.terminalNoop(token, existing as CommunityRoom);
+      }
+      if (existing?.is_community) {
+        return this.markDeleted(token, existing);
+      }
+      throw error;
+    }
+
+    return this.persistCommunityState(token, state, existing);
+  }
+
+  /**
+   * Upsert a non-community `[TG]` token's room with public defaults (D8). Still
+   * emits `tgr.community.upserted` on first insert / any change.
+   */
+  async applyDefaults(
+    token: Token,
+    existing?: CommunityRoom | null,
+  ): Promise<RoomStateUpsertResult> {
+    const prior =
+      existing ??
+      (await this.communityRoomRepository.findOne({
+        where: { sale_address: token.sale_address },
+      }));
+
+    const ownerAddress = token.owner_address ?? token.creator_address ?? '';
+    const desired: Partial<CommunityRoom> = {
+      sale_address: token.sale_address,
+      token_address: token.address,
+      symbol: token.symbol,
+      owner_address: ownerAddress,
+      is_private: false,
+      min_token_threshold: new BigNumber(0),
+      moderators: [],
+      muted: [],
+      is_community: false,
+      deleted: false,
+    };
+
+    return this.writeAndMaybeEmit(token, desired, prior);
+  }
+
+  /**
+   * Map an on-chain community `get_state()` record → `community_room` and persist.
+   */
+  private async persistCommunityState(
+    token: Token,
+    state: CommunityManagementState,
+    existing: CommunityRoom | null,
+  ): Promise<RoomStateUpsertResult> {
+    const moderators = this.toStringArray(state.moderator_accounts);
+    const muted = this.toStringArray(state.muted_user_ids);
+    const threshold = new BigNumber(String(state.minimum_token_threshold));
+
+    const desired: Partial<CommunityRoom> = {
+      sale_address: token.sale_address,
+      token_address: token.address,
+      symbol: token.symbol,
+      owner_address: state.owner,
+      is_private: !!state.is_private,
+      min_token_threshold: threshold,
+      moderators,
+      muted,
+      is_community: true,
+      deleted: false,
+    };
+
+    return this.writeAndMaybeEmit(token, desired, existing);
+  }
+
+  /**
+   * Mark an existing community room as `deleted` (DAO/community removed). The row
+   * is RETAINED (relay 9008 recreate is terminal — task 10 owns the publish).
+   */
+  private async markDeleted(
+    token: Token,
+    existing: CommunityRoom,
+  ): Promise<RoomStateUpsertResult> {
+    const desired: Partial<CommunityRoom> = {
+      ...existing,
+      deleted: true,
+    };
+    return this.writeAndMaybeEmit(token, desired, existing);
+  }
+
+  /**
+   * Terminal state: an already-deleted community whose management is still gone.
+   * Nothing to write, nothing to emit (deletion is terminal — task 10).
+   */
+  private terminalNoop(
+    token: Token,
+    existing: CommunityRoom,
+  ): RoomStateUpsertResult {
+    return {
+      saleAddress: token.sale_address,
+      emitted: false,
+      isCommunity: existing.is_community,
+      deleted: true,
+    };
+  }
+
+  /**
+   * Diff `desired` vs `existing`, upsert on PK `sale_address`, and emit
+   * `tgr.community.upserted` only when something changed.
+   */
+  private async writeAndMaybeEmit(
+    token: Token,
+    desired: Partial<CommunityRoom>,
+    existing: CommunityRoom | null,
+  ): Promise<RoomStateUpsertResult> {
+    const isNew = !existing;
+    const changed = this.diff(existing, desired);
+    const somethingChanged =
+      isNew ||
+      changed.moderators !== undefined ||
+      changed.muted !== undefined ||
+      changed.threshold === true ||
+      changed.owner === true ||
+      changed.is_private === true ||
+      (existing?.is_community ?? false) !== (desired.is_community ?? false) ||
+      (existing?.deleted ?? false) !== (desired.deleted ?? false);
+
+    const now = new Date();
+    const row: Partial<CommunityRoom> = {
+      ...desired,
+      state_synced_at: now,
+    };
+
+    // `created_height` is set on first insert and NEVER overwritten.
+    if (isNew) {
+      row.created_height = token.last_sync_block_height ?? null;
+    } else {
+      delete row.created_height;
+    }
+
+    await this.communityRoomRepository.upsert(row as CommunityRoom, {
+      conflictPaths: ['sale_address'],
+    });
+
+    if (somethingChanged) {
+      this.emitUpserted(desired, changed);
+    }
+
+    return {
+      saleAddress: token.sale_address,
+      emitted: somethingChanged,
+      isCommunity: !!desired.is_community,
+      deleted: !!desired.deleted,
+    };
+  }
+
+  private emitUpserted(
+    desired: Partial<CommunityRoom>,
+    changed: TgrCommunityUpsertedDetail['changed'],
+  ): void {
+    const payload: TgrCommunityUpsertedDetail = {
+      saleAddress: desired.sale_address as string,
+      is_community: !!desired.is_community,
+      is_private: !!desired.is_private,
+      min_token_threshold: (
+        desired.min_token_threshold ?? new BigNumber(0)
+      ).toFixed(),
+      owner_address: desired.owner_address ?? '',
+      moderators: desired.moderators ?? [],
+      muted: desired.muted ?? [],
+      deleted: !!desired.deleted,
+      changed,
+    };
+    this.eventEmitter.emit(TGR_COMMUNITY_UPSERTED, payload);
+  }
+
+  /**
+   * Compute the change-set between the stored row and the desired state. Only
+   * populated keys signal a change; `moderators`/`muted` carry added/removed.
+   */
+  private diff(
+    existing: CommunityRoom | null,
+    desired: Partial<CommunityRoom>,
+  ): TgrCommunityUpsertedDetail['changed'] {
+    if (!existing) {
+      // New row: report the full sets as "added" so downstream (10) can publish.
+      const moderators = desired.moderators ?? [];
+      const muted = desired.muted ?? [];
+      const changed: TgrCommunityUpsertedDetail['changed'] = {};
+      if (moderators.length > 0) {
+        changed.moderators = { added: [...moderators], removed: [] };
+      }
+      if (muted.length > 0) {
+        changed.muted = { added: [...muted], removed: [] };
+      }
+      changed.threshold = true;
+      changed.owner = true;
+      changed.is_private = true;
+      return changed;
+    }
+
+    const changed: TgrCommunityUpsertedDetail['changed'] = {};
+
+    const modDiff = this.setDiff(
+      existing.moderators ?? [],
+      desired.moderators ?? [],
+    );
+    if (modDiff.added.length > 0 || modDiff.removed.length > 0) {
+      changed.moderators = modDiff;
+    }
+
+    const mutedDiff = this.setDiff(existing.muted ?? [], desired.muted ?? []);
+    if (mutedDiff.added.length > 0 || mutedDiff.removed.length > 0) {
+      changed.muted = mutedDiff;
+    }
+
+    const existingThreshold = existing.min_token_threshold ?? new BigNumber(0);
+    const desiredThreshold = desired.min_token_threshold ?? new BigNumber(0);
+    if (!existingThreshold.isEqualTo(desiredThreshold)) {
+      changed.threshold = true;
+    }
+
+    if ((existing.owner_address ?? '') !== (desired.owner_address ?? '')) {
+      changed.owner = true;
+    }
+
+    if ((existing.is_private ?? false) !== (desired.is_private ?? false)) {
+      changed.is_private = true;
+    }
+
+    return changed;
+  }
+
+  /** Set difference of two string lists (order-independent). */
+  private setDiff(before: string[], after: string[]): SetDiff {
+    const beforeSet = new Set(before);
+    const afterSet = new Set(after);
+    const added = after.filter((x) => !beforeSet.has(x));
+    const removed = before.filter((x) => !afterSet.has(x));
+    return { added, removed };
+  }
+
+  /** Normalize a Sophia `Set.set` (JS `Set`) or array into a string[]. */
+  private toStringArray(value: Set<string> | string[] | undefined): string[] {
+    if (!value) {
+      return [];
+    }
+    return Array.from(value).map((v) => String(v));
+  }
+
+  /**
+   * Public resolver used by the plugin's allowlist refresh: returns the
+   * `CommunityManagement` address for a sale, or `undefined` for `None`.
+   */
+  async resolveManagementAddress(
+    saleAddress: string,
+  ): Promise<string | undefined> {
+    return this.resolveManagement(saleAddress);
+  }
+
+  /**
+   * Resolve a token sale's `CommunityManagement` address via the cheap per-key
+   * `get_community_management(sale)` entrypoint. Returns `undefined` for `None`
+   * (the token is not a gated community — a `[TG]` token).
+   */
+  private async resolveManagement(
+    saleAddress: string,
+  ): Promise<Encoded.ContractAddress | undefined> {
+    const factory = await this.getContract(
+      BCL_CONTRACT.contractAddress,
+      CommunityFactoryACI,
+    );
+    const { decodedResult } =
+      await factory.get_community_management(saleAddress);
+    if (!decodedResult) {
+      return undefined;
+    }
+    return decodedResult as Encoded.ContractAddress;
+  }
+
+  /** Read `CommunityManagement.get_state()` via the cached per-address contract. */
+  private async readManagementState(
+    managementAddress: Encoded.ContractAddress,
+  ): Promise<CommunityManagementState> {
+    const management = await this.getContract(
+      managementAddress,
+      CommunityManagementACI,
+    );
+    const { decodedResult } = await management.get_state();
+    return decodedResult as CommunityManagementState;
+  }
+
+  /**
+   * Cached contract initializer (mirrors `BasePluginSyncService.getContract`):
+   * one instance per address, LRU-evicted at `MAX_CACHED_CONTRACTS`. The
+   * management ACI is shared across all rooms, so the cache key is the address.
+   */
+  private async getContract(
+    contractAddress: string,
+    aci: any,
+  ): Promise<ContractInstance> {
+    const cached = this.contractCache[contractAddress];
+    if (cached) {
+      cached.lastUsedAt = Date.now();
+      return cached.instance;
+    }
+    const contract = await Contract.initialize({
+      ...this.aeSdkService.sdk.getContext(),
+      aci,
+      address: contractAddress as Encoded.ContractAddress,
+    });
+    this.contractCache[contractAddress] = {
+      instance: contract,
+      lastUsedAt: Date.now(),
+    };
+    this.evictStalestContract();
+    return contract;
+  }
+
+  private evictStalestContract(): void {
+    const keys = Object.keys(this.contractCache);
+    if (keys.length <= RoomStateService.MAX_CACHED_CONTRACTS) {
+      return;
+    }
+    let oldestKey = keys[0];
+    let oldestTime = this.contractCache[oldestKey]?.lastUsedAt ?? 0;
+    for (const key of keys) {
+      const t = this.contractCache[key]?.lastUsedAt ?? 0;
+      if (t < oldestTime) {
+        oldestTime = t;
+        oldestKey = key;
+      }
+    }
+    delete this.contractCache[oldestKey];
+  }
+
+  /** Test/introspection helper. */
+  getCacheSize(): number {
+    return Object.keys(this.contractCache).length;
+  }
+}

--- a/src/token-gated-rooms/services/rooms-query.service.spec.ts
+++ b/src/token-gated-rooms/services/rooms-query.service.spec.ts
@@ -1,0 +1,243 @@
+import { NotFoundException } from '@nestjs/common';
+
+jest.mock('nestjs-typeorm-paginate', () => ({
+  paginate: jest.fn(),
+  paginateRaw: jest.fn(),
+}));
+
+import { paginate, paginateRaw } from 'nestjs-typeorm-paginate';
+import { RoomsQueryService } from './rooms-query.service';
+
+const paginateRawMock = paginateRaw as jest.Mock;
+const paginateMock = paginate as jest.Mock;
+
+const ADDR = 'ak_member';
+const SALE = 'ct_sale';
+
+/** A QB stub that records the chain and returns itself for fluent calls. */
+function fakeQb() {
+  const qb: any = {};
+  for (const m of [
+    'innerJoin',
+    'where',
+    'andWhere',
+    'select',
+    'orderBy',
+    'addOrderBy',
+  ]) {
+    qb[m] = jest.fn().mockReturnValue(qb);
+  }
+  return qb;
+}
+
+describe('RoomsQueryService', () => {
+  let roomRepo: any;
+  let membershipRepo: any;
+  let service: RoomsQueryService;
+
+  // a valid bech32 nsec (secret = 32 bytes of 0x01) for the config test; the
+  // service must derive the pubkey hex from it and NEVER echo the nsec back.
+  const NSEC =
+    'nsec1qyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqstywftw';
+  const EXPECTED_PUB =
+    '1b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f';
+
+  beforeEach(() => {
+    paginateRawMock.mockReset();
+    paginateMock.mockReset();
+    roomRepo = { findOne: jest.fn() };
+    membershipRepo = { createQueryBuilder: jest.fn(() => fakeQb()) };
+    service = new RoomsQueryService(roomRepo, membershipRepo, {
+      nostrRelayUrl: 'ws://relay.local',
+      nostrBotNsec: NSEC,
+    } as any);
+  });
+
+  describe('listEligibleRooms', () => {
+    it('maps raw rows to DTOs and derives readable for an added+linked member', async () => {
+      paginateRawMock.mockResolvedValue({
+        items: [
+          {
+            sale_address: SALE,
+            token_address: 'ct_token',
+            symbol: 'WORDS',
+            is_private: true,
+            min_token_threshold: '1000',
+            is_community: false,
+            role: 'member',
+            relay_state: 'added',
+            member_pubkey: 'a'.repeat(64),
+          },
+        ],
+        meta: { totalItems: 1 },
+      } as any);
+
+      const res = await service.listEligibleRooms(ADDR, 1, 100);
+      expect(res.items[0]).toEqual({
+        sale_address: SALE,
+        token_address: 'ct_token',
+        symbol: 'WORDS',
+        is_private: true,
+        min_token_threshold: '1000',
+        is_community: false,
+        role: 'member',
+        relay_state: 'added',
+        member_pubkey: 'a'.repeat(64),
+        readable: true,
+      });
+    });
+
+    it('§6.6 unlinked-eligible case → readable=false (pubkey null / pending_add)', async () => {
+      paginateRawMock.mockResolvedValue({
+        items: [
+          {
+            sale_address: SALE,
+            token_address: 'ct_token',
+            symbol: 'WORDS',
+            is_private: true,
+            min_token_threshold: null,
+            is_community: false,
+            role: 'member',
+            relay_state: 'pending_add',
+            member_pubkey: null,
+          },
+        ],
+        meta: { totalItems: 1 },
+      } as any);
+
+      const res = await service.listEligibleRooms(ADDR, 1, 100);
+      expect(res.items[0].readable).toBe(false);
+      expect(res.items[0].member_pubkey).toBeNull();
+      // null threshold normalizes to "0"
+      expect(res.items[0].min_token_threshold).toBe('0');
+    });
+
+    it('added but pubkey null → readable=false', async () => {
+      paginateRawMock.mockResolvedValue({
+        items: [
+          {
+            sale_address: SALE,
+            token_address: 'ct_token',
+            symbol: 'WORDS',
+            is_private: false,
+            min_token_threshold: '0',
+            is_community: false,
+            role: 'member',
+            relay_state: 'added',
+            member_pubkey: null,
+          },
+        ],
+        meta: { totalItems: 1 },
+      } as any);
+      const res = await service.listEligibleRooms(ADDR, 1, 100);
+      expect(res.items[0].readable).toBe(false);
+    });
+
+    it('filters to eligible + non-deleted for the given address', async () => {
+      const qb = fakeQb();
+      membershipRepo.createQueryBuilder.mockReturnValue(qb);
+      paginateRawMock.mockResolvedValue({ items: [], meta: {} } as any);
+      await service.listEligibleRooms(ADDR, 1, 100);
+      expect(qb.where).toHaveBeenCalledWith('rm.member_address = :address', {
+        address: ADDR,
+      });
+      expect(qb.andWhere).toHaveBeenCalledWith('rm.eligible = true');
+      expect(qb.andWhere).toHaveBeenCalledWith('cr.deleted = false');
+      expect(paginateRawMock).toHaveBeenCalledWith(qb, { page: 1, limit: 100 });
+    });
+  });
+
+  describe('listRoomMembers', () => {
+    it('throws 404 when the room is unknown', async () => {
+      roomRepo.findOne.mockResolvedValue(null);
+      await expect(
+        service.listRoomMembers(SALE, 1, 100),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('defaults to the added (readable) set and maps without a balance field', async () => {
+      roomRepo.findOne.mockResolvedValue({ sale_address: SALE });
+      const qb = fakeQb();
+      membershipRepo.createQueryBuilder.mockReturnValue(qb);
+      paginateMock.mockResolvedValue({
+        items: [
+          {
+            member_address: ADDR,
+            member_pubkey: 'b'.repeat(64),
+            role: 'member',
+            relay_state: 'added',
+            eligible: true,
+          },
+        ],
+        meta: { totalItems: 1 },
+      } as any);
+
+      const res = await service.listRoomMembers(SALE, 1, 100);
+      expect(qb.andWhere).toHaveBeenCalledWith('rm.relay_state = :added', {
+        added: 'added',
+      });
+      expect(res.items[0]).toEqual({
+        member_address: ADDR,
+        member_pubkey: 'b'.repeat(64),
+        role: 'member',
+        relay_state: 'added',
+        eligible: true,
+      });
+      expect(res.items[0]).not.toHaveProperty('balance');
+    });
+
+    it('include_pending=true drops the relay_state filter', async () => {
+      roomRepo.findOne.mockResolvedValue({ sale_address: SALE });
+      const qb = fakeQb();
+      membershipRepo.createQueryBuilder.mockReturnValue(qb);
+      paginateMock.mockResolvedValue({ items: [], meta: {} } as any);
+      await service.listRoomMembers(SALE, 1, 100, true);
+      expect(qb.andWhere).not.toHaveBeenCalledWith(
+        'rm.relay_state = :added',
+        expect.anything(),
+      );
+    });
+
+    it('maps a null member_pubkey to null', async () => {
+      roomRepo.findOne.mockResolvedValue({ sale_address: SALE });
+      membershipRepo.createQueryBuilder.mockReturnValue(fakeQb());
+      paginateMock.mockResolvedValue({
+        items: [
+          {
+            member_address: ADDR,
+            member_pubkey: undefined,
+            role: 'admin',
+            relay_state: 'added',
+            eligible: true,
+          },
+        ],
+        meta: {},
+      } as any);
+      const res = await service.listRoomMembers(SALE, 1, 100);
+      expect(res.items[0].member_pubkey).toBeNull();
+    });
+  });
+
+  describe('getRoomConfig', () => {
+    it('returns the configured relay_url and the derived hex admin_pubkey', () => {
+      const cfg = service.getRoomConfig();
+      expect(cfg.relay_url).toBe('ws://relay.local');
+      expect(cfg.admin_pubkey).toMatch(/^[0-9a-f]{64}$/);
+      expect(cfg.admin_pubkey).toBe(EXPECTED_PUB);
+    });
+
+    it('never returns the nsec', () => {
+      const cfg = service.getRoomConfig();
+      expect(cfg.admin_pubkey).not.toContain('nsec');
+      expect(JSON.stringify(cfg)).not.toContain(NSEC);
+    });
+
+    it('returns empty pubkey when no nsec is configured (main without secret)', () => {
+      const svc = new RoomsQueryService(roomRepo, membershipRepo, {
+        nostrRelayUrl: 'ws://relay.local',
+        nostrBotNsec: undefined,
+      } as any);
+      expect(svc.getRoomConfig().admin_pubkey).toBe('');
+    });
+  });
+});

--- a/src/token-gated-rooms/services/rooms-query.service.ts
+++ b/src/token-gated-rooms/services/rooms-query.service.ts
@@ -1,0 +1,214 @@
+import { Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { ConfigType } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, SelectQueryBuilder } from 'typeorm';
+import { Pagination, paginate, paginateRaw } from 'nestjs-typeorm-paginate';
+import tgrConfig from '../config/tgr.config';
+import { CommunityRoom } from '../entities/community-room.entity';
+import {
+  RoomMembership,
+  RoomMembershipRelayState,
+} from '../entities/room-membership.entity';
+import { RoomViewDto } from '../dto/room.view.dto';
+import { RoomMemberViewDto } from '../dto/room-member.view.dto';
+import { RoomConfigViewDto } from '../dto/room-config.view.dto';
+
+// nostr-tools subpaths via require() — same pattern as `nostr/pubkey.ts`. The
+// package ENTRY pulls in ESM-only @noble/curves which ts-jest cannot transform;
+// the `nip19` (bech32) + `pure` (key derivation) subpaths resolve fine at runtime
+// and are on the jest transform whitelist (`nostr-tools|@noble|@scure`).
+const nip19: {
+  decode: (value: string) => { type: string; data: unknown };
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+} = require('nostr-tools/nip19');
+
+const nostrPure: {
+  getPublicKey: (sk: Uint8Array) => string;
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+} = require('nostr-tools/pure');
+
+const HEX64 = /^[0-9a-f]{64}$/;
+
+/**
+ * Read-only query surface for the client room API (Task 13). MAIN-MODE ONLY — it
+ * is the HTTP read path served by the API process. Reads straight from Postgres
+ * (plan §9): the eligible-rooms list and members list ride the Task 00 indexes
+ * (`idx_room_membership_eligible`, `idx_room_membership_sale_relay_state`,
+ * `uq_room_membership_sale_member`). No chain reads, no relay I/O, no writes.
+ */
+@Injectable()
+export class RoomsQueryService {
+  constructor(
+    @InjectRepository(CommunityRoom)
+    private readonly roomRepo: Repository<CommunityRoom>,
+    @InjectRepository(RoomMembership)
+    private readonly membershipRepo: Repository<RoomMembership>,
+    @Inject(tgrConfig.KEY)
+    private readonly config: ConfigType<typeof tgrConfig>,
+  ) {}
+
+  /**
+   * Paginated rooms `address` is eligible for. Joins `room_membership` (the
+   * caller's own row, `eligible=true`) to `community_room` (`deleted=false`).
+   * Deterministic order: newest room first, then `sale_address` as a tiebreak so
+   * pagination is stable across pages.
+   */
+  async listEligibleRooms(
+    address: string,
+    page: number,
+    limit: number,
+  ): Promise<Pagination<RoomViewDto>> {
+    const qb: SelectQueryBuilder<RoomMembership> = this.membershipRepo
+      .createQueryBuilder('rm')
+      .innerJoin(CommunityRoom, 'cr', 'cr.sale_address = rm.sale_address')
+      .where('rm.member_address = :address', { address })
+      .andWhere('rm.eligible = true')
+      .andWhere('cr.deleted = false')
+      .select([
+        'rm.id AS rm_id',
+        'rm.sale_address AS sale_address',
+        'rm.role AS role',
+        'rm.relay_state AS relay_state',
+        'rm.member_pubkey AS member_pubkey',
+        'cr.token_address AS token_address',
+        'cr.symbol AS symbol',
+        'cr.is_private AS is_private',
+        'cr.min_token_threshold AS min_token_threshold',
+        'cr.is_community AS is_community',
+        'cr.created_height AS created_height',
+      ])
+      .orderBy('cr.created_height', 'DESC', 'NULLS LAST')
+      .addOrderBy('rm.sale_address', 'ASC');
+
+    // Raw-row pagination: the SELECT mixes two tables, so use paginateRaw and
+    // map raw rows → DTO (paginate() would call getMany() and drop the join cols).
+    // Cast the builder to the raw-row shape — paginateRaw returns the selected
+    // aliases, not RoomMembership entities.
+    const { items, meta } = await paginateRaw<RawEligibleRoomRow>(
+      qb as unknown as SelectQueryBuilder<RawEligibleRoomRow>,
+      { page, limit },
+    );
+    return {
+      items: items.map(toRoomViewDto),
+      meta,
+    } as Pagination<RoomViewDto>;
+  }
+
+  /**
+   * Paginated members of a room. 404 if the room is unknown. Defaults to the
+   * READABLE set (`relay_state='added'`) — the members actually published on the
+   * relay; pass `includePending=true` to also surface eligible-but-not-yet-added
+   * rows (the §6.6 unlinked / in-flight cases).
+   */
+  async listRoomMembers(
+    saleAddress: string,
+    page: number,
+    limit: number,
+    includePending = false,
+  ): Promise<Pagination<RoomMemberViewDto>> {
+    const room = await this.roomRepo.findOne({
+      where: { sale_address: saleAddress },
+    });
+    if (!room) {
+      throw new NotFoundException('Room not found');
+    }
+
+    const qb = this.membershipRepo
+      .createQueryBuilder('rm')
+      .where('rm.sale_address = :saleAddress', { saleAddress });
+    if (!includePending) {
+      qb.andWhere('rm.relay_state = :added', {
+        added: 'added' as RoomMembershipRelayState,
+      });
+    }
+    qb.orderBy('rm.member_address', 'ASC');
+
+    const { items, meta } = await paginate(qb, { page, limit });
+    return {
+      items: items.map((rm) => ({
+        member_address: rm.member_address,
+        member_pubkey: rm.member_pubkey ?? null,
+        role: rm.role,
+        relay_state: rm.relay_state,
+        eligible: rm.eligible,
+      })),
+      meta,
+    };
+  }
+
+  /**
+   * Relay handshake info for the app's NIP-42 AUTH (plan §16). `relay_url` is
+   * `TG_RELAY_URL`; `admin_pubkey` is the bot pubkey in hex, derived from
+   * `TG_BOT_NSEC` via nip19 (same decode as the worker's RelayWriter, which is
+   * not loaded in main). The nsec is NEVER returned or logged here.
+   */
+  getRoomConfig(): RoomConfigViewDto {
+    return {
+      relay_url: this.config.nostrRelayUrl ?? '',
+      admin_pubkey: this.deriveBotPubkeyHex(),
+    };
+  }
+
+  /** Decode `TG_BOT_NSEC` → 32-byte secret → hex public key. */
+  private deriveBotPubkeyHex(): string {
+    const nsec = this.config.nostrBotNsec;
+    if (!nsec) {
+      // The relay may be unconfigured (the duties just stay dormant). Surface an
+      // empty pubkey rather than crashing the read.
+      return '';
+    }
+    try {
+      const decoded = nip19.decode(nsec);
+      if (decoded.type !== 'nsec' || !(decoded.data instanceof Uint8Array)) {
+        return '';
+      }
+      return secretToPublicHex(decoded.data);
+    } catch {
+      // TG_BOT_NSEC is set but not a valid bech32 nsec — surface an empty pubkey
+      // instead of 500-ing this read endpoint (the relay duties are dormant too).
+      return '';
+    }
+  }
+}
+
+interface RawEligibleRoomRow {
+  sale_address: string;
+  token_address: string;
+  symbol: string;
+  is_private: boolean;
+  // numeric column comes back as a string from pg/typeorm raw select
+  min_token_threshold: string | null;
+  is_community: boolean;
+  role: RoomViewDto['role'];
+  relay_state: RoomMembershipRelayState;
+  member_pubkey: string | null;
+}
+
+/** Map a raw join row to the client DTO, deriving `readable` (§6.6). */
+function toRoomViewDto(row: RawEligibleRoomRow): RoomViewDto {
+  const memberPubkey = row.member_pubkey ?? null;
+  return {
+    sale_address: row.sale_address,
+    token_address: row.token_address,
+    symbol: row.symbol,
+    is_private: row.is_private,
+    min_token_threshold:
+      row.min_token_threshold === null ? '0' : String(row.min_token_threshold),
+    is_community: row.is_community,
+    role: row.role,
+    relay_state: row.relay_state,
+    member_pubkey: memberPubkey,
+    readable: row.relay_state === 'added' && memberPubkey !== null,
+  };
+}
+
+/**
+ * secp256k1 secret-key bytes → 32-byte x-only public key, hex (via
+ * `nostr-tools/pure`'s `getPublicKey`). Kept here, not via the worker-only
+ * RelayWriterService, because that writer is never constructed in the main API
+ * process this controller runs in.
+ */
+function secretToPublicHex(sk: Uint8Array): string {
+  const hex = nostrPure.getPublicKey(sk).toLowerCase();
+  return HEX64.test(hex) ? hex : '';
+}

--- a/src/token-gated-rooms/token-gated-rooms.module.spec.ts
+++ b/src/token-gated-rooms/token-gated-rooms.module.spec.ts
@@ -1,0 +1,176 @@
+import 'reflect-metadata';
+import { ConfigModule } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { BullModule } from '@nestjs/bull';
+import { TokenGatedRoomsModule } from './token-gated-rooms.module';
+import { isRelayConfigured } from './config/tgr.config';
+import { PublishNip29Module } from './queues/publish-nip29.module';
+import { RoomNotificationsModule } from './room-notifications.module';
+import { ClientRoomApiModule } from './client-room-api.module';
+import { TgrObservabilityModule } from './observability/tgr-observability.module';
+import { IdentityService } from './services/identity.service';
+import { IdentityBackfillService } from './services/identity-backfill.service';
+import { EligibilityService } from './services/eligibility.service';
+import { RoomAdminsService } from './services/room-admins.service';
+import { RelayAdminHealthService } from './nostr/relay-admin-health';
+import { RoomBackfillService } from './services/room-backfill.service';
+import { RoomBackfillProcessor } from './queues/room-backfill.processor';
+import { MembershipSyncService } from './services/membership-sync.service';
+import { ReconciliationService } from './services/reconciliation.service';
+import { ReorgEvictionService } from './services/reorg-eviction.service';
+import { ReconcileProcessor } from './queues/reconcile.processor';
+
+/**
+ * Static wiring assertions for the token-gated-rooms module.
+ *
+ * Worker mode is gone (see `deworker-plan.md`): there is no longer a
+ * `main`/`worker`/`combined` trichotomy and no `TokenGatedRoomsModule.forRoot({mode})`.
+ * The module is a PLAIN `@Module` that registers EVERY provider once — the
+ * chain-driven indexing listeners (eligibility, identity backfill), the relay
+ * actuators (writer/subscriber consumers + backfill/reconcile/membership-sync), and
+ * the HTTP read API — and exports the public providers unconditionally. The relay
+ * actuators self-enable at runtime iff a relay is configured (`isRelayConfigured`);
+ * un-configured they construct but stay dormant, so the public API + indexer still
+ * boot.
+ *
+ * The old boot smoke asserted which providers loaded per process mode (e.g.
+ * `EligibilityService` main-only, `RoomAdminsService`/relay actuators worker-only,
+ * `validateTgrEnv` fail-fast in worker/combined). Those distinctions no longer exist.
+ * To keep these assertions infra-free (the old version `app.init()`-booted a real
+ * Postgres + Redis), the unified wiring is asserted via the static `@Module`
+ * metadata (`Reflect.getMetadata`) instead of a live Nest container.
+ */
+describe('TokenGatedRoomsModule wiring', () => {
+  const providers: unknown[] =
+    Reflect.getMetadata('providers', TokenGatedRoomsModule) ?? [];
+  const imports: unknown[] =
+    Reflect.getMetadata('imports', TokenGatedRoomsModule) ?? [];
+  const exports: unknown[] =
+    Reflect.getMetadata('exports', TokenGatedRoomsModule) ?? [];
+
+  it('is a plain @Module — no forRoot factory (mode trichotomy removed)', () => {
+    // The `main`/`worker`/`combined` split + the per-mode `forRoot({mode})` factory
+    // are gone. Asserting the absence guards against a regression that reintroduces
+    // a mode-conditional wiring path.
+    expect(
+      (TokenGatedRoomsModule as unknown as { forRoot?: unknown }).forRoot,
+    ).toBeUndefined();
+  });
+
+  it('registers the indexing listeners unconditionally (were main-only)', () => {
+    // Previously `processRunsMain`-gated (loaded only in main/combined). In the
+    // single always-on process they always load.
+    expect(providers).toContain(IdentityService);
+    expect(providers).toContain(IdentityBackfillService);
+    expect(providers).toContain(EligibilityService);
+  });
+
+  it('registers the relay actuators unconditionally (were worker-only)', () => {
+    // Previously `processRunsWorker`-gated (loaded only in worker/combined). They now
+    // always construct in the single process and self-gate on `isRelayConfigured` at
+    // runtime — no longer absent in a relay-less process.
+    expect(providers).toContain(RoomAdminsService);
+    expect(providers).toContain(RelayAdminHealthService);
+    expect(providers).toContain(RoomBackfillService);
+    expect(providers).toContain(RoomBackfillProcessor);
+    expect(providers).toContain(MembershipSyncService);
+    expect(providers).toContain(ReconciliationService);
+    expect(providers).toContain(ReorgEvictionService);
+    expect(providers).toContain(ReconcileProcessor);
+  });
+
+  it('imports the feature config + the three sub-modules + the publish queue path', () => {
+    // All imported unconditionally now (no per-mode dedupe). The sub-modules are
+    // plain `@Module` classes (their own `forRoot({mode})` was removed too), so they
+    // appear in the metadata as the class reference itself.
+    expect(imports).toContain(PublishNip29Module);
+    expect(imports).toContain(RoomNotificationsModule);
+    expect(imports).toContain(ClientRoomApiModule);
+    expect(imports).toContain(TgrObservabilityModule);
+    // ConfigModule.forFeature(tgrConfig) + TypeOrmModule.forFeature(...) + the Bull
+    // queues are DYNAMIC modules — stored as `{ module, providers, exports }` objects,
+    // not the class — so match on the host `module` reference.
+    const hostModules = imports.map((entry) =>
+      entry && typeof entry === 'object' && 'module' in entry
+        ? (entry as { module: unknown }).module
+        : entry,
+    );
+    expect(hostModules).toContain(ConfigModule);
+    expect(hostModules).toContain(TypeOrmModule);
+    expect(hostModules).toContain(BullModule);
+  });
+
+  it('exports the public providers (identity/eligibility/admins) and shared modules', () => {
+    expect(exports).toContain(IdentityService);
+    expect(exports).toContain(EligibilityService);
+    expect(exports).toContain(RoomAdminsService);
+    expect(exports).toContain(RoomNotificationsModule);
+    expect(exports).toContain(TypeOrmModule);
+  });
+
+  it('shares ONE RoomNotificationsModule class across both parents (no double-registration)', () => {
+    // Regression guard for the prior combined-mode "Cannot define the same handler
+    // twice" bug: when RoomNotificationsModule was a `forRoot({mode})` DynamicModule,
+    // TokenGatedRoomsModule and the nested ClientRoomApiModule each produced a fresh
+    // dynamic module that re-registered the `worker:room-notify` queue + its
+    // @Processor. As a PLAIN @Module class it is the SAME reference in both parents'
+    // imports, so NestJS instantiates it once → the queue + processors register once.
+    const clientImports: unknown[] =
+      Reflect.getMetadata('imports', ClientRoomApiModule) ?? [];
+    expect(imports).toContain(RoomNotificationsModule);
+    expect(clientImports).toContain(RoomNotificationsModule);
+    // It must be a plain class, NOT a `{ module, ... }` DynamicModule and NOT carry a
+    // forRoot factory — those are what reintroduce duplicate registration.
+    expect(typeof RoomNotificationsModule).toBe('function');
+    expect(
+      (RoomNotificationsModule as unknown as { forRoot?: unknown }).forRoot,
+    ).toBeUndefined();
+  });
+});
+
+/**
+ * The relay-config predicate is the single runtime gate that replaced the process
+ * mode (worker/combined → "relay configured"; pure-main / no worker → "relay NOT
+ * configured" → dormant). The module wires every provider regardless; whether the
+ * relay actuators DO anything is decided by this predicate at runtime, so it is
+ * asserted here directly. It accepts either the injected typed config
+ * (`{ nostrRelayUrl, nostrBotNsec }`) or a raw env map (`{ TG_RELAY_URL, TG_BOT_NSEC }`).
+ */
+describe('isRelayConfigured (replaces the worker/main mode gate)', () => {
+  // A valid (throwaway, test-only) bech32 nsec, mirroring the live relay env.
+  const NSEC =
+    'nsec16uz59vnceujqavzclzakpavkmwhxe0rc4krhzl6ewmv7lg0wrktqaagg40';
+
+  it('relay configured (was "worker"/"combined") → enabled, via typed config', () => {
+    expect(
+      isRelayConfigured({
+        nostrRelayUrl: 'ws://localhost:1',
+        nostrBotNsec: NSEC,
+      }),
+    ).toBe(true);
+  });
+
+  it('relay configured → enabled, via raw env map', () => {
+    expect(
+      isRelayConfigured({
+        TG_RELAY_URL: 'ws://localhost:1',
+        TG_BOT_NSEC: NSEC,
+      }),
+    ).toBe(true);
+  });
+
+  it('relay NOT configured (was "main"/no worker) → dormant', () => {
+    // Both missing.
+    expect(isRelayConfigured({})).toBe(false);
+    // URL only.
+    expect(isRelayConfigured({ nostrRelayUrl: 'ws://localhost:1' })).toBe(
+      false,
+    );
+    // nsec only.
+    expect(isRelayConfigured({ nostrBotNsec: NSEC })).toBe(false);
+    // Blank strings count as unset (no longer a fail-fast — just dormant).
+    expect(isRelayConfigured({ nostrRelayUrl: '', nostrBotNsec: '   ' })).toBe(
+      false,
+    );
+  });
+});

--- a/src/token-gated-rooms/token-gated-rooms.module.ts
+++ b/src/token-gated-rooms/token-gated-rooms.module.ts
@@ -10,6 +10,7 @@ import tgrConfig from './config/tgr.config';
 import { prefixQueue, TGR_QUEUE_NAMES } from './config/queue-prefix';
 import { CommunityRoom } from './entities/community-room.entity';
 import { RoomMembership } from './entities/room-membership.entity';
+import { RoomMembershipEvent } from './entities/room-membership-event.entity';
 import { RoomNotificationPreference } from './entities/room-notification-preference.entity';
 import { RoomMessageSeen } from './entities/room-message-seen.entity';
 import { TokenBalance } from './entities/token-balance.entity';
@@ -17,6 +18,7 @@ import { RoomBackfillState } from './entities/room-backfill-state.entity';
 import { IdentityService } from './services/identity.service';
 import { IdentityBackfillService } from './services/identity-backfill.service';
 import { EligibilityService } from './services/eligibility.service';
+import { MembershipAccessService } from './services/membership-access.service';
 import { RoomAdminsService } from './services/room-admins.service';
 import { RelayAdminHealthService } from './nostr/relay-admin-health';
 import { PublishNip29Module } from './queues/publish-nip29.module';
@@ -52,6 +54,7 @@ import { TgrObservabilityModule } from './observability/tgr-observability.module
 const TGR_ENTITIES = [
   CommunityRoom,
   RoomMembership,
+  RoomMembershipEvent,
   RoomNotificationPreference,
   RoomMessageSeen,
   TokenBalance,
@@ -116,6 +119,10 @@ const TGR_ENTITIES = [
     // Indexer-driven desired-state (Postgres writes + enqueue only).
     IdentityBackfillService,
     EligibilityService,
+    // Access-transition ledger (durable membership-push dedup + debounced revoke).
+    // Injected by MembershipSyncService (grant/revoke folding) + ReconcileProcessor
+    // (the finalize job).
+    MembershipAccessService,
     // Relay actuators — construct always, self-gate on `isRelayConfigured`.
     RoomAdminsService,
     RelayAdminHealthService,

--- a/src/token-gated-rooms/token-gated-rooms.module.ts
+++ b/src/token-gated-rooms/token-gated-rooms.module.ts
@@ -1,0 +1,144 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { BullModule } from '@nestjs/bull';
+import { Account } from '@/account/entities/account.entity';
+import { Token } from '@/tokens/entities/token.entity';
+import { TokenHolder } from '@/tokens/entities/token-holders.entity';
+import { SyncState } from '@/mdw-sync/entities/sync-state.entity';
+import tgrConfig from './config/tgr.config';
+import { prefixQueue, TGR_QUEUE_NAMES } from './config/queue-prefix';
+import { CommunityRoom } from './entities/community-room.entity';
+import { RoomMembership } from './entities/room-membership.entity';
+import { RoomNotificationPreference } from './entities/room-notification-preference.entity';
+import { RoomMessageSeen } from './entities/room-message-seen.entity';
+import { TokenBalance } from './entities/token-balance.entity';
+import { RoomBackfillState } from './entities/room-backfill-state.entity';
+import { IdentityService } from './services/identity.service';
+import { IdentityBackfillService } from './services/identity-backfill.service';
+import { EligibilityService } from './services/eligibility.service';
+import { RoomAdminsService } from './services/room-admins.service';
+import { RelayAdminHealthService } from './nostr/relay-admin-health';
+import { PublishNip29Module } from './queues/publish-nip29.module';
+import { RoomBackfillService } from './services/room-backfill.service';
+import { RoomBackfillProcessor } from './queues/room-backfill.processor';
+import { MembershipSyncService } from './services/membership-sync.service';
+import { GroupMissingTracker } from './services/group-missing-tracker.service';
+import { ReconciliationService } from './services/reconciliation.service';
+import { ReorgEvictionService } from './services/reorg-eviction.service';
+import { ReconcileProcessor } from './queues/reconcile.processor';
+import { RoomRecheckService } from './services/room-recheck.service';
+import { RoomRecheckController } from './controllers/room-recheck.controller';
+import { RoomNotificationsModule } from './room-notifications.module';
+import { ClientRoomApiModule } from './client-room-api.module';
+import { TgrObservabilityModule } from './observability/tgr-observability.module';
+
+/**
+ * TGR entities registered for repository injection (Task 00). Registered in both
+ * modes so services in either process can read/write the desired-state tables.
+ *
+ * `Account` (Task 05) is added so {@link IdentityService} /
+ * {@link IdentityBackfillService} can `@InjectRepository(Account)` to read the
+ * already-materialized `Account.links[<provider>]` value.
+ *
+ * `Token` (Task 09) is added so {@link RoomBackfillService} can
+ * `@InjectRepository(Token)` to drive the whole-registry eager room backfill off
+ * the per-token `has_nostr_room` / `nostr_room_state` source of truth.
+ *
+ * `SyncState` (Task 11) is added so {@link ReconciliationService} and
+ * {@link ReorgEvictionService} can `@InjectRepository(SyncState)` to read the chain
+ * tip height (`id='global'`) that gates reorg holds / flush.
+ */
+const TGR_ENTITIES = [
+  CommunityRoom,
+  RoomMembership,
+  RoomNotificationPreference,
+  RoomMessageSeen,
+  TokenBalance,
+  RoomBackfillState,
+  Account,
+  Token,
+  // `token_holder` is the canonical, already-populated holder ledger (BCL indexer
+  // + MDW reconcile). EligibilityService reads it directly — see its balance read.
+  TokenHolder,
+  SyncState,
+];
+
+/**
+ * Token-gated rooms (NIP-29 / groups_relay).
+ *
+ * ONE always-on process (worker mode removed — see `deworker-plan.md`). Every
+ * provider loads here: the chain-driven indexing listeners (eligibility, identity
+ * backfill), the HTTP read API, AND the relay actuators (writer/subscriber + their
+ * Bull consumers + the backfill/reconcile/membership-sync crons). The actuators
+ * self-enable at runtime iff a relay is configured (`isRelayConfigured`) — when it
+ * is not, they construct but stay dormant, so the public API + indexer still boot.
+ *
+ * The MDW indexer **plugins** (AEX9 transfer / community-room state) are NOT
+ * registered here — they live in the global plugin registry (`src/plugins/index.ts`)
+ * so the indexer + reorg service reach them.
+ *
+ * Bull queues are registered with their historical `main:`/`worker:` name prefixes
+ * (now just a stable name component, DW5). The `worker:room-notify` queue is NOT
+ * registered here — it lives entirely inside `RoomNotificationsModule` (its sole
+ * producer + consumer), so registering it here would double-register the token.
+ */
+@Module({
+  imports: [
+    ConfigModule.forFeature(tgrConfig),
+    TypeOrmModule.forFeature(TGR_ENTITIES),
+    BullModule.registerQueue({
+      name: prefixQueue('reconcile-balance', 'main'),
+    }),
+    BullModule.registerQueue({ name: prefixQueue('publish-nip29', 'worker') }),
+    BullModule.registerQueue({
+      name: prefixQueue(TGR_QUEUE_NAMES.ROOM_BACKFILL, 'worker'),
+    }),
+    BullModule.registerQueue({
+      name: prefixQueue(TGR_QUEUE_NAMES.RECONCILE_MEMBERSHIP, 'worker'),
+    }),
+    // Relay write path: the publish queue (rate limiter + capped-backoff) + the
+    // RelayWriter binding. Always imported now; the writer is dormant until a relay
+    // is configured.
+    PublishNip29Module,
+    // Membership push notifications + per-room mute (its own `worker:room-notify`
+    // queue + listener/processor + relay subscriber). Self-contained.
+    RoomNotificationsModule,
+    // HTTP read/query + signed per-room mute write.
+    ClientRoomApiModule,
+    // Metrics collector + `GET /api/tgr/metrics`. Imported AFTER the queues so its
+    // @Optional() @InjectQueue tokens resolve.
+    TgrObservabilityModule,
+  ],
+  providers: [
+    // Shared: AE↔nostr resolution (eligibility + membership-sync inject it).
+    IdentityService,
+    // Indexer-driven desired-state (Postgres writes + enqueue only).
+    IdentityBackfillService,
+    EligibilityService,
+    // Relay actuators — construct always, self-gate on `isRelayConfigured`.
+    RoomAdminsService,
+    RelayAdminHealthService,
+    RoomBackfillService,
+    RoomBackfillProcessor,
+    MembershipSyncService,
+    // In-memory "group missing on relay" registry: debounces re-creates + lets
+    // membership-sync stop adding members to a group being re-created.
+    GroupMissingTracker,
+    ReconciliationService,
+    ReorgEvictionService,
+    ReconcileProcessor,
+    // On-demand per-caller access recheck (relay→DB heal + provision) backing the
+    // `POST /rooms/:saleAddress/recheck` controller below.
+    RoomRecheckService,
+  ],
+  controllers: [RoomRecheckController],
+  exports: [
+    IdentityService,
+    EligibilityService,
+    RoomAdminsService,
+    RoomNotificationsModule,
+    TypeOrmModule,
+  ],
+})
+export class TokenGatedRoomsModule {}

--- a/src/token-gated-rooms/token-gated-rooms.module.ts
+++ b/src/token-gated-rooms/token-gated-rooms.module.ts
@@ -4,7 +4,6 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { BullModule } from '@nestjs/bull';
 import { Account } from '@/account/entities/account.entity';
 import { Token } from '@/tokens/entities/token.entity';
-import { TokenHolder } from '@/tokens/entities/token-holders.entity';
 import { SyncState } from '@/mdw-sync/entities/sync-state.entity';
 import tgrConfig from './config/tgr.config';
 import { prefixQueue, TGR_QUEUE_NAMES } from './config/queue-prefix';
@@ -61,9 +60,6 @@ const TGR_ENTITIES = [
   RoomBackfillState,
   Account,
   Token,
-  // `token_holder` is the canonical, already-populated holder ledger (BCL indexer
-  // + MDW reconcile). EligibilityService reads it directly — see its balance read.
-  TokenHolder,
   SyncState,
 ];
 

--- a/src/token-gated-rooms/utils/decimals.ts
+++ b/src/token-gated-rooms/utils/decimals.ts
@@ -1,0 +1,55 @@
+import { BigNumber } from 'bignumber.js';
+
+/**
+ * Decimals helpers for AEX9 balances (plan §5.4). The indexed `token_balance`
+ * is already stored in **raw integer base units** (the on-chain `Transfer`
+ * `value`), so there is no scaling on the indexing path. These helpers exist for
+ * the *human → raw* direction (turning an operator-entered threshold like
+ * `"5"` tokens at 18 decimals into `5_000000000000000000`) and for raw-vs-raw
+ * threshold comparison. Never float-scale a balance for comparison.
+ *
+ * `Token.decimals` is a **string** (`type:'bigint'`) — every consumer must coerce
+ * with `Number(...)` before shifting; that is what `toShiftedBigNumber` does.
+ */
+
+/**
+ * Mirror of the bot's `toShiftedBigNumber(value, precision)`:
+ * `new BigNumber(value).shiftedBy(Number(precision))`. `precision` may be a
+ * string (`Token.decimals`), number, or bigint; it is coerced via `Number(...)`.
+ */
+export function toShiftedBigNumber(
+  value: number | string | BigNumber,
+  precision: number | bigint | string,
+): BigNumber {
+  return new BigNumber(value).shiftedBy(Number(precision));
+}
+
+/**
+ * Convert a human-entered token amount (e.g. `"5"`, `5`, or `BigNumber(5)`) into
+ * **raw integer base units** for a token with `decimals` (string|number|bigint).
+ * The result is an integer (any fractional remainder finer than the token's
+ * precision is floored — base units cannot be fractional).
+ *
+ * @example humanToRaw('1', 18) // BigNumber('1000000000000000000')
+ * @example humanToRaw('1.5', 6) // BigNumber('1500000')
+ */
+export function humanToRaw(
+  amount: number | string | BigNumber,
+  decimals: number | bigint | string,
+): BigNumber {
+  return toShiftedBigNumber(amount, decimals).integerValue(
+    BigNumber.ROUND_FLOOR,
+  );
+}
+
+/**
+ * Raw-vs-raw threshold compare (plan §5.4): both args are already raw integer
+ * base units; this never scales by decimals. Returns true iff `rawBalance` is at
+ * least `rawThreshold` (`rawBalance.gte(rawThreshold)`).
+ */
+export function hasAtLeast(
+  rawBalance: BigNumber,
+  rawThreshold: BigNumber,
+): boolean {
+  return rawBalance.gte(rawThreshold);
+}

--- a/src/tokens/dto/collection-info.dto.ts
+++ b/src/tokens/dto/collection-info.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CollectionInfoDto {
+  @ApiProperty({
+    description: 'Full collection id, "<NAME>-ak_<deployer>"',
+    example: 'CHINESE-ak_2AoM8kAJn9Q6zVbxjfoBUfMkyfP8SxgoZ2Nw88M4Xd8Xk8ct6r',
+  })
+  id: string;
+
+  @ApiProperty({
+    description: 'Human-readable collection name (badge label)',
+    example: 'CHINESE',
+  })
+  name: string;
+
+  @ApiProperty({ required: false, nullable: true })
+  description?: string;
+
+  @ApiProperty({
+    description: 'Max token name length allowed in this collection',
+    example: '20',
+  })
+  allowed_name_length: string;
+}

--- a/src/tokens/dto/token.dto.ts
+++ b/src/tokens/dto/token.dto.ts
@@ -1,6 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { PriceDto } from './price.dto';
 import { TokenPerformanceDto } from './token-performance.dto';
+import { CollectionInfoDto } from './collection-info.dto';
 
 export class TokenDto {
   @ApiProperty()
@@ -35,6 +36,15 @@ export class TokenDto {
 
   @ApiProperty()
   collection: string;
+
+  @ApiProperty({
+    description:
+      "Resolved metadata for the token's collection, or null when the " +
+      'token has no collection / the collection is unknown to the factory.',
+    type: () => CollectionInfoDto,
+    nullable: true,
+  })
+  collection_info: CollectionInfoDto | null;
 
   @ApiProperty()
   metaInfo: Record<string, string>;

--- a/src/tokens/entities/token.entity.ts
+++ b/src/tokens/entities/token.entity.ts
@@ -1,4 +1,8 @@
 import { BigNumberTransformer } from '@/utils/BigNumberTransformer';
+import {
+  NOSTR_ROOM_STATES,
+  NostrRoomState,
+} from '@/token-gated-rooms/enums/nostr-room-state.enum';
 import { BigNumber } from 'bignumber.js';
 import {
   Column,
@@ -185,4 +189,66 @@ export class Token {
     default: () => 'CURRENT_TIMESTAMP(6)',
   })
   public created_at: Date;
+
+  /**
+   * Token-gated rooms (plan §4.1).
+   *
+   * Immutable NIP-29 group id (= `sale_address` per D3); set once when the room
+   * is requested. Index for room lookups by group id.
+   */
+  @Index()
+  @Column({
+    type: 'varchar',
+    nullable: true,
+  })
+  nostr_group_id: string;
+
+  /** True only after the relay ACKs the group create (set by later tasks). */
+  @Column({
+    default: false,
+  })
+  has_nostr_room: boolean;
+
+  @Column({
+    type: 'timestamptz',
+    nullable: true,
+  })
+  nostr_room_created_at: Date;
+
+  /**
+   * `nostr_room_state` machine (plan §4.7):
+   *   none → pending → created; pending → failed; failed → pending (retry, capped
+   *   backoff); pending stale >24h w/o ACK → re-publish (stays pending); relay
+   *   `"Group already exists"` → created; community deleted → deleted (TERMINAL,
+   *   relay blocks recreate of a 9008-deleted id).
+   * Transition enforcement is Task 09 — see
+   * `@/token-gated-rooms/enums/nostr-room-state.enum`.
+   */
+  @Index('idx_token_nostr_room_state_pending', ['nostr_room_state'], {
+    where: "nostr_room_state <> 'created'",
+  })
+  @Column({
+    type: 'enum',
+    enum: NOSTR_ROOM_STATES,
+    default: 'none',
+  })
+  nostr_room_state: NostrRoomState;
+
+  /**
+   * The NIP-29 group id (= `sale_address`) once the room is CONFIRMED created on
+   * the relay; NULL = no room yet. Source of truth for the provisioning cron
+   * (`room_id IS NULL` ⟺ not yet created). Set on the `9007` ok ACK
+   * (`RoomBackfillService.onPublishAck`), the same place `has_nostr_room`/
+   * `nostr_room_created_at` are stamped. Indexed (partial, `WHERE room_id IS NULL`)
+   * for the roomless-token selection.
+   */
+  @Index('idx_token_room_id_null', ['room_id'], {
+    where: 'room_id IS NULL',
+  })
+  @Column({
+    type: 'varchar',
+    length: 64,
+    nullable: true,
+  })
+  room_id: string;
 }

--- a/src/tokens/tokens.controller.spec.ts
+++ b/src/tokens/tokens.controller.spec.ts
@@ -159,7 +159,8 @@ describe('TokensController', () => {
           useValue: {
             getCurrentFactory: jest
               .fn()
-              .mockResolvedValue({ address: 'ct_123' }),
+              .mockResolvedValue({ address: 'ct_123', collections: {} }),
+            mapCollectionInfo: jest.fn().mockReturnValue(null),
           },
         },
       ],
@@ -272,7 +273,10 @@ describe('TokensController', () => {
   });
 
   it('should return cached trending-score token lists', async () => {
-    cacheManager.get.mockResolvedValueOnce({ items: ['cached'], meta: {} });
+    cacheManager.get.mockResolvedValueOnce({
+      items: [{ sale_address: 'ct_a', collection: 'CHINESE-ak_x' }],
+      meta: {},
+    });
 
     const result = await controller.listAll(
       undefined,
@@ -286,9 +290,46 @@ describe('TokensController', () => {
       'all',
     );
 
-    expect(result).toEqual({ items: ['cached'], meta: {} });
+    expect((result as any).items[0].sale_address).toBe('ct_a');
     expect(tokensService.applyListEligibilityFilters).not.toHaveBeenCalled();
     expect(tokensService.queryTokensWithRanks).not.toHaveBeenCalled();
+  });
+
+  it('enriches cached trending-score token lists with collection_info on read', async () => {
+    // Simulate an entry cached before collection_info existed: it lacks the
+    // field, but the hit path must still resolve and attach it.
+    cacheManager.get.mockResolvedValueOnce({
+      items: [{ sale_address: 'ct_a', collection: 'CHINESE-ak_x' }],
+      meta: {},
+    });
+    const collectionInfo = {
+      id: 'CHINESE-ak_x',
+      name: 'CHINESE',
+      description: 'Chinese collection',
+      allowed_name_length: '20',
+    };
+    (communityFactoryService.mapCollectionInfo as jest.Mock).mockReturnValue(
+      collectionInfo,
+    );
+
+    const result = await controller.listAll(
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      1,
+      100,
+      'trending_score',
+      'DESC',
+      'all',
+    );
+
+    expect(tokensService.queryTokensWithRanks).not.toHaveBeenCalled();
+    expect(communityFactoryService.mapCollectionInfo).toHaveBeenCalledWith(
+      expect.anything(),
+      'CHINESE-ak_x',
+    );
+    expect((result as any).items[0].collection_info).toEqual(collectionInfo);
   });
 
   it('should not collide trending cache keys when filter values contain separators', async () => {
@@ -334,6 +375,7 @@ describe('TokensController', () => {
       rank: 5,
       total_supply: { toNumber: expect.any(Function) },
       factory_address: 'ct_123',
+      collection_info: null,
     });
   });
 

--- a/src/tokens/tokens.controller.ts
+++ b/src/tokens/tokens.controller.ts
@@ -67,6 +67,28 @@ export class TokensController {
     //
   }
 
+  /**
+   * Attaches the resolved `collection_info` badge object to each token, mapping
+   * the stored `collection` id through the factory's collection registry. The
+   * factory schema is loaded once for the whole batch. Tokens with no/unknown
+   * collection get `collection_info: null`.
+   */
+  private async attachCollectionInfo(
+    items: Array<{ collection?: string | null }>,
+  ): Promise<void> {
+    if (!items?.length) {
+      return;
+    }
+    const factory = await this.communityFactoryService.getCurrentFactory();
+    for (const item of items) {
+      (item as any).collection_info =
+        this.communityFactoryService.mapCollectionInfo(
+          factory,
+          item?.collection,
+        );
+    }
+  }
+
   private validatePagination(page: number, limit: number): void {
     if (page < 1) {
       throw new BadRequestException('Page must be greater than or equal to 1');
@@ -190,6 +212,10 @@ export class TokensController {
       const cached =
         await this.cacheManager.get<Pagination<Token>>(trendingCacheKey);
       if (cached) {
+        // Enrich on read as well: entries cached before collection_info existed
+        // (or with stale collection metadata) must still carry the field on the
+        // hit path, which otherwise returns before attachCollectionInfo runs.
+        await this.attachCollectionInfo(cached.items);
         return cached;
       }
     }
@@ -272,6 +298,8 @@ export class TokensController {
       );
     }
 
+    await this.attachCollectionInfo(result.items);
+
     if (trendingCacheKey) {
       await this.cacheManager.set(
         trendingCacheKey,
@@ -308,6 +336,10 @@ export class TokensController {
   })
   async findByAddress(@Param('address') address: string) {
     const token = await this.tokensService.getToken(address);
+
+    if (token) {
+      await this.attachCollectionInfo([token as any]);
+    }
 
     return token;
   }
@@ -455,6 +487,14 @@ export class TokensController {
       token.sale_address,
       halfLimit,
     ]);
+
+    for (const rankedToken of rankedTokens) {
+      rankedToken.collection_info =
+        this.communityFactoryService.mapCollectionInfo(
+          factory,
+          rankedToken?.collection,
+        );
+    }
 
     return {
       items: rankedTokens,

--- a/src/tokens/tokens.service.spec.ts
+++ b/src/tokens/tokens.service.spec.ts
@@ -599,6 +599,61 @@ describe('TokensService', () => {
     });
   });
 
+  describe('lookup by name or symbol', () => {
+    const lookupQueryBuilder = () => {
+      const qb = {
+        where: jest.fn().mockReturnThis(),
+        orWhere: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(null),
+      };
+      tokensRepository.createQueryBuilder = jest.fn().mockReturnValue(qb);
+      return qb;
+    };
+
+    it('folds the input so /tokens/привет resolves like /tokens/ПРИВЕТ', async () => {
+      const qb = lookupQueryBuilder();
+
+      await service.findByNameOrSymbol('привет');
+
+      // The column stays bare so the btree index on name/symbol is still used;
+      // it is the caller's input that gets folded onto the stored symbol.
+      expect(qb.where).toHaveBeenCalledWith('token.name = :name', {
+        name: 'ПРИВЕТ',
+      });
+      expect(qb.orWhere).toHaveBeenCalledWith('token.symbol = :name', {
+        name: 'ПРИВЕТ',
+      });
+    });
+
+    it('leaves caseless symbols untouched', async () => {
+      const qb = lookupQueryBuilder();
+
+      await service.findByNameOrSymbol('汉字');
+
+      expect(qb.where).toHaveBeenCalledWith('token.name = :name', {
+        name: '汉字',
+      });
+    });
+
+    it('keeps address matching case-sensitive, since base58 is', async () => {
+      const qb = lookupQueryBuilder();
+
+      await service.findByAddress('ct_Sale');
+
+      // Addresses must NOT be folded — base58 is case-significant.
+      expect(qb.where).toHaveBeenCalledWith('token.address = :address', {
+        address: 'ct_Sale',
+      });
+      expect(qb.orWhere).toHaveBeenCalledWith('token.sale_address = :address', {
+        address: 'ct_Sale',
+      });
+      // ...while the name/symbol branches of the same query are folded.
+      expect(qb.orWhere).toHaveBeenCalledWith('token.name = :symbol', {
+        symbol: 'CT_SALE',
+      });
+    });
+  });
+
   describe('SQL parameterization', () => {
     it('removes duplicated sale addresses in bounded batches', async () => {
       tokensRepository.query.mockResolvedValueOnce([{ ctid: '(0,1)' }]);

--- a/src/tokens/tokens.service.ts
+++ b/src/tokens/tokens.service.ts
@@ -28,6 +28,7 @@ import { TokenWebsocketGateway } from './token-websocket.gateway';
 import { Transaction } from '@/transactions/entities/transaction.entity';
 import { Post } from '@/social/entities/post.entity';
 import { buildTokenMentionExistsSql } from '@/social/utils/token-mentions-sql.util';
+import { normalizeTokenSymbol } from './utils/token-symbol.util';
 
 type TokenContracts = {
   instance?: TokenSale;
@@ -212,8 +213,8 @@ export class TokensService {
   async findByNameOrSymbol(name: string) {
     return this.tokensRepository
       .createQueryBuilder('token')
-      .where('token.name = :name', { name })
-      .orWhere('token.symbol = :name', { name })
+      .where('token.name = :name', { name: normalizeTokenSymbol(name) })
+      .orWhere('token.symbol = :name', { name: normalizeTokenSymbol(name) })
       .getOne();
   }
 
@@ -223,10 +224,19 @@ export class TokensService {
   ): Promise<Token | null> {
     const token = await this.tokensRepository
       .createQueryBuilder('token')
+      // Addresses are base58 and case-significant, so they stay exact. Names and
+      // symbols are the on-chain community name, which the collections only ever
+      // permit in uppercase (A-Z, А-Я) or a caseless script — so folding the
+      // *input* makes `/tokens/привет` resolve like `/tokens/ПРИВЕТ` while still
+      // hitting the btree indexes on name/symbol (UPPER(column) would not).
       .where('token.address = :address', { address })
       .orWhere('token.sale_address = :address', { address })
-      .orWhere('token.name = :address', { address })
-      .orWhere('token.symbol = :address', { address })
+      .orWhere('token.name = :symbol', {
+        symbol: normalizeTokenSymbol(address),
+      })
+      .orWhere('token.symbol = :symbol', {
+        symbol: normalizeTokenSymbol(address),
+      })
       .getOne();
 
     if (!token) {

--- a/src/tokens/utils/token-symbol.util.ts
+++ b/src/tokens/utils/token-symbol.util.ts
@@ -1,0 +1,11 @@
+/**
+ * A token's name and symbol are its on-chain community name verbatim, and every
+ * BCL collection permits only uppercase letters (WORDS: `A-Z`, RUSSIAN: `А-Я`)
+ * or a caseless script (CHINESE, ARABIC). So a stored symbol is always already
+ * in this form, and folding the *caller's* input onto it is enough to make a
+ * lookup case-insensitive — without wrapping the column in `UPPER()`, which
+ * would give up the btree indexes on `token.name` / `token.symbol`.
+ */
+export function normalizeTokenSymbol(symbol: string): string {
+  return (symbol ?? '').trim().toUpperCase();
+}

--- a/src/trending-tags/controllers/trending-tags.controller.ts
+++ b/src/trending-tags/controllers/trending-tags.controller.ts
@@ -25,6 +25,7 @@ import { Repository } from 'typeorm';
 import { TrendingTag } from '../entities/trending-tags.entity';
 import { CreateTrendingTagsDto } from '../dto/create-trending-tags.dto';
 import { TrendingTagsService } from '../services/trending-tags.service';
+import { normalizeTagName } from '../utils/tag-name.util';
 import { ApiKeyGuard } from '../guards/api-key.guard';
 import { TopicParamPipe } from '@/common/validation/request-validation';
 
@@ -106,7 +107,7 @@ export class TrendingTagsController {
   @Get(':tag')
   async getTrendingTag(@Param('tag', TopicParamPipe) tag: string) {
     const trendingTag = await this.trendingTagRepository.findOne({
-      where: { tag },
+      where: { tag: normalizeTagName(tag) },
     });
 
     if (!trendingTag) {

--- a/src/trending-tags/services/trending-tags.service.ts
+++ b/src/trending-tags/services/trending-tags.service.ts
@@ -4,6 +4,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { CreateTrendingTagsDto } from '../dto/create-trending-tags.dto';
 import { TrendingTag } from '../entities/trending-tags.entity';
+import { normalizeTagName } from '../utils/tag-name.util';
 
 @Injectable()
 export class TrendingTagsService {
@@ -37,23 +38,6 @@ export class TrendingTagsService {
   }
 
   /**
-   * Process and normalize tag name according to business rules:
-   * - Convert to uppercase
-   * - Remove special characters (only A-Z, 0-9 allowed)
-   * - Convert camelCase to kebab-case
-   */
-  private normalizeTag(tag: string): string {
-    // First, convert camelCase to kebab-case
-    const kebabCase = tag.replace(/([a-z])([A-Z])/g, '$1-$2');
-
-    // Convert to uppercase and remove all special characters except alphanumeric and hyphens
-    const normalized = kebabCase.toUpperCase().replace(/[^A-Z0-9-]/g, '');
-
-    // Clean up multiple hyphens and leading/trailing hyphens
-    return normalized.replace(/-+/g, '-').replace(/^-|-$/g, '');
-  }
-
-  /**
    * Create trending tags from external provider data
    */
   async createTrendingTags(
@@ -72,7 +56,7 @@ export class TrendingTagsService {
 
     for (const item of data.items) {
       try {
-        const normalizedTag = this.normalizeTag(item.tag);
+        const normalizedTag = normalizeTagName(item.tag);
 
         // Skip if normalized tag is empty
         if (!normalizedTag) {

--- a/src/trending-tags/utils/tag-name.util.spec.ts
+++ b/src/trending-tags/utils/tag-name.util.spec.ts
@@ -1,0 +1,76 @@
+import { normalizeTagName } from './tag-name.util';
+import { extractTopics } from '@/social/utils/content-parser.util';
+import { normalizeTopicName } from '@/social/utils/topic-name.util';
+
+describe('normalizeTagName', () => {
+  it('keeps tags from the non-Latin collections instead of emptying them', () => {
+    // The old `[^A-Z0-9-]` strip reduced each of these to '', so ingest skipped
+    // the tag entirely and it could never reach a topic or a token.
+    expect(normalizeTagName('汉字')).toBe('汉字');
+    expect(normalizeTagName('مرحبا')).toBe('مرحبا');
+    expect(normalizeTagName('ПРИВЕТ')).toBe('ПРИВЕТ');
+  });
+
+  it('uppercases so the tag matches the symbol the token is stored under', () => {
+    expect(normalizeTagName('привет')).toBe('ПРИВЕТ');
+    expect(normalizeTagName('words-1')).toBe('WORDS-1');
+  });
+
+  it('still normalizes Latin tags the way it always did', () => {
+    expect(normalizeTagName('CamelCase')).toBe('CAMEL-CASE');
+    expect(normalizeTagName('UPPERCASE')).toBe('UPPERCASE');
+    expect(normalizeTagName('--messy--tag--')).toBe('MESSY-TAG');
+  });
+
+  it('drops punctuation and emoji a tag may not contain', () => {
+    expect(normalizeTagName('汉字。')).toBe('汉字');
+    expect(normalizeTagName('hello!')).toBe('HELLO');
+    expect(normalizeTagName('dog🐶')).toBe('DOG');
+  });
+
+  it('returns empty for a tag with nothing usable left', () => {
+    expect(normalizeTagName('!!!')).toBe('');
+    expect(normalizeTagName('')).toBe('');
+  });
+
+  /**
+   * PopularRankingService keys its trending-tag cache on `tag.toLowerCase()` and
+   * looks it up with `topic.name.toLowerCase()`. If the tag normalizer and the
+   * topic normalizer ever disagree, the trending boost silently reads 0 for
+   * every affected topic — no error, just worse ranking. This pins them together.
+   */
+  describe('agrees with topic normalization, so the trending boost can match', () => {
+    const topicKeyFor = (hashtagBody: string) => {
+      const [topic] = extractTopics(`#${hashtagBody}`);
+      return normalizeTopicName(topic);
+    };
+
+    it.each([
+      ['汉字'],
+      ['مرحبا'],
+      ['привет'],
+      ['ПРИВЕТ'],
+      ['ёлка'],
+      ['WORDS-1'],
+      ['CamelCase'],
+    ])('tag %s keys the same as its topic', (raw) => {
+      const tagKey = normalizeTagName(raw).toLowerCase();
+
+      expect(tagKey).not.toBe('');
+      expect(tagKey).toBe(topicKeyFor(raw));
+    });
+  });
+
+  /**
+   * The trending-tags controller joins `token.name = trending_tag.tag`. Tokens
+   * store the on-chain name verbatim, and the collections only permit uppercase
+   * (A-Z, А-Я) or caseless scripts — so a normalized tag has to come out equal to
+   * the symbol, or the join never resolves.
+   */
+  it('produces exactly the symbol a token is stored under', () => {
+    expect(normalizeTagName('привет')).toBe('ПРИВЕТ'); // RUSSIAN collection
+    expect(normalizeTagName('汉字')).toBe('汉字'); // CHINESE (caseless)
+    expect(normalizeTagName('مرحبا')).toBe('مرحبا'); // ARABIC (caseless)
+    expect(normalizeTagName('words-1')).toBe('WORDS-1'); // WORDS
+  });
+});

--- a/src/trending-tags/utils/tag-name.util.ts
+++ b/src/trending-tags/utils/tag-name.util.ts
@@ -1,0 +1,25 @@
+/**
+ * Trending tags are stored uppercased, so every read has to fold the caller's
+ * input the same way the writer did.
+ *
+ * The character class deliberately admits letters and numbers in any script. A
+ * tag is matched against `topic.name` (for the popular-ranking trending boost)
+ * and against `token.name` (for the trending-tag → token join), and tokens now
+ * come from non-Latin collections — an `[^A-Z0-9-]` strip silently reduced every
+ * Chinese, Arabic and Cyrillic tag to the empty string, so it was dropped on
+ * ingest and neither of those two consumers could ever see it.
+ *
+ * Kept in step with `normalizeTopic` in `content-parser.util.ts`: the two must
+ * agree on camelCase splitting or a tag will never match its topic.
+ */
+export function normalizeTagName(tag: string): string {
+  return (
+    tag
+      // camelCase -> kebab-case, in any script that has letter case
+      .replace(/(\p{Ll})(\p{Lu})/gu, '$1-$2')
+      .toUpperCase()
+      .replace(/[^\p{L}\p{N}-]+/gu, '')
+      .replace(/-+/g, '-')
+      .replace(/^-|-$/g, '')
+  );
+}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -216,3 +216,13 @@ export type ICommunityFactorySchema = {
     };
   };
 };
+
+/**
+ * Trimmed collection metadata surfaced to API clients (e.g. as a token's
+ * collection badge). Drops `allowed_name_chars` — the bulky per-character
+ * validation rules are not needed on token/mention list responses.
+ */
+export type ICollectionInfo = Pick<
+  ICommunityFactorySchema['collections'][keyof ICommunityFactorySchema['collections']],
+  'id' | 'name' | 'description' | 'allowed_name_length'
+>;

--- a/test/harness/README.md
+++ b/test/harness/README.md
@@ -1,0 +1,121 @@
+# TGR test harness
+
+Shared infrastructure for Token-Gated-Rooms (TGR) integration specs. Provides
+**hermetic DB isolation** and a **relay reachability fixture** so integration
+specs don't contend on the shared local Postgres / relay.
+
+## What lives here
+
+| File | Purpose |
+|---|---|
+| `db.ts` | DB isolation helpers — a throwaway **database** per run (`createIsolatedDatabase`) and a throwaway **schema** per run (`createIsolatedSchema`). |
+| `relay.ts` | Local relay fixture — `relayReachable()` probe + the relay-admin keypair (`RELAY_ADMIN_NSEC`) + default `RELAY_URL`, so relay-backed specs auto-skip when no relay is up. |
+
+Self-tests proving these work live in the unit project so they always run:
+`src/token-gated-rooms/__tests__/harness-db.integration.spec.ts` and
+`src/token-gated-rooms/__tests__/harness-relay.spec.ts`.
+
+## DB isolation — two patterns, pick by what you test
+
+### 1. Throwaway database — for migration specs (`createIsolatedDatabase`)
+
+The TGR migrations **hard-code the `"public"` schema** (e.g.
+`CREATE TYPE "public"."token_nostr_room_state_enum"`,
+`DROP INDEX "public"."idx_..."`) and `ALTER TABLE "token"` resolves `token` via
+the connection `search_path`. So a *dedicated non-`public` schema* is **not** a
+sufficient sandbox — the enum types and `"public".*` references would still land
+in (and collide with) the shared `public` schema, and a left-behind migrations
+history row or half-reverted index makes the spec non-deterministic.
+
+A **fresh database** has its own private `public` schema, so every migration
+object is naturally scoped to the run and the real `migration:run`/`revert` path
+can be exercised repeatedly and concurrently without touching the dev DB:
+
+```ts
+import { createIsolatedDatabase, MINIMAL_TOKEN_TABLE_SQL } from '@/test/harness/db';
+
+let db;
+beforeAll(async () => {
+  db = await createIsolatedDatabase({
+    entities: [/* ... */],
+    migrations: [__dirname + '/../../migrations/*{.ts,.js}'],
+    seedSql: [MINIMAL_TOKEN_TABLE_SQL], // migration #1 alters `token`
+  });
+  await db.dataSource.runMigrations();
+});
+afterAll(async () => { if (db) await db.drop(); }); // drops the whole DB
+```
+
+Used by `src/token-gated-rooms/entities/migrations.integration.spec.ts`.
+`dropDatabase()` refuses to target the configured application database.
+
+### 2. Throwaway schema — for service/controller specs (`createIsolatedSchema`)
+
+Cheaper than a whole database. For specs that drive services/repositories (not
+the migration SQL), `synchronize` the entities into a fresh schema:
+
+```ts
+import { createIsolatedSchema } from '@/test/harness/db';
+
+const iso = await createIsolatedSchema({ entities: [CommunityRoom, RoomMembership /* ... */] });
+// ... use iso.dataSource ...
+await iso.drop(); // DROP SCHEMA ... CASCADE
+```
+
+This mirrors the inline `CREATE SCHEMA tgr13_test` pattern already in
+`rooms.integration.spec.ts`. Do **not** use it for migration specs (see above).
+
+## Relay fixture (`relay.ts`)
+
+During local runs a NIP-29 relay (`groups_relay` / strfry29) listens at
+`ws://localhost:7777` (override with `TG_RELAY_URL`). Relay-backed specs must
+**auto-skip** when it is unreachable so no-container CI stays green:
+
+```ts
+import { relayReachable, RELAY_URL, RELAY_ADMIN_NSEC } from '@/test/harness/relay';
+
+let relayUp = false;
+beforeAll(async () => {
+  relayUp = !!process.env.TG_RELAY_URL || (await relayReachable(RELAY_URL));
+});
+(relayUp ? it : it.skip)('publishes to the relay', async () => { /* ... */ });
+```
+
+`RELAY_ADMIN_NSEC` defaults to the `groups_relay/config/settings.test.yml`
+relay-admin key (D7: the bot key under test == the relay admin, so it may create
+managed groups on a freshly-booted relay). Override via `TG_BOT_NSEC`.
+
+The existing relay-backed specs (`relay-subscriber`, `relay-writer`,
+`room-admins`, `membership-sync`) already inline this auto-skip; they were left
+as-is. New relay-backed specs should import from `relay.ts` instead of copying it.
+
+## Commands
+
+```sh
+# Full TGR suite (unit + DB integration; relay cases auto-skip if no relay).
+# Requires the local Postgres at $DB_HOST:$DB_PORT.
+npx jest src/token-gated-rooms --runInBand
+
+# Existing repo aliases:
+npm test          # whole unit project (.spec.ts under src/)
+npm run test:e2e  # the separate e2e project (test/jest-e2e.json)
+```
+
+## Env knobs
+
+| Var | Default | Meaning |
+|---|---|---|
+| `DB_HOST` / `DB_PORT` / `DB_USER` / `DB_PASSWORD` / `DB_DATABASE` | repo `.env` | Test Postgres. DB-integration specs auto-skip when `DB_HOST` is unset. |
+| `TG_TEST_DB_ADMIN_DATABASE` | `DB_DATABASE` | Maintenance DB used only to `CREATE`/`DROP` throwaway databases. |
+| `TG_RELAY_URL` | `ws://localhost:7777` | Relay endpoint; setting it also forces relay-backed cases to run (vouched external relay). |
+| `TG_BOT_NSEC` | `settings.test.yml` relay-admin nsec | Bot/relay-admin key for relay-backed specs. |
+
+## Isolation guarantees
+
+- `createIsolatedDatabase` never touches the shared application database; its
+  objects live in a uniquely-named throwaway DB dropped on teardown.
+- The migration spec is deterministic regardless of whether the shared `public`
+  schema already has TGR objects (verified: a dirty `public` is left untouched).
+- DB-integration and relay specs both auto-skip when their backing service is
+  absent, so unit-only / CI-without-services runs stay green.
+```

--- a/test/harness/db.ts
+++ b/test/harness/db.ts
@@ -1,0 +1,279 @@
+import { DataSource, DataSourceOptions } from 'typeorm';
+import { DATABASE_CONFIG } from '@/configs/database';
+
+/**
+ * Isolated throwaway-database helper for DB integration specs (Task 02 harness).
+ *
+ * The TGR migrations hard-code the `"public"` schema (e.g.
+ * `CREATE TYPE "public"."token_nostr_room_state_enum"`, `DROP INDEX
+ * "public"."idx_..."`) and `ALTER TABLE "token"` resolves `token` via the
+ * connection `search_path`. That makes a *dedicated schema* on the shared DB an
+ * incomplete sandbox — the enum types and any `"public".*` references would still
+ * land in (and collide with) the shared `public` schema.
+ *
+ * So instead we provision a brand-new **database** per run. A fresh database has
+ * its own private `public` schema, so every `"public".*` reference in the
+ * migrations is naturally scoped to the throwaway DB and never touches the dev
+ * `bcl_api` / `api` database. This is the hermetic isolation the harness promises:
+ * a spec can run the *real* migration:run/revert path repeatedly and concurrently
+ * without contending on shared state (a leftover `migrations_tgr_test` row, a
+ * half-reverted index, etc.).
+ *
+ * Usage:
+ *
+ * ```ts
+ * const db = await createIsolatedDatabase({ migrations: ['src/migrations/*.ts'] });
+ * try {
+ *   await db.dataSource.runMigrations();
+ *   // ...assert against db.dataSource...
+ * } finally {
+ *   await db.drop(); // drops the throwaway database, never the shared one
+ * }
+ * ```
+ */
+
+/** Connection/config knobs for a throwaway database. */
+export interface IsolatedDbOptions {
+  /**
+   * Glob(s) or class list passed to the DataSource `migrations` option. When
+   * omitted, defaults to the repo's ordered migration files so callers can just
+   * `runMigrations()`.
+   */
+  migrations?: DataSourceOptions['migrations'];
+  /** Entity classes/globs to register on the throwaway DataSource. */
+  entities?: DataSourceOptions['entities'];
+  /** Migrations history table name (defaults to TypeORM's `migrations`). */
+  migrationsTableName?: string;
+  /**
+   * SQL statements run *before* `runMigrations()` against the empty database —
+   * e.g. a minimal `token` table so migration #1's `ALTER TABLE "token"` has a
+   * target. Each is executed in order via `dataSource.query`.
+   */
+  seedSql?: string[];
+  /** Override the generated database name (mostly for debugging). */
+  databaseName?: string;
+}
+
+/** Handle to a provisioned throwaway database. */
+export interface IsolatedDb {
+  /** The unique database name created for this run. */
+  name: string;
+  /** An initialized DataSource scoped to the throwaway database. */
+  dataSource: DataSource;
+  /**
+   * Tear down: destroy the DataSource, then DROP the throwaway database via the
+   * admin connection. Idempotent and safe to call in `afterAll`.
+   */
+  drop: () => Promise<void>;
+}
+
+const baseConfig = DATABASE_CONFIG as DataSourceOptions & {
+  host?: string;
+  port?: number;
+  username?: string;
+  password?: string;
+  database?: string;
+};
+
+/** Maintenance DB used only to CREATE/DROP throwaway databases. */
+const ADMIN_DATABASE =
+  process.env.TG_TEST_DB_ADMIN_DATABASE || baseConfig.database || 'postgres';
+
+function uniqueDbName(prefix = 'tgr_test'): string {
+  const stamp = Date.now().toString(36);
+  const rand = Math.random().toString(36).slice(2, 8);
+  // Lower-case, no dashes — valid unquoted Postgres identifier.
+  return `${prefix}_${stamp}_${rand}`;
+}
+
+async function withAdminConnection<T>(
+  fn: (ds: DataSource) => Promise<T>,
+): Promise<T> {
+  const admin = new DataSource({
+    ...(baseConfig as DataSourceOptions),
+    database: ADMIN_DATABASE,
+    synchronize: false,
+    entities: [],
+    migrations: [],
+    logging: false,
+  } as DataSourceOptions);
+  await admin.initialize();
+  try {
+    return await fn(admin);
+  } finally {
+    await admin.destroy();
+  }
+}
+
+/**
+ * Create a fresh throwaway database, optionally seed it, and hand back an
+ * initialized DataSource scoped to it plus a `drop()` teardown. The shared
+ * application database is never modified.
+ */
+export async function createIsolatedDatabase(
+  options: IsolatedDbOptions = {},
+): Promise<IsolatedDb> {
+  if (!process.env.DB_HOST) {
+    throw new Error(
+      'createIsolatedDatabase requires DB_HOST (test Postgres) to be set.',
+    );
+  }
+
+  const name = options.databaseName || uniqueDbName();
+
+  // 1) CREATE DATABASE via the admin/maintenance connection.
+  await withAdminConnection(async (admin) => {
+    await admin.query(`CREATE DATABASE "${name}"`);
+  });
+
+  // 2) Connect to the throwaway database and seed it.
+  const dataSource = new DataSource({
+    ...(baseConfig as DataSourceOptions),
+    database: name,
+    synchronize: false,
+    entities: options.entities ?? [],
+    migrations: options.migrations ?? [
+      __dirname + '/../../src/migrations/*{.ts,.js}',
+    ],
+    migrationsTableName: options.migrationsTableName,
+    logging: false,
+  } as DataSourceOptions);
+
+  try {
+    await dataSource.initialize();
+    for (const sql of options.seedSql ?? []) {
+      await dataSource.query(sql);
+    }
+  } catch (err) {
+    // Roll back the half-provisioned database on a seed/init failure.
+    if (dataSource.isInitialized) {
+      await dataSource.destroy().catch(() => undefined);
+    }
+    await dropDatabase(name).catch(() => undefined);
+    throw err;
+  }
+
+  return {
+    name,
+    dataSource,
+    drop: async () => {
+      if (dataSource.isInitialized) {
+        await dataSource.destroy().catch(() => undefined);
+      }
+      await dropDatabase(name);
+    },
+  };
+}
+
+/**
+ * DROP a throwaway database, terminating any lingering backends first so the
+ * DROP cannot hang behind a stray connection. Never targets the shared DB.
+ */
+export async function dropDatabase(name: string): Promise<void> {
+  if (name === ADMIN_DATABASE || name === baseConfig.database) {
+    throw new Error(`refusing to drop the application database "${name}"`);
+  }
+  await withAdminConnection(async (admin) => {
+    await admin.query(
+      `SELECT pg_terminate_backend(pid)
+         FROM pg_stat_activity
+        WHERE datname = $1 AND pid <> pg_backend_pid()`,
+      [name],
+    );
+    await admin.query(`DROP DATABASE IF EXISTS "${name}"`);
+  });
+}
+
+/**
+ * Minimal stand-in for the production `token` table so migration #1
+ * (`ALTER TABLE "token" ADD COLUMN ...`) has a target inside the throwaway DB.
+ * The TGR migrations only add columns/indexes to `token`, so a single PK column
+ * is enough; we never need the full token schema here.
+ */
+export const MINIMAL_TOKEN_TABLE_SQL =
+  'CREATE TABLE "token" ("address" character varying NOT NULL, CONSTRAINT "PK_token_address" PRIMARY KEY ("address"))';
+
+/** Options for the dedicated-schema isolation helper. */
+export interface IsolatedSchemaOptions {
+  /** Entity classes/globs to materialize via `synchronize` in the schema. */
+  entities: DataSourceOptions['entities'];
+  /** Override the generated schema name (mostly for debugging). */
+  schemaName?: string;
+}
+
+/** Handle to a provisioned throwaway schema on the shared database. */
+export interface IsolatedSchema {
+  /** The unique schema name created for this run. */
+  schema: string;
+  /** An initialized DataSource scoped (`schema:`) to the throwaway schema. */
+  dataSource: DataSource;
+  /** Drop the schema CASCADE and destroy the DataSource. Idempotent. */
+  drop: () => Promise<void>;
+}
+
+/**
+ * Lighter-weight isolation for service/controller integration specs that do
+ * **not** test the migration SQL itself: create a fresh schema on the shared
+ * test database, `synchronize` the given entities into it (TypeORM emits the DDL
+ * un-prefixed so it lands in the schema), and scope a DataSource to it via
+ * `schema:`. Cheaper than a whole database, and good enough whenever the spec
+ * drives services/repositories rather than `runMigrations()`.
+ *
+ * Prefer {@link createIsolatedDatabase} for specs that exercise the real
+ * `migration:run`/`revert` path — those migrations hard-code `"public"` and so
+ * cannot be contained by a non-`public` schema.
+ *
+ * Mirrors the inline pattern already used by `rooms.integration.spec.ts`
+ * (`CREATE SCHEMA tgr13_test` → `schema: SCHEMA` → `DROP SCHEMA ... CASCADE`).
+ */
+export async function createIsolatedSchema(
+  options: IsolatedSchemaOptions,
+): Promise<IsolatedSchema> {
+  if (!process.env.DB_HOST) {
+    throw new Error(
+      'createIsolatedSchema requires DB_HOST (test Postgres) to be set.',
+    );
+  }
+  const schema =
+    options.schemaName ||
+    `tgr_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+
+  // Create the schema via a schema-less bootstrap connection.
+  const boot = new DataSource({
+    ...(baseConfig as DataSourceOptions),
+    synchronize: false,
+    entities: [],
+    migrations: [],
+    logging: false,
+  } as DataSourceOptions);
+  await boot.initialize();
+  try {
+    await boot.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`);
+    await boot.query(`CREATE SCHEMA "${schema}"`);
+  } finally {
+    await boot.destroy();
+  }
+
+  const dataSource = new DataSource({
+    ...(baseConfig as DataSourceOptions),
+    schema,
+    synchronize: true,
+    entities: options.entities,
+    migrations: [],
+    logging: false,
+  } as DataSourceOptions);
+  await dataSource.initialize();
+
+  return {
+    schema,
+    dataSource,
+    drop: async () => {
+      if (dataSource.isInitialized) {
+        await dataSource
+          .query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`)
+          .catch(() => undefined);
+        await dataSource.destroy().catch(() => undefined);
+      }
+    },
+  };
+}

--- a/test/harness/relay.ts
+++ b/test/harness/relay.ts
@@ -1,0 +1,83 @@
+import { Relay } from 'nostr-tools';
+
+/**
+ * Local relay fixture helper for relay-backed integration specs (Task 02 harness).
+ *
+ * During local runs a NIP-29 relay (`groups_relay` / strfry29) listens at
+ * `ws://localhost:7777` (override with `TG_RELAY_URL`). Relay-backed specs must
+ * **auto-skip** when it is unreachable so unit-only / no-container CI stays green.
+ *
+ * This centralizes the `relayReachable` probe + the relay-admin keypair that was
+ * copy-pasted across `relay-subscriber`, `relay-writer`, `room-admins`,
+ * `membership-sync` specs. New relay-backed specs should import from here instead
+ * of redefining it. (Existing specs already auto-skip correctly and are not
+ * rewritten — see the harness README.)
+ */
+
+/** Default relay URL for local runs; overridable via env. */
+export const RELAY_URL = process.env.TG_RELAY_URL || 'ws://localhost:7777';
+
+/**
+ * The relay-admin keypair (D7: the bot key under test == the relay admin so it
+ * may create managed groups on a freshly-booted relay). Defaults to the
+ * `groups_relay/config/settings.test.yml` pair; override via `TG_BOT_NSEC`.
+ */
+export const RELAY_ADMIN_NSEC =
+  process.env.TG_BOT_NSEC ||
+  'nsec1dwg3l5mumawgr4xq4kc6klagytkj2w4s4kd2rrthy47g3v5mwx8qwrh7sx';
+
+/**
+ * Probe whether a relay is reachable at `url`. Connects, immediately closes, and
+ * never throws — returns `false` on any failure so specs can `describe.skip`.
+ * A bounded timeout keeps a dead/wrong port from hanging the suite.
+ */
+export async function relayReachable(
+  url: string = RELAY_URL,
+  timeoutMs = 3000,
+): Promise<boolean> {
+  let relay: Relay | undefined;
+  try {
+    relay = await Promise.race([
+      Relay.connect(url),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error('relay connect timeout')), timeoutMs),
+      ),
+    ]);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    try {
+      relay?.close();
+    } catch {
+      // ignore — best-effort close
+    }
+  }
+}
+
+/**
+ * Resolve a `describe`/`describe.skip` for relay-backed specs: skips unless a
+ * relay is reachable (or `TG_RELAY_URL` was explicitly set, signalling an
+ * external relay the caller vouches for).
+ *
+ * ```ts
+ * let d = describe.skip;
+ * beforeAll(async () => { d = await relayDescribe(); });
+ * ```
+ *
+ * Because Jest needs the `describe` synchronously, most specs instead gate
+ * individual relay cases at runtime with `relayReachable()` inside `beforeAll`;
+ * this helper is for new specs that prefer a top-level gate.
+ */
+export async function relayDescribe(
+  url: string = RELAY_URL,
+): Promise<jest.Describe> {
+  const reachable = !!process.env.TG_RELAY_URL || (await relayReachable(url));
+  if (!reachable) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[harness/relay] skipping relay-backed cases — no relay at ${url}`,
+    );
+  }
+  return reachable ? describe : describe.skip;
+}

--- a/test/token-gated-rooms/identity.int-spec.ts
+++ b/test/token-gated-rooms/identity.int-spec.ts
@@ -1,0 +1,301 @@
+import 'dotenv/config';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken, TypeOrmModule } from '@nestjs/typeorm';
+import { EventEmitter2, EventEmitterModule } from '@nestjs/event-emitter';
+import { DataSource, Repository } from 'typeorm';
+import { DATABASE_CONFIG } from '@/configs/database';
+import { Account } from '@/account/entities/account.entity';
+import { Token } from '@/tokens/entities/token.entity';
+import { CommunityRoom } from '@/token-gated-rooms/entities/community-room.entity';
+import { RoomMembership } from '@/token-gated-rooms/entities/room-membership.entity';
+import { RoomNotificationPreference } from '@/token-gated-rooms/entities/room-notification-preference.entity';
+import { RoomMessageSeen } from '@/token-gated-rooms/entities/room-message-seen.entity';
+import { TokenBalance } from '@/token-gated-rooms/entities/token-balance.entity';
+import { RoomBackfillState } from '@/token-gated-rooms/entities/room-backfill-state.entity';
+import { IdentityService } from '@/token-gated-rooms/services/identity.service';
+import { IdentityBackfillService } from '@/token-gated-rooms/services/identity-backfill.service';
+import { TGR_LINK_CHANGED } from '@/token-gated-rooms/events';
+import tgrConfig from '@/token-gated-rooms/config/tgr.config';
+
+/**
+ * DB integration for Task 05 identity resolution. Applies the TGR migrations on
+ * the real local Postgres (DB_* env / repo .env), seeds `accounts` with mixed
+ * `links` + `room_membership` rows, then exercises:
+ *   - the one-time backfill → member_pubkey populated for linked holders, null
+ *     for unlinked, none malformed (unlinked invariant §6.6);
+ *   - a reactive link change (`tgr.link.changed`) for a previously-unlinked
+ *     holder → member_pubkey re-resolved + the signal re-fanned-out.
+ *
+ * Mirrors `src/token-gated-rooms/entities/migrations.integration.spec.ts`: an
+ * isolated migrations history table + best-effort drop so it owns a clean slate
+ * on the shared `public` schema.
+ *
+ * `nostr-tools/nip19` is mocked (the real module pulls in @noble/* ESM that
+ * ts-jest can't transform) with a fixed npub↔hex pair so normalization is real.
+ */
+const HEX_A = 'a'.repeat(64);
+const HEX_B = 'b'.repeat(64);
+const NPUB_B = 'npub1bbbb';
+
+jest.mock('nostr-tools/nip19', () => ({
+  decode: (value: string) => {
+    if (value === NPUB_B) return { type: 'npub', data: 'b'.repeat(64) };
+    throw new Error('invalid bech32');
+  },
+}));
+
+const HAS_DB = !!process.env.DB_HOST;
+const d = HAS_DB ? describe : describe.skip;
+
+const PROVIDER = 'nostr';
+
+// Holders covering each branch.
+const A_HEX = 'ak_int_hexlinked';
+const A_NPUB = 'ak_int_npublinked';
+const A_NONE = 'ak_int_nonostr';
+const A_OTHER = 'ak_int_otheronly';
+const A_MALFORMED = 'ak_int_malformed';
+const A_LATELINK = 'ak_int_latelink'; // unlinked at backfill, linked later
+const SALE = 'ct_int_sale_identity';
+
+async function dropTgrObjects(ds: DataSource): Promise<void> {
+  const stmts = [
+    `DROP TABLE IF EXISTS "room_backfill_state"`,
+    `DROP TABLE IF EXISTS "token_balance"`,
+    `DROP TABLE IF EXISTS "room_message_seen"`,
+    `DROP TABLE IF EXISTS "room_notification_preference"`,
+    `DROP TABLE IF EXISTS "room_membership"`,
+    `DROP TABLE IF EXISTS "community_room"`,
+    `DROP TYPE IF EXISTS "room_membership_relay_state_enum"`,
+    `DROP TYPE IF EXISTS "room_membership_role_enum"`,
+    `ALTER TABLE "token" DROP COLUMN IF EXISTS "nostr_room_state"`,
+    `ALTER TABLE "token" DROP COLUMN IF EXISTS "nostr_room_created_at"`,
+    `ALTER TABLE "token" DROP COLUMN IF EXISTS "has_nostr_room"`,
+    `ALTER TABLE "token" DROP COLUMN IF EXISTS "nostr_group_id"`,
+    `DROP TYPE IF EXISTS "token_nostr_room_state_enum"`,
+  ];
+  for (const s of stmts) {
+    await ds.query(s);
+  }
+  await ds
+    .query(`DELETE FROM "migrations" WHERE "name" LIKE 'Tgr%'`)
+    .catch(() => undefined);
+}
+
+d('IdentityService / IdentityBackfillService (integration)', () => {
+  let ds: DataSource;
+  let moduleRef: TestingModule;
+  let identity: IdentityService;
+  let backfill: IdentityBackfillService;
+  let accountRepo: Repository<Account>;
+  let membershipRepo: Repository<RoomMembership>;
+  let eventEmitter: EventEmitter2;
+
+  beforeAll(async () => {
+    // 1) Apply TGR migrations on the live DB via an isolated history table.
+    ds = new DataSource({
+      ...(DATABASE_CONFIG as any),
+      synchronize: false,
+      entities: [
+        Token,
+        Account,
+        CommunityRoom,
+        RoomMembership,
+        RoomNotificationPreference,
+        RoomMessageSeen,
+        TokenBalance,
+        RoomBackfillState,
+      ],
+      migrations: [__dirname + '/../../src/migrations/*{.ts,.js}'],
+      migrationsTableName: 'migrations_tgr_identity_test',
+    });
+    await ds.initialize();
+    await dropTgrObjects(ds);
+    await ds.runMigrations();
+
+    // 2) Nest module wiring the two services on the real DB + real event bus.
+    moduleRef = await Test.createTestingModule({
+      imports: [
+        EventEmitterModule.forRoot(),
+        TypeOrmModule.forRoot({
+          ...(DATABASE_CONFIG as any),
+          synchronize: false,
+          entities: [Account, RoomMembership, Token],
+        }),
+        TypeOrmModule.forFeature([Account, RoomMembership]),
+      ],
+      providers: [
+        IdentityService,
+        IdentityBackfillService,
+        {
+          provide: tgrConfig.KEY,
+          useValue: { nostrLinkProvider: PROVIDER, backfillBatchSize: 2 },
+        },
+      ],
+    }).compile();
+    // init() so @OnEvent subscriptions register on the event bus.
+    await moduleRef.init();
+
+    identity = moduleRef.get(IdentityService);
+    backfill = moduleRef.get(IdentityBackfillService);
+    accountRepo = moduleRef.get(getRepositoryToken(Account));
+    membershipRepo = moduleRef.get(getRepositoryToken(RoomMembership));
+    eventEmitter = moduleRef.get(EventEmitter2);
+  }, 90_000);
+
+  afterAll(async () => {
+    if (moduleRef) {
+      await cleanupRows();
+      await moduleRef.close();
+    }
+    if (ds?.isInitialized) {
+      for (let i = 0; i < 7; i++) {
+        await ds.undoLastMigration();
+      }
+      await ds.query('DROP TABLE IF EXISTS "migrations_tgr_identity_test"');
+      await ds.destroy();
+    }
+  }, 90_000);
+
+  const allAddresses = [
+    A_HEX,
+    A_NPUB,
+    A_NONE,
+    A_OTHER,
+    A_MALFORMED,
+    A_LATELINK,
+  ];
+
+  async function cleanupRows(): Promise<void> {
+    await membershipRepo.delete({ sale_address: SALE });
+    await accountRepo.delete(allAddresses.map((address) => ({ address })));
+  }
+
+  async function seed(): Promise<void> {
+    await cleanupRows();
+    await accountRepo.insert([
+      { address: A_HEX, links: { [PROVIDER]: HEX_A } },
+      { address: A_NPUB, links: { [PROVIDER]: NPUB_B } },
+      { address: A_NONE, links: {} },
+      { address: A_OTHER, links: { x: 'someone' } },
+      { address: A_MALFORMED, links: { [PROVIDER]: 'deadbeef' } },
+      { address: A_LATELINK, links: {} },
+    ]);
+    // One eligible membership row per holder (member_pubkey starts null).
+    await membershipRepo.insert(
+      allAddresses.map((member_address) => ({
+        sale_address: SALE,
+        member_address,
+        eligible: true,
+        relay_state: 'pending_add' as const,
+      })),
+    );
+  }
+
+  it('backfill populates member_pubkey for linked holders, null otherwise, none malformed', async () => {
+    await seed();
+
+    const result = await backfill.run({ batchSize: 2 });
+    expect(result.scanned).toBe(allAddresses.length);
+
+    const rows = await membershipRepo.find({ where: { sale_address: SALE } });
+    const byAddr = Object.fromEntries(
+      rows.map((r) => [r.member_address, r.member_pubkey]),
+    );
+
+    expect(byAddr[A_HEX]).toBe(HEX_A);
+    expect(byAddr[A_NPUB]).toBe(HEX_B); // npub normalized to hex
+    expect(byAddr[A_NONE]).toBeNull();
+    expect(byAddr[A_OTHER]).toBeNull();
+    // Unlinked invariant: malformed link → treated as unlinked (null), and the
+    // row is left eligible / pending_add (never advanced, never the bad value).
+    expect(byAddr[A_MALFORMED]).toBeNull();
+    const malformedRow = rows.find((r) => r.member_address === A_MALFORMED)!;
+    expect(malformedRow.eligible).toBe(true);
+    expect(malformedRow.relay_state).toBe('pending_add');
+    expect(byAddr[A_LATELINK]).toBeNull();
+
+    // No row ever holds a non-HEX64 value.
+    for (const r of rows) {
+      if (r.member_pubkey !== null) {
+        expect(/^[0-9a-f]{64}$/.test(r.member_pubkey)).toBe(true);
+      }
+    }
+
+    // Read API resolves through cache/DB consistently.
+    expect(await identity.getPubkeyForAddress(A_HEX)).toBe(HEX_A);
+    expect(await identity.getPubkeyForAddress(A_NPUB)).toBe(HEX_B);
+    expect(await identity.getPubkeyForAddress(A_NONE)).toBeNull();
+    expect(await identity.getAddressForPubkey(HEX_A)).toBe(A_HEX);
+    expect(await identity.getAddressForPubkey(NPUB_B)).toBe(A_NPUB);
+  });
+
+  it('reactive link change re-resolves member_pubkey and re-emits the signal', async () => {
+    await seed();
+    await backfill.run({ batchSize: 2 });
+
+    // Simulate the address-links seam: the account links nostr, then the event
+    // fires. We update the DB the way the reactive sync would, then emit.
+    await accountRepo.update(
+      { address: A_LATELINK },
+      { links: { [PROVIDER]: HEX_A } },
+    );
+
+    // Capture the re-fanned-out signal. The @OnEvent handler runs with
+    // emit:false (no re-broadcast), but we assert a *direct* reresolve re-emits
+    // and that the @OnEvent path updates the DB.
+    const seen: string[] = [];
+    const listener = (p: { address: string }) => seen.push(p.address);
+    eventEmitter.on(TGR_LINK_CHANGED, listener);
+
+    // Drive the @OnEvent handler by emitting the seam event and awaiting all
+    // async listeners.
+    await eventEmitter.emitAsync(TGR_LINK_CHANGED, { address: A_LATELINK });
+
+    eventEmitter.off(TGR_LINK_CHANGED, listener);
+
+    const row = await membershipRepo.findOneByOrFail({
+      sale_address: SALE,
+      member_address: A_LATELINK,
+    });
+    expect(row.member_pubkey).toBe(HEX_A);
+
+    // The originating emit reached our listener (and Task 06 would consume it
+    // too); the handler itself must NOT re-broadcast (loop-guard).
+    expect(seen).toEqual([A_LATELINK]);
+
+    // A direct reresolve (e.g. backfill correction) DOES re-emit.
+    const seen2: string[] = [];
+    const l2 = (p: { address: string }) => seen2.push(p.address);
+    eventEmitter.on(TGR_LINK_CHANGED, l2);
+    await identity.reresolveAddress(A_LATELINK);
+    eventEmitter.off(TGR_LINK_CHANGED, l2);
+    expect(seen2).toEqual([A_LATELINK]);
+  });
+
+  it('unlink nulls member_pubkey across rooms', async () => {
+    await seed();
+    await backfill.run({ batchSize: 2 });
+    expect(
+      (
+        await membershipRepo.findOneByOrFail({
+          sale_address: SALE,
+          member_address: A_HEX,
+        })
+      ).member_pubkey,
+    ).toBe(HEX_A);
+
+    // Unlink: remove the nostr key, then drive the handler.
+    await accountRepo.update({ address: A_HEX }, { links: {} });
+    await eventEmitter.emitAsync(TGR_LINK_CHANGED, { address: A_HEX });
+
+    const row = await membershipRepo.findOneByOrFail({
+      sale_address: SALE,
+      member_address: A_HEX,
+    });
+    expect(row.member_pubkey).toBeNull();
+    // Eligibility / relay_state untouched by this task.
+    expect(row.eligible).toBe(true);
+    expect(row.relay_state).toBe('pending_add');
+  });
+});

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -6,5 +6,5 @@
     "rootDir": "src",
     "tsBuildInfoFile": "./dist/tsconfig.build.tsbuildinfo"
   },
-  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+  "exclude": ["node_modules", "test", "dist", "scripts", "**/*spec.ts"]
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Large surface area: new migrations and relay/membership logic on boot, plus eligibility and balance emits tied to trading txs; misconfiguration or migration races could affect schema and room access at deploy time.
> 
> **Overview**
> This release bundles **token-gated NIP-29 rooms** into the main app: new TypeORM migrations and entities (`community_room`, `room_membership`, `token_balance`, access ledger, etc.), MDW plugins for AEX9 transfers and on-chain room state, balance/eligibility pipelines wired from BCL buy/sell, nostr link change events, push notification types and signed room-mute challenges, plus extensive `.env` knobs for relay provisioning/backfill. The module stays dormant until `TG_RELAY_URL` and `TG_BOT_NSEC` are set.
> 
> **Deploy and schema** move off `synchronize`: Docker runs `migrate:prod:locked` (Postgres advisory lock + keepalive) then `exec node dist/main` for graceful SIGTERM; TypeORM CLI scripts and `src/data-source.ts` support migrations in dev/prod.
> 
> **Popular feed** changes are documented in `docs/popular-post-ranking.md`: 48h freshness/velocity window, always-on interaction momentum, recursive thread comment counts, read dedup/caps, tie rotation, gentle age gravity on the `all` window only, longer Redis TTL, and a 10-minute locked cron refresh (24h/7d scheduled recomputes removed as unused).
> 
> **Product/API polish**: `GET /accounts/by-nostr` and `has_nostr` on account list; topic validation and lookups normalized for non-Latin scripts; trend mentions resolve Unicode token symbols and attach collection metadata; collection-name index migration and `CommunityFactoryService` helpers for multi-collection tokens.
> 
> **Stability**: shared `registerProcessGuards`, websocket/indexer interval cleanup with `.unref()`, Jest fixes for ESM `nostr-tools` and test path mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38603d011eecc7ba1174130091d8d8e8f30d0695. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->