### PR TITLE
feat: add collection info to the token list endpoints

### DIFF
--- a/src/ae/community-factory.service.spec.ts
+++ b/src/ae/community-factory.service.spec.ts
@@ -114,4 +114,91 @@ describe('CommunityFactoryService', () => {
     expect(result.collections['name-ak_1']).toBeDefined();
     expect(result.collections['name-ak_1'].allowed_name_length).toBe('10');
   });
+
+  describe('mapCollectionInfo', () => {
+    const collectionId = 'CHINESE-ak_deployer' as const;
+    const factory = {
+      collections: {
+        [collectionId]: {
+          id: collectionId,
+          name: 'CHINESE',
+          description: 'Chinese collection',
+          allowed_name_length: '20',
+          // Bulky per-char rules that must NOT leak into the trimmed output.
+          allowed_name_chars: [{ ascii: [97, 98, 99] }],
+        },
+      },
+    } as unknown as ICommunityFactorySchema;
+
+    it('maps a known collection id to its trimmed metadata', () => {
+      expect(service.mapCollectionInfo(factory, collectionId)).toEqual({
+        id: collectionId,
+        name: 'CHINESE',
+        description: 'Chinese collection',
+        allowed_name_length: '20',
+      });
+    });
+
+    it('omits allowed_name_chars from the mapped result', () => {
+      const result = service.mapCollectionInfo(factory, collectionId);
+      expect(result).not.toHaveProperty('allowed_name_chars');
+    });
+
+    it('returns null for an unknown collection id', () => {
+      expect(service.mapCollectionInfo(factory, 'UNKNOWN-ak_x')).toBeNull();
+    });
+
+    it.each([[undefined], [null], ['']])(
+      'returns null for an empty collection id (%p)',
+      (collection) => {
+        expect(
+          service.mapCollectionInfo(factory, collection as any),
+        ).toBeNull();
+      },
+    );
+  });
+
+  describe('getCollectionInfo', () => {
+    const collectionId = 'CHINESE-ak_deployer' as const;
+
+    beforeEach(() => {
+      const factoryAddress = 'ct_cached' as Encoded.ContractAddress;
+      BCL_FACTORY[ACTIVE_NETWORK.networkId] = {
+        address: factoryAddress,
+      } as ICommunityFactorySchema;
+      // Prime the cache so getCurrentFactory resolves without touching the chain.
+      service.cachedFactorySchema[factoryAddress] = {
+        address: factoryAddress,
+        collections: {
+          [collectionId]: {
+            id: collectionId,
+            name: 'CHINESE',
+            description: 'Chinese collection',
+            allowed_name_length: '20',
+            allowed_name_chars: [],
+          },
+        },
+      } as unknown as ICommunityFactorySchema;
+    });
+
+    it('resolves a known collection id against the current factory', async () => {
+      await expect(service.getCollectionInfo(collectionId)).resolves.toEqual({
+        id: collectionId,
+        name: 'CHINESE',
+        description: 'Chinese collection',
+        allowed_name_length: '20',
+      });
+    });
+
+    it('short-circuits to null for an empty id without loading the factory', async () => {
+      await expect(service.getCollectionInfo('')).resolves.toBeNull();
+      expect(initCommunityFactory).not.toHaveBeenCalled();
+    });
+
+    it('returns null when the id is unknown to the current factory', async () => {
+      await expect(
+        service.getCollectionInfo('UNKNOWN-ak_x'),
+      ).resolves.toBeNull();
+    });
+  });
 });

--- a/src/ae/community-factory.service.ts
+++ b/src/ae/community-factory.service.ts
@@ -2,7 +2,7 @@ import { Encoded } from '@aeternity/aepp-sdk';
 import { Injectable } from '@nestjs/common';
 import { CommunityFactory, initCommunityFactory } from 'bctsl-sdk';
 import { ACTIVE_NETWORK, BCL_FACTORY } from '@/configs';
-import { ICommunityFactorySchema } from '@/utils/types';
+import { ICollectionInfo, ICommunityFactorySchema } from '@/utils/types';
 import { AeSdkService } from './ae-sdk.service';
 
 @Injectable()
@@ -85,5 +85,44 @@ export class CommunityFactoryService {
     this.cachedFactorySchema[factory.address] = factory;
 
     return factory;
+  }
+
+  /**
+   * Maps a token's stored collection id (the "<NAME>-ak_<deployer>" string) to
+   * its trimmed collection metadata using an already-loaded factory schema.
+   * Returns null when the token has no collection or the collection is unknown.
+   * Prefer this over {@link getCollectionInfo} when enriching many items — load
+   * the factory once and reuse it instead of awaiting per item.
+   */
+  mapCollectionInfo(
+    factory: ICommunityFactorySchema,
+    collectionId?: string | null,
+  ): ICollectionInfo | null {
+    const collection = collectionId
+      ? factory.collections?.[collectionId]
+      : undefined;
+    if (!collection) {
+      return null;
+    }
+    return {
+      id: collection.id,
+      name: collection.name,
+      description: collection.description,
+      allowed_name_length: collection.allowed_name_length,
+    };
+  }
+
+  /**
+   * Resolves the trimmed collection metadata for a single collection id.
+   * Returns null when the id is empty or unknown to the current factory.
+   */
+  async getCollectionInfo(
+    collectionId?: string | null,
+  ): Promise<ICollectionInfo | null> {
+    if (!collectionId) {
+      return null;
+    }
+    const factory = await this.getCurrentFactory();
+    return this.mapCollectionInfo(factory, collectionId);
   }
 }

--- a/src/social/controllers/posts.controller.spec.ts
+++ b/src/social/controllers/posts.controller.spec.ts
@@ -56,6 +56,7 @@ describe('PostsController', () => {
       {} as any,
       {} as any,
       {} as any,
+      {} as any,
     );
   });
 
@@ -101,6 +102,10 @@ describe('PostsController', () => {
       {
         getProfilesByAddresses: jest.fn().mockResolvedValue([]),
       } as any,
+      {
+        getCurrentFactory: jest.fn().mockResolvedValue({ collections: {} }),
+        mapCollectionInfo: jest.fn().mockReturnValue(null),
+      } as any,
     );
 
     await popularController.popular({
@@ -122,6 +127,7 @@ describe('PostsController', () => {
     const attachTrendMentions = (
       items: Array<{ id: string; content: string }>,
       tokens: Array<Record<string, any>>,
+      collections: Record<string, any> = {},
     ) => {
       const tokenQueryBuilder = {
         leftJoinAndMapOne: jest.fn().mockReturnThis(),
@@ -133,12 +139,31 @@ describe('PostsController', () => {
       const tokenRepository = {
         createQueryBuilder: jest.fn().mockReturnValue(tokenQueryBuilder),
       };
+      // Faithful stand-in for CommunityFactoryService.mapCollectionInfo so the
+      // resolved collection badge reflects the real lookup behaviour.
+      const communityFactoryService = {
+        getCurrentFactory: jest.fn().mockResolvedValue({ collections }),
+        mapCollectionInfo: jest.fn((factory, collectionId) => {
+          const collection = collectionId
+            ? factory?.collections?.[collectionId]
+            : undefined;
+          return collection
+            ? {
+                id: collection.id,
+                name: collection.name,
+                description: collection.description,
+                allowed_name_length: collection.allowed_name_length,
+              }
+            : null;
+        }),
+      };
       const trendController = new PostsController(
         {} as any,
         tokenRepository as any,
         {} as any,
         {} as any,
         {} as any,
+        communityFactoryService as any,
       );
 
       return {
@@ -164,6 +189,7 @@ describe('PostsController', () => {
         {
           name: '汉字',
           sale_address: 'ct_chinese',
+          collection_info: null,
           performance: { pct: 1 },
         },
       ]);
@@ -182,7 +208,12 @@ describe('PostsController', () => {
         { names: ['ПРИВЕТ'] },
       );
       expect((items[0] as any).trend_mentions).toEqual([
-        { name: 'ПРИВЕТ', sale_address: 'ct_russian', performance: null },
+        {
+          name: 'ПРИВЕТ',
+          sale_address: 'ct_russian',
+          collection_info: null,
+          performance: null,
+        },
       ]);
     });
 
@@ -196,8 +227,18 @@ describe('PostsController', () => {
       await run();
 
       expect((items[0] as any).trend_mentions).toEqual([
-        { name: 'WORDS-1', sale_address: 'ct_words', performance: null },
-        { name: '汉字', sale_address: 'ct_chinese', performance: null },
+        {
+          name: 'WORDS-1',
+          sale_address: 'ct_words',
+          collection_info: null,
+          performance: null,
+        },
+        {
+          name: '汉字',
+          sale_address: 'ct_chinese',
+          collection_info: null,
+          performance: null,
+        },
       ]);
     });
 
@@ -208,7 +249,52 @@ describe('PostsController', () => {
       await run();
 
       expect((items[0] as any).trend_mentions).toEqual([
-        { name: '汉字', sale_address: null, performance: null },
+        {
+          name: '汉字',
+          sale_address: null,
+          collection_info: null,
+          performance: null,
+        },
+      ]);
+    });
+
+    it('attaches resolved collection metadata to a mentioned token', async () => {
+      const items = [{ id: 'post-5', content: 'buying #汉字' }];
+      const collectionId = '汉字-ak_deployer';
+      const { run } = attachTrendMentions(
+        items,
+        [
+          {
+            symbol: '汉字',
+            sale_address: 'ct_chinese',
+            collection: collectionId,
+            performance: null,
+          },
+        ],
+        {
+          [collectionId]: {
+            id: collectionId,
+            name: '汉字',
+            description: 'Chinese collection',
+            allowed_name_length: '20',
+          },
+        },
+      );
+
+      await run();
+
+      expect((items[0] as any).trend_mentions).toEqual([
+        {
+          name: '汉字',
+          sale_address: 'ct_chinese',
+          collection_info: {
+            id: collectionId,
+            name: '汉字',
+            description: 'Chinese collection',
+            allowed_name_length: '20',
+          },
+          performance: null,
+        },
       ]);
     });
   });

--- a/src/social/controllers/posts.controller.ts
+++ b/src/social/controllers/posts.controller.ts
@@ -29,6 +29,7 @@ import { TokenPerformanceView } from '@/tokens/entities/tokens-performance.view'
 import { PopularRankingContentItem } from '@/plugins/popular-ranking.interface';
 import { extractTrendMentions } from '../utils/content-parser.util';
 import { ProfileReadService } from '@/profile/services/profile-read.service';
+import { CommunityFactoryService } from '@/ae/community-factory.service';
 import {
   OpaqueIdPipe,
   OptionalAeAccountAddressPipe,
@@ -45,6 +46,7 @@ export class PostsController {
     private readonly popularRankingService: PopularRankingService,
     private readonly readsService: ReadsService,
     private readonly profileReadService: ProfileReadService,
+    private readonly communityFactoryService: CommunityFactoryService,
   ) {
     //
   }
@@ -106,6 +108,10 @@ export class PostsController {
       }
     }
 
+    // Loaded once so every mention resolves its collection badge from the same
+    // cached factory schema instead of awaiting per mention.
+    const factory = await this.communityFactoryService.getCurrentFactory();
+
     for (const item of items) {
       const names = mentionsByPost.get(item.id);
       if (!names) {
@@ -116,6 +122,10 @@ export class PostsController {
         return {
           name,
           sale_address: token?.sale_address ?? null,
+          collection_info: this.communityFactoryService.mapCollectionInfo(
+            factory,
+            token?.collection,
+          ),
           performance: token?.performance ?? null,
         };
       });

--- a/src/social/dto/post-trend-mention.dto.ts
+++ b/src/social/dto/post-trend-mention.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { PerformancePeriodDto } from '@/tokens/dto/performance-period.dto';
+import { CollectionInfoDto } from '@/tokens/dto/collection-info.dto';
 
 export class TrendPerformanceSummaryDto {
   @ApiProperty({ type: () => PerformancePeriodDto, nullable: true })
@@ -27,6 +28,15 @@ export class PostTrendMentionDto {
     nullable: true,
   })
   sale_address?: string | null;
+
+  @ApiProperty({
+    description:
+      "Collection metadata for the mentioned token's collection, or null " +
+      'when the token is unresolved / has no known collection.',
+    type: () => CollectionInfoDto,
+    nullable: true,
+  })
+  collection_info?: CollectionInfoDto | null;
 
   @ApiProperty({
     description: 'Performance summary for 24h and 7d windows',

--- a/src/social/post.module.ts
+++ b/src/social/post.module.ts
@@ -20,11 +20,13 @@ import { GovernancePluginModule } from '@/plugins/governance/governance-plugin.m
 import { getPopularRankingContributorProvider } from '@/plugins';
 import { ProfileModule } from '@/profile/profile.module';
 import { TokensModule } from '@/tokens/tokens.module';
+import { AeModule } from '@/ae/ae.module';
 
 @Module({
   imports: [
     ProfileModule,
     TokensModule,
+    AeModule,
     TransactionsModule,
     GovernancePluginModule, // Import to access GovernancePopularRankingService
     TypeOrmModule.forFeature([

--- a/src/tokens/dto/collection-info.dto.ts
+++ b/src/tokens/dto/collection-info.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CollectionInfoDto {
+  @ApiProperty({
+    description: 'Full collection id, "<NAME>-ak_<deployer>"',
+    example: 'CHINESE-ak_2AoM8kAJn9Q6zVbxjfoBUfMkyfP8SxgoZ2Nw88M4Xd8Xk8ct6r',
+  })
+  id: string;
+
+  @ApiProperty({
+    description: 'Human-readable collection name (badge label)',
+    example: 'CHINESE',
+  })
+  name: string;
+
+  @ApiProperty({ required: false, nullable: true })
+  description?: string;
+
+  @ApiProperty({
+    description: 'Max token name length allowed in this collection',
+    example: '20',
+  })
+  allowed_name_length: string;
+}

--- a/src/tokens/dto/token.dto.ts
+++ b/src/tokens/dto/token.dto.ts
@@ -1,6 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { PriceDto } from './price.dto';
 import { TokenPerformanceDto } from './token-performance.dto';
+import { CollectionInfoDto } from './collection-info.dto';
 
 export class TokenDto {
   @ApiProperty()
@@ -35,6 +36,15 @@ export class TokenDto {
 
   @ApiProperty()
   collection: string;
+
+  @ApiProperty({
+    description:
+      "Resolved metadata for the token's collection, or null when the " +
+      'token has no collection / the collection is unknown to the factory.',
+    type: () => CollectionInfoDto,
+    nullable: true,
+  })
+  collection_info: CollectionInfoDto | null;
 
   @ApiProperty()
   metaInfo: Record<string, string>;

--- a/src/tokens/tokens.controller.spec.ts
+++ b/src/tokens/tokens.controller.spec.ts
@@ -159,7 +159,8 @@ describe('TokensController', () => {
           useValue: {
             getCurrentFactory: jest
               .fn()
-              .mockResolvedValue({ address: 'ct_123' }),
+              .mockResolvedValue({ address: 'ct_123', collections: {} }),
+            mapCollectionInfo: jest.fn().mockReturnValue(null),
           },
         },
       ],
@@ -272,7 +273,10 @@ describe('TokensController', () => {
   });
 
   it('should return cached trending-score token lists', async () => {
-    cacheManager.get.mockResolvedValueOnce({ items: ['cached'], meta: {} });
+    cacheManager.get.mockResolvedValueOnce({
+      items: [{ sale_address: 'ct_a', collection: 'CHINESE-ak_x' }],
+      meta: {},
+    });
 
     const result = await controller.listAll(
       undefined,
@@ -286,9 +290,46 @@ describe('TokensController', () => {
       'all',
     );
 
-    expect(result).toEqual({ items: ['cached'], meta: {} });
+    expect((result as any).items[0].sale_address).toBe('ct_a');
     expect(tokensService.applyListEligibilityFilters).not.toHaveBeenCalled();
     expect(tokensService.queryTokensWithRanks).not.toHaveBeenCalled();
+  });
+
+  it('enriches cached trending-score token lists with collection_info on read', async () => {
+    // Simulate an entry cached before collection_info existed: it lacks the
+    // field, but the hit path must still resolve and attach it.
+    cacheManager.get.mockResolvedValueOnce({
+      items: [{ sale_address: 'ct_a', collection: 'CHINESE-ak_x' }],
+      meta: {},
+    });
+    const collectionInfo = {
+      id: 'CHINESE-ak_x',
+      name: 'CHINESE',
+      description: 'Chinese collection',
+      allowed_name_length: '20',
+    };
+    (communityFactoryService.mapCollectionInfo as jest.Mock).mockReturnValue(
+      collectionInfo,
+    );
+
+    const result = await controller.listAll(
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      1,
+      100,
+      'trending_score',
+      'DESC',
+      'all',
+    );
+
+    expect(tokensService.queryTokensWithRanks).not.toHaveBeenCalled();
+    expect(communityFactoryService.mapCollectionInfo).toHaveBeenCalledWith(
+      expect.anything(),
+      'CHINESE-ak_x',
+    );
+    expect((result as any).items[0].collection_info).toEqual(collectionInfo);
   });
 
   it('should not collide trending cache keys when filter values contain separators', async () => {
@@ -334,6 +375,7 @@ describe('TokensController', () => {
       rank: 5,
       total_supply: { toNumber: expect.any(Function) },
       factory_address: 'ct_123',
+      collection_info: null,
     });
   });
 

--- a/src/tokens/tokens.controller.ts
+++ b/src/tokens/tokens.controller.ts
@@ -67,6 +67,28 @@ export class TokensController {
     //
   }
 
+  /**
+   * Attaches the resolved `collection_info` badge object to each token, mapping
+   * the stored `collection` id through the factory's collection registry. The
+   * factory schema is loaded once for the whole batch. Tokens with no/unknown
+   * collection get `collection_info: null`.
+   */
+  private async attachCollectionInfo(
+    items: Array<{ collection?: string | null }>,
+  ): Promise<void> {
+    if (!items?.length) {
+      return;
+    }
+    const factory = await this.communityFactoryService.getCurrentFactory();
+    for (const item of items) {
+      (item as any).collection_info =
+        this.communityFactoryService.mapCollectionInfo(
+          factory,
+          item?.collection,
+        );
+    }
+  }
+
   private validatePagination(page: number, limit: number): void {
     if (page < 1) {
       throw new BadRequestException('Page must be greater than or equal to 1');
@@ -190,6 +212,10 @@ export class TokensController {
       const cached =
         await this.cacheManager.get<Pagination<Token>>(trendingCacheKey);
       if (cached) {
+        // Enrich on read as well: entries cached before collection_info existed
+        // (or with stale collection metadata) must still carry the field on the
+        // hit path, which otherwise returns before attachCollectionInfo runs.
+        await this.attachCollectionInfo(cached.items);
         return cached;
       }
     }
@@ -272,6 +298,8 @@ export class TokensController {
       );
     }
 
+    await this.attachCollectionInfo(result.items);
+
     if (trendingCacheKey) {
       await this.cacheManager.set(
         trendingCacheKey,
@@ -308,6 +336,10 @@ export class TokensController {
   })
   async findByAddress(@Param('address') address: string) {
     const token = await this.tokensService.getToken(address);
+
+    if (token) {
+      await this.attachCollectionInfo([token as any]);
+    }
 
     return token;
   }
@@ -455,6 +487,14 @@ export class TokensController {
       token.sale_address,
       halfLimit,
     ]);
+
+    for (const rankedToken of rankedTokens) {
+      rankedToken.collection_info =
+        this.communityFactoryService.mapCollectionInfo(
+          factory,
+          rankedToken?.collection,
+        );
+    }
 
     return {
       items: rankedTokens,

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -216,3 +216,13 @@ export type ICommunityFactorySchema = {
     };
   };
 };
+
+/**
+ * Trimmed collection metadata surfaced to API clients (e.g. as a token's
+ * collection badge). Drops `allowed_name_chars` — the bulky per-character
+ * validation rules are not needed on token/mention list responses.
+ */
+export type ICollectionInfo = Pick<
+  ICommunityFactorySchema['collections'][keyof ICommunityFactorySchema['collections']],
+  'id' | 'name' | 'description' | 'allowed_name_length'
+>;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive API fields and read-path enrichment using cached factory schema; no auth or persistence changes. Extra factory load per affected request batch is bounded by existing caching.
> 
> **Overview**
> Adds **`collection_info`** (trimmed factory collection metadata: id, name, description, `allowed_name_length`, without bulky `allowed_name_chars`) to token list/detail/rankings responses and to post **`trend_mentions`**.
> 
> **`CommunityFactoryService`** gains **`mapCollectionInfo`** (batch-friendly, one loaded factory) and **`getCollectionInfo`** (single-id). **`TokensController`** uses **`attachCollectionInfo`** after queries and **on trending list cache hits** so older cached payloads still get the field. **`PostsController`** loads the factory once when attaching trend mentions and maps each resolved token’s `collection` id. Swagger types: new **`CollectionInfoDto`**, wired on **`TokenDto`** and **`PostTrendMentionDto`**. **`PostModule`** imports **`AeModule`** for factory access.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 377b4506a726519baa255973c8aec010380fd808. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->