### PR TITLE
refactor: adjust popular post ranking

### DIFF
--- a/src/configs/constants.ts
+++ b/src/configs/constants.ts
@@ -275,9 +275,30 @@ export const POPULAR_RANKING_CONFIG = {
   // trending scaling
   TRENDING_MAX_SCORE: 100, // scale trending tag score to [0..1]
 
-  // live popular behavior — 48h, not 24h: on a low-activity network posts
-  // need longer to gather their fair share of signal
-  FRESHNESS_BOOST_HOURS: 48,
+  // Freshness curve (all-time feed de-staling). A new post carries a full
+  // freshness lift for its first ~5 days, then the lift fades linearly to zero
+  // by ~10 days. After that the stale penalty below takes over. On a
+  // low-activity network posts need days, not hours, to gather their signal.
+  FRESHNESS_FULL_BOOST_HOURS: 120, // 5 days at full freshness factor (=1)
+  FRESHNESS_BOOST_HOURS: 240, // freshness factor reaches 0 by 10 days
+
+  // Beyond the freshness window a post with no interaction inside
+  // VELOCITY_WINDOW_HOURS is actively demoted so dead evergreen content sinks
+  // instead of pinning the feed forever. The penalty grows with age (deadest
+  // posts sink furthest) and is applied after age gravity. Any recent activity
+  // (a fresh comment/tip) revives the post and zeroes the penalty — "become
+  // minus unless new activity appears".
+  STALE_PENALTY_START_HOURS: 240, // begins where the freshness lift ends
+  STALE_PENALTY_RAMP_HOURS: 240, // reaches the full penalty 10 days later
+  STALE_PENALTY_MAX: 5, // max score subtracted from a fully-stale post
+
+  // Deterministic per-UTC-day multiplicative jitter applied to the default
+  // (non-personalized) feed's final score so the visible order rotates daily
+  // instead of being frozen between recomputes. Stable within a UTC day so
+  // pagination stays consistent through the day; reseeds at midnight UTC.
+  // ±20%: enough to reshuffle the dense engaged middle, too small to let a
+  // clearly weaker post leapfrog a clearly stronger one.
+  DAILY_SHUFFLE_MAGNITUDE: 0.2,
 
   // velocity looks at interactions inside this window (divided by post age
   // when the post is younger), so an old post catching fire still registers

--- a/src/social/services/popular-ranking.service.spec.ts
+++ b/src/social/services/popular-ranking.service.spec.ts
@@ -1014,21 +1014,21 @@ describe('PopularRankingService', () => {
     });
 
     it('keeps a positive velocity contribution past the freshness window on default weights', () => {
-      // Both posts are past FRESHNESS_BOOST_HOURS with identical totals, so
-      // freshness-gated terms are zero for both and any score gap comes from
-      // the always-on interactionsPerHour term.
+      // Both posts are the same age and past FRESHNESS_BOOST_HOURS, so the
+      // freshness-gated terms are zero for both and there is no gravity/penalty
+      // to confound them (7d window). The only gap comes from the always-on
+      // interactionsPerHour term, driven here by recent activity.
+      const age = POPULAR_RANKING_CONFIG.FRESHNESS_BOOST_HOURS + 60;
       const weights = (service as any).resolveWeights();
       const momentum = (service as any).computeScore(
         noTrending,
-        scoreInput(POPULAR_RANKING_CONFIG.FRESHNESS_BOOST_HOURS + 10, {
-          comments: 48,
-        }),
+        scoreInput(age, { comments: 48, recentInteractions: 96 }),
         weights,
         '7d',
       );
       const slowBurn = (service as any).computeScore(
         noTrending,
-        scoreInput(160, { comments: 48 }),
+        scoreInput(age, { comments: 48, recentInteractions: 0 }),
         weights,
         '7d',
       );
@@ -1209,6 +1209,72 @@ describe('PopularRankingService', () => {
       const svc = service as any;
       expect(svc.computeTieRotation(undefined)).toBe(0);
       expect(svc.computeTieRotation('')).toBe(0);
+    });
+
+    it('holds full freshness for the boost plateau then fades to zero', () => {
+      const svc = service as any;
+      const full = POPULAR_RANKING_CONFIG.FRESHNESS_FULL_BOOST_HOURS;
+      const zero = POPULAR_RANKING_CONFIG.FRESHNESS_BOOST_HOURS;
+
+      // Anywhere inside the plateau the factor is a flat 1.
+      expect(svc.computeFreshnessFactor(scoreInput(1))).toBeCloseTo(1);
+      expect(svc.computeFreshnessFactor(scoreInput(full - 1))).toBeCloseTo(1);
+      // Midway through the fade it is partial, and it hits 0 at the window end.
+      const mid = svc.computeFreshnessFactor(scoreInput((full + zero) / 2));
+      expect(mid).toBeGreaterThan(0);
+      expect(mid).toBeLessThan(1);
+      expect(svc.computeFreshnessFactor(scoreInput(zero + 1))).toBe(0);
+    });
+
+    it('demotes stale posts by age unless recent activity revives them', () => {
+      const svc = service as any;
+      const start = POPULAR_RANKING_CONFIG.STALE_PENALTY_START_HOURS;
+      const ramp = POPULAR_RANKING_CONFIG.STALE_PENALTY_RAMP_HOURS;
+      const max = POPULAR_RANKING_CONFIG.STALE_PENALTY_MAX;
+
+      // Inside the freshness window: never penalized.
+      expect(
+        svc.computeStalePenalty(
+          scoreInput(start - 10, { recentInteractions: 0 }),
+        ),
+      ).toBe(0);
+      // Past the window with no recent activity: penalty grows with age...
+      const younger = svc.computeStalePenalty(
+        scoreInput(start + ramp / 4, { recentInteractions: 0 }),
+      );
+      const older = svc.computeStalePenalty(
+        scoreInput(start + ramp / 2, { recentInteractions: 0 }),
+      );
+      expect(older).toBeGreaterThan(younger);
+      expect(younger).toBeGreaterThan(0);
+      // ...and is capped.
+      expect(
+        svc.computeStalePenalty(
+          scoreInput(start + ramp * 10, { recentInteractions: 0 }),
+        ),
+      ).toBeCloseTo(max);
+      // Recent activity revives the post; unknown activity (plugin items) is
+      // never penalized.
+      expect(
+        svc.computeStalePenalty(
+          scoreInput(start + ramp, { recentInteractions: 1 }),
+        ),
+      ).toBe(0);
+      expect(svc.computeStalePenalty(scoreInput(start + ramp))).toBe(0);
+    });
+
+    it('applies bounded, per-day-deterministic shuffle jitter', () => {
+      const svc = service as any;
+      const mag = POPULAR_RANKING_CONFIG.DAILY_SHUFFLE_MAGNITUDE;
+      const first = svc.computeDailyJitter('post-a');
+      const second = svc.computeDailyJitter('post-a');
+      const other = svc.computeDailyJitter('post-b');
+
+      expect(first).toBe(second);
+      expect(Math.abs(first)).toBeLessThanOrEqual(mag);
+      expect(other).not.toBe(first);
+      expect(svc.computeDailyJitter(undefined)).toBe(0);
+      expect(svc.computeDailyJitter('')).toBe(0);
     });
 
     it('penalizes short emoji-only posts in content quality', () => {

--- a/src/social/services/popular-ranking.service.ts
+++ b/src/social/services/popular-ranking.service.ts
@@ -806,6 +806,9 @@ export class PopularRankingService implements OnModuleDestroy {
 
     const trendingByTag = await this.loadTrendingByTagMap();
     const resolvedWeights = this.resolveWeights(weightOverrides);
+    // Personalized (weight-override) queries stay deterministic; only the
+    // default cached feed gets the daily rotation.
+    const applyDailyShuffle = !this.hasWeightOverrides(weightOverrides);
 
     const scoredPosts: PopularScoreItem[] = candidates.map((post) => {
       const tipsAgg = tipsByPost.get(post.id);
@@ -833,6 +836,7 @@ export class PopularRankingService implements OnModuleDestroy {
           },
           resolvedWeights,
           window,
+          applyDailyShuffle,
         ),
         type: 'post',
       };
@@ -856,6 +860,7 @@ export class PopularRankingService implements OnModuleDestroy {
           },
           resolvedWeights,
           window,
+          applyDailyShuffle,
         ),
         type: item.type,
         metadata: item.metadata,
@@ -1052,12 +1057,79 @@ export class PopularRankingService implements OnModuleDestroy {
       return 0;
     }
 
-    const boostHours = POPULAR_RANKING_CONFIG.FRESHNESS_BOOST_HOURS;
-    if (ageHours >= boostHours) {
+    const full = POPULAR_RANKING_CONFIG.FRESHNESS_FULL_BOOST_HOURS;
+    const zero = POPULAR_RANKING_CONFIG.FRESHNESS_BOOST_HOURS;
+
+    // Full lift for the first few days, then a linear fade to zero. A plateau
+    // (instead of decaying from age 0) gives new posts a real window to gather
+    // signal on a low-activity network before their boost starts eroding.
+    if (ageHours <= full) {
+      return 1;
+    }
+    if (ageHours >= zero) {
+      return 0;
+    }
+    return (zero - ageHours) / (zero - full);
+  }
+
+  /**
+   * Active demotion for posts past the freshness window that have gone quiet.
+   * Grows with age (deadest posts sink furthest) and is applied after gravity
+   * so an older dead post ranks below a younger dead one — the opposite of what
+   * dividing a fixed penalty by the gravity term would produce. Any interaction
+   * inside VELOCITY_WINDOW_HOURS (recentInteractions > 0) revives the post and
+   * cancels the penalty. Sources without recent-activity data (plugin items,
+   * recentInteractions === undefined) are never penalized.
+   */
+  private computeStalePenalty(input: PopularScoreInput): number {
+    const ageHours = this.computeAgeHours(input.createdAt, 0);
+    if (ageHours === null) {
       return 0;
     }
 
-    return Math.max(0, 1 - ageHours / boostHours);
+    const start = POPULAR_RANKING_CONFIG.STALE_PENALTY_START_HOURS;
+    if (ageHours <= start) {
+      return 0;
+    }
+
+    if (input.recentInteractions === undefined) {
+      return 0;
+    }
+    if (input.recentInteractions > 0) {
+      return 0;
+    }
+
+    const ramp = Math.min(
+      1,
+      (ageHours - start) / POPULAR_RANKING_CONFIG.STALE_PENALTY_RAMP_HOURS,
+    );
+    return POPULAR_RANKING_CONFIG.STALE_PENALTY_MAX * ramp;
+  }
+
+  /**
+   * Deterministic per-UTC-day multiplicative jitter in [-mag, +mag] seeded by
+   * (id + day) so the default feed's order rotates daily instead of being
+   * frozen between recomputes. Stable within a UTC day → pagination stays
+   * consistent; reseeds at midnight UTC. Only the default (non-personalized)
+   * feed is shuffled — personalized weight-override queries stay deterministic.
+   */
+  private computeDailyJitter(id?: string): number {
+    if (!id) {
+      return 0;
+    }
+
+    const dayBucket = Math.floor(Date.now() / (24 * 60 * 60 * 1000));
+    const seed = `${id}:${dayBucket}`;
+    let hash = 0x811c9dc5; // FNV-1a
+    for (let i = 0; i < seed.length; i++) {
+      hash ^= seed.charCodeAt(i);
+      hash = Math.imul(hash, 0x01000193);
+    }
+
+    const normalized = (hash >>> 0) / 0x100000000; // [0, 1)
+    return (
+      (normalized * 2 - 1) * POPULAR_RANKING_CONFIG.DAILY_SHUFFLE_MAGNITUDE
+    );
   }
 
   private computeScore(
@@ -1065,6 +1137,7 @@ export class PopularRankingService implements OnModuleDestroy {
     input: PopularScoreInput,
     weights: PopularRankingResolvedWeights,
     window: PopularWindow,
+    applyDailyShuffle = true,
   ): number {
     const { comments, tipsAmountAE, tipsCount, uniqueTippers, reads } = input;
 
@@ -1112,18 +1185,28 @@ export class PopularRankingService implements OnModuleDestroy {
       weights.interactionsPerHour * Math.log(1 + interactionsPerHour) +
       this.computeTieRotation(input.id);
 
+    // Daily rotation is applied before gravity/penalty so it scales the whole
+    // final score. Only the default feed is shuffled (see computeDailyJitter);
+    // an id-less input (unit tests, sources without an id) jitters by 0.
+    const shuffle = applyDailyShuffle
+      ? 1 + this.computeDailyJitter(input.id)
+      : 1;
+
     if (window !== 'all') {
-      return baseScore;
+      return baseScore * shuffle;
     }
 
     // Log-dampened engagement never decays on its own, so without gravity old
     // high-total posts pin the 'all' feed forever. +2 keeps brand-new posts
     // from being divided by ~0.
     const ageHours = this.computeAgeHours(input.createdAt, 1) ?? 1;
-    return (
-      baseScore /
-      Math.pow(ageHours + 2, POPULAR_RANKING_CONFIG.ALL_WINDOW_GRAVITY)
-    );
+    const decayed =
+      (baseScore * shuffle) /
+      Math.pow(ageHours + 2, POPULAR_RANKING_CONFIG.ALL_WINDOW_GRAVITY);
+
+    // Subtracted after gravity so a fully-stale old post lands below a merely
+    // old one (dividing the penalty by the gravity term would invert that).
+    return decayed - this.computeStalePenalty(input);
   }
 
   async explain(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how the default popular/all-time feed is ordered and cached in Redis; personalized overrides are unaffected for shuffle, but stale and freshness rules still alter all-window scores on recompute.
> 
> **Overview**
> **Popular ranking** is retuned so the all-time feed stays fresher and less pinned on old evergreen posts.
> 
> **Freshness** no longer decays from hour zero over ~48h. Posts keep a **full freshness lift for ~5 days**, then it **fades linearly to zero by ~10 days** (`FRESHNESS_FULL_BOOST_HOURS` / `FRESHNESS_BOOST_HOURS`).
> 
> For the **`all` window**, **quiet posts past that window** get an **age-ramped stale penalty** (up to 5 points subtracted after gravity) when there is **no recent interaction** in the velocity window; **any recent comment/tip revives** them. Plugin items without recent-activity data are **not** penalized.
> 
> The **default (non–weight-override) feed** gets **±20% deterministic daily score jitter** (`computeDailyJitter`) so order rotates each UTC day while staying stable for pagination; **personalized ranking stays deterministic** (no shuffle).
> 
> Unit tests cover the new freshness plateau, stale penalty, daily jitter, and a tightened momentum test using `recentInteractions`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 066a86aebe81a8bbee52f2006291a24762bca7b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->