### PR TITLE
Improve performance

### DIFF
--- a/src/account/controllers/accounts.controller.spec.ts
+++ b/src/account/controllers/accounts.controller.spec.ts
@@ -23,6 +23,9 @@ describe('AccountsController', () => {
     findOne: jest.Mock;
     update: jest.Mock;
   };
+  let tokenHolderRepository: {
+    count: jest.Mock;
+  };
   let queryBuilder: ReturnType<typeof createQueryBuilder>;
   let accountService: {
     getChainNameForAccount: jest.Mock;
@@ -49,6 +52,9 @@ describe('AccountsController', () => {
       findOne: jest.fn(),
       update: jest.fn().mockResolvedValue(undefined),
     };
+    tokenHolderRepository = {
+      count: jest.fn().mockResolvedValue(0),
+    };
     accountService = {
       getChainNameForAccount: jest.fn(),
       ensureAccountFromTransactions: jest.fn().mockResolvedValue(null),
@@ -69,6 +75,7 @@ describe('AccountsController', () => {
 
     controller = new AccountsController(
       accountRepository as any,
+      tokenHolderRepository as any,
       portfolioService as any,
       bclPnlService as any,
       accountService as any,
@@ -189,13 +196,20 @@ describe('AccountsController', () => {
       profile: null,
       public_name: null,
     });
+    tokenHolderRepository.count.mockResolvedValue(3);
 
     const result = await controller.getAccount(account.address);
 
     expect(accountRepository.findOne).toHaveBeenCalledWith({
       where: { address: account.address },
     });
-    expect(result).toMatchObject({ address: account.address });
+    expect(tokenHolderRepository.count).toHaveBeenCalledWith({
+      where: { address: account.address, balance: expect.anything() },
+    });
+    expect(result).toMatchObject({
+      address: account.address,
+      holdings_count: 3,
+    });
     expect(loggerError).toHaveBeenCalled();
     loggerError.mockRestore();
   });
@@ -219,6 +233,7 @@ describe('AccountsController', () => {
     );
     expect(accountRepository.findOne).not.toHaveBeenCalled();
     expect(result).toMatchObject({ address: account.address });
+    expect(result.holdings_count).toBe(0);
   });
 
   describe('getPortfolioPnlChart', () => {

--- a/src/account/controllers/accounts.controller.ts
+++ b/src/account/controllers/accounts.controller.ts
@@ -574,6 +574,25 @@ export class AccountsController {
     };
   }
 
+  // Lightweight current portfolio value - MUST come before :address route to avoid route conflict
+  @ApiOperation({
+    operationId: 'getCurrentPortfolioValue',
+    summary: 'Latest portfolio value',
+    description:
+      'Returns only the latest portfolio value snapshot ({ value, timestamp }), ' +
+      'for callers polling for a live ticker. Use :address/portfolio/history for a full series.',
+  })
+  @ApiParam({ name: 'address', type: 'string', description: 'Account address' })
+  @ApiQuery({ name: 'convertTo', enum: ['ae', 'usd'], required: false })
+  @CacheTTL(30_000)
+  @Get(':address/portfolio/value')
+  async getCurrentPortfolioValue(
+    @Param('address', AeAccountReferencePipe) address: string,
+    @Query('convertTo') convertTo: 'ae' | 'usd' = 'ae',
+  ): Promise<{ value: number; timestamp: Date }> {
+    return this.portfolioService.getCurrentPortfolioValue(address, convertTo);
+  }
+
   // single account - MUST come after more specific routes
   @ApiOperation({ operationId: 'getAccount' })
   @ApiParam({ name: 'address', type: 'string' })

--- a/src/account/controllers/accounts.controller.ts
+++ b/src/account/controllers/accounts.controller.ts
@@ -23,8 +23,9 @@ import {
 import { InjectRepository } from '@nestjs/typeorm';
 import moment from 'moment';
 import { paginate } from 'nestjs-typeorm-paginate';
-import { Brackets, Repository } from 'typeorm';
+import { Brackets, MoreThan, Repository } from 'typeorm';
 import { Account } from '../entities/account.entity';
+import { TokenHolder } from '@/tokens/entities/token-holders.entity';
 import { PortfolioService } from '../services/portfolio.service';
 import { BclPnlService } from '../services/bcl-pnl.service';
 import { AccountService } from '../services/account.service';
@@ -76,6 +77,8 @@ export class AccountsController {
   constructor(
     @InjectRepository(Account)
     private readonly accountRepository: Repository<Account>,
+    @InjectRepository(TokenHolder)
+    private readonly tokenHolderRepository: Repository<TokenHolder>,
     private readonly portfolioService: PortfolioService,
     private readonly bclPnlService: BclPnlService,
     private readonly accountService: AccountService,
@@ -615,7 +618,12 @@ export class AccountsController {
       }
     }
 
-    const profile = await this.profileReadService.getProfile(address);
+    const [profile, holdingsCount] = await Promise.all([
+      this.profileReadService.getProfile(address),
+      this.tokenHolderRepository.count({
+        where: { address, balance: MoreThan(0) },
+      }),
+    ]);
 
     return {
       ...account,
@@ -623,6 +631,7 @@ export class AccountsController {
       chain_name_updated_at: chainNameUpdatedAt,
       profile: profile.profile,
       public_name: profile.public_name,
+      holdings_count: holdingsCount,
     };
   }
 

--- a/src/account/services/account.service.spec.ts
+++ b/src/account/services/account.service.spec.ts
@@ -325,4 +325,15 @@ describe('AccountService', () => {
       expect(result).toBeNull();
     });
   });
+
+  describe('scheduledFullAccountsRebuild', () => {
+    it('is a no-op while PULL_ACCOUNTS_ENABLED is false (current config)', async () => {
+      const { service } = createService();
+      const rebuildSpy = jest.spyOn(service, 'saveAllActiveAccounts');
+
+      await service.scheduledFullAccountsRebuild();
+
+      expect(rebuildSpy).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/account/services/account.service.spec.ts
+++ b/src/account/services/account.service.spec.ts
@@ -1,4 +1,13 @@
 import { AccountService } from './account.service';
+import { fetchJson } from '@/utils/common';
+
+jest.mock('@/utils/common', () => {
+  const actual = jest.requireActual('@/utils/common');
+  return {
+    ...actual,
+    fetchJson: jest.fn(),
+  };
+});
 
 describe('AccountService', () => {
   const createQueryBuilder = () => ({
@@ -163,6 +172,157 @@ describe('AccountService', () => {
 
       expect(Object.keys(result)).toHaveLength(25);
       expect(Object.keys(result)).toEqual(addresses.slice(0, 25));
+    });
+  });
+
+  describe('getChainNameForAccount', () => {
+    const ACCOUNT = 'ak_owner';
+
+    beforeEach(() => {
+      (fetchJson as jest.Mock).mockReset();
+    });
+
+    it('verifies candidate names in parallel and returns the newest match', async () => {
+      const { service } = createService();
+
+      (fetchJson as jest.Mock).mockImplementation((url: string) => {
+        if (url.includes('/names/pointees')) {
+          return Promise.resolve({
+            data: [
+              {
+                active: true,
+                name: 'old.chain',
+                block_height: 100,
+                tx: { pointers: [{ id: ACCOUNT, key: '', encoded_key: '' }] },
+              },
+              {
+                active: true,
+                name: 'new.chain',
+                block_height: 200,
+                tx: { pointers: [{ id: ACCOUNT, key: '', encoded_key: '' }] },
+              },
+            ],
+          });
+        }
+        // Per-name verification calls
+        if (url.includes('old.chain')) {
+          return Promise.resolve({
+            active: true,
+            pointers: [{ id: ACCOUNT }],
+          });
+        }
+        if (url.includes('new.chain')) {
+          return Promise.resolve({
+            active: true,
+            pointers: [{ id: ACCOUNT }],
+          });
+        }
+        return Promise.resolve(null);
+      });
+
+      const result = await service.getChainNameForAccount(ACCOUNT);
+
+      expect(result).toBe('new.chain'); // higher block_height wins
+      // 1 pointees call + 2 per-name verification calls
+      expect(fetchJson).toHaveBeenCalledTimes(3);
+      // Per-name verification calls pass a timeout signal
+      const verifyCalls = (fetchJson as jest.Mock).mock.calls.filter(([url]) =>
+        url.includes('/v3/names/'),
+      );
+      expect(verifyCalls).toHaveLength(2);
+      for (const [, options] of verifyCalls) {
+        expect(options?.signal).toBeInstanceOf(AbortSignal);
+      }
+    });
+
+    it('never exceeds CHAIN_NAME_VERIFY_CONCURRENCY in-flight verification calls for an account with many candidate names', async () => {
+      const { service } = createService();
+      const CANDIDATE_COUNT = 20;
+      // Mirrors the CHAIN_NAME_VERIFY_CONCURRENCY constant in account.service.ts.
+      // Kept low deliberately: refreshChainNamesPeriodically already runs 10
+      // accounts concurrently, so this value multiplies into the real
+      // worst-case outbound fan-out (see the constant's own comment).
+      const EXPECTED_MAX_CONCURRENCY = 2;
+
+      let inFlight = 0;
+      let peakInFlight = 0;
+
+      (fetchJson as jest.Mock).mockImplementation((url: string) => {
+        if (url.includes('/names/pointees')) {
+          return Promise.resolve({
+            data: Array.from({ length: CANDIDATE_COUNT }, (_, i) => ({
+              active: true,
+              name: `name${i}.chain`,
+              block_height: i,
+              tx: { pointers: [{ id: ACCOUNT, key: '', encoded_key: '' }] },
+            })),
+          });
+        }
+
+        // Per-name verification calls: track how many are in flight at once.
+        inFlight += 1;
+        peakInFlight = Math.max(peakInFlight, inFlight);
+        return new Promise((resolve) => {
+          setTimeout(() => {
+            inFlight -= 1;
+            resolve({ active: true, pointers: [{ id: ACCOUNT }] });
+          }, 1);
+        });
+      });
+
+      await service.getChainNameForAccount(ACCOUNT);
+
+      expect(peakInFlight).toBeLessThanOrEqual(EXPECTED_MAX_CONCURRENCY);
+      expect(peakInFlight).toBeGreaterThan(0);
+    });
+
+    it('falls back to historical pointer data when the per-name verification call throws', async () => {
+      const { service } = createService();
+
+      (fetchJson as jest.Mock).mockImplementation((url: string) => {
+        if (url.includes('/names/pointees')) {
+          return Promise.resolve({
+            data: [
+              {
+                active: true,
+                name: 'flaky.chain',
+                block_height: 100,
+                tx: { pointers: [{ id: ACCOUNT, key: '', encoded_key: '' }] },
+              },
+            ],
+          });
+        }
+        return Promise.reject(new Error('network timeout'));
+      });
+
+      const result = await service.getChainNameForAccount(ACCOUNT);
+
+      expect(result).toBe('flaky.chain');
+    });
+
+    it('skips a name whose current state no longer points to the account', async () => {
+      const { service } = createService();
+
+      (fetchJson as jest.Mock).mockImplementation((url: string) => {
+        if (url.includes('/names/pointees')) {
+          return Promise.resolve({
+            data: [
+              {
+                active: true,
+                name: 'stale.chain',
+                block_height: 100,
+                tx: { pointers: [{ id: ACCOUNT, key: '', encoded_key: '' }] },
+              },
+            ],
+          });
+        }
+        // Current state: no longer active
+        return Promise.resolve({ active: false, pointers: [{ id: ACCOUNT }] });
+      });
+
+      const result = await service.getChainNameForAccount(ACCOUNT);
+
+      expect(result).toBeNull();
     });
   });
 });

--- a/src/account/services/account.service.ts
+++ b/src/account/services/account.service.ts
@@ -66,10 +66,18 @@ export class AccountService {
     //
   }
 
-  onModuleInit() {
-    if (PULL_ACCOUNTS_ENABLED) {
-      this.saveAllActiveAccounts();
+  // Full rebuild moved off the boot path onto an off-peak daily cron
+  // (`scheduledFullAccountsRebuild`) instead of running unconditionally on
+  // every process start/restart -- ensureAccountFromTransactions already
+  // keeps individual accounts fresh incrementally, so a full GROUP BY over
+  // the whole transactions table doesn't need to happen on every boot,
+  // just periodically as a consistency catch-up sweep.
+  @Cron(CronExpression.EVERY_DAY_AT_3AM)
+  async scheduledFullAccountsRebuild() {
+    if (!PULL_ACCOUNTS_ENABLED) {
+      return;
     }
+    await this.saveAllActiveAccounts();
   }
 
   /**

--- a/src/account/services/account.service.ts
+++ b/src/account/services/account.service.ts
@@ -16,6 +16,7 @@ import {
 } from 'typeorm';
 import { Account } from '../entities/account.entity';
 import { fetchJson } from '@/utils/common';
+import { mapWithConcurrency } from '@/utils/concurrency.util';
 
 const SEARCH_DEFAULT_LIMIT = 8;
 const SEARCH_MIN_LIMIT = 1;
@@ -25,6 +26,22 @@ const SEARCH_MAX_LIMIT = 20;
 // that would scan the whole table for no useful typeahead value.
 const SEARCH_MIN_QUERY_LENGTH = 2;
 const CHAIN_NAMES_MAX_ADDRESSES = 25;
+// Bounded concurrency + a tight per-call timeout for verifying candidate
+// chain names against middleware, so one slow/hanging name lookup can't
+// stall (or blow past fetchJson's much longer default timeout for) the
+// whole account's chain-name resolution.
+//
+// refreshChainNamesPeriodically (below) already runs 10 accounts concurrently
+// via its own batching, and calls getChainNameForAccount -- which uses this
+// constant -- for each. That nests per-account concurrency inside the
+// per-batch concurrency, so the real worst-case fan-out is
+// (outer batch size) x CHAIN_NAME_VERIFY_CONCURRENCY, not just this value on
+// its own. Kept low (2, not the 8 a single account's verification alone
+// would justify) so that product stays a reasonable ceiling (20) on
+// concurrent outbound middleware requests; raise either number only with the
+// other in mind.
+const CHAIN_NAME_VERIFY_CONCURRENCY = 2;
+const CHAIN_NAME_VERIFY_TIMEOUT_MS = 5_000;
 
 type AggregatedAccountRow = {
   address: string;
@@ -330,62 +347,73 @@ export class AccountService {
       }
 
       // Verify current pointer state for each name by querying the name directly
-      // The /names/pointees endpoint returns historical records, so we need to check current state
-      const verifiedNames: Array<{
-        name: string;
-        blockHeight: number;
-        time: number;
-      }> = [];
+      // The /names/pointees endpoint returns historical records, so we need to check current state.
+      // Bounded concurrency + a per-call timeout instead of one sequential
+      // fetchJson per candidate name, so an account with several candidate
+      // names (or one slow/hanging lookup) doesn't serialize the whole check.
+      type VerifiedName = { name: string; blockHeight: number; time: number };
 
-      // Check each name's current state
-      for (const name of latestByName.values()) {
-        try {
-          // Query the name directly to get its current pointer state
-          const nameUrl = `${middlewareUrl}/v3/names/${encodeURIComponent(name.name)}`;
-          const nameResponse = await fetchJson<{
-            active: boolean;
-            pointers: Array<{ id: string }>;
-          }>(nameUrl);
-
-          // If response doesn't have pointers array, the name doesn't exist (e.g., 404)
-          // Skip it - don't fall back to historical data as it would be stale
-          if (
-            !nameResponse?.pointers ||
-            !Array.isArray(nameResponse.pointers)
-          ) {
-            continue;
-          }
-
-          // Check if the name is active AND the CURRENT pointer points to this account address
-          // An inactive name shouldn't be considered as "currently pointing" to the account
-          const isActive = nameResponse.active === true;
-          const hasMatchingPointer = nameResponse.pointers.some(
-            (pointer: any) => pointer && pointer.id === accountAddress,
-          );
-
-          if (isActive && hasMatchingPointer) {
-            verifiedNames.push({
-              name: name.name,
-              blockHeight: name.block_height ?? 0,
-              time: name.block_time ?? 0,
+      const verificationResults = await mapWithConcurrency(
+        [...latestByName.values()],
+        CHAIN_NAME_VERIFY_CONCURRENCY,
+        async (name): Promise<VerifiedName | null> => {
+          try {
+            // Query the name directly to get its current pointer state
+            const nameUrl = `${middlewareUrl}/v3/names/${encodeURIComponent(name.name)}`;
+            const nameResponse = await fetchJson<{
+              active: boolean;
+              pointers: Array<{ id: string }>;
+            }>(nameUrl, {
+              signal: AbortSignal.timeout(CHAIN_NAME_VERIFY_TIMEOUT_MS),
             });
+
+            // If response doesn't have pointers array, the name doesn't exist (e.g., 404)
+            // Skip it - don't fall back to historical data as it would be stale
+            if (
+              !nameResponse?.pointers ||
+              !Array.isArray(nameResponse.pointers)
+            ) {
+              return null;
+            }
+
+            // Check if the name is active AND the CURRENT pointer points to this account address
+            // An inactive name shouldn't be considered as "currently pointing" to the account
+            const isActive = nameResponse.active === true;
+            const hasMatchingPointer = nameResponse.pointers.some(
+              (pointer: any) => pointer && pointer.id === accountAddress,
+            );
+
+            if (isActive && hasMatchingPointer) {
+              return {
+                name: name.name,
+                blockHeight: name.block_height ?? 0,
+                time: name.block_time ?? 0,
+              };
+            }
+            return null;
+          } catch (e) {
+            // Only fall back to historical data on true network errors (caught exceptions,
+            // including our own timeout abort). This handles cases like network timeouts,
+            // connection failures, etc. HTTP errors (like 404) are not caught here - they
+            // return parsed JSON without pointers.
+            const hasMatchingPointer = name.tx.pointers.some(
+              (pointer) => pointer && pointer.id === accountAddress,
+            );
+            if (hasMatchingPointer && name.active) {
+              return {
+                name: name.name,
+                blockHeight: name.block_height ?? 0,
+                time: name.block_time ?? 0,
+              };
+            }
+            return null;
           }
-        } catch (e) {
-          // Only fall back to historical data on true network errors (caught exceptions)
-          // This handles cases like network timeouts, connection failures, etc.
-          // HTTP errors (like 404) are not caught here - they return parsed JSON without pointers
-          const hasMatchingPointer = name.tx.pointers.some(
-            (pointer) => pointer && pointer.id === accountAddress,
-          );
-          if (hasMatchingPointer && name.active) {
-            verifiedNames.push({
-              name: name.name,
-              blockHeight: name.block_height ?? 0,
-              time: name.block_time ?? 0,
-            });
-          }
-        }
-      }
+        },
+      );
+
+      const verifiedNames = verificationResults.filter(
+        (result): result is VerifiedName => result !== null,
+      );
 
       if (verifiedNames.length === 0) {
         return null;

--- a/src/account/services/bcl-pnl.service.spec.ts
+++ b/src/account/services/bcl-pnl.service.spec.ts
@@ -198,6 +198,98 @@ describe('BclPnlService', () => {
     expect(params).toEqual(['ak_test', [500], 50]);
   });
 
+  it('calculateTokenPnlsBatchForAddresses runs a single query for all addresses and heights', async () => {
+    const { service, transactionRepository } = createService();
+
+    transactionRepository.query.mockResolvedValue([
+      {
+        snapshot_height: 200,
+        address: 'ak_one',
+        sale_address: 'ct_alpha',
+        current_holdings: '3',
+        total_volume_bought: '3',
+        total_amount_spent_ae: '9',
+        total_amount_spent_usd: '18',
+        total_amount_received_ae: '0',
+        total_amount_received_usd: '0',
+        total_volume_sold: '0',
+        current_unit_price_ae: '4',
+        current_unit_price_usd: '8',
+      },
+      {
+        snapshot_height: 300,
+        address: 'ak_two',
+        sale_address: 'ct_alpha',
+        current_holdings: '5',
+        total_volume_bought: '5',
+        total_amount_spent_ae: '15',
+        total_amount_spent_usd: '30',
+        total_amount_received_ae: '0',
+        total_amount_received_usd: '0',
+        total_volume_sold: '0',
+        current_unit_price_ae: '6',
+        current_unit_price_usd: '12',
+      },
+    ]);
+
+    const result = await service.calculateTokenPnlsBatchForAddresses(
+      ['ak_one', 'ak_two'],
+      [200, 300],
+    );
+
+    // Single DB round-trip regardless of number of addresses or heights
+    expect(transactionRepository.query).toHaveBeenCalledTimes(1);
+    const [sql, params] = transactionRepository.query.mock.calls[0];
+
+    expect(sql).toContain('unnest($2::int[])');
+    expect(sql).toContain('address = ANY($1::text[])');
+    expect(sql).toContain('AS MATERIALIZED');
+    expect(sql).toContain('addr_txs');
+    expect(sql).toContain('GROUP BY h.snapshot_height, tx.address, tx.sale_address');
+    expect(params).toEqual([['ak_one', 'ak_two'], [200, 300]]);
+
+    expect(result).toBeInstanceOf(Map);
+    expect(result.size).toBe(2);
+
+    const one = result.get('ak_one')!;
+    expect(one.get(200)!.pnls.ct_alpha.current_value.ae).toBe(12); // 3 * 4
+    expect(one.get(300)!.totalCurrentValueAe).toBe(0); // no rows for ak_one at 300
+
+    const two = result.get('ak_two')!;
+    expect(two.get(300)!.pnls.ct_alpha.current_value.ae).toBe(30); // 5 * 6
+    expect(two.get(200)!.totalCurrentValueAe).toBe(0); // no rows for ak_two at 200
+  });
+
+  it('calculateTokenPnlsBatchForAddresses returns empty map when addresses or heights are empty', async () => {
+    const { service, transactionRepository } = createService();
+
+    const emptyAddresses =
+      await service.calculateTokenPnlsBatchForAddresses([], [100]);
+    const emptyHeights = await service.calculateTokenPnlsBatchForAddresses(
+      ['ak_test'],
+      [],
+    );
+
+    expect(transactionRepository.query).not.toHaveBeenCalled();
+    expect(emptyAddresses.size).toBe(0);
+    expect(emptyHeights.size).toBe(0);
+  });
+
+  it('calculateTokenPnlsBatchForAddresses passes fromBlockHeight as $3 when provided', async () => {
+    const { service, transactionRepository } = createService();
+    transactionRepository.query.mockResolvedValue([]);
+
+    await service.calculateTokenPnlsBatchForAddresses(
+      ['ak_test'],
+      [500],
+      50,
+    );
+
+    const [sql, params] = transactionRepository.query.mock.calls[0];
+    expect(sql).toContain('block_height >= $3');
+    expect(params).toEqual([['ak_test'], [500], 50]);
+  });
+
   it('preserves range-based pnl result semantics (realized gains only)', async () => {
     const { service, transactionRepository } = createService();
 

--- a/src/account/services/bcl-pnl.service.spec.ts
+++ b/src/account/services/bcl-pnl.service.spec.ts
@@ -245,8 +245,13 @@ describe('BclPnlService', () => {
     expect(sql).toContain('address = ANY($1::text[])');
     expect(sql).toContain('AS MATERIALIZED');
     expect(sql).toContain('addr_txs');
-    expect(sql).toContain('GROUP BY h.snapshot_height, tx.address, tx.sale_address');
-    expect(params).toEqual([['ak_one', 'ak_two'], [200, 300]]);
+    expect(sql).toContain(
+      'GROUP BY h.snapshot_height, tx.address, tx.sale_address',
+    );
+    expect(params).toEqual([
+      ['ak_one', 'ak_two'],
+      [200, 300],
+    ]);
 
     expect(result).toBeInstanceOf(Map);
     expect(result.size).toBe(2);
@@ -263,8 +268,10 @@ describe('BclPnlService', () => {
   it('calculateTokenPnlsBatchForAddresses returns empty map when addresses or heights are empty', async () => {
     const { service, transactionRepository } = createService();
 
-    const emptyAddresses =
-      await service.calculateTokenPnlsBatchForAddresses([], [100]);
+    const emptyAddresses = await service.calculateTokenPnlsBatchForAddresses(
+      [],
+      [100],
+    );
     const emptyHeights = await service.calculateTokenPnlsBatchForAddresses(
       ['ak_test'],
       [],
@@ -279,11 +286,7 @@ describe('BclPnlService', () => {
     const { service, transactionRepository } = createService();
     transactionRepository.query.mockResolvedValue([]);
 
-    await service.calculateTokenPnlsBatchForAddresses(
-      ['ak_test'],
-      [500],
-      50,
-    );
+    await service.calculateTokenPnlsBatchForAddresses(['ak_test'], [500], 50);
 
     const [sql, params] = transactionRepository.query.mock.calls[0];
     expect(sql).toContain('block_height >= $3');

--- a/src/account/services/bcl-pnl.service.ts
+++ b/src/account/services/bcl-pnl.service.ts
@@ -95,6 +95,49 @@ export class BclPnlService {
   }
 
   /**
+   * Calculate PNL for each token, for MANY addresses, across multiple shared
+   * block heights, in a single SQL query.
+   *
+   * Built for the leaderboard's event-window path, which previously called
+   * `calculateTokenPnlsBatch` once per candidate address (concurrency 8, cap
+   * 500) even though every candidate shares the same sample heights. This
+   * adds `address` as a grouping dimension to the same aggregation so the
+   * whole candidate set resolves in one query.
+   *
+   * @param addresses - Candidate account addresses
+   * @param blockHeights - Array of block heights to calculate PNL at (shared across all addresses)
+   * @param fromBlockHeight - Optional: If provided, restrict cost-basis aggregates to this range
+   * @returns Map from address to its Map from block height to TokenPnlResult
+   */
+  async calculateTokenPnlsBatchForAddresses(
+    addresses: string[],
+    blockHeights: number[],
+    fromBlockHeight?: number,
+  ): Promise<Map<string, Map<number, TokenPnlResult>>> {
+    const uniqueAddresses = [...new Set(addresses)];
+    const uniqueHeights = [...new Set(blockHeights)];
+    if (uniqueAddresses.length === 0 || uniqueHeights.length === 0) {
+      return new Map();
+    }
+
+    const rows = await this.transactionRepository.query(
+      this.buildBatchTokenPnlsQueryForAddresses(fromBlockHeight),
+      this.buildBatchQueryParametersForAddresses(
+        uniqueAddresses,
+        uniqueHeights,
+        fromBlockHeight,
+      ),
+    );
+
+    return this.mapTokenPnlsBatchForAddresses(
+      rows,
+      uniqueAddresses,
+      uniqueHeights,
+      fromBlockHeight,
+    );
+  }
+
+  /**
    * Calculate per-day realized PnL for each token using timestamp-based windows.
    * Each window defines an isolated [dayStartTs, snapshotTs) sell range so the
    * result for each day only reflects trades closed on that specific day.
@@ -508,6 +551,246 @@ export class BclPnlService {
     return fromBlockHeight !== undefined && fromBlockHeight !== null
       ? [address, blockHeights, fromBlockHeight]
       : [address, blockHeights];
+  }
+
+  // Mirrors buildBatchTokenPnlsQuery, adding `address` as an extra grouping
+  // dimension so many candidates resolve in one query instead of one per
+  // address. Keep the aggregation CASE expressions identical to the
+  // single-address version above.
+  private buildBatchTokenPnlsQueryForAddresses(
+    fromBlockHeight?: number,
+  ): string {
+    const hasRange = fromBlockHeight !== undefined && fromBlockHeight !== null;
+    const rangeCondition = hasRange ? ' AND tx.block_height >= $3' : '';
+
+    const cumulativeColumns = hasRange
+      ? `,
+          COALESCE(
+            SUM(
+              CASE
+                WHEN tx.tx_type IN ('buy', 'create_community')
+                  THEN CAST(tx.volume AS DECIMAL)
+                ELSE 0
+              END
+            ),
+            0
+          ) AS cumulative_volume_bought,
+          COALESCE(
+            SUM(
+              CASE
+                WHEN tx.tx_type IN ('buy', 'create_community')
+                  THEN CAST(NULLIF(tx.amount->>'ae', 'NaN') AS DECIMAL)
+                ELSE 0
+              END
+            ),
+            0
+          ) AS cumulative_amount_spent_ae,
+          COALESCE(
+            SUM(
+              CASE
+                WHEN tx.tx_type IN ('buy', 'create_community')
+                  THEN CAST(NULLIF(tx.amount->>'usd', 'NaN') AS DECIMAL)
+                ELSE 0
+              END
+            ),
+            0
+          ) AS cumulative_amount_spent_usd`
+      : '';
+
+    const cumulativeSelectColumns = hasRange
+      ? `
+        agg.cumulative_volume_bought,
+        agg.cumulative_amount_spent_ae,
+        agg.cumulative_amount_spent_usd,`
+      : '';
+
+    return `
+      WITH heights AS (
+        SELECT unnest($2::int[]) AS snapshot_height
+      ),
+      -- Scan every candidate's transactions exactly once and materialise the
+      -- result, same rationale as address_txs in buildBatchTokenPnlsQuery.
+      addr_txs AS MATERIALIZED (
+        SELECT address, sale_address, block_height, tx_type, volume, amount
+        FROM transactions
+        WHERE address = ANY($1::text[])
+      ),
+      aggregated_holdings AS (
+        SELECT
+          h.snapshot_height,
+          tx.address AS address,
+          tx.sale_address AS sale_address,
+          COALESCE(
+            SUM(
+              CASE
+                WHEN tx.tx_type IN ('buy', 'create_community')
+                  THEN CAST(tx.volume AS DECIMAL)
+                ELSE 0
+              END
+            ) -
+            COALESCE(
+              SUM(
+                CASE
+                  WHEN tx.tx_type = 'sell'
+                    THEN CAST(tx.volume AS DECIMAL)
+                  ELSE 0
+                END
+              ),
+              0
+            ),
+            0
+          ) AS current_holdings,
+          COALESCE(
+            SUM(
+              CASE
+                WHEN tx.tx_type IN ('buy', 'create_community')${rangeCondition}
+                  THEN CAST(tx.volume AS DECIMAL)
+                ELSE 0
+              END
+            ),
+            0
+          ) AS total_volume_bought,
+          COALESCE(
+            SUM(
+              CASE
+                WHEN tx.tx_type IN ('buy', 'create_community')${rangeCondition}
+                  THEN CAST(NULLIF(tx.amount->>'ae', 'NaN') AS DECIMAL)
+                ELSE 0
+              END
+            ),
+            0
+          ) AS total_amount_spent_ae,
+          COALESCE(
+            SUM(
+              CASE
+                WHEN tx.tx_type IN ('buy', 'create_community')${rangeCondition}
+                  THEN CAST(NULLIF(tx.amount->>'usd', 'NaN') AS DECIMAL)
+                ELSE 0
+              END
+            ),
+            0
+          ) AS total_amount_spent_usd,
+          COALESCE(
+            SUM(
+              CASE
+                WHEN tx.tx_type = 'sell'${rangeCondition}
+                  THEN CAST(NULLIF(tx.amount->>'ae', 'NaN') AS DECIMAL)
+                ELSE 0
+              END
+            ),
+            0
+          ) AS total_amount_received_ae,
+          COALESCE(
+            SUM(
+              CASE
+                WHEN tx.tx_type = 'sell'${rangeCondition}
+                  THEN CAST(NULLIF(tx.amount->>'usd', 'NaN') AS DECIMAL)
+                ELSE 0
+              END
+            ),
+            0
+          ) AS total_amount_received_usd,
+          COALESCE(
+            SUM(
+              CASE
+                WHEN tx.tx_type = 'sell'${rangeCondition}
+                  THEN CAST(tx.volume AS DECIMAL)
+                ELSE 0
+              END
+            ),
+            0
+          ) AS total_volume_sold${cumulativeColumns}
+        FROM heights h
+        JOIN addr_txs tx ON tx.block_height < h.snapshot_height
+        GROUP BY h.snapshot_height, tx.address, tx.sale_address
+      )
+      SELECT
+        agg.snapshot_height,
+        agg.address,
+        agg.sale_address,
+        agg.current_holdings,
+        agg.total_volume_bought,
+        agg.total_amount_spent_ae,
+        agg.total_amount_spent_usd,
+        agg.total_amount_received_ae,
+        agg.total_amount_received_usd,
+        agg.total_volume_sold,${cumulativeSelectColumns}
+        ae_price.current_unit_price_ae,
+        usd_price.current_unit_price_usd
+      FROM aggregated_holdings agg
+      LEFT JOIN LATERAL (
+        SELECT CAST(NULLIF(p.buy_price->>'ae', 'NaN') AS DECIMAL) AS current_unit_price_ae
+        FROM transactions p
+        WHERE p.sale_address = agg.sale_address
+          AND p.block_height <= agg.snapshot_height
+          AND p.buy_price->>'ae' IS NOT NULL
+          AND p.buy_price->>'ae' NOT IN ('NaN', 'null', '')
+        ORDER BY p.block_height DESC, p.created_at DESC
+        LIMIT 1
+      ) ae_price ON true
+      LEFT JOIN LATERAL (
+        SELECT CAST(NULLIF(p.buy_price->>'usd', 'NaN') AS DECIMAL) AS current_unit_price_usd
+        FROM transactions p
+        WHERE p.sale_address = agg.sale_address
+          AND p.block_height <= agg.snapshot_height
+          AND p.buy_price->>'usd' IS NOT NULL
+          AND p.buy_price->>'usd' NOT IN ('NaN', 'null', '')
+        ORDER BY p.block_height DESC, p.created_at DESC
+        LIMIT 1
+      ) usd_price ON true
+      WHERE agg.current_holdings > 0
+         OR agg.total_volume_bought > 0
+         OR agg.total_volume_sold > 0
+    `;
+  }
+
+  private buildBatchQueryParametersForAddresses(
+    addresses: string[],
+    blockHeights: number[],
+    fromBlockHeight?: number,
+  ): Array<string[] | number[] | number> {
+    return fromBlockHeight !== undefined && fromBlockHeight !== null
+      ? [addresses, blockHeights, fromBlockHeight]
+      : [addresses, blockHeights];
+  }
+
+  private mapTokenPnlsBatchForAddresses(
+    rows: Array<Record<string, any>>,
+    addresses: string[],
+    heights: number[],
+    fromBlockHeight?: number,
+  ): Map<string, Map<number, TokenPnlResult>> {
+    const isRangeBased =
+      fromBlockHeight !== undefined && fromBlockHeight !== null;
+
+    const rowsByAddressHeight = new Map<
+      string,
+      Map<number, Array<Record<string, any>>>
+    >();
+    for (const address of addresses) {
+      const byHeight = new Map<number, Array<Record<string, any>>>();
+      for (const height of heights) {
+        byHeight.set(height, []);
+      }
+      rowsByAddressHeight.set(address, byHeight);
+    }
+    for (const row of rows) {
+      const byHeight = rowsByAddressHeight.get(row.address);
+      const group = byHeight?.get(Number(row.snapshot_height));
+      if (group) {
+        group.push(row);
+      }
+    }
+
+    const result = new Map<string, Map<number, TokenPnlResult>>();
+    for (const [address, byHeight] of rowsByAddressHeight.entries()) {
+      const heightMap = new Map<number, TokenPnlResult>();
+      for (const [height, heightRows] of byHeight.entries()) {
+        heightMap.set(height, this.mapTokenPnls(heightRows, isRangeBased));
+      }
+      result.set(address, heightMap);
+    }
+    return result;
   }
 
   private buildDailyPnlQuery(): string {

--- a/src/account/services/leaderboard.service.spec.ts
+++ b/src/account/services/leaderboard.service.spec.ts
@@ -398,11 +398,9 @@ describe('LeaderboardService', () => {
       points: 2,
     });
 
-    expect(bclPnlService.calculateTokenPnlsBatchForAddresses).toHaveBeenCalledWith(
-      ['ak_transfer_gain', 'ak_trader'],
-      [100, 101],
-      100,
-    );
+    expect(
+      bclPnlService.calculateTokenPnlsBatchForAddresses,
+    ).toHaveBeenCalledWith(['ak_transfer_gain', 'ak_trader'], [100, 101], 100);
     expect(result.items[0]).toMatchObject({
       address: 'ak_trader',
       aum_usd: 130,

--- a/src/account/services/leaderboard.service.spec.ts
+++ b/src/account/services/leaderboard.service.spec.ts
@@ -58,22 +58,27 @@ describe('LeaderboardService', () => {
       .fn()
       .mockResolvedValue(options?.activeRows ?? []);
     const find = jest.fn().mockResolvedValue(options?.accounts ?? []);
-    const calculateTokenPnlsBatch = jest.fn(
-      (address: string, heights: number[]) => {
-        const values = options?.pnlByAddress?.[address] ?? [];
-        return Promise.resolve(
-          new Map(
-            heights.map((height, index) => {
-              const value = values[index] ?? 0;
-              return [
-                height,
-                typeof value === 'number'
-                  ? pnlResult(value)
-                  : pnlResult(value.aum, value.gain ?? 0, value.cost ?? 0),
-              ];
-            }),
-          ),
-        );
+    const calculateTokenPnlsBatchForAddresses = jest.fn(
+      (addresses: string[], heights: number[]) => {
+        const result = new Map<string, Map<number, unknown>>();
+        for (const address of addresses) {
+          const values = options?.pnlByAddress?.[address] ?? [];
+          result.set(
+            address,
+            new Map(
+              heights.map((height, index) => {
+                const value = values[index] ?? 0;
+                return [
+                  height,
+                  typeof value === 'number'
+                    ? pnlResult(value)
+                    : pnlResult(value.aum, value.gain ?? 0, value.cost ?? 0),
+                ];
+              }),
+            ),
+          );
+        }
+        return Promise.resolve(result);
       },
     );
 
@@ -82,13 +87,13 @@ describe('LeaderboardService', () => {
         { query } as never,
         { query: transactionQuery } as never,
         { find } as never,
-        { calculateTokenPnlsBatch } as never,
+        { calculateTokenPnlsBatchForAddresses } as never,
         {} as never,
       ),
       snapshotRepository: { query },
       transactionsRepository: { query: transactionQuery },
       accountRepository: { find },
-      bclPnlService: { calculateTokenPnlsBatch },
+      bclPnlService: { calculateTokenPnlsBatchForAddresses },
     };
   };
 
@@ -272,7 +277,9 @@ describe('LeaderboardService', () => {
       100,
     ]);
     expect(batchTimestampToAeHeightMock).toHaveBeenCalledTimes(1);
-    expect(bclPnlService.calculateTokenPnlsBatch).toHaveBeenCalledTimes(2);
+    expect(
+      bclPnlService.calculateTokenPnlsBatchForAddresses,
+    ).toHaveBeenCalledTimes(1);
 
     expect(result.timeFilter).toEqual({
       start: new Date('2026-04-28T10:00:00.000Z'),
@@ -391,13 +398,8 @@ describe('LeaderboardService', () => {
       points: 2,
     });
 
-    expect(bclPnlService.calculateTokenPnlsBatch).toHaveBeenCalledWith(
-      'ak_transfer_gain',
-      [100, 101],
-      100,
-    );
-    expect(bclPnlService.calculateTokenPnlsBatch).toHaveBeenCalledWith(
-      'ak_trader',
+    expect(bclPnlService.calculateTokenPnlsBatchForAddresses).toHaveBeenCalledWith(
+      ['ak_transfer_gain', 'ak_trader'],
       [100, 101],
       100,
     );

--- a/src/account/services/leaderboard.service.ts
+++ b/src/account/services/leaderboard.service.ts
@@ -5,7 +5,7 @@ import { Transaction } from '@/transactions/entities/transaction.entity';
 import { batchTimestampToAeHeight } from '@/utils/getBlochHeight';
 import { Account } from '../entities/account.entity';
 import { AccountLeaderboardSnapshot } from '../entities/account-leaderboard-snapshot.entity';
-import { BclPnlService } from './bcl-pnl.service';
+import { BclPnlService, TokenPnlResult } from './bcl-pnl.service';
 import {
   GetLeadersParams,
   LEADERBOARD_SNAPSHOT_MAX_CANDIDATES,
@@ -452,49 +452,45 @@ export class LeaderboardService {
     heights: number[];
     tradingOnly: boolean;
   }): Promise<LeaderboardItem[]> {
+    // Single set-based query for every candidate instead of one
+    // calculateTokenPnlsBatch call per address (previously concurrency 8,
+    // cap 500 — up to 500 separate PnL queries per request).
+    const startHeight = params.heights[0];
+    const pnlByAddress =
+      await this.bclPnlService.calculateTokenPnlsBatchForAddresses(
+        params.addresses,
+        params.heights,
+        params.tradingOnly ? startHeight : undefined,
+      );
+
     const items: LeaderboardItem[] = [];
-    const concurrency = 8;
-    const queue = [...params.addresses];
-
-    const workers = Array.from({ length: concurrency }, async () => {
-      while (queue.length) {
-        const address = queue.shift();
-        if (!address) {
-          continue;
-        }
-
-        const item = await this.computeEventItem({
-          address,
-          activeRow: params.activeByAddress.get(address),
-          account: params.accountByAddress.get(address),
-          sampleTimestamps: params.sampleTimestamps,
-          heights: params.heights,
-          tradingOnly: params.tradingOnly,
-        });
-        if (item) {
-          items.push(item);
-        }
+    for (const address of params.addresses) {
+      const item = this.buildEventItem({
+        address,
+        pnlByHeight: pnlByAddress.get(address) ?? new Map(),
+        activeRow: params.activeByAddress.get(address),
+        account: params.accountByAddress.get(address),
+        sampleTimestamps: params.sampleTimestamps,
+        heights: params.heights,
+        tradingOnly: params.tradingOnly,
+      });
+      if (item) {
+        items.push(item);
       }
-    });
-
-    await Promise.all(workers);
+    }
     return items;
   }
 
-  private async computeEventItem(params: {
+  private buildEventItem(params: {
     address: string;
+    pnlByHeight: Map<number, TokenPnlResult>;
     activeRow?: EventActiveAddressRow;
     account?: Account;
     sampleTimestamps: number[];
     heights: number[];
     tradingOnly: boolean;
-  }): Promise<LeaderboardItem | undefined> {
-    const startHeight = params.heights[0];
-    const pnlByHeight = await this.bclPnlService.calculateTokenPnlsBatch(
-      params.address,
-      params.heights,
-      params.tradingOnly ? startHeight : undefined,
-    );
+  }): LeaderboardItem | undefined {
+    const pnlByHeight = params.pnlByHeight;
     const sparkline = params.heights.map((height, index): [number, number] => {
       const pnl = pnlByHeight.get(height);
       return [

--- a/src/account/services/portfolio.service.spec.ts
+++ b/src/account/services/portfolio.service.spec.ts
@@ -27,6 +27,7 @@ describe('PortfolioService', () => {
     const aeSdkService = {
       sdk: {
         getBalance: jest.fn(),
+        getHeight: jest.fn(),
       },
     };
     const coinGeckoService = {
@@ -446,6 +447,60 @@ describe('PortfolioService', () => {
 
       expect(result).toEqual([]);
       expect(bclPnlService.calculateDailyPnlBatch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getCurrentPortfolioValue', () => {
+    it('sums the live AE balance and current token holdings value at the latest height', async () => {
+      const { service, aeSdkService, coinGeckoService, bclPnlService } =
+        createService();
+
+      aeSdkService.sdk.getBalance.mockResolvedValue('5000000000000000000'); // 5 AE
+      aeSdkService.sdk.getHeight.mockResolvedValue(123456);
+      coinGeckoService.getPriceData.mockResolvedValue({ usd: 2 });
+      bclPnlService.calculateTokenPnlsBatch.mockResolvedValue(
+        new Map([
+          [
+            123456,
+            {
+              ...basePnlResult,
+              totalCurrentValueAe: 10,
+              totalCurrentValueUsd: 20,
+            },
+          ],
+        ]),
+      );
+
+      const resultAe = await service.getCurrentPortfolioValue('ak_test', 'ae');
+      expect(resultAe.value).toBeCloseTo(15); // 5 AE balance + 10 AE tokens
+      expect(resultAe.timestamp).toBeInstanceOf(Date);
+
+      const resultUsd = await service.getCurrentPortfolioValue(
+        'ak_test',
+        'usd',
+      );
+      expect(resultUsd.value).toBeCloseTo(30); // 5*2 + 20
+
+      expect(bclPnlService.calculateTokenPnlsBatch).toHaveBeenCalledWith(
+        'ak_test',
+        [123456],
+        undefined,
+      );
+      expect(aeSdkService.sdk.getBalance).toHaveBeenCalledWith('ak_test');
+    });
+
+    it('falls back to zero token value when no pnl data exists for the current height', async () => {
+      const { service, aeSdkService, coinGeckoService, bclPnlService } =
+        createService();
+
+      aeSdkService.sdk.getBalance.mockResolvedValue('1000000000000000000'); // 1 AE
+      aeSdkService.sdk.getHeight.mockResolvedValue(999);
+      coinGeckoService.getPriceData.mockResolvedValue({ usd: 3 });
+      bclPnlService.calculateTokenPnlsBatch.mockResolvedValue(new Map());
+
+      const result = await service.getCurrentPortfolioValue('ak_test', 'ae');
+
+      expect(result.value).toBeCloseTo(1);
     });
   });
 });

--- a/src/account/services/portfolio.service.spec.ts
+++ b/src/account/services/portfolio.service.spec.ts
@@ -458,10 +458,13 @@ describe('PortfolioService', () => {
       aeSdkService.sdk.getBalance.mockResolvedValue('5000000000000000000'); // 5 AE
       aeSdkService.sdk.getHeight.mockResolvedValue(123456);
       coinGeckoService.getPriceData.mockResolvedValue({ usd: 2 });
+      // Holdings are valued at currentHeight + 1 so the strict
+      // `block_height < snapshot_height` rule includes current-block trades,
+      // matching the tip-inclusive AE balance from getBalance.
       bclPnlService.calculateTokenPnlsBatch.mockResolvedValue(
         new Map([
           [
-            123456,
+            123457,
             {
               ...basePnlResult,
               totalCurrentValueAe: 10,
@@ -483,7 +486,7 @@ describe('PortfolioService', () => {
 
       expect(bclPnlService.calculateTokenPnlsBatch).toHaveBeenCalledWith(
         'ak_test',
-        [123456],
+        [123457],
         undefined,
       );
       expect(aeSdkService.sdk.getBalance).toHaveBeenCalledWith('ak_test');

--- a/src/account/services/portfolio.service.ts
+++ b/src/account/services/portfolio.service.ts
@@ -363,6 +363,46 @@ export class PortfolioService {
   }
 
   /**
+   * Latest portfolio value only — no historical series.
+   *
+   * Callers polling for a live ticker (e.g. every 30-60s) previously had to
+   * hit `getPortfolioHistory`, which generates a full timestamp range,
+   * batch-resolves block heights, and buckets the AE-node balance lookup to
+   * a 300-block window (acceptable staleness for a daily chart, not for a
+   * "current" value). This reads the current height/balance directly instead.
+   */
+  async getCurrentPortfolioValue(
+    address: string,
+    convertTo: 'ae' | 'usd' = 'ae',
+  ): Promise<{ value: number; timestamp: Date }> {
+    const resolvedAddress = await this.resolveAccountAddress(address);
+
+    const [aeBalance, currentHeight, currentAePrice] = await Promise.all([
+      this.aeSdkService.sdk.getBalance(resolvedAddress as any),
+      this.aeSdkService.sdk.getHeight(),
+      this.coinGeckoService.getPriceData(new BigNumber(1)),
+    ]);
+
+    const pnlMap = await this.bclPnlService.calculateTokenPnlsBatch(
+      resolvedAddress,
+      [currentHeight],
+      undefined,
+    );
+    const tokensPnl = pnlMap.get(currentHeight);
+
+    const balance = Number(toAe(aeBalance));
+    const price = currentAePrice?.usd || 0;
+    const totalValueAe = balance + (tokensPnl?.totalCurrentValueAe ?? 0);
+    const totalValueUsd =
+      balance * price + (tokensPnl?.totalCurrentValueUsd ?? 0);
+
+    return {
+      value: convertTo === 'usd' ? totalValueUsd : totalValueAe,
+      timestamp: new Date(),
+    };
+  }
+
+  /**
    * Lightweight PnL time-series for charting.
    *
    * Only runs `calculateDailyPnlBatch` (one SQL query). Skips block-height

--- a/src/account/services/portfolio.service.ts
+++ b/src/account/services/portfolio.service.ts
@@ -384,12 +384,21 @@ export class PortfolioService {
       this.coinGeckoService.getPriceData(new BigNumber(1)),
     ]);
 
+    // getBalance reflects the chain tip *inclusive* of the current block, but
+    // the holdings aggregation uses `tx.block_height < snapshot_height` (strict).
+    // Passing `currentHeight` would omit trades mined in the current block from
+    // token holdings while their AE effect is already in the balance, so a poll
+    // right after latest-block activity would be inconsistent. Use
+    // `currentHeight + 1` so `block_height < currentHeight + 1` includes the
+    // current block; the price lateral joins (`block_height <= snapshot_height`)
+    // are unaffected since no rows exist above currentHeight yet.
+    const holdingsHeight = currentHeight + 1;
     const pnlMap = await this.bclPnlService.calculateTokenPnlsBatch(
       resolvedAddress,
-      [currentHeight],
+      [holdingsHeight],
       undefined,
     );
-    const tokensPnl = pnlMap.get(currentHeight);
+    const tokensPnl = pnlMap.get(holdingsHeight);
 
     const balance = Number(toAe(aeBalance));
     const price = currentAePrice?.usd || 0;

--- a/src/account/services/portfolio.service.ts
+++ b/src/account/services/portfolio.service.ts
@@ -18,6 +18,7 @@ import {
   TokenPnlResult,
 } from './bcl-pnl.service';
 import { fetchJson } from '@/utils/common';
+import { mapWithConcurrency } from '@/utils/concurrency.util';
 
 export interface PortfolioHistorySnapshot {
   timestamp: Moment | Date;
@@ -260,7 +261,7 @@ export class PortfolioService {
     };
 
     const balanceCache = new Map<number, Promise<string>>();
-    const data = await this.mapWithConcurrency(
+    const data = await mapWithConcurrency(
       timestamps,
       this.snapshotConcurrency,
       async (timestamp, index) => {
@@ -594,32 +595,5 @@ export class PortfolioService {
     }
 
     return closestPrice;
-  }
-
-  private async mapWithConcurrency<T, R>(
-    items: T[],
-    concurrency: number,
-    mapper: (item: T, index: number) => Promise<R>,
-  ): Promise<R[]> {
-    if (items.length === 0) {
-      return [];
-    }
-
-    const results = new Array<R>(items.length);
-    let nextIndex = 0;
-    const workerCount = Math.min(Math.max(concurrency, 1), items.length);
-
-    const workers = Array.from({ length: workerCount }, async () => {
-      while (true) {
-        const currentIndex = nextIndex++;
-        if (currentIndex >= items.length) {
-          return;
-        }
-        results[currentIndex] = await mapper(items[currentIndex], currentIndex);
-      }
-    });
-
-    await Promise.all(workers);
-    return results;
   }
 }

--- a/src/affiliation/controllers/invitations.controller.spec.ts
+++ b/src/affiliation/controllers/invitations.controller.spec.ts
@@ -1,0 +1,110 @@
+import { InvitationsController } from './invitations.controller';
+import { paginate } from 'nestjs-typeorm-paginate';
+
+jest.mock('nestjs-typeorm-paginate', () => ({
+  paginate: jest.fn(),
+}));
+
+describe('InvitationsController', () => {
+  let controller: InvitationsController;
+  let invitationRepository: { createQueryBuilder: jest.Mock };
+  let queryBuilder: {
+    orderBy: jest.Mock;
+    andWhere: jest.Mock;
+    leftJoinAndMapOne: jest.Mock;
+  };
+
+  beforeEach(() => {
+    queryBuilder = {
+      orderBy: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      leftJoinAndMapOne: jest.fn().mockReturnThis(),
+    };
+    invitationRepository = {
+      createQueryBuilder: jest.fn().mockReturnValue(queryBuilder),
+    };
+    controller = new InvitationsController(invitationRepository as any);
+    (paginate as jest.Mock).mockReset();
+  });
+
+  it('filters by inviter when provided', async () => {
+    (paginate as jest.Mock).mockResolvedValue({ items: [], meta: {} });
+
+    await controller.listAll(1, 100, 'amount', 'DESC', 'ak_inviter');
+
+    expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+      'invitation.sender_address = :inviter',
+      { inviter: 'ak_inviter' },
+    );
+  });
+
+  it('does not filter by inviter when absent', async () => {
+    (paginate as jest.Mock).mockResolvedValue({ items: [], meta: {} });
+
+    await controller.listAll(1, 100, 'amount', 'DESC');
+
+    expect(queryBuilder.andWhere).not.toHaveBeenCalled();
+  });
+
+  it('annotates each item with derived claim status', async () => {
+    (paginate as jest.Mock).mockResolvedValue({
+      items: [
+        {
+          id: '1',
+          status: 'claimed',
+          invitee_address: 'ak_claimer',
+          status_updated_at: new Date('2026-01-01'),
+          claim_tx_hash: 'th_claim',
+        },
+        {
+          id: '2',
+          status: 'pending',
+          invitee_address: null,
+          status_updated_at: null,
+          claim_tx_hash: null,
+        },
+        {
+          id: '3',
+          status: 'revoked',
+          invitee_address: null,
+          status_updated_at: new Date('2026-01-02'),
+          claim_tx_hash: null,
+        },
+      ],
+      meta: { totalItems: 3 },
+    });
+
+    const result = await controller.listAll(1, 100, 'amount', 'DESC');
+
+    expect(result.items).toEqual([
+      expect.objectContaining({
+        id: '1',
+        claimed: true,
+        claimer_address: 'ak_claimer',
+        claimed_at: new Date('2026-01-01'),
+        claim_tx_hash: 'th_claim',
+      }),
+      expect.objectContaining({
+        id: '2',
+        claimed: false,
+        claimer_address: null,
+        claimed_at: null,
+        claim_tx_hash: null,
+      }),
+      expect.objectContaining({
+        id: '3',
+        claimed: false,
+        claimer_address: null,
+        claimed_at: null,
+        claim_tx_hash: null,
+      }),
+    ]);
+    expect(result.meta).toEqual({ totalItems: 3 });
+  });
+
+  it('rejects an out-of-range limit', async () => {
+    await expect(
+      controller.listAll(1, 500, 'amount', 'DESC'),
+    ).rejects.toThrow('Limit must be between 1 and 100');
+  });
+});

--- a/src/affiliation/controllers/invitations.controller.spec.ts
+++ b/src/affiliation/controllers/invitations.controller.spec.ts
@@ -103,8 +103,8 @@ describe('InvitationsController', () => {
   });
 
   it('rejects an out-of-range limit', async () => {
-    await expect(
-      controller.listAll(1, 500, 'amount', 'DESC'),
-    ).rejects.toThrow('Limit must be between 1 and 100');
+    await expect(controller.listAll(1, 500, 'amount', 'DESC')).rejects.toThrow(
+      'Limit must be between 1 and 100',
+    );
   });
 });

--- a/src/affiliation/controllers/invitations.controller.ts
+++ b/src/affiliation/controllers/invitations.controller.ts
@@ -97,9 +97,7 @@ export class InvitationsController {
         claimed: invitation.status === 'claimed',
         claimer_address: invitation.invitee_address ?? null,
         claimed_at:
-          invitation.status === 'claimed'
-            ? invitation.status_updated_at
-            : null,
+          invitation.status === 'claimed' ? invitation.status_updated_at : null,
         claim_tx_hash: invitation.claim_tx_hash ?? null,
       })),
     };

--- a/src/affiliation/controllers/invitations.controller.ts
+++ b/src/affiliation/controllers/invitations.controller.ts
@@ -12,6 +12,7 @@ import { paginate } from 'nestjs-typeorm-paginate';
 import { Repository } from 'typeorm';
 import { Invitation } from '../entities/invitation.entity';
 import { Account } from '@/account/entities/account.entity';
+import { OptionalAeAccountAddressPipe } from '@/common/validation/request-validation';
 
 const ALLOWED_ORDER_BY = new Set(['amount', 'created_at']);
 const ALLOWED_ORDER_DIRECTIONS = new Set(['ASC', 'DESC']);
@@ -34,6 +35,15 @@ export class InvitationsController {
     required: false,
   })
   @ApiQuery({ name: 'order_direction', enum: ['ASC', 'DESC'], required: false })
+  @ApiQuery({
+    name: 'inviter',
+    type: 'string',
+    required: false,
+    description:
+      'Filter to invitations sent by this address; each item includes its ' +
+      'claim status (claimed, claimer_address, claimed_at, claim_tx_hash) ' +
+      'so callers no longer need a per-invitee middleware lookup.',
+  })
   @ApiOperation({ operationId: 'listAll' })
   @Get()
   async listAll(
@@ -41,6 +51,7 @@ export class InvitationsController {
     @Query('limit', new DefaultValuePipe(100), ParseIntPipe) limit = 100,
     @Query('order_by') orderBy: string = 'amount',
     @Query('order_direction') orderDirection: 'ASC' | 'DESC' = 'DESC',
+    @Query('inviter', OptionalAeAccountAddressPipe) inviter?: string,
   ) {
     if (page < 1) {
       throw new BadRequestException('Page must be greater than or equal to 1');
@@ -60,6 +71,9 @@ export class InvitationsController {
     if (orderBy) {
       query.orderBy(`invitation.${orderBy}`, orderDirection);
     }
+    if (inviter) {
+      query.andWhere('invitation.sender_address = :inviter', { inviter });
+    }
     // left join account and map as nested account object
     query.leftJoinAndMapOne(
       'invitation.invitee',
@@ -74,6 +88,20 @@ export class InvitationsController {
       'sender',
       'sender.address = invitation.sender_address',
     );
-    return paginate(query, { page, limit });
+    const result = await paginate(query, { page, limit });
+
+    return {
+      ...result,
+      items: result.items.map((invitation) => ({
+        ...invitation,
+        claimed: invitation.status === 'claimed',
+        claimer_address: invitation.invitee_address ?? null,
+        claimed_at:
+          invitation.status === 'claimed'
+            ? invitation.status_updated_at
+            : null,
+        claim_tx_hash: invitation.claim_tx_hash ?? null,
+      })),
+    };
   }
 }

--- a/src/api-core/base/base.controller.spec.ts
+++ b/src/api-core/base/base.controller.spec.ts
@@ -1,0 +1,80 @@
+import { BadRequestException } from '@nestjs/common';
+import { createBaseController } from './base.controller';
+import { EntityConfig } from '../types/entity-config.interface';
+
+jest.mock('nestjs-typeorm-paginate', () => ({
+  paginate: jest.fn().mockResolvedValue({
+    items: [],
+    meta: { itemCount: 0, totalItems: 0, itemsPerPage: 100, totalPages: 0, currentPage: 1 },
+  }),
+}));
+
+class FakeEntity {
+  id: string;
+}
+
+function makeConfig(
+  overrides: Partial<EntityConfig<FakeEntity>> = {},
+): EntityConfig<FakeEntity> {
+  return {
+    entity: FakeEntity,
+    primaryKey: 'id',
+    defaultOrderBy: 'id',
+    tableAlias: 'fake_entity',
+    routePrefix: 'fake-entities',
+    queryNames: { plural: 'fakeEntities', singular: 'fakeEntity' },
+    swaggerTag: 'Fake',
+    orderByFields: ['id'],
+    ...overrides,
+  };
+}
+
+function makeRepository() {
+  const queryBuilder = {
+    createQueryBuilder: undefined as any,
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    select: jest.fn().mockReturnThis(),
+    getOne: jest.fn().mockResolvedValue(null),
+  };
+  return {
+    createQueryBuilder: jest.fn(() => queryBuilder),
+  };
+}
+
+describe('createBaseController maxPage', () => {
+  it('rejects page 501 for the default cap (no per-entity maxPage set)', async () => {
+    const Controller = createBaseController(makeConfig());
+    const controller = new Controller(makeRepository() as any);
+
+    await expect(
+      controller.listAll(501, 100, undefined, 'DESC', undefined, {}),
+    ).rejects.toThrow(BadRequestException);
+    await expect(
+      controller.listAll(501, 100, undefined, 'DESC', undefined, {}),
+    ).rejects.toThrow('Maximum page is 500');
+  });
+
+  it('accepts a page beyond 500 when the entity config raises maxPage', async () => {
+    const Controller = createBaseController(
+      makeConfig({ maxPage: 1_000_000 }),
+    );
+    const controller = new Controller(makeRepository() as any);
+
+    await expect(
+      controller.listAll(501, 100, undefined, 'DESC', undefined, {}),
+    ).resolves.toBeDefined();
+  });
+
+  it('still rejects a page beyond the raised cap', async () => {
+    const Controller = createBaseController(
+      makeConfig({ maxPage: 1_000_000 }),
+    );
+    const controller = new Controller(makeRepository() as any);
+
+    await expect(
+      controller.listAll(1_000_001, 100, undefined, 'DESC', undefined, {}),
+    ).rejects.toThrow('Maximum page is 1000000');
+  });
+});

--- a/src/api-core/base/base.controller.spec.ts
+++ b/src/api-core/base/base.controller.spec.ts
@@ -5,7 +5,13 @@ import { EntityConfig } from '../types/entity-config.interface';
 jest.mock('nestjs-typeorm-paginate', () => ({
   paginate: jest.fn().mockResolvedValue({
     items: [],
-    meta: { itemCount: 0, totalItems: 0, itemsPerPage: 100, totalPages: 0, currentPage: 1 },
+    meta: {
+      itemCount: 0,
+      totalItems: 0,
+      itemsPerPage: 100,
+      totalPages: 0,
+      currentPage: 1,
+    },
   }),
 }));
 
@@ -57,9 +63,7 @@ describe('createBaseController maxPage', () => {
   });
 
   it('accepts a page beyond 500 when the entity config raises maxPage', async () => {
-    const Controller = createBaseController(
-      makeConfig({ maxPage: 1_000_000 }),
-    );
+    const Controller = createBaseController(makeConfig({ maxPage: 1_000_000 }));
     const controller = new Controller(makeRepository() as any);
 
     await expect(
@@ -68,9 +72,7 @@ describe('createBaseController maxPage', () => {
   });
 
   it('still rejects a page beyond the raised cap', async () => {
-    const Controller = createBaseController(
-      makeConfig({ maxPage: 1_000_000 }),
-    );
+    const Controller = createBaseController(makeConfig({ maxPage: 1_000_000 }));
     const controller = new Controller(makeRepository() as any);
 
     await expect(

--- a/src/api-core/base/base.controller.ts
+++ b/src/api-core/base/base.controller.ts
@@ -37,6 +37,15 @@ import {
 } from '../utils/relation-loader';
 import { RateLimitGuard } from '../guards/rate-limit.guard';
 
+// Deep OFFSET pagination (e.g. ?page=100000) forces Postgres to scan and
+// discard every prior row before returning a page; page size is already
+// capped at 100, but page itself had no ceiling. 500 pages * 100/page =
+// 50,000 rows deep, generous for real pagination UIs while bounding the
+// worst case. Entities with a legitimate deep-paging use case (e.g.
+// full-history blockchain mirror tables with no range-filter alternative to
+// OFFSET paging) can raise this via `EntityConfig.maxPage`.
+const MAX_PAGE = 500;
+
 /**
  * Builds a description of available relations for Swagger documentation
  * @param entityConfig - The entity config
@@ -161,6 +170,7 @@ export function createBaseController<T>(
   configRegistry?: EntityConfigRegistry,
 ) {
   const ResponseType = config.dto || config.entity;
+  const maxPage = config.maxPage ?? MAX_PAGE;
 
   // Read sortable and searchable fields from entity metadata
   const sortableFields = getSortableFields(config.entity);
@@ -296,6 +306,9 @@ export function createBaseController<T>(
         throw new BadRequestException(
           'Page must be greater than or equal to 1',
         );
+      }
+      if (page > maxPage) {
+        throw new BadRequestException(`Maximum page is ${maxPage}`);
       }
       if (limit < 1) {
         throw new BadRequestException(

--- a/src/api-core/base/base.resolver.spec.ts
+++ b/src/api-core/base/base.resolver.spec.ts
@@ -5,7 +5,13 @@ import { EntityConfig } from '../types/entity-config.interface';
 jest.mock('nestjs-typeorm-paginate', () => ({
   paginate: jest.fn().mockResolvedValue({
     items: [],
-    meta: { itemCount: 0, totalItems: 0, itemsPerPage: 100, totalPages: 0, currentPage: 1 },
+    meta: {
+      itemCount: 0,
+      totalItems: 0,
+      itemsPerPage: 100,
+      totalPages: 0,
+      currentPage: 1,
+    },
   }),
 }));
 

--- a/src/api-core/base/base.resolver.spec.ts
+++ b/src/api-core/base/base.resolver.spec.ts
@@ -1,0 +1,65 @@
+import { BadRequestException } from '@nestjs/common';
+import { createBaseResolver } from './base.resolver';
+import { EntityConfig } from '../types/entity-config.interface';
+
+jest.mock('nestjs-typeorm-paginate', () => ({
+  paginate: jest.fn().mockResolvedValue({
+    items: [],
+    meta: { itemCount: 0, totalItems: 0, itemsPerPage: 100, totalPages: 0, currentPage: 1 },
+  }),
+}));
+
+class FakeEntity {
+  id: string;
+}
+
+function makeConfig(
+  overrides: Partial<EntityConfig<FakeEntity>> = {},
+): EntityConfig<FakeEntity> {
+  return {
+    entity: FakeEntity,
+    primaryKey: 'id',
+    defaultOrderBy: 'id',
+    tableAlias: 'fake_entity',
+    routePrefix: 'fake-entities',
+    queryNames: { plural: 'fakeEntities', singular: 'fakeEntity' },
+    swaggerTag: 'Fake',
+    ...overrides,
+  };
+}
+
+function makeRepository() {
+  const queryBuilder = {
+    orderBy: jest.fn().mockReturnThis(),
+  };
+  return {
+    createQueryBuilder: jest.fn(() => queryBuilder),
+  };
+}
+
+describe('createBaseResolver maxPage', () => {
+  it('rejects page 501 for the default cap (no per-entity maxPage set)', async () => {
+    const Resolver = createBaseResolver(makeConfig());
+    const resolver = new Resolver(makeRepository() as any);
+
+    await expect(resolver.findAll(501, 100)).rejects.toThrow(
+      'Maximum page is 500',
+    );
+  });
+
+  it('accepts a page beyond 500 when the entity config raises maxPage', async () => {
+    const Resolver = createBaseResolver(makeConfig({ maxPage: 1_000_000 }));
+    const resolver = new Resolver(makeRepository() as any);
+
+    await expect(resolver.findAll(501, 100)).resolves.toBeDefined();
+  });
+
+  it('still rejects a page beyond the raised cap', async () => {
+    const Resolver = createBaseResolver(makeConfig({ maxPage: 1_000_000 }));
+    const resolver = new Resolver(makeRepository() as any);
+
+    await expect(resolver.findAll(1_000_001, 100)).rejects.toThrow(
+      new BadRequestException('Maximum page is 1000000'),
+    );
+  });
+});

--- a/src/api-core/base/base.resolver.ts
+++ b/src/api-core/base/base.resolver.ts
@@ -16,11 +16,25 @@ import { EntityConfig } from '../types/entity-config.interface';
 import { getSortableFields } from '../utils/metadata-reader';
 
 const MAX_GRAPHQL_PAGE_SIZE = 100;
+// Deep OFFSET pagination (e.g. page: 100000) forces Postgres to scan and
+// discard every prior row before returning a page; page size is already
+// capped, but page itself had no ceiling. Entities with a legitimate
+// deep-paging use case (e.g. full-history blockchain mirror tables with no
+// range-filter alternative to OFFSET paging) can raise this via
+// `EntityConfig.maxPage`.
+const MAX_GRAPHQL_PAGE = 500;
 const ALLOWED_ORDER_DIRECTIONS = new Set(['ASC', 'DESC']);
 
-function validateGraphqlPagination(page: number, limit: number): void {
+function validateGraphqlPagination(
+  page: number,
+  limit: number,
+  maxPage: number = MAX_GRAPHQL_PAGE,
+): void {
   if (page < 1) {
     throw new BadRequestException('Page must be greater than or equal to 1');
+  }
+  if (page > maxPage) {
+    throw new BadRequestException(`Maximum page is ${maxPage}`);
   }
   if (limit < 1) {
     throw new BadRequestException('Limit must be greater than or equal to 1');
@@ -99,7 +113,7 @@ export function createBaseResolver<T>(config: EntityConfig<T>) {
       orderDirection?: 'ASC' | 'DESC',
     ) {
       const query = this.repository.createQueryBuilder(config.tableAlias);
-      validateGraphqlPagination(page, limit);
+      validateGraphqlPagination(page, limit, config.maxPage);
       if (orderBy && !orderByFields.includes(orderBy)) {
         throw new BadRequestException(`Invalid orderBy value: ${orderBy}`);
       }

--- a/src/api-core/types/entity-config.interface.ts
+++ b/src/api-core/types/entity-config.interface.ts
@@ -40,4 +40,9 @@ export interface EntityConfig<TEntity = any> {
   orderByFields?: string[]; // Optional: specify allowed order_by fields for Swagger. If not provided, will be extracted from entity metadata
   customResolveFields?: CustomResolveFieldConfig<TEntity>[];
   relations?: RelationConfig[]; // Array of relation configurations
+  // Overrides the base controller/resolver's default deep-OFFSET-pagination
+  // cap (see MAX_PAGE/MAX_GRAPHQL_PAGE) for entities where legitimate use
+  // needs to page deeper than that default -- e.g. full-history blockchain
+  // mirror tables with no range-filter alternative to OFFSET paging.
+  maxPage?: number;
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -39,6 +39,7 @@ import { AddressLinksModule } from './plugins/address-links/address-links.module
 import { NotificationsModule } from './notifications/notifications.module';
 import { AnnouncementsModule } from './announcements/announcements.module';
 import { TokenGatedRoomsModule } from './token-gated-rooms/token-gated-rooms.module';
+import { SearchModule } from './search/search.module';
 
 @Module({
   imports: [
@@ -118,6 +119,7 @@ import { TokenGatedRoomsModule } from './token-gated-rooms/token-gated-rooms.mod
     // all load here; the relay duties self-enable iff a relay is configured
     // (`TG_RELAY_URL` + `TG_BOT_NSEC`). See deworker-plan.md.
     TokenGatedRoomsModule,
+    SearchModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -40,6 +40,7 @@ import { NotificationsModule } from './notifications/notifications.module';
 import { AnnouncementsModule } from './announcements/announcements.module';
 import { TokenGatedRoomsModule } from './token-gated-rooms/token-gated-rooms.module';
 import { SearchModule } from './search/search.module';
+import { FeedModule } from './feed/feed.module';
 
 @Module({
   imports: [
@@ -120,6 +121,7 @@ import { SearchModule } from './search/search.module';
     // (`TG_RELAY_URL` + `TG_BOT_NSEC`). See deworker-plan.md.
     TokenGatedRoomsModule,
     SearchModule,
+    FeedModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/feed/feed-cursor.util.spec.ts
+++ b/src/feed/feed-cursor.util.spec.ts
@@ -1,7 +1,4 @@
-import {
-  decodeFeedCursor,
-  encodeFeedCursor,
-} from './feed-cursor.util';
+import { decodeFeedCursor, encodeFeedCursor } from './feed-cursor.util';
 
 describe('feed cursor util', () => {
   it('round-trips a latest cursor including seenIds', () => {

--- a/src/feed/feed-cursor.util.spec.ts
+++ b/src/feed/feed-cursor.util.spec.ts
@@ -1,0 +1,77 @@
+import {
+  decodeFeedCursor,
+  encodeFeedCursor,
+} from './feed-cursor.util';
+
+describe('feed cursor util', () => {
+  it('round-trips a latest cursor including seenIds', () => {
+    const encoded = encodeFeedCursor({
+      sort: 'latest',
+      ts: 12345,
+      seenIds: ['post_1', 'ct_1'],
+    });
+    const decoded = decodeFeedCursor(encoded, 'latest');
+
+    expect(decoded).toEqual({
+      sort: 'latest',
+      ts: 12345,
+      seenIds: ['post_1', 'ct_1'],
+    });
+  });
+
+  it('defaults seenIds to an empty array when absent from the cursor', () => {
+    const tampered = Buffer.from(
+      JSON.stringify({ sort: 'latest', ts: 12345 }),
+      'utf8',
+    ).toString('base64url');
+
+    const decoded = decodeFeedCursor(tampered, 'latest');
+
+    expect(decoded).toEqual({ sort: 'latest', ts: 12345, seenIds: [] });
+  });
+
+  it('rejects a latest cursor whose seenIds is not an array of strings', () => {
+    const tampered = Buffer.from(
+      JSON.stringify({ sort: 'latest', ts: 12345, seenIds: [1, 2] }),
+      'utf8',
+    ).toString('base64url');
+
+    expect(() => decodeFeedCursor(tampered, 'latest')).toThrow(
+      'Invalid cursor',
+    );
+  });
+
+  it('round-trips a hot cursor', () => {
+    const encoded = encodeFeedCursor({ sort: 'hot', offset: 40 });
+    const decoded = decodeFeedCursor(encoded, 'hot');
+
+    expect(decoded).toEqual({ sort: 'hot', offset: 40 });
+  });
+
+  it('returns null for an absent cursor', () => {
+    expect(decodeFeedCursor(undefined, 'latest')).toBeNull();
+  });
+
+  it('rejects a cursor encoded for a different sort', () => {
+    const encoded = encodeFeedCursor({ sort: 'latest', ts: 1 });
+
+    expect(() => decodeFeedCursor(encoded, 'hot')).toThrow(
+      'Invalid cursor for sort=hot',
+    );
+  });
+
+  it('rejects a malformed cursor', () => {
+    expect(() => decodeFeedCursor('not-base64-json', 'latest')).toThrow(
+      'Invalid cursor',
+    );
+  });
+
+  it('rejects a negative hot offset', () => {
+    const tampered = Buffer.from(
+      JSON.stringify({ sort: 'hot', offset: -1 }),
+      'utf8',
+    ).toString('base64url');
+
+    expect(() => decodeFeedCursor(tampered, 'hot')).toThrow('Invalid cursor');
+  });
+});

--- a/src/feed/feed-cursor.util.ts
+++ b/src/feed/feed-cursor.util.ts
@@ -51,9 +51,7 @@ export function decodeFeedCursor(
     typeof parsed !== 'object' ||
     (parsed as { sort?: unknown }).sort !== sort
   ) {
-    throw new BadRequestException(
-      `Invalid cursor for sort=${sort}`,
-    );
+    throw new BadRequestException(`Invalid cursor for sort=${sort}`);
   }
 
   if (sort === 'latest') {

--- a/src/feed/feed-cursor.util.ts
+++ b/src/feed/feed-cursor.util.ts
@@ -1,0 +1,80 @@
+import { BadRequestException } from '@nestjs/common';
+
+export type FeedSort = 'latest' | 'hot';
+
+export interface LatestFeedCursor {
+  sort: 'latest';
+  ts: number;
+  // Primary keys (post.id / token.sale_address / transaction.tx_hash — their
+  // string formats never collide) of every item already returned whose
+  // created_at equals `ts` exactly. None of the three merged sources has a
+  // secondary key that's both monotonic with time and shared across all
+  // three, so ties at the cutoff are broken by exclusion instead: without
+  // this, an item sharing the last item's timestamp could be silently
+  // skipped at the page boundary. Bounded by the page limit, so this stays
+  // small. Optional on encode (older/hand-built cursors just carry none);
+  // decode always fills it in as `[]`.
+  seenIds?: string[];
+}
+
+export interface HotFeedCursor {
+  sort: 'hot';
+  offset: number;
+}
+
+export type FeedCursor = LatestFeedCursor | HotFeedCursor;
+
+// Opaque cursor: callers should treat this as a black box. Base64-encoded
+// JSON is enough here — there is nothing sensitive in it and it never needs
+// to be validated against tampering beyond "does it parse and match `sort`".
+export function encodeFeedCursor(cursor: FeedCursor): string {
+  return Buffer.from(JSON.stringify(cursor), 'utf8').toString('base64url');
+}
+
+export function decodeFeedCursor(
+  cursor: string | undefined,
+  sort: FeedSort,
+): FeedCursor | null {
+  if (!cursor) {
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(Buffer.from(cursor, 'base64url').toString('utf8'));
+  } catch {
+    throw new BadRequestException('Invalid cursor');
+  }
+
+  if (
+    !parsed ||
+    typeof parsed !== 'object' ||
+    (parsed as { sort?: unknown }).sort !== sort
+  ) {
+    throw new BadRequestException(
+      `Invalid cursor for sort=${sort}`,
+    );
+  }
+
+  if (sort === 'latest') {
+    const ts = (parsed as { ts?: unknown }).ts;
+    if (typeof ts !== 'number' || !Number.isFinite(ts)) {
+      throw new BadRequestException('Invalid cursor');
+    }
+    const rawSeenIds = (parsed as { seenIds?: unknown }).seenIds;
+    if (
+      rawSeenIds !== undefined &&
+      (!Array.isArray(rawSeenIds) ||
+        !rawSeenIds.every((id) => typeof id === 'string'))
+    ) {
+      throw new BadRequestException('Invalid cursor');
+    }
+    return { sort: 'latest', ts, seenIds: (rawSeenIds as string[]) ?? [] };
+  }
+
+  const offset = (parsed as { offset?: unknown }).offset;
+  if (typeof offset !== 'number' || !Number.isFinite(offset) || offset < 0) {
+    throw new BadRequestException('Invalid cursor');
+  }
+  return { sort: 'hot', offset };
+}

--- a/src/feed/feed.controller.spec.ts
+++ b/src/feed/feed.controller.spec.ts
@@ -1,0 +1,474 @@
+import { Brackets } from 'typeorm';
+import { FeedController } from './feed.controller';
+import { decodeFeedCursor, encodeFeedCursor } from './feed-cursor.util';
+
+describe('FeedController', () => {
+  let controller: FeedController;
+  let postsRepository: { createQueryBuilder: jest.Mock };
+  let tokensRepository: { createQueryBuilder: jest.Mock };
+  let transactionsRepository: { createQueryBuilder: jest.Mock };
+  let popularRankingService: { getPopularPostsPage: jest.Mock };
+
+  const makeQueryBuilder = (rows: any[]) => ({
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    innerJoin: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    getMany: jest.fn().mockResolvedValue(rows),
+  });
+
+  beforeEach(() => {
+    postsRepository = { createQueryBuilder: jest.fn(() => makeQueryBuilder([])) };
+    tokensRepository = { createQueryBuilder: jest.fn(() => makeQueryBuilder([])) };
+    transactionsRepository = {
+      createQueryBuilder: jest.fn(() => makeQueryBuilder([])),
+    };
+    popularRankingService = {
+      getPopularPostsPage: jest.fn().mockResolvedValue({
+        items: [],
+        totalItems: 0,
+      }),
+    };
+
+    controller = new FeedController(
+      postsRepository as any,
+      tokensRepository as any,
+      transactionsRepository as any,
+      popularRankingService as any,
+    );
+  });
+
+  it('rejects an invalid sort value', async () => {
+    await expect(controller.getFeed('unknown', undefined, 20)).rejects.toThrow(
+      'sort must be one of: latest, hot',
+    );
+  });
+
+  describe('sort=latest', () => {
+    it('merges posts, token creations, and trades by created_at desc', async () => {
+      const post = { id: 'post_1', created_at: new Date('2026-01-03T00:00:00Z') };
+      const token = {
+        sale_address: 'ct_1',
+        created_at: new Date('2026-01-02T00:00:00Z'),
+      };
+      const trade = {
+        tx_hash: 'th_1',
+        created_at: new Date('2026-01-01T00:00:00Z'),
+      };
+      postsRepository.createQueryBuilder.mockReturnValue(
+        makeQueryBuilder([post]),
+      );
+      tokensRepository.createQueryBuilder.mockReturnValue(
+        makeQueryBuilder([token]),
+      );
+      transactionsRepository.createQueryBuilder.mockReturnValue(
+        makeQueryBuilder([trade]),
+      );
+
+      const result = await controller.getFeed('latest', undefined, 20);
+
+      expect(result.items).toEqual([
+        { type: 'post', created_at: post.created_at, data: post },
+        { type: 'token_created', created_at: token.created_at, data: token },
+        { type: 'trade', created_at: trade.created_at, data: trade },
+      ]);
+      expect(result.next_cursor).toBeNull();
+    });
+
+    it('sets next_cursor when a source fills its own page', async () => {
+      const posts = Array.from({ length: 2 }, (_, i) => ({
+        id: `post_${i}`,
+        created_at: new Date(Date.UTC(2026, 0, 3, 0, 0, i)),
+      }));
+      postsRepository.createQueryBuilder.mockReturnValue(
+        makeQueryBuilder(posts),
+      );
+
+      const result = await controller.getFeed('latest', undefined, 2);
+
+      expect(result.next_cursor).not.toBeNull();
+      const decoded = decodeFeedCursor(result.next_cursor!, 'latest');
+      const lastItem = result.items[result.items.length - 1];
+      expect(decoded).toEqual({
+        sort: 'latest',
+        ts: lastItem.created_at.getTime(),
+        seenIds: [(lastItem.data as { id: string }).id],
+      });
+    });
+
+    it('applies the decoded cursor as a `created_at <` filter on every source', async () => {
+      const postsQb = makeQueryBuilder([]);
+      const tokensQb = makeQueryBuilder([]);
+      const tradesQb = makeQueryBuilder([]);
+      postsRepository.createQueryBuilder.mockReturnValue(postsQb);
+      tokensRepository.createQueryBuilder.mockReturnValue(tokensQb);
+      transactionsRepository.createQueryBuilder.mockReturnValue(tradesQb);
+
+      const cursor = encodeFeedCursor({ sort: 'latest', ts: 1735689600000 });
+      await controller.getFeed('latest', cursor, 20);
+
+      const before = new Date(1735689600000);
+      expect(postsQb.andWhere).toHaveBeenCalledWith(
+        'post.created_at < :before',
+        { before },
+      );
+      expect(tokensQb.andWhere).toHaveBeenCalledWith(
+        'token.created_at < :before',
+        { before },
+      );
+      expect(tradesQb.andWhere).toHaveBeenCalledWith(
+        'transaction.created_at < :before',
+        { before },
+      );
+    });
+
+    it('excludes already-seen ids at an exact-timestamp tie instead of only filtering by <', async () => {
+      const postsQb = makeQueryBuilder([]);
+      const tokensQb = makeQueryBuilder([]);
+      const tradesQb = makeQueryBuilder([]);
+      postsRepository.createQueryBuilder.mockReturnValue(postsQb);
+      tokensRepository.createQueryBuilder.mockReturnValue(tokensQb);
+      transactionsRepository.createQueryBuilder.mockReturnValue(tradesQb);
+
+      const before = new Date(1735689600000);
+      const cursor = encodeFeedCursor({
+        sort: 'latest',
+        ts: before.getTime(),
+        seenIds: ['post_seen', 'th_seen'],
+      });
+      await controller.getFeed('latest', cursor, 20);
+
+      // Rather than only filtering by `<`, each source's query must OR in an
+      // exact-tie branch that excludes the ids already returned for that
+      // timestamp -- otherwise an item tied with the previous page's cutoff
+      // would be silently skipped.
+      for (const [qb, createdAtColumn, pkColumn] of [
+        [postsQb, 'post.created_at', 'post.id'],
+        [tokensQb, 'token.created_at', 'token.sale_address'],
+        [tradesQb, 'transaction.created_at', 'transaction.tx_hash'],
+      ] as const) {
+        expect(qb.andWhere).toHaveBeenCalledWith(expect.any(Brackets));
+        const brackets = qb.andWhere.mock.calls[0][0] as Brackets;
+        const outer = { where: jest.fn().mockReturnThis(), orWhere: jest.fn().mockReturnThis() };
+        brackets.whereFactory(outer as any);
+
+        expect(outer.where).toHaveBeenCalledWith(`${createdAtColumn} < :before`, {
+          before,
+        });
+        expect(outer.orWhere).toHaveBeenCalledWith(expect.any(Brackets));
+        const inner = outer.orWhere.mock.calls[0][0] as Brackets;
+        const innerQb = { where: jest.fn().mockReturnThis(), andWhere: jest.fn().mockReturnThis() };
+        inner.whereFactory(innerQb as any);
+
+        expect(innerQb.where).toHaveBeenCalledWith(
+          `${createdAtColumn} = :before`,
+          { before },
+        );
+        expect(innerQb.andWhere).toHaveBeenCalledWith(
+          `${pkColumn} NOT IN (:...excludeIds)`,
+          { excludeIds: ['post_seen', 'th_seen'] },
+        );
+      }
+    });
+
+    it('accumulates seenIds across pages when a tie spans more pages than fit in one limit', async () => {
+      // 10 posts sharing the exact same created_at -- more than `limit` (4),
+      // so the tie spans 3 pages. Each call's mock simulates what the real
+      // DB would return once the previous pages' ids are excluded (that
+      // exclusion SQL itself is covered by the test above); this test only
+      // exercises the controller's own seenIds bookkeeping across pages.
+      const tiedTs = Date.UTC(2026, 0, 3, 0, 0, 0);
+      const allPosts = Array.from({ length: 10 }, (_, i) => ({
+        id: `post_${i}`,
+        created_at: new Date(tiedTs),
+      }));
+      tokensRepository.createQueryBuilder.mockReturnValue(makeQueryBuilder([]));
+      transactionsRepository.createQueryBuilder.mockReturnValue(
+        makeQueryBuilder([]),
+      );
+
+      // Page 1: no cursor yet.
+      postsRepository.createQueryBuilder.mockReturnValue(
+        makeQueryBuilder(allPosts.slice(0, 4)),
+      );
+      const page1 = await controller.getFeed('latest', undefined, 4);
+      expect(page1.items.map((i) => (i.data as any).id)).toEqual([
+        'post_0',
+        'post_1',
+        'post_2',
+        'post_3',
+      ]);
+      const cursor1 = decodeFeedCursor(page1.next_cursor!, 'latest');
+      expect(cursor1).toMatchObject({
+        ts: tiedTs,
+        seenIds: ['post_0', 'post_1', 'post_2', 'post_3'],
+      });
+
+      // Page 2: DB (simulated) excludes posts 0-3, returns the next 4.
+      postsRepository.createQueryBuilder.mockReturnValue(
+        makeQueryBuilder(allPosts.slice(4, 8)),
+      );
+      const page2 = await controller.getFeed(
+        'latest',
+        page1.next_cursor!,
+        4,
+      );
+      expect(page2.items.map((i) => (i.data as any).id)).toEqual([
+        'post_4',
+        'post_5',
+        'post_6',
+        'post_7',
+      ]);
+      const cursor2 = decodeFeedCursor(page2.next_cursor!, 'latest');
+      // Must carry forward posts 0-3 from cursor1 in addition to 4-7, or a
+      // page-3 query excluding only {4-7} would re-serve posts 0-3.
+      expect(cursor2).toMatchObject({
+        ts: tiedTs,
+        seenIds: expect.arrayContaining([
+          'post_0',
+          'post_1',
+          'post_2',
+          'post_3',
+          'post_4',
+          'post_5',
+          'post_6',
+          'post_7',
+        ]),
+      });
+      expect((cursor2 as any).seenIds).toHaveLength(8);
+
+      // Page 3: DB (simulated) excludes posts 0-7, returns the final 2.
+      postsRepository.createQueryBuilder.mockReturnValue(
+        makeQueryBuilder(allPosts.slice(8, 10)),
+      );
+      const page3 = await controller.getFeed(
+        'latest',
+        page2.next_cursor!,
+        4,
+      );
+      expect(page3.items.map((i) => (i.data as any).id)).toEqual([
+        'post_8',
+        'post_9',
+      ]);
+      expect(page3.next_cursor).toBeNull();
+    });
+
+    it('rejects a hot cursor passed while sorting latest', async () => {
+      const cursor = encodeFeedCursor({ sort: 'hot', offset: 10 });
+
+      await expect(
+        controller.getFeed('latest', cursor, 20),
+      ).rejects.toThrow('Invalid cursor for sort=latest');
+    });
+  });
+
+  describe('sort=hot', () => {
+    it('delegates to PopularRankingService and paginates by offset', async () => {
+      const post = { id: 'post_1', created_at: new Date('2026-01-01T00:00:00Z') };
+      popularRankingService.getPopularPostsPage.mockResolvedValue({
+        items: [post],
+        totalItems: 5,
+      });
+
+      const result = await controller.getFeed('hot', undefined, 1);
+
+      expect(popularRankingService.getPopularPostsPage).toHaveBeenCalledWith(
+        'all',
+        1,
+        0,
+      );
+      expect(result.items).toEqual([
+        { type: 'post', created_at: post.created_at, data: post },
+      ]);
+      expect(result.next_cursor).not.toBeNull();
+      expect(decodeFeedCursor(result.next_cursor!, 'hot')).toEqual({
+        sort: 'hot',
+        offset: 1,
+      });
+    });
+
+    it('returns null next_cursor once every item has been paged through', async () => {
+      popularRankingService.getPopularPostsPage.mockResolvedValue({
+        items: [{ id: 'post_1', created_at: new Date() }],
+        totalItems: 1,
+      });
+
+      const result = await controller.getFeed('hot', undefined, 20);
+
+      expect(result.next_cursor).toBeNull();
+    });
+
+    it('resumes from the offset encoded in the cursor', async () => {
+      const cursor = encodeFeedCursor({ sort: 'hot', offset: 40 });
+
+      await controller.getFeed('hot', cursor, 20);
+
+      expect(popularRankingService.getPopularPostsPage).toHaveBeenCalledWith(
+        'all',
+        20,
+        40,
+      );
+    });
+  });
+});
+
+// The dumb `makeQueryBuilder` stub above always returns a fixed array
+// regardless of the query, which can't catch a bug in the *pagination
+// invariant itself* (does a full multi-page walk ever skip or duplicate an
+// item?). This fake actually filters/sorts/limits an in-memory dataset --
+// including evaluating the Brackets-based tie-break predicate -- so a full
+// sweep across many pages exercises the real cursor/merge/slice logic
+// end-to-end.
+function makeRealisticQueryBuilder<T extends Record<string, any>>(
+  rows: T[],
+  createdAtField: string,
+  pkField: string,
+) {
+  const conditions: Array<(row: T) => boolean> = [];
+  let limitN = Infinity;
+
+  function buildStringPredicate(
+    sql: string,
+    params: any,
+  ): (row: T) => boolean {
+    if (sql.includes(`${createdAtField} < :before`)) {
+      const before = params.before as Date;
+      return (row) => row[createdAtField].getTime() < before.getTime();
+    }
+    if (sql.includes(`${createdAtField} = :before`)) {
+      const before = params.before as Date;
+      return (row) => row[createdAtField].getTime() === before.getTime();
+    }
+    if (sql.includes(`${pkField} NOT IN (:...excludeIds)`)) {
+      const excludeIds = params.excludeIds as string[];
+      return (row) => !excludeIds.includes(row[pkField]);
+    }
+    // is_hidden/unlisted/tx_type filters -- not exercised by this harness.
+    return () => true;
+  }
+
+  function buildBracketPredicate(brackets: Brackets): (row: T) => boolean {
+    let combined: ((row: T) => boolean) | null = null;
+    const subQb = {
+      where(sqlOrBrackets: any, params?: any) {
+        combined = toPredicate(sqlOrBrackets, params);
+        return subQb;
+      },
+      andWhere(sqlOrBrackets: any, params?: any) {
+        const next = toPredicate(sqlOrBrackets, params);
+        const prev = combined!;
+        combined = (row) => prev(row) && next(row);
+        return subQb;
+      },
+      orWhere(sqlOrBrackets: any, params?: any) {
+        const next = toPredicate(sqlOrBrackets, params);
+        const prev = combined!;
+        combined = (row) => prev(row) || next(row);
+        return subQb;
+      },
+    };
+    brackets.whereFactory(subQb as any);
+    return combined!;
+  }
+
+  function toPredicate(sqlOrBrackets: any, params?: any): (row: T) => boolean {
+    if (sqlOrBrackets instanceof Brackets) {
+      return buildBracketPredicate(sqlOrBrackets);
+    }
+    return buildStringPredicate(sqlOrBrackets, params);
+  }
+
+  const qb: any = {
+    where(sqlOrBrackets: any, params?: any) {
+      conditions.push(toPredicate(sqlOrBrackets, params));
+      return qb;
+    },
+    andWhere(sqlOrBrackets: any, params?: any) {
+      conditions.push(toPredicate(sqlOrBrackets, params));
+      return qb;
+    },
+    innerJoin() {
+      return qb;
+    },
+    orderBy() {
+      return qb;
+    },
+    limit(n: number) {
+      limitN = n;
+      return qb;
+    },
+    getMany: async () => {
+      const filtered = rows.filter((row) =>
+        conditions.every((cond) => cond(row)),
+      );
+      filtered.sort(
+        (a, b) => b[createdAtField].getTime() - a[createdAtField].getTime(),
+      );
+      return filtered.slice(0, limitN);
+    },
+  };
+  return qb;
+}
+
+describe('FeedController sort=latest full pagination sweep (no skips/duplicates)', () => {
+  // A source that returns exactly `limit` rows this page but has no more
+  // data ("phantom" hasMore) costs at most one extra, empty-tailed page --
+  // it does not affect correctness, only causes one avoidable round trip.
+  it('serves every eligible item exactly once, even when one source dominates every page', async () => {
+    const now = Date.UTC(2026, 0, 1, 0, 0, 0);
+    // Posts: dense, one per second. Trades: sparse and offset from posts
+    // (no ties), clustered in the same recent window -- designed so posts
+    // alone can crowd trades out of the top `limit` for many consecutive
+    // pages, the scenario a "dropped from the merge" bug would show up in.
+    const posts = Array.from({ length: 60 }, (_, i) => ({
+      id: `post_${i}`,
+      created_at: new Date(now - i * 1000),
+    }));
+    const trades = Array.from({ length: 8 }, (_, i) => ({
+      tx_hash: `th_${i}`,
+      created_at: new Date(now - (i * 1000 + 500)),
+    }));
+
+    const controller = new FeedController(
+      {
+        createQueryBuilder: () =>
+          makeRealisticQueryBuilder(posts, 'created_at', 'id'),
+      } as any,
+      {
+        createQueryBuilder: () =>
+          makeRealisticQueryBuilder([], 'created_at', 'sale_address'),
+      } as any,
+      {
+        createQueryBuilder: () =>
+          makeRealisticQueryBuilder(trades, 'created_at', 'tx_hash'),
+      } as any,
+      { getPopularPostsPage: jest.fn() } as any,
+    );
+
+    const seen = new Set<string>();
+    let cursor: string | undefined;
+    let pages = 0;
+    const MAX_PAGES = 50;
+
+    do {
+      const result: any = await controller.getFeed('latest', cursor, 5);
+      for (const item of result.items) {
+        const id =
+          item.type === 'trade' ? item.data.tx_hash : item.data.id;
+        expect(seen.has(id)).toBe(false); // never re-served
+        seen.add(id);
+      }
+      cursor = result.next_cursor ?? undefined;
+      pages++;
+    } while (cursor && pages < MAX_PAGES);
+
+    expect(pages).toBeLessThan(MAX_PAGES); // pagination actually terminated
+
+    const expectedIds = new Set([
+      ...posts.map((p) => p.id),
+      ...trades.map((t) => t.tx_hash),
+    ]);
+    expect(seen).toEqual(expectedIds); // nothing skipped, nothing missing
+  });
+});

--- a/src/feed/feed.controller.spec.ts
+++ b/src/feed/feed.controller.spec.ts
@@ -19,8 +19,12 @@ describe('FeedController', () => {
   });
 
   beforeEach(() => {
-    postsRepository = { createQueryBuilder: jest.fn(() => makeQueryBuilder([])) };
-    tokensRepository = { createQueryBuilder: jest.fn(() => makeQueryBuilder([])) };
+    postsRepository = {
+      createQueryBuilder: jest.fn(() => makeQueryBuilder([])),
+    };
+    tokensRepository = {
+      createQueryBuilder: jest.fn(() => makeQueryBuilder([])),
+    };
     transactionsRepository = {
       createQueryBuilder: jest.fn(() => makeQueryBuilder([])),
     };
@@ -47,7 +51,10 @@ describe('FeedController', () => {
 
   describe('sort=latest', () => {
     it('merges posts, token creations, and trades by created_at desc', async () => {
-      const post = { id: 'post_1', created_at: new Date('2026-01-03T00:00:00Z') };
+      const post = {
+        id: 'post_1',
+        created_at: new Date('2026-01-03T00:00:00Z'),
+      };
       const token = {
         sale_address: 'ct_1',
         created_at: new Date('2026-01-02T00:00:00Z'),
@@ -150,15 +157,24 @@ describe('FeedController', () => {
       ] as const) {
         expect(qb.andWhere).toHaveBeenCalledWith(expect.any(Brackets));
         const brackets = qb.andWhere.mock.calls[0][0] as Brackets;
-        const outer = { where: jest.fn().mockReturnThis(), orWhere: jest.fn().mockReturnThis() };
+        const outer = {
+          where: jest.fn().mockReturnThis(),
+          orWhere: jest.fn().mockReturnThis(),
+        };
         brackets.whereFactory(outer as any);
 
-        expect(outer.where).toHaveBeenCalledWith(`${createdAtColumn} < :before`, {
-          before,
-        });
+        expect(outer.where).toHaveBeenCalledWith(
+          `${createdAtColumn} < :before`,
+          {
+            before,
+          },
+        );
         expect(outer.orWhere).toHaveBeenCalledWith(expect.any(Brackets));
         const inner = outer.orWhere.mock.calls[0][0] as Brackets;
-        const innerQb = { where: jest.fn().mockReturnThis(), andWhere: jest.fn().mockReturnThis() };
+        const innerQb = {
+          where: jest.fn().mockReturnThis(),
+          andWhere: jest.fn().mockReturnThis(),
+        };
         inner.whereFactory(innerQb as any);
 
         expect(innerQb.where).toHaveBeenCalledWith(
@@ -209,11 +225,7 @@ describe('FeedController', () => {
       postsRepository.createQueryBuilder.mockReturnValue(
         makeQueryBuilder(allPosts.slice(4, 8)),
       );
-      const page2 = await controller.getFeed(
-        'latest',
-        page1.next_cursor!,
-        4,
-      );
+      const page2 = await controller.getFeed('latest', page1.next_cursor!, 4);
       expect(page2.items.map((i) => (i.data as any).id)).toEqual([
         'post_4',
         'post_5',
@@ -242,11 +254,7 @@ describe('FeedController', () => {
       postsRepository.createQueryBuilder.mockReturnValue(
         makeQueryBuilder(allPosts.slice(8, 10)),
       );
-      const page3 = await controller.getFeed(
-        'latest',
-        page2.next_cursor!,
-        4,
-      );
+      const page3 = await controller.getFeed('latest', page2.next_cursor!, 4);
       expect(page3.items.map((i) => (i.data as any).id)).toEqual([
         'post_8',
         'post_9',
@@ -257,15 +265,18 @@ describe('FeedController', () => {
     it('rejects a hot cursor passed while sorting latest', async () => {
       const cursor = encodeFeedCursor({ sort: 'hot', offset: 10 });
 
-      await expect(
-        controller.getFeed('latest', cursor, 20),
-      ).rejects.toThrow('Invalid cursor for sort=latest');
+      await expect(controller.getFeed('latest', cursor, 20)).rejects.toThrow(
+        'Invalid cursor for sort=latest',
+      );
     });
   });
 
   describe('sort=hot', () => {
     it('delegates to PopularRankingService and paginates by offset', async () => {
-      const post = { id: 'post_1', created_at: new Date('2026-01-01T00:00:00Z') };
+      const post = {
+        id: 'post_1',
+        created_at: new Date('2026-01-01T00:00:00Z'),
+      };
       popularRankingService.getPopularPostsPage.mockResolvedValue({
         items: [post],
         totalItems: 5,
@@ -328,10 +339,7 @@ function makeRealisticQueryBuilder<T extends Record<string, any>>(
   const conditions: Array<(row: T) => boolean> = [];
   let limitN = Infinity;
 
-  function buildStringPredicate(
-    sql: string,
-    params: any,
-  ): (row: T) => boolean {
+  function buildStringPredicate(sql: string, params: any): (row: T) => boolean {
     if (sql.includes(`${createdAtField} < :before`)) {
       const before = params.before as Date;
       return (row) => row[createdAtField].getTime() < before.getTime();
@@ -454,8 +462,7 @@ describe('FeedController sort=latest full pagination sweep (no skips/duplicates)
     do {
       const result: any = await controller.getFeed('latest', cursor, 5);
       for (const item of result.items) {
-        const id =
-          item.type === 'trade' ? item.data.tx_hash : item.data.id;
+        const id = item.type === 'trade' ? item.data.tx_hash : item.data.id;
         expect(seen.has(id)).toBe(false); // never re-served
         seen.add(id);
       }

--- a/src/feed/feed.controller.ts
+++ b/src/feed/feed.controller.ts
@@ -8,7 +8,12 @@ import {
   Query,
   UseInterceptors,
 } from '@nestjs/common';
-import { ApiOkResponse, ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
+import {
+  ApiOkResponse,
+  ApiOperation,
+  ApiQuery,
+  ApiTags,
+} from '@nestjs/swagger';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Brackets, Repository } from 'typeorm';
 import { Post } from '@/social/entities/post.entity';
@@ -138,21 +143,27 @@ export class FeedController {
     ]);
 
     const candidates: FeedItem[] = [
-      ...posts.map((post): FeedItem => ({
-        type: 'post',
-        created_at: post.created_at,
-        data: post,
-      })),
-      ...tokens.map((token): FeedItem => ({
-        type: 'token_created',
-        created_at: token.created_at,
-        data: token,
-      })),
-      ...trades.map((trade): FeedItem => ({
-        type: 'trade',
-        created_at: trade.created_at,
-        data: trade,
-      })),
+      ...posts.map(
+        (post): FeedItem => ({
+          type: 'post',
+          created_at: post.created_at,
+          data: post,
+        }),
+      ),
+      ...tokens.map(
+        (token): FeedItem => ({
+          type: 'token_created',
+          created_at: token.created_at,
+          data: token,
+        }),
+      ),
+      ...trades.map(
+        (trade): FeedItem => ({
+          type: 'trade',
+          created_at: trade.created_at,
+          data: trade,
+        }),
+      ),
     ].sort((a, b) => b.created_at.getTime() - a.created_at.getTime());
 
     const items = candidates.slice(0, limit);

--- a/src/feed/feed.controller.ts
+++ b/src/feed/feed.controller.ts
@@ -1,0 +1,294 @@
+import { CacheInterceptor, CacheTTL } from '@nestjs/cache-manager';
+import {
+  BadRequestException,
+  Controller,
+  DefaultValuePipe,
+  Get,
+  ParseIntPipe,
+  Query,
+  UseInterceptors,
+} from '@nestjs/common';
+import { ApiOkResponse, ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Brackets, Repository } from 'typeorm';
+import { Post } from '@/social/entities/post.entity';
+import { Token } from '@/tokens/entities/token.entity';
+import { Transaction } from '@/transactions/entities/transaction.entity';
+import { PopularRankingService } from '@/social/services/popular-ranking.service';
+import {
+  FeedSort,
+  LatestFeedCursor,
+  decodeFeedCursor,
+  encodeFeedCursor,
+} from './feed-cursor.util';
+
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 50;
+const VALID_SORTS = new Set<FeedSort>(['latest', 'hot']);
+
+type FeedItemType = 'post' | 'token_created' | 'trade';
+
+interface FeedItem {
+  type: FeedItemType;
+  created_at: Date;
+  data: unknown;
+}
+
+// Replaces the frontend's separate posts + token-creations + trades fetches
+// (deduped/merged/sorted client-side) with one keyset-paginated feed.
+@Controller('feed')
+@ApiTags('Feed')
+@UseInterceptors(CacheInterceptor)
+export class FeedController {
+  constructor(
+    @InjectRepository(Post)
+    private readonly postsRepository: Repository<Post>,
+
+    @InjectRepository(Token)
+    private readonly tokensRepository: Repository<Token>,
+
+    @InjectRepository(Transaction)
+    private readonly transactionsRepository: Repository<Transaction>,
+
+    private readonly popularRankingService: PopularRankingService,
+  ) {
+    //
+  }
+
+  @ApiOperation({
+    operationId: 'getFeed',
+    summary: 'Combined home feed',
+    description:
+      'Keyset-paginated UNION of posts, token creations, and trades for ' +
+      '`sort=latest`. `sort=hot` returns posts only, ranked by the existing ' +
+      'popular-ranking algorithm (trades and token creations are never ' +
+      'ranked under "Hot").',
+  })
+  @ApiQuery({ name: 'sort', enum: ['latest', 'hot'], required: false })
+  @ApiQuery({ name: 'cursor', type: 'string', required: false })
+  @ApiQuery({ name: 'limit', type: 'number', required: false })
+  @ApiOkResponse({
+    description: '{ items: [{ type, created_at, data }], next_cursor }',
+  })
+  @CacheTTL(15_000)
+  @Get()
+  async getFeed(
+    @Query('sort') sortParam: string = 'latest',
+    @Query('cursor') cursorParam?: string,
+    @Query('limit', new DefaultValuePipe(DEFAULT_LIMIT), ParseIntPipe)
+    limit = DEFAULT_LIMIT,
+  ): Promise<{ items: FeedItem[]; next_cursor: string | null }> {
+    if (!VALID_SORTS.has(sortParam as FeedSort)) {
+      throw new BadRequestException('sort must be one of: latest, hot');
+    }
+    const sort = sortParam as FeedSort;
+    const clampedLimit = Math.min(Math.max(limit, 1), MAX_LIMIT);
+    const cursor = decodeFeedCursor(cursorParam, sort);
+
+    if (sort === 'hot') {
+      return this.getHotFeed(
+        cursor?.sort === 'hot' ? cursor.offset : 0,
+        clampedLimit,
+      );
+    }
+
+    return this.getLatestFeed(
+      cursor?.sort === 'latest' ? cursor : null,
+      clampedLimit,
+    );
+  }
+
+  private async getHotFeed(
+    offset: number,
+    limit: number,
+  ): Promise<{ items: FeedItem[]; next_cursor: string | null }> {
+    const { items, totalItems } =
+      await this.popularRankingService.getPopularPostsPage(
+        'all',
+        limit,
+        offset,
+      );
+
+    const feedItems: FeedItem[] = items.map((item) => ({
+      type: 'post',
+      created_at: item.created_at,
+      data: item,
+    }));
+
+    const nextOffset = offset + items.length;
+    const nextCursor =
+      items.length > 0 && nextOffset < totalItems
+        ? encodeFeedCursor({ sort: 'hot', offset: nextOffset })
+        : null;
+
+    return { items: feedItems, next_cursor: nextCursor };
+  }
+
+  private async getLatestFeed(
+    cursor: LatestFeedCursor | null,
+    limit: number,
+  ): Promise<{ items: FeedItem[]; next_cursor: string | null }> {
+    const before = cursor ? new Date(cursor.ts) : null;
+    const excludeIds = cursor?.seenIds ?? [];
+
+    const [posts, tokens, trades] = await Promise.all([
+      this.fetchPosts(before, limit, excludeIds),
+      this.fetchTokenCreations(before, limit, excludeIds),
+      this.fetchTrades(before, limit, excludeIds),
+    ]);
+
+    const candidates: FeedItem[] = [
+      ...posts.map((post): FeedItem => ({
+        type: 'post',
+        created_at: post.created_at,
+        data: post,
+      })),
+      ...tokens.map((token): FeedItem => ({
+        type: 'token_created',
+        created_at: token.created_at,
+        data: token,
+      })),
+      ...trades.map((trade): FeedItem => ({
+        type: 'trade',
+        created_at: trade.created_at,
+        data: trade,
+      })),
+    ].sort((a, b) => b.created_at.getTime() - a.created_at.getTime());
+
+    const items = candidates.slice(0, limit);
+    // Any candidate fetched but not surfaced this page (either because a
+    // source alone hit its own `limit` cap, or the merged pool exceeded
+    // `limit`) means there is more to page through.
+    const hasMore =
+      candidates.length > items.length ||
+      posts.length === limit ||
+      tokens.length === limit ||
+      trades.length === limit;
+
+    const lastItem = items[items.length - 1];
+    let nextCursor: string | null = null;
+    if (lastItem && hasMore) {
+      const cutoff = lastItem.created_at.getTime();
+      const idsAtCutoffThisPage = items
+        .filter((item) => item.created_at.getTime() === cutoff)
+        .map((item) => getFeedItemId(item));
+      // If the tie at `cutoff` spans more than one page (more items share
+      // this exact timestamp than fit in `limit`), the cutoff stays the same
+      // across pages -- carry forward every id already excluded so far, or a
+      // later page would stop excluding earlier pages' ids and re-serve
+      // them. A cutoff that moved past the tie starts a fresh exclusion set:
+      // the strict `created_at < cutoff` filter alone already excludes
+      // everything at the old (later) timestamp.
+      const seenIds =
+        cursor && cursor.ts === cutoff
+          ? [...new Set([...(cursor.seenIds ?? []), ...idsAtCutoffThisPage])]
+          : idsAtCutoffThisPage;
+      nextCursor = encodeFeedCursor({ sort: 'latest', ts: cutoff, seenIds });
+    }
+
+    return { items, next_cursor: nextCursor };
+  }
+
+  private fetchPosts(
+    before: Date | null,
+    limit: number,
+    excludeIds: string[],
+  ): Promise<Post[]> {
+    const query = this.postsRepository
+      .createQueryBuilder('post')
+      .where('post.is_hidden = false')
+      .orderBy('post.created_at', 'DESC')
+      .limit(limit);
+    applyCursorFilter(query, 'post.created_at', 'post.id', before, excludeIds);
+    return query.getMany();
+  }
+
+  private fetchTokenCreations(
+    before: Date | null,
+    limit: number,
+    excludeIds: string[],
+  ): Promise<Token[]> {
+    const query = this.tokensRepository
+      .createQueryBuilder('token')
+      .where('token.unlisted = false')
+      .orderBy('token.created_at', 'DESC')
+      .limit(limit);
+    applyCursorFilter(
+      query,
+      'token.created_at',
+      'token.sale_address',
+      before,
+      excludeIds,
+    );
+    return query.getMany();
+  }
+
+  private fetchTrades(
+    before: Date | null,
+    limit: number,
+    excludeIds: string[],
+  ): Promise<Transaction[]> {
+    const query = this.transactionsRepository
+      .createQueryBuilder('transaction')
+      .innerJoin(
+        Token,
+        'token',
+        'token.sale_address = transaction.sale_address AND token.unlisted = false',
+      )
+      .where("transaction.tx_type IN ('buy', 'sell')")
+      .orderBy('transaction.created_at', 'DESC')
+      .limit(limit);
+    applyCursorFilter(
+      query,
+      'transaction.created_at',
+      'transaction.tx_hash',
+      before,
+      excludeIds,
+    );
+    return query.getMany();
+  }
+}
+
+function getFeedItemId(item: FeedItem): string {
+  switch (item.type) {
+    case 'post':
+      return (item.data as Post).id;
+    case 'token_created':
+      return (item.data as Token).sale_address;
+    case 'trade':
+      return (item.data as Transaction).tx_hash;
+  }
+}
+
+// created_at < before OR (created_at = before AND <pk> NOT IN (excludeIds)):
+// the first page (no `before`) needs no filter at all. When there is nothing
+// to exclude (the overwhelmingly common case -- an exact tie at the cutoff
+// is rare), this stays the plain `created_at < before` filter; the OR branch
+// only appears when a previous page actually returned tied items, so it
+// isn't skipped or re-served on the next page.
+function applyCursorFilter(
+  query: { andWhere: (...args: any[]) => any },
+  createdAtColumn: string,
+  pkColumn: string,
+  before: Date | null,
+  excludeIds: string[],
+): void {
+  if (!before) {
+    return;
+  }
+  if (!excludeIds.length) {
+    query.andWhere(`${createdAtColumn} < :before`, { before });
+    return;
+  }
+  query.andWhere(
+    new Brackets((qb) => {
+      qb.where(`${createdAtColumn} < :before`, { before }).orWhere(
+        new Brackets((qb2) => {
+          qb2
+            .where(`${createdAtColumn} = :before`, { before })
+            .andWhere(`${pkColumn} NOT IN (:...excludeIds)`, { excludeIds });
+        }),
+      );
+    }),
+  );
+}

--- a/src/feed/feed.module.ts
+++ b/src/feed/feed.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Post } from '@/social/entities/post.entity';
+import { Token } from '@/tokens/entities/token.entity';
+import { Transaction } from '@/transactions/entities/transaction.entity';
+import { PostModule } from '@/social/post.module';
+import { FeedController } from './feed.controller';
+
+// Kept a leaf module: PostModule already imports TokensModule/TransactionsModule,
+// so importing either of those back here would risk a circular module graph.
+@Module({
+  imports: [
+    PostModule,
+    TypeOrmModule.forFeature([Post, Token, Transaction]),
+  ],
+  controllers: [FeedController],
+})
+export class FeedModule {}

--- a/src/feed/feed.module.ts
+++ b/src/feed/feed.module.ts
@@ -9,10 +9,7 @@ import { FeedController } from './feed.controller';
 // Kept a leaf module: PostModule already imports TokensModule/TransactionsModule,
 // so importing either of those back here would risk a circular module graph.
 @Module({
-  imports: [
-    PostModule,
-    TypeOrmModule.forFeature([Post, Token, Transaction]),
-  ],
+  imports: [PostModule, TypeOrmModule.forFeature([Post, Token, Transaction])],
   controllers: [FeedController],
 })
 export class FeedModule {}

--- a/src/mdw-sync/config/entity-configs.ts
+++ b/src/mdw-sync/config/entity-configs.ts
@@ -5,6 +5,13 @@ import { SyncState } from '../entities/sync-state.entity';
 import { PluginSyncState } from '../entities/plugin-sync-state.entity';
 import { EntityConfig } from '@/api-core/types/entity-config.interface';
 
+// Full-history blockchain mirror tables: no range-filter alternative to
+// OFFSET paging exists for these (unlike app tables, a client walking chain
+// history has no other way to reach old rows), so they need a far higher
+// cap than the base controller/resolver's default MAX_PAGE/MAX_GRAPHQL_PAGE
+// (500) to stay usable for explorer/backfill clients.
+const MDW_MIRROR_MAX_PAGE = 1_000_000;
+
 export const TX_CONFIG: EntityConfig<Tx> = {
   entity: Tx,
   primaryKey: 'hash',
@@ -17,6 +24,7 @@ export const TX_CONFIG: EntityConfig<Tx> = {
     singular: 'tx',
   },
   swaggerTag: 'MDW Transactions',
+  maxPage: MDW_MIRROR_MAX_PAGE,
   orderByFields: [
     'hash',
     'block_hash',
@@ -59,6 +67,7 @@ export const MICRO_BLOCK_CONFIG: EntityConfig<MicroBlock> = {
     singular: 'microBlock',
   },
   swaggerTag: 'MDW Micro Blocks',
+  maxPage: MDW_MIRROR_MAX_PAGE,
   orderByFields: [
     'height',
     'hash',
@@ -120,6 +129,7 @@ export const KEY_BLOCK_CONFIG: EntityConfig<KeyBlock> = {
     singular: 'keyBlock',
   },
   swaggerTag: 'MDW Key Blocks',
+  maxPage: MDW_MIRROR_MAX_PAGE,
   orderByFields: [
     'height',
     'hash',

--- a/src/migrations/1718900000014-TransactionsBuySellIndexes.ts
+++ b/src/migrations/1718900000014-TransactionsBuySellIndexes.ts
@@ -27,9 +27,7 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
  * `transaction = false` override is rejected by TypeORM
  * (ForbiddenTransactionModeOverrideError) rather than actually skip it.
  */
-export class TransactionsBuySellIndexes1718900000014
-  implements MigrationInterface
-{
+export class TransactionsBuySellIndexes1718900000014 implements MigrationInterface {
   name = 'TransactionsBuySellIndexes1718900000014';
 
   public async up(queryRunner: QueryRunner): Promise<void> {

--- a/src/migrations/1718900000014-TransactionsBuySellIndexes.ts
+++ b/src/migrations/1718900000014-TransactionsBuySellIndexes.ts
@@ -1,0 +1,52 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Two targeted indexes for `transactions` lookups that currently
+ * sequential-scan the table:
+ *
+ * - `IDX_TRANSACTION_SALE_ADDRESS_TX_TYPE`: general `sale_address` + `tx_type`
+ *   composite, backing the `sale_address = ? AND tx_type = ?` equality lookup
+ *   in `cleanupOldTransactions` (`TransactionPersistenceService` and the
+ *   deprecated `TransactionService.saveTransaction`).
+ * - `IDX_TRANSACTIONS_BUYSELL_ADDRESS`: partial index matching the exact
+ *   `tx_type IN ('buy','sell')` predicate used by leaderboard.service.ts's
+ *   `active_accounts` CTE and volume-by-address aggregate, keyed on `address`
+ *   (not `sale_address`).
+ *
+ * An earlier draft of this migration also added a `sale_address`-scoped
+ * `IDX_TRANSACTIONS_BUYSELL_SALE_ADDRESS` partial index for a token-list
+ * eligibility trade-count aggregate; that aggregate was replaced by the
+ * materialized `token_trade_eligibility_counts` table before this branch
+ * shipped, so that index was never created here to avoid landing dead
+ * write-overhead with no query to serve.
+ *
+ * Plain (non-CONCURRENTLY) index creation, matching this migration folder's
+ * existing convention (see QueryHotPathIndexes) -- migration:run defaults to
+ * `transaction: 'all'` (one batch transaction for every pending migration),
+ * and CONCURRENTLY cannot run inside a transaction at all, so a per-migration
+ * `transaction = false` override is rejected by TypeORM
+ * (ForbiddenTransactionModeOverrideError) rather than actually skip it.
+ */
+export class TransactionsBuySellIndexes1718900000014
+  implements MigrationInterface
+{
+  name = 'TransactionsBuySellIndexes1718900000014';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_TRANSACTION_SALE_ADDRESS_TX_TYPE" ON "transactions" ("sale_address", "tx_type")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_TRANSACTIONS_BUYSELL_ADDRESS" ON "transactions" ("address") WHERE tx_type IN ('buy', 'sell')`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "public"."IDX_TRANSACTIONS_BUYSELL_ADDRESS"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "public"."IDX_TRANSACTION_SALE_ADDRESS_TX_TYPE"`,
+    );
+  }
+}

--- a/src/migrations/1718900000015-TokenTradeEligibilityCounts.ts
+++ b/src/migrations/1718900000015-TokenTradeEligibilityCounts.ts
@@ -1,0 +1,45 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Materializes the buy/sell trade count per token (previously an unbounded
+ * `GROUP BY sale_address` aggregate over the whole `transactions` table run
+ * on every token-list eligibility check, see `applyListEligibilityFilters`).
+ * Backfilled once here from the current `transactions` table; kept up to
+ * date going forward by an incremental upsert in
+ * `TransactionPersistenceService.saveTransaction`.
+ */
+export class TokenTradeEligibilityCounts1718900000015
+  implements MigrationInterface
+{
+  name = 'TokenTradeEligibilityCounts1718900000015';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "token_trade_eligibility_counts" (
+        "sale_address" varchar PRIMARY KEY,
+        "trade_count" integer NOT NULL DEFAULT 0,
+        "updated_at" timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
+      )
+    `);
+
+    await queryRunner.query(`
+      INSERT INTO "token_trade_eligibility_counts" (sale_address, trade_count, updated_at)
+      SELECT
+        tx.sale_address,
+        COUNT(*) AS trade_count,
+        CURRENT_TIMESTAMP(6)
+      FROM transactions tx
+      WHERE tx.tx_type IN ('buy', 'sell')
+      GROUP BY tx.sale_address
+      ON CONFLICT (sale_address) DO UPDATE
+      SET trade_count = EXCLUDED.trade_count,
+          updated_at = EXCLUDED.updated_at
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP TABLE IF EXISTS "token_trade_eligibility_counts"`,
+    );
+  }
+}

--- a/src/migrations/1718900000015-TokenTradeEligibilityCounts.ts
+++ b/src/migrations/1718900000015-TokenTradeEligibilityCounts.ts
@@ -8,9 +8,7 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
  * date going forward by an incremental upsert in
  * `TransactionPersistenceService.saveTransaction`.
  */
-export class TokenTradeEligibilityCounts1718900000015
-  implements MigrationInterface
-{
+export class TokenTradeEligibilityCounts1718900000015 implements MigrationInterface {
   name = 'TokenTradeEligibilityCounts1718900000015';
 
   public async up(queryRunner: QueryRunner): Promise<void> {

--- a/src/migrations/1718900000016-PostsTokenMentionsGinIndex.ts
+++ b/src/migrations/1718900000016-PostsTokenMentionsGinIndex.ts
@@ -1,0 +1,33 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Backs the `token_mentions @> '["SYMBOL"]'` containment checks
+ * (`buildTokenMentionExistsSql`) used by trending-metrics/eligibility
+ * lookups, which previously fell back to a per-row
+ * `jsonb_array_elements_text` scan of every post. `jsonb_path_ops` is
+ * smaller and faster than the default GIN opclass for `@>`-only workloads
+ * (no key-existence `?`/`?|`/`?&` queries are run against this column).
+ *
+ * TypeORM's `@Index` decorator cannot express `USING GIN` + opclass, so
+ * this index is migration-only (see `community_room.moderators`/`muted`
+ * for the existing precedent) with no matching entity decorator.
+ * `CONCURRENTLY` cannot run inside a transaction, hence `transaction = false`.
+ */
+export class PostsTokenMentionsGinIndex1718900000016
+  implements MigrationInterface
+{
+  name = 'PostsTokenMentionsGinIndex1718900000016';
+  public transaction = false;
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_POSTS_TOKEN_MENTIONS_GIN" ON "posts" USING GIN ("token_mentions" jsonb_path_ops)`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX CONCURRENTLY IF EXISTS "public"."IDX_POSTS_TOKEN_MENTIONS_GIN"`,
+    );
+  }
+}

--- a/src/migrations/1718900000016-PostsTokenMentionsGinIndex.ts
+++ b/src/migrations/1718900000016-PostsTokenMentionsGinIndex.ts
@@ -19,9 +19,7 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
  * `transaction = false` override is rejected by TypeORM
  * (ForbiddenTransactionModeOverrideError) rather than actually skip it.
  */
-export class PostsTokenMentionsGinIndex1718900000016
-  implements MigrationInterface
-{
+export class PostsTokenMentionsGinIndex1718900000016 implements MigrationInterface {
   name = 'PostsTokenMentionsGinIndex1718900000016';
 
   public async up(queryRunner: QueryRunner): Promise<void> {

--- a/src/migrations/1718900000016-PostsTokenMentionsGinIndex.ts
+++ b/src/migrations/1718900000016-PostsTokenMentionsGinIndex.ts
@@ -11,23 +11,28 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
  * TypeORM's `@Index` decorator cannot express `USING GIN` + opclass, so
  * this index is migration-only (see `community_room.moderators`/`muted`
  * for the existing precedent) with no matching entity decorator.
- * `CONCURRENTLY` cannot run inside a transaction, hence `transaction = false`.
+ *
+ * Plain (non-CONCURRENTLY) index creation, matching this migration folder's
+ * existing convention -- migration:run defaults to `transaction: 'all'`
+ * (one batch transaction for every pending migration), and CONCURRENTLY
+ * cannot run inside a transaction at all, so a per-migration
+ * `transaction = false` override is rejected by TypeORM
+ * (ForbiddenTransactionModeOverrideError) rather than actually skip it.
  */
 export class PostsTokenMentionsGinIndex1718900000016
   implements MigrationInterface
 {
   name = 'PostsTokenMentionsGinIndex1718900000016';
-  public transaction = false;
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_POSTS_TOKEN_MENTIONS_GIN" ON "posts" USING GIN ("token_mentions" jsonb_path_ops)`,
+      `CREATE INDEX IF NOT EXISTS "IDX_POSTS_TOKEN_MENTIONS_GIN" ON "posts" USING GIN ("token_mentions" jsonb_path_ops)`,
     );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `DROP INDEX CONCURRENTLY IF EXISTS "public"."IDX_POSTS_TOKEN_MENTIONS_GIN"`,
+      `DROP INDEX IF EXISTS "public"."IDX_POSTS_TOKEN_MENTIONS_GIN"`,
     );
   }
 }

--- a/src/migrations/1718900000017-TokenCirculatingSupply.ts
+++ b/src/migrations/1718900000017-TokenCirculatingSupply.ts
@@ -6,9 +6,7 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
  * so the token detail page can stop calling `{mdw}/v3/aex9/{address}` from
  * the browser just to read this one field.
  */
-export class TokenCirculatingSupply1718900000017
-  implements MigrationInterface
-{
+export class TokenCirculatingSupply1718900000017 implements MigrationInterface {
   name = 'TokenCirculatingSupply1718900000017';
 
   public async up(queryRunner: QueryRunner): Promise<void> {

--- a/src/migrations/1718900000017-TokenCirculatingSupply.ts
+++ b/src/migrations/1718900000017-TokenCirculatingSupply.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Persists middleware's AEX9 `event_supply` as `circulating_supply` on
+ * `token`, fetched during `getTokeLivePrice` (token sync / PullTokenInfoQueue)
+ * so the token detail page can stop calling `{mdw}/v3/aex9/{address}` from
+ * the browser just to read this one field.
+ */
+export class TokenCirculatingSupply1718900000017
+  implements MigrationInterface
+{
+  name = 'TokenCirculatingSupply1718900000017';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "token"
+      ADD COLUMN IF NOT EXISTS "circulating_supply" numeric NULL
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "token"
+      DROP COLUMN IF EXISTS "circulating_supply"
+    `);
+  }
+}

--- a/src/migrations/1718900000018-TokenUnlistedCreatedAtIndex.ts
+++ b/src/migrations/1718900000018-TokenUnlistedCreatedAtIndex.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Backs the home feed's token-creation source (`unlisted = false ORDER BY
+ * created_at DESC`) — `token.created_at` had no covering index.
+ * `CONCURRENTLY` cannot run inside a transaction, hence `transaction = false`.
+ */
+export class TokenUnlistedCreatedAtIndex1718900000018
+  implements MigrationInterface
+{
+  name = 'TokenUnlistedCreatedAtIndex1718900000018';
+  public transaction = false;
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_TOKEN_UNLISTED_CREATED_AT" ON "token" ("unlisted", "created_at")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX CONCURRENTLY IF EXISTS "public"."IDX_TOKEN_UNLISTED_CREATED_AT"`,
+    );
+  }
+}

--- a/src/migrations/1718900000018-TokenUnlistedCreatedAtIndex.ts
+++ b/src/migrations/1718900000018-TokenUnlistedCreatedAtIndex.ts
@@ -11,9 +11,7 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
  * `transaction = false` override is rejected by TypeORM
  * (ForbiddenTransactionModeOverrideError) rather than actually skip it.
  */
-export class TokenUnlistedCreatedAtIndex1718900000018
-  implements MigrationInterface
-{
+export class TokenUnlistedCreatedAtIndex1718900000018 implements MigrationInterface {
   name = 'TokenUnlistedCreatedAtIndex1718900000018';
 
   public async up(queryRunner: QueryRunner): Promise<void> {

--- a/src/migrations/1718900000018-TokenUnlistedCreatedAtIndex.ts
+++ b/src/migrations/1718900000018-TokenUnlistedCreatedAtIndex.ts
@@ -3,23 +3,28 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
 /**
  * Backs the home feed's token-creation source (`unlisted = false ORDER BY
  * created_at DESC`) — `token.created_at` had no covering index.
- * `CONCURRENTLY` cannot run inside a transaction, hence `transaction = false`.
+ *
+ * Plain (non-CONCURRENTLY) index creation, matching this migration folder's
+ * existing convention -- migration:run defaults to `transaction: 'all'`
+ * (one batch transaction for every pending migration), and CONCURRENTLY
+ * cannot run inside a transaction at all, so a per-migration
+ * `transaction = false` override is rejected by TypeORM
+ * (ForbiddenTransactionModeOverrideError) rather than actually skip it.
  */
 export class TokenUnlistedCreatedAtIndex1718900000018
   implements MigrationInterface
 {
   name = 'TokenUnlistedCreatedAtIndex1718900000018';
-  public transaction = false;
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_TOKEN_UNLISTED_CREATED_AT" ON "token" ("unlisted", "created_at")`,
+      `CREATE INDEX IF NOT EXISTS "IDX_TOKEN_UNLISTED_CREATED_AT" ON "token" ("unlisted", "created_at")`,
     );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `DROP INDEX CONCURRENTLY IF EXISTS "public"."IDX_TOKEN_UNLISTED_CREATED_AT"`,
+      `DROP INDEX IF EXISTS "public"."IDX_TOKEN_UNLISTED_CREATED_AT"`,
     );
   }
 }

--- a/src/migrations/1718900000019-TokenRankColumn.ts
+++ b/src/migrations/1718900000019-TokenRankColumn.ts
@@ -1,0 +1,50 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Persists the market-cap rank (previously a live `RANK() OVER (...)` window
+ * function recomputed across the whole `token` table on every list request
+ * in `queryTokensWithRanks`) as a column, backfilled once here and kept
+ * current by `RefreshTokenRanksService`.
+ *
+ * Defaults to 2147483647 (Postgres int4 max, see `UNRANKED_TOKEN_RANK` on the
+ * `Token` entity), not 0: listings sort `rank ASC` (1 = highest market cap),
+ * so a brand-new token would otherwise outrank every real token until the
+ * next refresh cron tick.
+ */
+export class TokenRankColumn1718900000019 implements MigrationInterface {
+  name = 'TokenRankColumn1718900000019';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "token"
+      ADD COLUMN IF NOT EXISTS "rank" integer NOT NULL DEFAULT 2147483647
+    `);
+
+    await queryRunner.query(`
+      UPDATE "token"
+      SET "rank" = ranked.rank
+      FROM (
+        SELECT
+          sale_address,
+          CAST(RANK() OVER (
+            ORDER BY
+              CASE WHEN market_cap = 0 THEN 1 ELSE 0 END,
+              market_cap DESC,
+              created_at ASC
+          ) AS INTEGER) AS rank
+        FROM "token"
+        WHERE unlisted = false
+      ) ranked
+      WHERE "token".sale_address = ranked.sale_address
+    `);
+
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_TOKEN_RANK" ON "token" ("rank")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "public"."IDX_TOKEN_RANK"`);
+    await queryRunner.query(`ALTER TABLE "token" DROP COLUMN IF EXISTS "rank"`);
+  }
+}

--- a/src/plugins/bcl/services/transaction-persistence.service.spec.ts
+++ b/src/plugins/bcl/services/transaction-persistence.service.spec.ts
@@ -19,10 +19,12 @@ describe('TransactionPersistenceService', () => {
     const findOne = jest.fn().mockResolvedValue({ tx_hash: 'th_1' });
     const count = jest.fn().mockResolvedValue(7);
     const update = jest.fn().mockResolvedValue(undefined);
+    const exists = jest.fn().mockResolvedValue(false);
     const manager = {
+      query: jest.fn().mockResolvedValue(undefined),
       getRepository: jest.fn((entity) => {
         if (entity === Transaction) {
-          return { upsert, findOne, count };
+          return { upsert, findOne, count, exists };
         }
 
         if (entity === Token) {
@@ -55,6 +57,185 @@ describe('TransactionPersistenceService', () => {
       manager,
     );
     expect(transaction).toEqual({ tx_hash: 'th_1' });
+  });
+
+  it('acquires an advisory lock on tx_hash before checking whether the transaction is new', async () => {
+    const upsert = jest.fn().mockResolvedValue(undefined);
+    const findOne = jest.fn().mockResolvedValue({ tx_hash: 'th_lock' });
+    const count = jest.fn().mockResolvedValue(1);
+    const exists = jest.fn().mockResolvedValue(false);
+    const query = jest.fn().mockResolvedValue(undefined);
+    const manager = {
+      query,
+      getRepository: jest.fn((entity) => {
+        if (entity === Transaction) {
+          return { upsert, findOne, count, exists };
+        }
+        if (entity === Token) {
+          return { update: jest.fn() };
+        }
+        throw new Error('Unexpected repository request');
+      }),
+    };
+
+    await service.saveTransaction(
+      {
+        tx_hash: 'th_lock',
+        sale_address: 'ct_sale',
+        tx_type: 'buy',
+      } as any,
+      manager as any,
+    );
+
+    expect(query).toHaveBeenCalledWith(
+      expect.stringContaining('pg_advisory_xact_lock(hashtext($1))'),
+      ['th_lock'],
+    );
+    const lockCallOrder = query.mock.invocationCallOrder[0];
+    const existsCallOrder = exists.mock.invocationCallOrder[0];
+    expect(lockCallOrder).toBeLessThan(existsCallOrder);
+  });
+
+  it('does not fail transaction persistence when the advisory lock cannot be acquired', async () => {
+    const upsert = jest.fn().mockResolvedValue(undefined);
+    const findOne = jest.fn().mockResolvedValue({ tx_hash: 'th_lockfail' });
+    const count = jest.fn().mockResolvedValue(1);
+    const exists = jest.fn().mockResolvedValue(false);
+    const loggerError = jest
+      .spyOn(Logger.prototype, 'error')
+      .mockImplementation(() => undefined);
+    const query = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('lock unavailable'))
+      .mockResolvedValue(undefined);
+    const manager = {
+      query,
+      getRepository: jest.fn((entity) => {
+        if (entity === Transaction) {
+          return { upsert, findOne, count, exists };
+        }
+        if (entity === Token) {
+          return { update: jest.fn() };
+        }
+        throw new Error('Unexpected repository request');
+      }),
+    };
+
+    const transaction = await service.saveTransaction(
+      {
+        tx_hash: 'th_lockfail',
+        sale_address: 'ct_sale',
+        tx_type: 'buy',
+      } as any,
+      manager as any,
+    );
+
+    expect(transaction).toEqual({ tx_hash: 'th_lockfail' });
+    expect(loggerError).toHaveBeenCalled();
+    loggerError.mockRestore();
+  });
+
+  it('increments the trade eligibility counter for a new buy/sell transaction', async () => {
+    const upsert = jest.fn().mockResolvedValue(undefined);
+    const findOne = jest.fn().mockResolvedValue({ tx_hash: 'th_buy' });
+    const count = jest.fn().mockResolvedValue(1);
+    const exists = jest.fn().mockResolvedValue(false);
+    const query = jest.fn().mockResolvedValue(undefined);
+    const manager = {
+      query,
+      getRepository: jest.fn((entity) => {
+        if (entity === Transaction) {
+          return { upsert, findOne, count, exists };
+        }
+        if (entity === Token) {
+          return { update: jest.fn() };
+        }
+        throw new Error('Unexpected repository request');
+      }),
+    };
+
+    await service.saveTransaction(
+      {
+        tx_hash: 'th_buy',
+        sale_address: 'ct_sale',
+        tx_type: 'buy',
+      } as any,
+      manager as any,
+    );
+
+    expect(exists).toHaveBeenCalledWith({ where: { tx_hash: 'th_buy' } });
+    expect(query).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO token_trade_eligibility_counts'),
+      ['ct_sale'],
+    );
+  });
+
+  it('does not increment the trade eligibility counter for a re-processed transaction', async () => {
+    const upsert = jest.fn().mockResolvedValue(undefined);
+    const findOne = jest.fn().mockResolvedValue({ tx_hash: 'th_buy' });
+    const count = jest.fn().mockResolvedValue(1);
+    const exists = jest.fn().mockResolvedValue(true);
+    const query = jest.fn().mockResolvedValue(undefined);
+    const manager = {
+      query,
+      getRepository: jest.fn((entity) => {
+        if (entity === Transaction) {
+          return { upsert, findOne, count, exists };
+        }
+        if (entity === Token) {
+          return { update: jest.fn() };
+        }
+        throw new Error('Unexpected repository request');
+      }),
+    };
+
+    await service.saveTransaction(
+      {
+        tx_hash: 'th_buy',
+        sale_address: 'ct_sale',
+        tx_type: 'buy',
+      } as any,
+      manager as any,
+    );
+
+    expect(query).not.toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO token_trade_eligibility_counts'),
+      expect.anything(),
+    );
+  });
+
+  it('does not increment the trade eligibility counter for non-trade tx types', async () => {
+    const upsert = jest.fn().mockResolvedValue(undefined);
+    const findOne = jest.fn().mockResolvedValue({ tx_hash: 'th_create' });
+    const count = jest.fn().mockResolvedValue(1);
+    const exists = jest.fn().mockResolvedValue(false);
+    const query = jest.fn().mockResolvedValue(undefined);
+    const manager = {
+      query,
+      getRepository: jest.fn((entity) => {
+        if (entity === Transaction) {
+          return { upsert, findOne, count, exists };
+        }
+        if (entity === Token) {
+          return { update: jest.fn() };
+        }
+        throw new Error('Unexpected repository request');
+      }),
+    };
+
+    await service.saveTransaction(
+      {
+        tx_hash: 'th_create',
+        sale_address: 'ct_sale',
+        tx_type: 'create_community',
+      } as any,
+      manager as any,
+    );
+
+    expect(query).not.toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO token_trade_eligibility_counts'),
+      expect.anything(),
+    );
   });
 
   it('returns cleaned up account addresses so callers can refresh stale totals', async () => {
@@ -99,10 +280,12 @@ describe('TransactionPersistenceService', () => {
     const loggerError = jest
       .spyOn(Logger.prototype, 'error')
       .mockImplementation(() => undefined);
+    const exists = jest.fn().mockResolvedValue(false);
     const manager = {
+      query: jest.fn().mockResolvedValue(undefined),
       getRepository: jest.fn((entity) => {
         if (entity === Transaction) {
-          return { upsert, findOne, count };
+          return { upsert, findOne, count, exists };
         }
 
         if (entity === Token) {
@@ -136,11 +319,12 @@ describe('TransactionPersistenceService', () => {
     const loggerError = jest
       .spyOn(Logger.prototype, 'error')
       .mockImplementation(() => undefined);
+    const exists = jest.fn().mockResolvedValue(false);
     const manager = {
       query,
       getRepository: jest.fn((entity) => {
         if (entity === Transaction) {
-          return { upsert, findOne };
+          return { upsert, findOne, exists };
         }
         if (entity === Token) {
           return { update: jest.fn() };

--- a/src/plugins/bcl/services/transaction-persistence.service.ts
+++ b/src/plugins/bcl/services/transaction-persistence.service.ts
@@ -5,6 +5,10 @@ import { Transaction } from '@/transactions/entities/transaction.entity';
 import { Token } from '@/tokens/entities/token.entity';
 import { BCL_FUNCTIONS } from '@/configs';
 import { TransactionData } from './transaction-data.service';
+import {
+  TRADE_ELIGIBLE_TX_TYPES,
+  incrementTradeEligibilityCount,
+} from '../utils/trade-eligibility.util';
 
 @Injectable()
 export class TransactionPersistenceService {
@@ -62,12 +66,48 @@ export class TransactionPersistenceService {
   ): Promise<Transaction> {
     const transactionRepository = manager.getRepository(Transaction);
     const tokenRepository = manager.getRepository(Token);
+
+    // Serializes concurrent saves of the same tx_hash (e.g. overlapping
+    // forward/backward sync passes) so the exists-check below can't race
+    // with another connection's upsert and double-count the eligibility
+    // increment. Xact-scoped: released automatically on commit/rollback of
+    // the caller's transaction. Best-effort -- a failure here only reopens
+    // the (rare) race window, so it's logged rather than thrown, consistent
+    // with how the other non-critical steps in this method are handled.
+    try {
+      await manager.query('SELECT pg_advisory_xact_lock(hashtext($1))', [
+        txData.tx_hash,
+      ]);
+    } catch (error) {
+      this.logger.error(
+        `Failed to acquire trade-eligibility lock for ${txData.tx_hash}`,
+        error instanceof Error ? error.stack : String(error),
+      );
+    }
+
+    // Checked before the upsert so a re-processed tx (backward sync/reorg
+    // replay of an already-persisted hash) is never double-counted below.
+    const isNewTransaction = !(await transactionRepository.exists({
+      where: { tx_hash: txData.tx_hash },
+    }));
+
     // Use upsert to handle race conditions where transaction might be created concurrently
     // Note: skipUpdateIfNoValuesChanged is removed because it causes PostgreSQL errors
     // when comparing JSON columns (operator does not exist: json = json)
     await transactionRepository.upsert(txData, {
       conflictPaths: ['tx_hash'],
     });
+
+    if (isNewTransaction && TRADE_ELIGIBLE_TX_TYPES.has(txData.tx_type)) {
+      try {
+        await incrementTradeEligibilityCount(txData.sale_address, manager);
+      } catch (error) {
+        this.logger.error(
+          `Failed to increment trade eligibility count for ${txData.sale_address}`,
+          error instanceof Error ? error.stack : String(error),
+        );
+      }
+    }
 
     if (txData.address) {
       try {

--- a/src/plugins/bcl/utils/trade-eligibility.util.ts
+++ b/src/plugins/bcl/utils/trade-eligibility.util.ts
@@ -1,0 +1,26 @@
+import { EntityManager } from 'typeorm';
+import { BCL_FUNCTIONS } from '@/configs';
+
+// Shared by every transaction-save path (current and deprecated) so a token's
+// trade-count eligibility is never undercounted just because a transaction
+// went through the legacy route instead of TransactionPersistenceService.
+export const TRADE_ELIGIBLE_TX_TYPES = new Set<string>([
+  BCL_FUNCTIONS.buy,
+  BCL_FUNCTIONS.sell,
+]);
+
+export async function incrementTradeEligibilityCount(
+  saleAddress: string,
+  manager: EntityManager,
+): Promise<void> {
+  await manager.query(
+    `
+      INSERT INTO token_trade_eligibility_counts (sale_address, trade_count, updated_at)
+      VALUES ($1, 1, CURRENT_TIMESTAMP(6))
+      ON CONFLICT (sale_address) DO UPDATE
+      SET trade_count = token_trade_eligibility_counts.trade_count + 1,
+          updated_at = CURRENT_TIMESTAMP(6)
+    `,
+    [saleAddress],
+  );
+}

--- a/src/plugins/social-tipping/services/social-tipping-transaction-processor.service.spec.ts
+++ b/src/plugins/social-tipping/services/social-tipping-transaction-processor.service.spec.ts
@@ -49,11 +49,9 @@ describe('SocialTippingTransactionProcessorService', () => {
     postRepository.findOne.mockResolvedValue({
       token_mentions: ['BETA'],
     });
-    tokensService.queueTrendingScoresForSymbols.mockImplementation(
-      async () => {
-        callOrder.push('recalculate');
-      },
-    );
+    tokensService.queueTrendingScoresForSymbols.mockImplementation(async () => {
+      callOrder.push('recalculate');
+    });
 
     tipRepository.manager.transaction.mockImplementation(
       async (handler: any) => {

--- a/src/plugins/social-tipping/services/social-tipping-transaction-processor.service.spec.ts
+++ b/src/plugins/social-tipping/services/social-tipping-transaction-processor.service.spec.ts
@@ -20,7 +20,7 @@ describe('SocialTippingTransactionProcessorService', () => {
       ensureAccountExists: jest.fn(),
     };
     tokensService = {
-      updateTrendingScoresForSymbols: jest.fn().mockResolvedValue(undefined),
+      queueTrendingScoresForSymbols: jest.fn().mockResolvedValue(undefined),
     };
 
     service = new SocialTippingTransactionProcessorService(
@@ -49,7 +49,7 @@ describe('SocialTippingTransactionProcessorService', () => {
     postRepository.findOne.mockResolvedValue({
       token_mentions: ['BETA'],
     });
-    tokensService.updateTrendingScoresForSymbols.mockImplementation(
+    tokensService.queueTrendingScoresForSymbols.mockImplementation(
       async () => {
         callOrder.push('recalculate');
       },
@@ -78,7 +78,7 @@ describe('SocialTippingTransactionProcessorService', () => {
       'transaction-commit',
       'recalculate',
     ]);
-    expect(tokensService.updateTrendingScoresForSymbols).toHaveBeenCalledWith([
+    expect(tokensService.queueTrendingScoresForSymbols).toHaveBeenCalledWith([
       'ALPHA',
       'BETA',
     ]);
@@ -93,7 +93,7 @@ describe('SocialTippingTransactionProcessorService', () => {
       tip: { tx_hash: 'th_tip' },
       post: { sender_address: 'ak_receiver', token_mentions: ['ALPHA'] },
     });
-    tokensService.updateTrendingScoresForSymbols.mockRejectedValue(
+    tokensService.queueTrendingScoresForSymbols.mockRejectedValue(
       new Error('refresh failed'),
     );
     tipRepository.manager.transaction.mockImplementation(async (handler: any) =>
@@ -110,7 +110,7 @@ describe('SocialTippingTransactionProcessorService', () => {
     );
 
     expect(result).toEqual({ tx_hash: 'th_tip' });
-    expect(tokensService.updateTrendingScoresForSymbols).toHaveBeenCalledWith([
+    expect(tokensService.queueTrendingScoresForSymbols).toHaveBeenCalledWith([
       'ALPHA',
     ]);
   });
@@ -136,7 +136,7 @@ describe('SocialTippingTransactionProcessorService', () => {
     );
 
     expect(result).toBeNull();
-    expect(tokensService.updateTrendingScoresForSymbols).not.toHaveBeenCalled();
+    expect(tokensService.queueTrendingScoresForSymbols).not.toHaveBeenCalled();
   });
 
   it('does not persist self-tips on a profile', async () => {

--- a/src/plugins/social-tipping/services/social-tipping-transaction-processor.service.ts
+++ b/src/plugins/social-tipping/services/social-tipping-transaction-processor.service.ts
@@ -62,7 +62,7 @@ export class SocialTippingTransactionProcessorService {
             where: { id: postId },
           }),
         updateTrendingScoresForSymbols: (symbols) =>
-          this.tokensService.updateTrendingScoresForSymbols(symbols),
+          this.tokensService.queueTrendingScoresForSymbols(symbols),
         logError: (message, trace) => this.logger.error(message, trace),
         errorMessage:
           'Failed to refresh trending scores after processing tip transaction',

--- a/src/plugins/social/services/post-transaction-processor.service.spec.ts
+++ b/src/plugins/social/services/post-transaction-processor.service.spec.ts
@@ -46,7 +46,7 @@ describe('PostTransactionProcessorService', () => {
       emitCommentCreatedEvent: jest.fn(),
     };
     tokensService = {
-      updateTrendingScoresForSymbols: jest.fn(),
+      queueTrendingScoresForSymbols: jest.fn(),
     };
 
     service = new PostTransactionProcessorService(
@@ -86,7 +86,7 @@ describe('PostTransactionProcessorService', () => {
     );
     persistenceService.savePost.mockResolvedValue(savedPost);
     topicManagementService.updateTopicPostCounts.mockResolvedValue(undefined);
-    tokensService.updateTrendingScoresForSymbols.mockRejectedValue(
+    tokensService.queueTrendingScoresForSymbols.mockRejectedValue(
       new Error('refresh failed'),
     );
 
@@ -102,7 +102,7 @@ describe('PostTransactionProcessorService', () => {
       success: true,
       skipped: false,
     });
-    expect(tokensService.updateTrendingScoresForSymbols).toHaveBeenCalledWith([
+    expect(tokensService.queueTrendingScoresForSymbols).toHaveBeenCalledWith([
       'ALPHA',
     ]);
   });
@@ -142,7 +142,7 @@ describe('PostTransactionProcessorService', () => {
     persistenceService.savePost.mockResolvedValue(savedComment);
     persistenceService.updatePostCommentCount.mockResolvedValue(undefined);
     topicManagementService.updateTopicPostCounts.mockResolvedValue(undefined);
-    tokensService.updateTrendingScoresForSymbols.mockResolvedValue(undefined);
+    tokensService.queueTrendingScoresForSymbols.mockResolvedValue(undefined);
 
     await service.processTransaction({
       hash: 'th_comment',
@@ -187,7 +187,7 @@ describe('PostTransactionProcessorService', () => {
       token_mentions: [],
     });
     topicManagementService.updateTopicPostCounts.mockResolvedValue(undefined);
-    tokensService.updateTrendingScoresForSymbols.mockResolvedValue(undefined);
+    tokensService.queueTrendingScoresForSymbols.mockResolvedValue(undefined);
 
     await service.processTransaction({
       hash: 'th_orphan',

--- a/src/plugins/social/services/post-transaction-processor.service.ts
+++ b/src/plugins/social/services/post-transaction-processor.service.ts
@@ -101,7 +101,7 @@ export class PostTransactionProcessorService {
                 where: { id: postId },
               }),
             updateTrendingScoresForSymbols: (symbols) =>
-              this.tokensService.updateTrendingScoresForSymbols(symbols),
+              this.tokensService.queueTrendingScoresForSymbols(symbols),
             logError: (message, trace) => this.logger.error(message, trace),
             errorMessage:
               'Failed to refresh trending scores after processing post transaction',
@@ -248,7 +248,7 @@ export class PostTransactionProcessorService {
             where: { id: postId },
           }),
         updateTrendingScoresForSymbols: (symbols) =>
-          this.tokensService.updateTrendingScoresForSymbols(symbols),
+          this.tokensService.queueTrendingScoresForSymbols(symbols),
         logError: (message, trace) => this.logger.error(message, trace),
         errorMessage:
           'Failed to refresh trending scores after processing post transaction',

--- a/src/profile/services/profile-chain-name.service.spec.ts
+++ b/src/profile/services/profile-chain-name.service.spec.ts
@@ -41,6 +41,7 @@ describe('ProfileChainNameService', () => {
   const getService = () => {
     const claimRepository = {
       findOne: jest.fn(),
+      find: jest.fn().mockResolvedValue([]),
       delete: jest.fn().mockResolvedValue({ affected: 1 }),
       save: jest.fn().mockImplementation(async (value) => value),
       create: jest.fn().mockImplementation((value) => value),
@@ -817,5 +818,54 @@ describe('ProfileChainNameService', () => {
         next_retry_at: null,
       }),
     );
+  });
+
+  describe('processDueClaims', () => {
+    it('processes due claims concurrently instead of one at a time', async () => {
+      const { service, claimRepository } = getService();
+      const dueClaims = Array.from({ length: 8 }, (_, i) => ({
+        address: `ak_claim_${i}`,
+      }));
+      claimRepository.find.mockResolvedValue(dueClaims);
+
+      let active = 0;
+      let maxActive = 0;
+      const processSpy = jest
+        .spyOn(service as any, 'processClaimWithGuard')
+        .mockImplementation(async () => {
+          active++;
+          maxActive = Math.max(maxActive, active);
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          active--;
+        });
+
+      await service.processDueClaims();
+
+      expect(processSpy).toHaveBeenCalledTimes(8);
+      dueClaims.forEach((claim) => {
+        expect(processSpy).toHaveBeenCalledWith(claim.address);
+      });
+      // Bounded concurrency (5), not one sequential await at a time.
+      expect(maxActive).toBeGreaterThan(1);
+      expect(maxActive).toBeLessThanOrEqual(5);
+    });
+
+    it('does not run a second pass while one is already in flight', async () => {
+      const { service, claimRepository } = getService();
+      claimRepository.find.mockResolvedValue([{ address: 'ak_claim_0' }]);
+      let resolveGuard: () => void;
+      jest.spyOn(service as any, 'processClaimWithGuard').mockReturnValue(
+        new Promise<void>((resolve) => {
+          resolveGuard = resolve;
+        }),
+      );
+
+      const first = service.processDueClaims();
+      await service.processDueClaims(); // should return immediately (isCronRunning guard)
+
+      expect(claimRepository.find).toHaveBeenCalledTimes(1);
+      resolveGuard!();
+      await first;
+    });
   });
 });

--- a/src/profile/services/profile-chain-name.service.ts
+++ b/src/profile/services/profile-chain-name.service.ts
@@ -332,10 +332,8 @@ export class ProfileChainNameService {
         order: { next_retry_at: 'ASC', updated_at: 'ASC' },
         take: BATCH_SIZE,
       });
-      await mapWithConcurrency(
-        dueClaims,
-        CLAIM_PROCESS_CONCURRENCY,
-        (claim) => this.processClaimWithGuard(claim.address),
+      await mapWithConcurrency(dueClaims, CLAIM_PROCESS_CONCURRENCY, (claim) =>
+        this.processClaimWithGuard(claim.address),
       );
     } catch (error) {
       this.logger.error('Failed to process due chain name claims', error);

--- a/src/profile/services/profile-chain-name.service.ts
+++ b/src/profile/services/profile-chain-name.service.ts
@@ -45,6 +45,7 @@ import {
 } from '../profile.constants';
 import { verifyAeAddressSignature } from './profile-signature.util';
 import { ProfileSpendQueueService } from './profile-spend-queue.service';
+import { mapWithConcurrency } from '@/utils/concurrency.util';
 
 const RETRYABLE_STATUSES: ChainNameClaimStatus[] = [
   'pending',
@@ -52,6 +53,10 @@ const RETRYABLE_STATUSES: ChainNameClaimStatus[] = [
   'claimed',
 ];
 const BATCH_SIZE = 50;
+// processClaimWithGuard already dedupes per-address, so different claims in
+// the same due-batch are safe to run concurrently -- was one on-chain claim
+// processed at a time (up to BATCH_SIZE sequential awaits every 30s).
+const CLAIM_PROCESS_CONCURRENCY = 5;
 const MAX_PRECLAIM_AGE_BLOCKS = 250;
 const STUB_ADDRESS: `ak_${string}` =
   'ak_11111111111111111111111111111111273Yts';
@@ -327,9 +332,11 @@ export class ProfileChainNameService {
         order: { next_retry_at: 'ASC', updated_at: 'ASC' },
         take: BATCH_SIZE,
       });
-      for (const claim of dueClaims) {
-        await this.processClaimWithGuard(claim.address);
-      }
+      await mapWithConcurrency(
+        dueClaims,
+        CLAIM_PROCESS_CONCURRENCY,
+        (claim) => this.processClaimWithGuard(claim.address),
+      );
     } catch (error) {
       this.logger.error('Failed to process due chain name claims', error);
     } finally {

--- a/src/search/search.controller.spec.ts
+++ b/src/search/search.controller.spec.ts
@@ -1,0 +1,114 @@
+import { SearchController } from './search.controller';
+
+describe('SearchController', () => {
+  let controller: SearchController;
+  let tokensRepository: { createQueryBuilder: jest.Mock };
+  let postsRepository: { createQueryBuilder: jest.Mock };
+  let accountService: { searchByNameOrAddress: jest.Mock };
+  let tokensQueryBuilder: {
+    where: jest.Mock;
+    andWhere: jest.Mock;
+    orderBy: jest.Mock;
+    addOrderBy: jest.Mock;
+    limit: jest.Mock;
+    getMany: jest.Mock;
+  };
+  let postsQueryBuilder: {
+    where: jest.Mock;
+    andWhere: jest.Mock;
+    orderBy: jest.Mock;
+    limit: jest.Mock;
+    getMany: jest.Mock;
+  };
+
+  beforeEach(() => {
+    tokensQueryBuilder = {
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      addOrderBy: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      getMany: jest.fn().mockResolvedValue([]),
+    };
+    postsQueryBuilder = {
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      getMany: jest.fn().mockResolvedValue([]),
+    };
+    tokensRepository = {
+      createQueryBuilder: jest.fn().mockReturnValue(tokensQueryBuilder),
+    };
+    postsRepository = {
+      createQueryBuilder: jest.fn().mockReturnValue(postsQueryBuilder),
+    };
+    accountService = {
+      searchByNameOrAddress: jest.fn().mockResolvedValue([]),
+    };
+
+    controller = new SearchController(
+      tokensRepository as any,
+      postsRepository as any,
+      accountService as any,
+    );
+  });
+
+  it('returns empty results without querying when q is blank', async () => {
+    const result = await controller.search(undefined, 5);
+
+    expect(result).toEqual({ tokens: [], accounts: [], posts: [] });
+    expect(tokensRepository.createQueryBuilder).not.toHaveBeenCalled();
+    expect(postsRepository.createQueryBuilder).not.toHaveBeenCalled();
+    expect(accountService.searchByNameOrAddress).not.toHaveBeenCalled();
+  });
+
+  it('returns empty results without querying when q is shorter than the minimum length', async () => {
+    const result = await controller.search('a', 5);
+
+    expect(result).toEqual({ tokens: [], accounts: [], posts: [] });
+    expect(tokensRepository.createQueryBuilder).not.toHaveBeenCalled();
+  });
+
+  it('rejects an overly long query', async () => {
+    await expect(
+      controller.search('a'.repeat(101), 5),
+    ).rejects.toThrow('q must be at most 100 characters');
+  });
+
+  it('runs the three lookups in parallel, each capped at the clamped limit', async () => {
+    const tokens = [{ sale_address: 'ct_1' }];
+    const posts = [{ id: 'post_1' }];
+    const accounts = [{ address: 'ak_1', chain_name: null }];
+    tokensQueryBuilder.getMany.mockResolvedValue(tokens);
+    postsQueryBuilder.getMany.mockResolvedValue(posts);
+    accountService.searchByNameOrAddress.mockResolvedValue(accounts);
+
+    const result = await controller.search('super', 500);
+
+    expect(tokensQueryBuilder.where).toHaveBeenCalledWith(
+      'token.unlisted = false',
+    );
+    expect(tokensQueryBuilder.andWhere).toHaveBeenCalledWith(
+      'token.name ILIKE :term',
+      { term: '%super%' },
+    );
+    expect(tokensQueryBuilder.limit).toHaveBeenCalledWith(20); // clamped to MAX_LIMIT
+
+    expect(postsQueryBuilder.where).toHaveBeenCalledWith(
+      'post.is_hidden = false',
+    );
+    expect(postsQueryBuilder.andWhere).toHaveBeenCalledWith(
+      'post.content ILIKE :term',
+      { term: '%super%' },
+    );
+    expect(postsQueryBuilder.limit).toHaveBeenCalledWith(20);
+
+    expect(accountService.searchByNameOrAddress).toHaveBeenCalledWith(
+      'super',
+      20,
+    );
+
+    expect(result).toEqual({ tokens, accounts, posts });
+  });
+});

--- a/src/search/search.controller.spec.ts
+++ b/src/search/search.controller.spec.ts
@@ -71,9 +71,9 @@ describe('SearchController', () => {
   });
 
   it('rejects an overly long query', async () => {
-    await expect(
-      controller.search('a'.repeat(101), 5),
-    ).rejects.toThrow('q must be at most 100 characters');
+    await expect(controller.search('a'.repeat(101), 5)).rejects.toThrow(
+      'q must be at most 100 characters',
+    );
   });
 
   it('runs the three lookups in parallel, each capped at the clamped limit', async () => {

--- a/src/search/search.controller.ts
+++ b/src/search/search.controller.ts
@@ -1,0 +1,141 @@
+import { CacheInterceptor, CacheTTL } from '@nestjs/cache-manager';
+import {
+  BadRequestException,
+  Controller,
+  DefaultValuePipe,
+  Get,
+  ParseIntPipe,
+  Query,
+  UseInterceptors,
+} from '@nestjs/common';
+import {
+  ApiOkResponse,
+  ApiOperation,
+  ApiProperty,
+  ApiQuery,
+  ApiTags,
+} from '@nestjs/swagger';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Token } from '@/tokens/entities/token.entity';
+import { Post } from '@/social/entities/post.entity';
+import { AccountService } from '@/account/services/account.service';
+import { AccountSearchResultDto } from '@/account/dto/account-search-result.dto';
+import { TokenDto } from '@/tokens/dto/token.dto';
+import { PostDto } from '@/social/dto/post.dto';
+
+const MAX_QUERY_LENGTH = 100;
+const MIN_QUERY_LENGTH = 2;
+const DEFAULT_LIMIT = 5;
+const MAX_LIMIT = 20;
+
+// Swagger documentation shape only. Handlers below return raw entities
+// (Token/Post) rather than instances of TokenDto/PostDto, matching this
+// codebase's existing pattern elsewhere (e.g. tokens.controller.ts's
+// `@ApiOkResponsePaginated(TokenDto)` over raw query rows).
+class SearchResultDto {
+  @ApiProperty({ type: () => TokenDto, isArray: true })
+  tokens: TokenDto[];
+
+  @ApiProperty({ type: () => AccountSearchResultDto, isArray: true })
+  accounts: AccountSearchResultDto[];
+
+  @ApiProperty({ type: () => PostDto, isArray: true })
+  posts: PostDto[];
+}
+
+interface SearchResult {
+  tokens: Token[];
+  accounts: AccountSearchResultDto[];
+  posts: Post[];
+}
+
+// Replaces 3 separate debounced-keystroke requests (tokens, accounts, posts)
+// with one server-side fan-out, so the client fires a single request per
+// keystroke instead of three.
+@Controller('search')
+@ApiTags('Search')
+@UseInterceptors(CacheInterceptor)
+export class SearchController {
+  constructor(
+    @InjectRepository(Token)
+    private readonly tokensRepository: Repository<Token>,
+
+    @InjectRepository(Post)
+    private readonly postsRepository: Repository<Post>,
+
+    private readonly accountService: AccountService,
+  ) {
+    //
+  }
+
+  @ApiOperation({
+    operationId: 'search',
+    summary: 'Unified search across tokens, accounts, and posts',
+    description:
+      'Runs the token/account/post lookups in parallel server-side, each ' +
+      `capped at \`limit\`. Returns empty arrays for \`q\` shorter than ${MIN_QUERY_LENGTH} characters.`,
+  })
+  @ApiQuery({
+    name: 'q',
+    type: 'string',
+    required: true,
+    description: `Search term, max ${MAX_QUERY_LENGTH} characters.`,
+  })
+  @ApiQuery({
+    name: 'limit',
+    type: 'number',
+    required: false,
+    description: 'Max results per category, clamped to 1-20 (default 5).',
+  })
+  @ApiOkResponse({ type: SearchResultDto })
+  @CacheTTL(30_000)
+  @Get()
+  async search(
+    @Query('q') q: string | undefined,
+    @Query('limit', new DefaultValuePipe(DEFAULT_LIMIT), ParseIntPipe)
+    limit = DEFAULT_LIMIT,
+  ): Promise<SearchResult> {
+    if (q && q.length > MAX_QUERY_LENGTH) {
+      throw new BadRequestException(
+        `q must be at most ${MAX_QUERY_LENGTH} characters`,
+      );
+    }
+
+    const term = (q ?? '').trim();
+    const clampedLimit = Math.min(Math.max(limit, 1), MAX_LIMIT);
+
+    if (term.length < MIN_QUERY_LENGTH) {
+      return { tokens: [], accounts: [], posts: [] };
+    }
+
+    const [tokens, accounts, posts] = await Promise.all([
+      this.searchTokens(term, clampedLimit),
+      this.accountService.searchByNameOrAddress(term, clampedLimit),
+      this.searchPosts(term, clampedLimit),
+    ]);
+
+    return { tokens, accounts, posts };
+  }
+
+  private searchTokens(term: string, limit: number): Promise<Token[]> {
+    return this.tokensRepository
+      .createQueryBuilder('token')
+      .where('token.unlisted = false')
+      .andWhere('token.name ILIKE :term', { term: `%${term}%` })
+      .orderBy('token.trending_score', 'DESC')
+      .addOrderBy('token.created_at', 'DESC')
+      .limit(limit)
+      .getMany();
+  }
+
+  private searchPosts(term: string, limit: number): Promise<Post[]> {
+    return this.postsRepository
+      .createQueryBuilder('post')
+      .where('post.is_hidden = false')
+      .andWhere('post.content ILIKE :term', { term: `%${term}%` })
+      .orderBy('post.created_at', 'DESC')
+      .limit(limit)
+      .getMany();
+  }
+}

--- a/src/search/search.module.ts
+++ b/src/search/search.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Token } from '@/tokens/entities/token.entity';
+import { Post } from '@/social/entities/post.entity';
+import { AccountModule } from '@/account/account.module';
+import { SearchController } from './search.controller';
+
+@Module({
+  imports: [AccountModule, TypeOrmModule.forFeature([Token, Post])],
+  controllers: [SearchController],
+})
+export class SearchModule {}

--- a/src/social/services/popular-ranking.service.spec.ts
+++ b/src/social/services/popular-ranking.service.spec.ts
@@ -26,9 +26,14 @@ jest.mock('ioredis', () => {
 import { PopularRankingService } from './popular-ranking.service';
 import { POPULAR_RANKING_CONFIG } from '@/configs/constants';
 
+// Serves both queries built off `postRepository.createQueryBuilder('post')`:
+// the candidate-id scan (select/where/andWhere/orderBy/limit/getRawMany) and
+// the slim hydration query (leftJoin/select/addSelect/where/getMany).
 function createCandidateQueryBuilder(posts: Array<{ id: string }>) {
   return {
     select: jest.fn().mockReturnThis(),
+    addSelect: jest.fn().mockReturnThis(),
+    leftJoin: jest.fn().mockReturnThis(),
     where: jest.fn().mockReturnThis(),
     andWhere: jest.fn().mockReturnThis(),
     orderBy: jest.fn().mockReturnThis(),
@@ -36,6 +41,7 @@ function createCandidateQueryBuilder(posts: Array<{ id: string }>) {
     getRawMany: jest
       .fn()
       .mockResolvedValue(posts.map((post) => ({ id: post.id }))),
+    getMany: jest.fn().mockResolvedValue(posts),
   };
 }
 
@@ -700,7 +706,9 @@ describe('PopularRankingService', () => {
       };
       const candidateQB = {
         leftJoinAndSelect: jest.fn().mockReturnThis(),
+        leftJoin: jest.fn().mockReturnThis(),
         select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
         andWhere: jest.fn().mockReturnThis(),
         orderBy: jest.fn().mockReturnThis(),
@@ -708,6 +716,7 @@ describe('PopularRankingService', () => {
         getRawMany: jest
           .fn()
           .mockResolvedValue([{ id: 'topic-heavy' }, { id: 'target-post' }]),
+        getMany: jest.fn().mockResolvedValue([targetPost, topicHeavyPost]),
       };
       const tipQB = {
         select: jest.fn().mockReturnThis(),
@@ -751,10 +760,15 @@ describe('PopularRankingService', () => {
 
       expect(candidateQB.leftJoinAndSelect).not.toHaveBeenCalled();
       expect(candidateQB.select).toHaveBeenCalledWith('post.id', 'id');
-      expect(repo.find).toHaveBeenCalledWith({
-        where: { id: expect.anything() },
-        relations: ['topics'],
-      });
+      // Slim hydration: joins topics for their name only, selects id/content/created_at.
+      expect(candidateQB.leftJoin).toHaveBeenCalledWith('post.topics', 'topic');
+      expect(candidateQB.select).toHaveBeenCalledWith([
+        'post.id',
+        'post.content',
+        'post.created_at',
+      ]);
+      expect(candidateQB.addSelect).toHaveBeenCalledWith(['topic.name']);
+      expect(repo.find).not.toHaveBeenCalled();
       expect(result.scoredItems!.map((item) => item.postId)).toEqual([
         'target-post',
         'topic-heavy',

--- a/src/social/services/popular-ranking.service.ts
+++ b/src/social/services/popular-ranking.service.ts
@@ -652,11 +652,18 @@ export class PopularRankingService implements OnModuleDestroy {
     const candidateOrder = new Map<string, number>(
       candidateIds.map((id, index) => [id, index] as const),
     );
+    // Only id/content/created_at + topic names ever reach computeScore below
+    // (see the `candidates.map` scoring pass) -- select just those instead of
+    // full Post rows (media, tx_args, token_mentions, ...) for up to
+    // maxCandidates (10k) rows every recompute.
     const hydratedCandidates = candidateIds.length
-      ? await this.postRepository.find({
-          where: { id: In(candidateIds) },
-          relations: ['topics'],
-        })
+      ? await this.postRepository
+          .createQueryBuilder('post')
+          .leftJoin('post.topics', 'topic')
+          .select(['post.id', 'post.content', 'post.created_at'])
+          .addSelect(['topic.name'])
+          .where('post.id IN (:...candidateIds)', { candidateIds })
+          .getMany()
       : [];
     const candidates = hydratedCandidates.sort(
       (a, b) => candidateOrder.get(a.id)! - candidateOrder.get(b.id)!,

--- a/src/social/services/post.service.spec.ts
+++ b/src/social/services/post.service.spec.ts
@@ -23,6 +23,7 @@ describe('PostService', () => {
     findOne: jest.fn(),
     create: jest.fn(),
     save: jest.fn(),
+    query: jest.fn(),
     manager: {
       transaction: jest.fn(),
     },
@@ -479,6 +480,59 @@ describe('PostService', () => {
       expect(logger.warn).toHaveBeenCalledWith(
         'Some topics could not be created or found',
         expect.objectContaining({ requested: ['alpha', 'missing'] }),
+      );
+    });
+  });
+
+  describe('fixOrphanedComments', () => {
+    it('runs one UPDATE to unlink still-orphaned comments and one to recount parents', async () => {
+      mockRepository.query
+        .mockResolvedValueOnce([[], 3]) // 3 comments converted to standalone posts
+        .mockResolvedValueOnce([[], 2]); // 2 parents recounted
+
+      await service.fixOrphanedComments();
+
+      expect(mockRepository.query).toHaveBeenCalledTimes(2);
+      const [unlinkSql] = mockRepository.query.mock.calls[0];
+      expect(unlinkSql).toContain('UPDATE posts');
+      expect(unlinkSql).toContain('SET post_id = NULL');
+      expect(unlinkSql).toContain('NOT EXISTS');
+
+      const [recountSql] = mockRepository.query.mock.calls[1];
+      expect(recountSql).toContain('SET total_comments = counts.cnt');
+      expect(recountSql).toContain('GROUP BY post_id');
+
+      expect(logger.log).toHaveBeenCalledWith(
+        'Orphaned comments cleanup completed',
+        { convertedToStandalonePosts: 3, parentsRecounted: 2 },
+      );
+    });
+
+    it('only unlinks comments old enough to rule out an in-progress sync race, not just any missing parent', async () => {
+      // A comment can be persisted before its parent post if MDW backward
+      // sync processes them out of order; without a grace period, a comment
+      // whose parent is seconds away from syncing would be permanently
+      // detached the instant this runs. The unlink UPDATE must therefore
+      // also require the comment to be older than the grace period, not
+      // just "parent currently missing".
+      mockRepository.query
+        .mockResolvedValueOnce([[], 0])
+        .mockResolvedValueOnce([[], 0]);
+
+      await service.fixOrphanedComments();
+
+      const [unlinkSql] = mockRepository.query.mock.calls[0];
+      expect(unlinkSql).toMatch(/created_at\s*<\s*NOW\(\)\s*-\s*INTERVAL/);
+    });
+
+    it('logs and swallows errors instead of throwing', async () => {
+      mockRepository.query.mockRejectedValue(new Error('db unavailable'));
+
+      await expect(service.fixOrphanedComments()).resolves.toBeUndefined();
+
+      expect(logger.error).toHaveBeenCalledWith(
+        'Failed to run orphaned comments cleanup',
+        expect.objectContaining({ error: 'db unavailable' }),
       );
     });
   });

--- a/src/social/services/post.service.spec.ts
+++ b/src/social/services/post.service.spec.ts
@@ -29,9 +29,11 @@ describe('PostService', () => {
   };
   const mockTopicRepository = {
     findOne: jest.fn(),
+    find: jest.fn(),
     create: jest.fn(),
     save: jest.fn(),
     update: jest.fn(),
+    query: jest.fn(),
   };
   const mockTokensService = {
     queueTrendingScoresForSymbols: jest.fn(),
@@ -422,6 +424,62 @@ describe('PostService', () => {
 
       expect(result).toBe(newPost);
       expect(parsePostContent).toHaveBeenCalledWith('test content', []);
+    });
+  });
+
+  describe('createOrGetTopics', () => {
+    it('returns [] without querying when given no topic names', async () => {
+      const result = await (service as any).createOrGetTopics([]);
+
+      expect(result).toEqual([]);
+      expect(mockTopicRepository.query).not.toHaveBeenCalled();
+      expect(mockTopicRepository.find).not.toHaveBeenCalled();
+    });
+
+    it('bulk-upserts missing topics with ON CONFLICT DO NOTHING, then reads them back in one query', async () => {
+      mockTopicRepository.query.mockResolvedValue(undefined);
+      mockTopicRepository.find.mockResolvedValue([
+        { name: 'alpha', post_count: 5 },
+        { name: 'beta', post_count: 0 },
+      ]);
+
+      const result = await (service as any).createOrGetTopics([
+        'Alpha',
+        'Beta',
+        'alpha',
+      ]);
+
+      expect(mockTopicRepository.query).toHaveBeenCalledTimes(1);
+      const [sql, params] = mockTopicRepository.query.mock.calls[0];
+      expect(sql).toContain('ON CONFLICT (name) DO NOTHING');
+      expect(params[1]).toEqual(['alpha', 'beta']); // normalized, deduped
+
+      expect(mockTopicRepository.find).toHaveBeenCalledWith({
+        where: { name: expect.anything() },
+      });
+
+      // Existing topic's post_count (5) must survive -- DO NOTHING never
+      // overwrites it.
+      expect(result).toEqual([
+        { name: 'alpha', post_count: 5 },
+        { name: 'beta', post_count: 0 },
+      ]);
+    });
+
+    it('logs a warning but does not throw when a requested topic cannot be resolved', async () => {
+      mockTopicRepository.query.mockResolvedValue(undefined);
+      mockTopicRepository.find.mockResolvedValue([{ name: 'alpha' }]);
+
+      const result = await (service as any).createOrGetTopics([
+        'Alpha',
+        'Missing',
+      ]);
+
+      expect(result).toEqual([{ name: 'alpha' }]);
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Some topics could not be created or found',
+        expect.objectContaining({ requested: ['alpha', 'missing'] }),
+      );
     });
   });
 });

--- a/src/social/services/post.service.spec.ts
+++ b/src/social/services/post.service.spec.ts
@@ -34,7 +34,7 @@ describe('PostService', () => {
     update: jest.fn(),
   };
   const mockTokensService = {
-    updateTrendingScoresForSymbols: jest.fn(),
+    queueTrendingScoresForSymbols: jest.fn(),
   };
 
   const createMockTransaction = (

--- a/src/social/services/post.service.trending.spec.ts
+++ b/src/social/services/post.service.trending.spec.ts
@@ -29,7 +29,7 @@ describe('PostService trending refresh', () => {
     };
     topicRepository = {};
     tokensService = {
-      updateTrendingScoresForSymbols: jest.fn(),
+      queueTrendingScoresForSymbols: jest.fn(),
     };
 
     service = new PostService(
@@ -53,7 +53,7 @@ describe('PostService trending refresh', () => {
       .spyOn(service as any, 'updateTopicPostCounts')
       .mockResolvedValue(undefined);
     postRepository.findOne.mockResolvedValue(null);
-    tokensService.updateTrendingScoresForSymbols.mockRejectedValue(
+    tokensService.queueTrendingScoresForSymbols.mockRejectedValue(
       new Error('refresh failed'),
     );
 
@@ -80,7 +80,7 @@ describe('PostService trending refresh', () => {
         token_mentions: ['ALPHA'],
       }),
     );
-    expect(tokensService.updateTrendingScoresForSymbols).toHaveBeenCalledWith([
+    expect(tokensService.queueTrendingScoresForSymbols).toHaveBeenCalledWith([
       'ALPHA',
     ]);
   });

--- a/src/social/services/post.service.ts
+++ b/src/social/services/post.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, EntityManager } from 'typeorm';
+import { In, Repository, EntityManager } from 'typeorm';
+import { randomUUID } from 'crypto';
 import { Post } from '../entities/post.entity';
 import { Topic } from '../entities/topic.entity';
 import {
@@ -952,42 +953,52 @@ export class PostService {
    * Creates or gets existing topics by name
    */
   private async createOrGetTopics(topicNames: string[]): Promise<Topic[]> {
-    if (!topicNames || topicNames.length === 0) {
+    const normalizedNames = [
+      ...new Set(
+        (topicNames || [])
+          .filter((topicName) => topicName && topicName.trim().length > 0)
+          .map((topicName) => normalizeTopicName(topicName)),
+      ),
+    ];
+
+    if (normalizedNames.length === 0) {
       return [];
     }
 
-    const topics: Topic[] = [];
+    // Bulk-upsert any missing topics in one round trip, then one IN() read,
+    // instead of a sequential findOne+save per topic name. DO NOTHING (not
+    // DO UPDATE) so an existing topic's accumulated post_count is never
+    // clobbered by a same-named insert racing in from another post.
+    await this.topicRepository.query(
+      `
+        INSERT INTO topics (id, name, post_count, version, created_at, updated_at)
+        SELECT unnest($1::uuid[]), unnest($2::text[]), 0, $3, CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6)
+        ON CONFLICT (name) DO NOTHING
+      `,
+      [
+        normalizedNames.map(() => randomUUID()),
+        normalizedNames,
+        this.syncVersion,
+      ],
+    );
 
-    for (const topicName of topicNames) {
-      if (!topicName || topicName.trim().length === 0) {
-        continue;
-      }
+    const topics = await this.topicRepository.find({
+      where: { name: In(normalizedNames) },
+    });
 
-      const normalizedName = normalizeTopicName(topicName);
+    const topicByName = new Map(topics.map((topic) => [topic.name, topic]));
+    const orderedTopics = normalizedNames
+      .map((name) => topicByName.get(name))
+      .filter((topic): topic is Topic => Boolean(topic));
 
-      // Try to find existing topic
-      let topic = await this.topicRepository.findOne({
-        where: { name: normalizedName },
+    if (orderedTopics.length !== normalizedNames.length) {
+      this.logger.warn('Some topics could not be created or found', {
+        requested: normalizedNames,
+        resolved: orderedTopics.map((topic) => topic.name),
       });
-
-      // Create new topic if it doesn't exist
-      if (!topic) {
-        topic = this.topicRepository.create({
-          name: normalizedName,
-          post_count: 0,
-          version: this.syncVersion,
-        });
-        topic = await this.topicRepository.save(topic);
-        this.logger.debug('Created new topic', {
-          topicName: normalizedName,
-          version: this.syncVersion,
-        });
-      }
-
-      topics.push(topic);
     }
 
-    return topics;
+    return orderedTopics;
   }
 
   /**

--- a/src/social/services/post.service.ts
+++ b/src/social/services/post.service.ts
@@ -411,7 +411,7 @@ export class PostService {
                 where: { id: postId },
               }),
             updateTrendingScoresForSymbols: (symbols) =>
-              this.tokensService.updateTrendingScoresForSymbols(symbols),
+              this.tokensService.queueTrendingScoresForSymbols(symbols),
             logError: (message, trace) => this.logger.error(message, trace),
             errorMessage: 'Failed to refresh trending scores after saving post',
           });
@@ -543,7 +543,7 @@ export class PostService {
             where: { id: postId },
           }),
         updateTrendingScoresForSymbols: (symbols) =>
-          this.tokensService.updateTrendingScoresForSymbols(symbols),
+          this.tokensService.queueTrendingScoresForSymbols(symbols),
         logError: (message, trace) => this.logger.error(message, trace),
         errorMessage: 'Failed to refresh trending scores after saving post',
       });

--- a/src/social/services/post.service.ts
+++ b/src/social/services/post.service.ts
@@ -33,6 +33,13 @@ import { refreshTrendingScoresForPostSafely } from '../utils/token-mentions.util
 import { normalizeTopicName } from '../utils/topic-name.util';
 import { TokensService } from '@/tokens/tokens.service';
 
+// How old a comment must be before fixOrphanedComments will permanently
+// detach it from a still-missing parent. Backward MDW sync doesn't guarantee
+// parent-before-child ordering, so a comment can be briefly "orphaned" simply
+// because its parent hasn't synced yet; this grace period gives that window
+// time to close before the cleanup commits to treating it as a real orphan.
+const ORPHAN_CLEANUP_GRACE_PERIOD = '1 hour';
+
 @Injectable()
 export class PostService {
   syncVersion = 8;
@@ -875,73 +882,57 @@ export class PostService {
   }
 
   /**
-   * Fixes orphaned comments by linking them to their parent posts
-   * This is a cleanup method for comments that were created before their parent posts
+   * Fixes orphaned comments by linking them to their parent posts.
+   * This is a cleanup method for comments that were created before their parent posts.
+   *
+   * Set-based instead of a per-comment validate+getCount() loop: one UPDATE
+   * converts every comment whose parent is still missing back to a standalone
+   * post, then one UPDATE (joined via a single GROUP BY) recomputes
+   * total_comments for every parent whose count is out of date -- this also
+   * catches up parents that only just appeared (their comment count update
+   * was a no-op while the parent row didn't exist yet), which is the actual
+   * race this cleanup exists for.
+   *
+   * This runs once, ~10s after boot (see `onModuleInit`/`sync`), with no
+   * later re-run -- so unlinking is permanent for whatever it decides is
+   * orphaned at that moment. Because comment/parent ordering during MDW
+   * backward sync isn't guaranteed, a comment can still be legitimately
+   * mid-flight (its parent post not synced yet, but on its way) at that
+   * instant; only comments older than `ORPHAN_CLEANUP_GRACE_PERIOD` are
+   * eligible for unlinking, so a parent that's merely running behind still
+   * has time to arrive before its children are permanently detached.
    */
   async fixOrphanedComments(): Promise<void> {
     try {
       this.logger.log('Starting orphaned comments cleanup...');
 
-      let fixedCount = 0;
-      let batchNumber = 0;
+      const orphanResult = await this.postRepository.query(`
+        UPDATE posts
+        SET post_id = NULL
+        WHERE post_id IS NOT NULL
+          AND created_at < NOW() - INTERVAL '${ORPHAN_CLEANUP_GRACE_PERIOD}'
+          AND NOT EXISTS (
+            SELECT 1 FROM posts parent WHERE parent.id = posts.post_id
+          )
+      `);
 
-      while (true) {
-        const orphanedComments = await this.postRepository
-          .createQueryBuilder('comment')
-          .leftJoin('posts', 'parent', 'parent.id = comment.post_id')
-          .where('comment.post_id IS NOT NULL')
-          .andWhere('parent.id IS NULL')
-          .take(500)
-          .getMany();
+      const recountResult = await this.postRepository.query(`
+        UPDATE posts parent
+        SET total_comments = counts.cnt
+        FROM (
+          SELECT post_id, COUNT(*)::int AS cnt
+          FROM posts
+          WHERE post_id IS NOT NULL
+          GROUP BY post_id
+        ) counts
+        WHERE parent.id = counts.post_id
+          AND parent.total_comments IS DISTINCT FROM counts.cnt
+      `);
 
-        if (orphanedComments.length === 0) {
-          break;
-        }
-
-        batchNumber++;
-        this.logger.log(
-          `Orphan cleanup batch ${batchNumber}: processing ${orphanedComments.length} comments`,
-        );
-
-        let batchProgress = 0;
-        for (const comment of orphanedComments) {
-          try {
-            const parentExists = await this.validateParentPost(
-              comment.post_id,
-              1,
-              0,
-            );
-            if (parentExists) {
-              await this.updatePostCommentCount(comment.post_id);
-              fixedCount++;
-            } else {
-              await this.postRepository.update(comment.id, { post_id: null });
-              this.logger.warn('Converted orphaned comment to regular post', {
-                commentId: comment.id,
-                originalParentId: comment.post_id,
-              });
-            }
-            batchProgress++;
-          } catch (error) {
-            this.logger.error('Failed to fix orphaned comment', {
-              commentId: comment.id,
-              parentId: comment.post_id,
-              error: error instanceof Error ? error.message : String(error),
-            });
-          }
-        }
-
-        if (batchProgress === 0) {
-          this.logger.error(
-            `Orphan cleanup batch ${batchNumber}: no progress (all ${orphanedComments.length} comments failed), aborting to prevent infinite loop`,
-          );
-          break;
-        }
-      }
-
-      this.logger.log(
-        `Orphaned comments cleanup completed: ${fixedCount} fixed across ${batchNumber} batch(es)`,
-      );
+      this.logger.log('Orphaned comments cleanup completed', {
+        convertedToStandalonePosts: orphanResult[1] ?? 0,
+        parentsRecounted: recountResult[1] ?? 0,
+      });
     } catch (error) {
       this.logger.error('Failed to run orphaned comments cleanup', {
         error: error instanceof Error ? error.message : String(error),

--- a/src/social/utils/token-mentions-sql.util.spec.ts
+++ b/src/social/utils/token-mentions-sql.util.spec.ts
@@ -130,9 +130,27 @@ describe('token-mentions-sql util', () => {
     it('scopes the exists check to the given alias and symbol', () => {
       const sql = buildTokenMentionExistsSql('post', '$2');
 
+      expect(sql).toContain('post.token_mentions');
+      // Explicit ::text cast: jsonb_build_array is VARIADIC "any", so a bare
+      // bind parameter here fails with "could not determine data type of
+      // parameter $2" (Postgres can't infer a type with no other context).
+      expect(sql).toContain('@> jsonb_build_array(($2)::text)');
       expect(sql).toContain('EXISTS (');
-      expect(sql).toContain('normalized_mentions.symbol = $2');
       expect(sql).toContain(`'${TOKEN_HASHTAG_REGEX_SOURCE}'`);
+      expect(sql).toContain('UPPER(content_match[1]) = $2');
+    });
+
+    it('does not wrap token_mentions in COALESCE on the containment check, so IDX_POSTS_TOKEN_MENTIONS_GIN can match it', () => {
+      const sql = buildTokenMentionExistsSql('post', '$2');
+      const containmentClause = sql.split('@>')[0];
+
+      // The clause feeding the `@>` operator must be the bare column -- any
+      // wrapping function (COALESCE included) stops Postgres from matching
+      // the GIN index built on the plain column.
+      expect(containmentClause.trim().endsWith('post.token_mentions')).toBe(
+        true,
+      );
+      expect(containmentClause).not.toContain('COALESCE');
     });
   });
 });

--- a/src/social/utils/token-mentions-sql.util.ts
+++ b/src/social/utils/token-mentions-sql.util.ts
@@ -215,15 +215,43 @@ export function buildNormalizedTokenMentionSelectSql(
   `;
 }
 
+/**
+ * Checks whether `postAlias` mentions `normalizedSymbolSql` (an already
+ * UPPER()-cased symbol expression or bind parameter). Stored `token_mentions`
+ * entries are always upper-cased at write time (`extractTrendMentions`), so
+ * the common case is a plain jsonb containment check — servable by
+ * `IDX_POSTS_TOKEN_MENTIONS_GIN` (`jsonb_path_ops`) instead of the per-row
+ * `jsonb_array_elements_text` scan the old EXISTS subquery required. The
+ * regex-over-`content` fallback only runs for the (increasingly rare) rows
+ * where `token_mentions` was never populated.
+ *
+ * The containment predicate below deliberately does NOT wrap `token_mentions`
+ * in `COALESCE(...)` (the column is `NOT NULL DEFAULT '[]'`, so it's never
+ * needed) — Postgres only matches a GIN index to a query predicate that is
+ * shaped exactly like the indexed expression, so wrapping the column here
+ * would silently defeat `IDX_POSTS_TOKEN_MENTIONS_GIN` and fall back to a
+ * full scan.
+ */
 export function buildTokenMentionExistsSql(
   postAlias: string,
   normalizedSymbolSql: string,
 ): string {
   return `
-    EXISTS (
-      SELECT 1
-      FROM (${buildNormalizedTokenMentionSelectSql(postAlias)}) normalized_mentions
-      WHERE normalized_mentions.symbol = ${normalizedSymbolSql}
+    (
+      ${postAlias}.token_mentions
+        @> jsonb_build_array((${normalizedSymbolSql})::text)
+      OR (
+        jsonb_array_length(COALESCE(${postAlias}.token_mentions, '[]'::jsonb)) = 0
+        AND EXISTS (
+          SELECT 1
+          FROM regexp_matches(
+            COALESCE(${postAlias}.content, ''),
+            '${TOKEN_HASHTAG_REGEX_SOURCE}',
+            'g'
+          ) AS content_match
+          WHERE UPPER(content_match[1]) = ${normalizedSymbolSql}
+        )
+      )
     )
   `;
 }

--- a/src/tipping/controllers/tips.controller.spec.ts
+++ b/src/tipping/controllers/tips.controller.spec.ts
@@ -1,4 +1,9 @@
 import { TipsController } from './tips.controller';
+import { paginate } from 'nestjs-typeorm-paginate';
+
+jest.mock('nestjs-typeorm-paginate', () => ({
+  paginate: jest.fn().mockResolvedValue({ items: [], meta: {} }),
+}));
 
 describe('TipsController', () => {
   let controller: TipsController;
@@ -51,5 +56,50 @@ describe('TipsController', () => {
       totalTipsSent: '5',
       totalTipsReceived: '7',
     });
+  });
+
+  it('filters listTips by post_id when provided', async () => {
+    const listQueryBuilder = {
+      leftJoinAndMapOne: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+    };
+    tipRepository.createQueryBuilder.mockReturnValue(listQueryBuilder);
+
+    await controller.listTips(
+      1,
+      100,
+      'created_at',
+      'DESC',
+      undefined,
+      undefined,
+      undefined,
+      'post_123',
+    );
+
+    expect(listQueryBuilder.andWhere).toHaveBeenCalledWith(
+      'tip.post_id = :postId',
+      { postId: 'post_123' },
+    );
+    expect(paginate).toHaveBeenCalledWith(listQueryBuilder, {
+      page: 1,
+      limit: 100,
+    });
+  });
+
+  it('does not filter listTips by post_id when absent', async () => {
+    const listQueryBuilder = {
+      leftJoinAndMapOne: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+    };
+    tipRepository.createQueryBuilder.mockReturnValue(listQueryBuilder);
+
+    await controller.listTips(1, 100, 'created_at', 'DESC');
+
+    expect(listQueryBuilder.andWhere).not.toHaveBeenCalledWith(
+      'tip.post_id = :postId',
+      expect.anything(),
+    );
   });
 });

--- a/src/tipping/controllers/tips.controller.ts
+++ b/src/tipping/controllers/tips.controller.ts
@@ -50,6 +50,7 @@ export class TipsController {
   @ApiQuery({ name: 'sender', type: 'string', required: false })
   @ApiQuery({ name: 'receiver', type: 'string', required: false })
   @ApiQuery({ name: 'type', type: 'string', required: false })
+  @ApiQuery({ name: 'post_id', type: 'string', required: false })
   @ApiOperation({
     operationId: 'listTips',
     summary: 'List tips',
@@ -65,6 +66,7 @@ export class TipsController {
     @Query('sender', OptionalAeAccountAddressPipe) sender?: string,
     @Query('receiver', OptionalAeAccountAddressPipe) receiver?: string,
     @Query('type') type?: string,
+    @Query('post_id') postId?: string,
   ) {
     if (page < 1) {
       throw new BadRequestException('Page must be greater than or equal to 1');
@@ -103,6 +105,9 @@ export class TipsController {
     }
     if (type) {
       query.andWhere('tip.type = :type', { type });
+    }
+    if (postId) {
+      query.andWhere('tip.post_id = :postId', { postId });
     }
 
     // amount stored as string; order by numeric cast to preserve numeric ordering

--- a/src/tipping/services/tips.service.spec.ts
+++ b/src/tipping/services/tips.service.spec.ts
@@ -19,7 +19,7 @@ describe('TipService', () => {
       ensureAccountExists: jest.fn(),
     };
     tokensService = {
-      updateTrendingScoresForSymbols: jest.fn(),
+      queueTrendingScoresForSymbols: jest.fn(),
     };
 
     service = new TipService(
@@ -43,7 +43,7 @@ describe('TipService', () => {
       .spyOn(accountService, 'ensureAccountExists')
       .mockResolvedValueOnce({ address: 'ak_sender' })
       .mockResolvedValueOnce({ address: 'ak_receiver' });
-    tokensService.updateTrendingScoresForSymbols.mockRejectedValue(
+    tokensService.queueTrendingScoresForSymbols.mockRejectedValue(
       new Error('refresh failed'),
     );
 
@@ -60,7 +60,7 @@ describe('TipService', () => {
     );
 
     expect(result).toBe(savedTip);
-    expect(tokensService.updateTrendingScoresForSymbols).toHaveBeenCalledWith([
+    expect(tokensService.queueTrendingScoresForSymbols).toHaveBeenCalledWith([
       'ALPHA',
     ]);
   });
@@ -92,7 +92,7 @@ describe('TipService', () => {
     expect(result).toBeNull();
     expect(ensureAccountExists).not.toHaveBeenCalled();
     expect(tipRepository.save).not.toHaveBeenCalled();
-    expect(tokensService.updateTrendingScoresForSymbols).not.toHaveBeenCalled();
+    expect(tokensService.queueTrendingScoresForSymbols).not.toHaveBeenCalled();
   });
 
   it('does not persist self-tips on a profile', async () => {
@@ -118,7 +118,7 @@ describe('TipService', () => {
     expect(postRepository.findOne).not.toHaveBeenCalled();
     expect(ensureAccountExists).not.toHaveBeenCalled();
     expect(tipRepository.save).not.toHaveBeenCalled();
-    expect(tokensService.updateTrendingScoresForSymbols).not.toHaveBeenCalled();
+    expect(tokensService.queueTrendingScoresForSymbols).not.toHaveBeenCalled();
   });
 
   it('marks self-tips as skipped during live handling', async () => {

--- a/src/tipping/services/tips.service.ts
+++ b/src/tipping/services/tips.service.ts
@@ -138,7 +138,7 @@ export class TipService {
           where: { id: postId },
         }),
       updateTrendingScoresForSymbols: (symbols) =>
-        this.tokensService.updateTrendingScoresForSymbols(symbols),
+        this.tokensService.queueTrendingScoresForSymbols(symbols),
       logError: (message, trace) => this.logger.error(message, trace),
       errorMessage: 'Failed to refresh trending scores after saving tip',
     });

--- a/src/token-gated-rooms/services/eligibility.service.spec.ts
+++ b/src/token-gated-rooms/services/eligibility.service.spec.ts
@@ -506,6 +506,9 @@ describe('EligibilityService.recomputeRoom (cursor batching, mocked QB)', () => 
     };
     const identity = {
       getPubkeyForAddress: jest.fn().mockResolvedValue(HEX),
+      getPubkeysForAddresses: jest.fn((addresses: string[]) =>
+        Promise.resolve(new Map(addresses.map((address) => [address, HEX]))),
+      ),
     };
     const emitter = new EventEmitter2();
     const emitSpy = jest.spyOn(emitter, 'emit');
@@ -525,6 +528,9 @@ describe('EligibilityService.recomputeRoom (cursor batching, mocked QB)', () => 
     expect(flips).toBe(3);
     expect(membershipRepo.update).toHaveBeenCalledTimes(3);
     expect(emitSpy).toHaveBeenCalledTimes(3);
+    // Batched: one getPubkeysForAddresses call per page, zero per-member reads.
+    expect(identity.getPubkeysForAddresses).toHaveBeenCalledTimes(2);
+    expect(identity.getPubkeyForAddress).not.toHaveBeenCalled();
   });
 });
 
@@ -546,7 +552,12 @@ describe('EligibilityService.recomputeRoomFromHolders (seed, batched reads)', ()
       update: jest.fn().mockResolvedValue(undefined),
       insert: jest.fn().mockResolvedValue(undefined),
     };
-    const identity = { getPubkeyForAddress: jest.fn().mockResolvedValue(HEX) };
+    const identity = {
+      getPubkeyForAddress: jest.fn().mockResolvedValue(HEX),
+      getPubkeysForAddresses: jest.fn((addresses: string[]) =>
+        Promise.resolve(new Map(addresses.map((address) => [address, HEX]))),
+      ),
+    };
     const emitter = new EventEmitter2();
     const service = new EligibilityService(
       communityRoomRepo as any,
@@ -571,5 +582,8 @@ describe('EligibilityService.recomputeRoomFromHolders (seed, batched reads)', ()
     expect(membershipRepo.findOne).not.toHaveBeenCalled();
     expect(tokenBalanceRepo.find).toHaveBeenCalledTimes(1);
     expect(membershipRepo.find).toHaveBeenCalledTimes(1);
+    // Pubkeys resolved once for the whole room roster, not per member.
+    expect(identity.getPubkeysForAddresses).toHaveBeenCalledTimes(1);
+    expect(identity.getPubkeyForAddress).not.toHaveBeenCalled();
   });
 });

--- a/src/token-gated-rooms/services/eligibility.service.ts
+++ b/src/token-gated-rooms/services/eligibility.service.ts
@@ -246,11 +246,19 @@ export class EligibilityService {
         break;
       }
 
+      // Batch-resolve pubkeys for this page in one IN(...) read instead of
+      // one findOne per member.
+      const pubkeyByAddress = await this.identity.getPubkeysForAddresses(
+        batch.map((row) => row.member_address),
+      );
+
       for (const existing of batch) {
         const flipped = await this.recomputeMember(
           room,
           existing.member_address,
           existing,
+          undefined,
+          pubkeyByAddress.get(existing.member_address) ?? null,
         );
         if (flipped) {
           flips += 1;
@@ -321,6 +329,12 @@ export class EligibilityService {
       addresses.add(moderator);
     }
 
+    // 4) Batch-resolve pubkeys for the WHOLE room roster in one IN(...) read
+    //    instead of one findOne per member (identity.getPubkeyForAddress).
+    const pubkeyByAddress = await this.identity.getPubkeysForAddresses([
+      ...addresses,
+    ]);
+
     let flips = 0;
     for (const address of addresses) {
       // Pass the pre-loaded membership row + balance (0 for a union member with no
@@ -330,6 +344,7 @@ export class EligibilityService {
         address,
         membershipByAddress.get(address) ?? null,
         balanceByAddress.get(address) ?? new BigNumber(0),
+        pubkeyByAddress.get(address) ?? null,
       );
       if (flipped) {
         flips += 1;
@@ -353,6 +368,7 @@ export class EligibilityService {
     memberAddress: string,
     existing?: RoomMembership | null,
     balanceRaw?: BigNumber.Value | null,
+    pubkeyOverride?: string | null,
   ): Promise<boolean> {
     // `existing === undefined` ⇒ not provided, load it. `existing === null` ⇒ the
     // caller already loaded the full room roster and this member has NO row (the
@@ -368,7 +384,13 @@ export class EligibilityService {
         : existing;
 
     // Resolved hex pubkey (or null) for the member — read-only (Task 05).
-    const memberPubkey = await this.identity.getPubkeyForAddress(memberAddress);
+    // `pubkeyOverride === undefined` ⇒ not provided, look it up (single-member
+    // reactive paths). Any other value (including null) ⇒ the caller already
+    // batch-resolved pubkeys for the whole room/page — skip the per-member read.
+    const memberPubkey =
+      pubkeyOverride === undefined
+        ? await this.identity.getPubkeyForAddress(memberAddress)
+        : pubkeyOverride;
 
     // Role: configured moderator → admin, else member.
     const role: RoomMembershipRole = (room.moderators ?? []).includes(

--- a/src/token-gated-rooms/services/identity.service.ts
+++ b/src/token-gated-rooms/services/identity.service.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { In, Repository } from 'typeorm';
 import { ConfigType } from '@nestjs/config';
 import { EventEmitter2, OnEvent } from '@nestjs/event-emitter';
 import { Account } from '@/account/entities/account.entity';
@@ -111,6 +111,54 @@ export class IdentityService {
     if (!hex) return null;
     this.setCacheEntry(address, hex);
     return hex;
+  }
+
+  /**
+   * Batch variant of {@link getPubkeyForAddress} for room-wide recomputes
+   * (thousands of holders): one `IN (...)` read instead of one `findOne`
+   * per member. The in-memory cache only stores resolved hits (a `null`
+   * result is never cached, since it's a single-address cache miss most
+   * callers hit at most once anyway) so this always queries for every
+   * address not already cached, then seeds the cache for any hits.
+   */
+  async getPubkeysForAddresses(
+    addresses: string[],
+  ): Promise<Map<string, string | null>> {
+    const result = new Map<string, string | null>();
+    const uncached: string[] = [];
+
+    for (const address of addresses) {
+      const cached = this.addressToPubkey.get(address);
+      if (cached) {
+        result.set(address, cached);
+      } else {
+        uncached.push(address);
+      }
+    }
+
+    if (uncached.length === 0) {
+      return result;
+    }
+
+    const accounts = await this.accountRepo.find({
+      where: { address: In(uncached) },
+      select: ['address', 'links'],
+    });
+    const accountByAddress = new Map(
+      accounts.map((account) => [account.address, account]),
+    );
+
+    for (const address of uncached) {
+      const hex = normalizePubkey(
+        accountByAddress.get(address)?.links?.[this.provider],
+      );
+      if (hex) {
+        this.setCacheEntry(address, hex);
+      }
+      result.set(address, hex ?? null);
+    }
+
+    return result;
   }
 
   /**

--- a/src/tokens/dto/token.dto.ts
+++ b/src/tokens/dto/token.dto.ts
@@ -100,6 +100,9 @@ export class TokenDto {
   @ApiProperty()
   total_supply: string;
 
+  @ApiProperty({ nullable: true })
+  circulating_supply: string | null;
+
   @ApiProperty()
   dao_balance: string;
 

--- a/src/tokens/entities/token-trade-eligibility-counts.entity.ts
+++ b/src/tokens/entities/token-trade-eligibility-counts.entity.ts
@@ -1,0 +1,20 @@
+import { Column, Entity, PrimaryColumn, UpdateDateColumn } from 'typeorm';
+
+// Materialized buy/sell trade count per token, incremented in
+// `TransactionPersistenceService.saveTransaction` as each new transaction is
+// persisted. Backs `applyListEligibilityFilters`/`getTrendingEligibilityBreakdown`
+// so they no longer aggregate the full `transactions` table on every request.
+@Entity({ name: 'token_trade_eligibility_counts' })
+export class TokenTradeEligibilityCounts {
+  @PrimaryColumn()
+  sale_address: string;
+
+  @Column({ default: 0 })
+  trade_count: number;
+
+  @UpdateDateColumn({
+    type: 'timestamp',
+    default: () => 'CURRENT_TIMESTAMP(6)',
+  })
+  updated_at: Date;
+}

--- a/src/tokens/entities/token.entity.spec.ts
+++ b/src/tokens/entities/token.entity.spec.ts
@@ -1,0 +1,23 @@
+import { getMetadataArgsStorage } from 'typeorm';
+import { Token, UNRANKED_TOKEN_RANK } from './token.entity';
+
+describe('Token entity', () => {
+  it('defaults rank to the unranked sentinel, not 0', () => {
+    // Guards the exact regression this constant fixes: `rank` sorts ASC
+    // (1 = highest market cap) in queryTokensWithRanks, so a default of 0
+    // would put every newly-created token ahead of the real #1 token until
+    // the next RefreshTokenRanksService tick.
+    const rankColumn = getMetadataArgsStorage().columns.find(
+      (column) => column.target === Token && column.propertyName === 'rank',
+    );
+
+    expect(rankColumn).toBeDefined();
+    expect(rankColumn!.options.default).toBe(UNRANKED_TOKEN_RANK);
+    expect(rankColumn!.options.default).not.toBe(0);
+  });
+
+  it('keeps the sentinel outside any realistic rank range', () => {
+    expect(UNRANKED_TOKEN_RANK).toBe(2147483647);
+    expect(UNRANKED_TOKEN_RANK).toBeGreaterThan(0);
+  });
+});

--- a/src/tokens/entities/token.entity.ts
+++ b/src/tokens/entities/token.entity.ts
@@ -169,6 +169,16 @@ export class Token {
   })
   total_supply: BigNumber;
 
+  // Middleware's AEX9 `event_supply`, tracked off the token's Mint/Burn/
+  // Transfer event log; persisted so the token page can stop calling
+  // `{mdw}/v3/aex9/{address}` from the browser just to read this field.
+  @Column({
+    type: 'numeric',
+    nullable: true,
+    transformer: BigNumberTransformer,
+  })
+  circulating_supply: BigNumber | null;
+
   @Index()
   @Column({
     type: 'decimal',

--- a/src/tokens/entities/token.entity.ts
+++ b/src/tokens/entities/token.entity.ts
@@ -13,6 +13,11 @@ import {
 } from 'typeorm';
 import { IPriceDto } from '../dto/price.dto';
 
+// Postgres int4 max -- safely outside any real rank (real ranks are ≤ the
+// count of unlisted=false tokens). Used as the "not yet ranked" sentinel for
+// `Token.rank` so an unranked row sorts last, not first, under `rank ASC`.
+export const UNRANKED_TOKEN_RANK = 2147483647;
+
 // Backs the home feed's token-creation source (`unlisted = false ORDER BY
 // created_at DESC`), which previously had no covering index on this table.
 @Index('IDX_TOKEN_UNLISTED_CREATED_AT', ['unlisted', 'created_at'])
@@ -164,6 +169,21 @@ export class Token {
     nullable: true,
   })
   market_cap_data!: IPriceDto;
+
+  // Persisted market-cap rank among unlisted=false tokens, refreshed
+  // periodically by RefreshTokenRanksService. Reading this column instead
+  // of a live `RANK() OVER (...)` window function is what lets
+  // queryTokensWithRanks skip re-sorting the whole token table on every
+  // list request.
+  //
+  // Defaults to UNRANKED_TOKEN_RANK (last place), not 0: listings sort
+  // `rank ASC` (1 = highest market cap), so a brand-new token would
+  // otherwise outrank every real token until the next refresh cron tick.
+  @Index()
+  @Column({
+    default: UNRANKED_TOKEN_RANK,
+  })
+  rank: number;
 
   @Column({
     default: 0n,

--- a/src/tokens/entities/token.entity.ts
+++ b/src/tokens/entities/token.entity.ts
@@ -13,6 +13,9 @@ import {
 } from 'typeorm';
 import { IPriceDto } from '../dto/price.dto';
 
+// Backs the home feed's token-creation source (`unlisted = false ORDER BY
+// created_at DESC`), which previously had no covering index on this table.
+@Index('IDX_TOKEN_UNLISTED_CREATED_AT', ['unlisted', 'created_at'])
 @Entity({ name: 'token' })
 export class Token {
   @PrimaryColumn()

--- a/src/tokens/queues/constants.ts
+++ b/src/tokens/queues/constants.ts
@@ -1,3 +1,4 @@
 export const PULL_TOKEN_INFO_QUEUE = 'pull-token-price';
 export const SYNC_TOKEN_HOLDERS_QUEUE = 'sync-token-holders';
 export const DELETE_OLD_TOKENS_QUEUE = 'delete-old-tokens';
+export const UPDATE_TRENDING_SCORES_QUEUE = 'update-trending-scores';

--- a/src/tokens/queues/update-trending-scores.queue.spec.ts
+++ b/src/tokens/queues/update-trending-scores.queue.spec.ts
@@ -1,0 +1,29 @@
+import { UpdateTrendingScoresQueue } from './update-trending-scores.queue';
+
+describe('UpdateTrendingScoresQueue', () => {
+  it('delegates to TokensService.updateTrendingScoresForSymbols for the job symbol', async () => {
+    const tokenService = {
+      updateTrendingScoresForSymbols: jest.fn().mockResolvedValue(undefined),
+    };
+    const queue = new UpdateTrendingScoresQueue(tokenService as any);
+
+    await queue.process({ data: { symbol: 'ALPHA' } } as any);
+
+    expect(tokenService.updateTrendingScoresForSymbols).toHaveBeenCalledWith([
+      'ALPHA',
+    ]);
+  });
+
+  it('rethrows so Bull can retry a failed recompute', async () => {
+    const tokenService = {
+      updateTrendingScoresForSymbols: jest
+        .fn()
+        .mockRejectedValue(new Error('boom')),
+    };
+    const queue = new UpdateTrendingScoresQueue(tokenService as any);
+
+    await expect(
+      queue.process({ data: { symbol: 'ALPHA' } } as any),
+    ).rejects.toThrow('boom');
+  });
+});

--- a/src/tokens/queues/update-trending-scores.queue.ts
+++ b/src/tokens/queues/update-trending-scores.queue.ts
@@ -1,0 +1,34 @@
+import { Process, Processor } from '@nestjs/bull';
+import { Logger } from '@nestjs/common';
+import { Job } from 'bull';
+import { TokensService } from '../tokens.service';
+import { UPDATE_TRENDING_SCORES_QUEUE } from './constants';
+
+export interface IUpdateTrendingScoresQueue {
+  symbol: string;
+}
+
+@Processor(UPDATE_TRENDING_SCORES_QUEUE)
+export class UpdateTrendingScoresQueue {
+  private readonly logger = new Logger(UpdateTrendingScoresQueue.name);
+
+  constructor(private readonly tokenService: TokensService) {
+    //
+  }
+
+  @Process({
+    concurrency: 5,
+  })
+  async process(job: Job<IUpdateTrendingScoresQueue>) {
+    const { symbol } = job.data;
+    try {
+      await this.tokenService.updateTrendingScoresForSymbols([symbol]);
+    } catch (error) {
+      this.logger.error(
+        `UpdateTrendingScoresQueue->error:${symbol}`,
+        error,
+      );
+      throw error;
+    }
+  }
+}

--- a/src/tokens/queues/update-trending-scores.queue.ts
+++ b/src/tokens/queues/update-trending-scores.queue.ts
@@ -24,10 +24,7 @@ export class UpdateTrendingScoresQueue {
     try {
       await this.tokenService.updateTrendingScoresForSymbols([symbol]);
     } catch (error) {
-      this.logger.error(
-        `UpdateTrendingScoresQueue->error:${symbol}`,
-        error,
-      );
+      this.logger.error(`UpdateTrendingScoresQueue->error:${symbol}`, error);
       throw error;
     }
   }

--- a/src/tokens/services/refresh-token-ranks.service.spec.ts
+++ b/src/tokens/services/refresh-token-ranks.service.spec.ts
@@ -1,0 +1,39 @@
+import { Logger } from '@nestjs/common';
+import { RefreshTokenRanksService } from './refresh-token-ranks.service';
+
+describe('RefreshTokenRanksService', () => {
+  it('runs a single set-based UPDATE ... RANK() OVER query', async () => {
+    const query = jest.fn().mockResolvedValue(undefined);
+    const service = new RefreshTokenRanksService({ query } as any);
+
+    await service.refreshRanks();
+
+    expect(query).toHaveBeenCalledTimes(1);
+    const [sql] = query.mock.calls[0];
+    expect(sql).toContain('UPDATE "token"');
+    expect(sql).toContain('RANK() OVER');
+    expect(sql).toContain('WHERE unlisted = false');
+  });
+
+  it('logs and swallows errors instead of throwing', async () => {
+    const query = jest.fn().mockRejectedValue(new Error('db unavailable'));
+    const service = new RefreshTokenRanksService({ query } as any);
+    const loggerError = jest
+      .spyOn(Logger.prototype, 'error')
+      .mockImplementation(() => undefined);
+
+    await expect(service.refreshRanks()).resolves.toBeUndefined();
+    expect(loggerError).toHaveBeenCalled();
+    loggerError.mockRestore();
+  });
+
+  it('manualRefresh delegates to refreshRanks', async () => {
+    const query = jest.fn().mockResolvedValue(undefined);
+    const service = new RefreshTokenRanksService({ query } as any);
+    const spy = jest.spyOn(service, 'refreshRanks');
+
+    await service.manualRefresh();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/tokens/services/refresh-token-ranks.service.ts
+++ b/src/tokens/services/refresh-token-ranks.service.ts
@@ -1,0 +1,58 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { InjectDataSource } from '@nestjs/typeorm';
+import { DataSource } from 'typeorm';
+
+/**
+ * Persists `token.rank` (market-cap rank among unlisted=false tokens) so
+ * `queryTokensWithRanks` reads a plain column instead of recomputing
+ * `RANK() OVER (...)` across the whole token table on every list request.
+ */
+@Injectable()
+export class RefreshTokenRanksService {
+  private readonly logger = new Logger(RefreshTokenRanksService.name);
+
+  constructor(
+    @InjectDataSource()
+    private readonly dataSource: DataSource,
+  ) {}
+
+  @Cron(CronExpression.EVERY_5_MINUTES)
+  async refreshRanks() {
+    try {
+      const startTime = Date.now();
+
+      await this.dataSource.query(`
+        UPDATE "token"
+        SET "rank" = ranked.rank
+        FROM (
+          SELECT
+            sale_address,
+            CAST(RANK() OVER (
+              ORDER BY
+                CASE WHEN market_cap = 0 THEN 1 ELSE 0 END,
+                market_cap DESC,
+                created_at ASC
+            ) AS INTEGER) AS rank
+          FROM "token"
+          WHERE unlisted = false
+        ) ranked
+        WHERE "token".sale_address = ranked.sale_address
+          AND "token".rank IS DISTINCT FROM ranked.rank
+      `);
+
+      this.logger.log(
+        `Refreshed token ranks in ${Date.now() - startTime}ms`,
+      );
+    } catch (error) {
+      this.logger.error(
+        'Failed to refresh token ranks',
+        error instanceof Error ? error.stack : String(error),
+      );
+    }
+  }
+
+  async manualRefresh(): Promise<void> {
+    await this.refreshRanks();
+  }
+}

--- a/src/tokens/services/refresh-token-ranks.service.ts
+++ b/src/tokens/services/refresh-token-ranks.service.ts
@@ -41,9 +41,7 @@ export class RefreshTokenRanksService {
           AND "token".rank IS DISTINCT FROM ranked.rank
       `);
 
-      this.logger.log(
-        `Refreshed token ranks in ${Date.now() - startTime}ms`,
-      );
+      this.logger.log(`Refreshed token ranks in ${Date.now() - startTime}ms`);
     } catch (error) {
       this.logger.error(
         'Failed to refresh token ranks',

--- a/src/tokens/tokens.module.ts
+++ b/src/tokens/tokens.module.ts
@@ -11,10 +11,12 @@ import {
   DELETE_OLD_TOKENS_QUEUE,
   PULL_TOKEN_INFO_QUEUE,
   SYNC_TOKEN_HOLDERS_QUEUE,
+  UPDATE_TRENDING_SCORES_QUEUE,
 } from './queues/constants';
 import { PullTokenInfoQueue } from './queues/pull-token-info.queue';
 import { RemoveOldTokensQueue } from './queues/remove-old-tokens.queue';
 import { SyncTokenHoldersQueue } from './queues/sync-token-holders.queue';
+import { UpdateTrendingScoresQueue } from './queues/update-trending-scores.queue';
 import { TokenWebsocketGateway } from './token-websocket.gateway';
 import { TokensController } from './tokens.controller';
 import { TokensService } from './tokens.service';
@@ -52,6 +54,9 @@ import { Post } from '@/social/entities/post.entity';
       {
         name: DELETE_OLD_TOKENS_QUEUE,
       },
+      {
+        name: UPDATE_TRENDING_SCORES_QUEUE,
+      },
     ),
   ],
   controllers: [
@@ -65,6 +70,7 @@ import { Post } from '@/social/entities/post.entity';
     TokenWebsocketGateway,
     PullTokenInfoQueue,
     SyncTokenHoldersQueue,
+    UpdateTrendingScoresQueue,
     RemoveOldTokensQueue,
     TokenHoldersLockService,
     UpdateTrendingTokensService,

--- a/src/tokens/tokens.module.ts
+++ b/src/tokens/tokens.module.ts
@@ -28,6 +28,7 @@ import { TokenTradeEligibilityCounts } from './entities/token-trade-eligibility-
 import { TokenPerformanceView } from './entities/tokens-performance.view';
 import { RefreshTokenEligibilityCountsService } from './services/refresh-token-eligibility-counts.service';
 import { RefreshPerformanceViewService } from './services/refresh-performance-view.service';
+import { RefreshTokenRanksService } from './services/refresh-token-ranks.service';
 import { TokenHoldersLockService } from './services/token-holders-lock.service';
 import { Post } from '@/social/entities/post.entity';
 
@@ -76,6 +77,7 @@ import { Post } from '@/social/entities/post.entity';
     UpdateTrendingTokensService,
     RefreshTokenEligibilityCountsService,
     RefreshPerformanceViewService,
+    RefreshTokenRanksService,
   ],
   exports: [TypeOrmModule, TokensService, TokenWebsocketGateway],
 })

--- a/src/tokens/tokens.module.ts
+++ b/src/tokens/tokens.module.ts
@@ -22,6 +22,7 @@ import { Transaction } from '@/transactions/entities/transaction.entity';
 import { UpdateTrendingTokensService } from './services/update-trending-tokens.service';
 import { TokenPerformanceController } from './controllers/token-performance.controller';
 import { TokenEligibilityCounts } from './entities/token-eligibility-counts.entity';
+import { TokenTradeEligibilityCounts } from './entities/token-trade-eligibility-counts.entity';
 import { TokenPerformanceView } from './entities/tokens-performance.view';
 import { RefreshTokenEligibilityCountsService } from './services/refresh-token-eligibility-counts.service';
 import { RefreshPerformanceViewService } from './services/refresh-performance-view.service';
@@ -34,6 +35,7 @@ import { Post } from '@/social/entities/post.entity';
       Token,
       TokenHolder,
       TokenEligibilityCounts,
+      TokenTradeEligibilityCounts,
       TokenPerformanceView,
       Transaction,
       Post,

--- a/src/tokens/tokens.service.spec.ts
+++ b/src/tokens/tokens.service.spec.ts
@@ -433,11 +433,9 @@ describe('TokensService', () => {
     expect(tokenEligibilityCountsRepository.findOne).toHaveBeenCalledWith({
       where: { symbol: 'TEST' },
     });
-    expect(tokenTradeEligibilityCountsRepository.findOne).toHaveBeenCalledWith(
-      {
-        where: { sale_address: 'ct_sale' },
-      },
-    );
+    expect(tokenTradeEligibilityCountsRepository.findOne).toHaveBeenCalledWith({
+      where: { sale_address: 'ct_sale' },
+    });
     expect(breakdown).toEqual({
       sale_address: 'ct_sale',
       symbol: 'TEST',

--- a/src/tokens/tokens.service.spec.ts
+++ b/src/tokens/tokens.service.spec.ts
@@ -26,6 +26,7 @@ describe('TokensService', () => {
   let tokenTradeEligibilityCountsRepository: any;
   let communityFactoryService: any;
   let pullTokenInfoQueue: any;
+  let updateTrendingScoresQueue: any;
 
   beforeEach(() => {
     (fetchJson as jest.Mock).mockReset();
@@ -56,6 +57,9 @@ describe('TokensService', () => {
     pullTokenInfoQueue = {
       add: jest.fn(),
     };
+    updateTrendingScoresQueue = {
+      add: jest.fn(),
+    };
 
     service = new TokensService(
       tokensRepository as any,
@@ -69,6 +73,7 @@ describe('TokensService', () => {
       {} as any,
       communityFactoryService as any,
       pullTokenInfoQueue as any,
+      updateTrendingScoresQueue as any,
     );
   });
 
@@ -729,6 +734,45 @@ describe('TokensService', () => {
       expect(params).toEqual(['ct_factory', ['ct_x']]);
       expect(sql).toContain('ANY($2::text[])');
       expect(result.get('ct_x')).toBe(3);
+    });
+  });
+
+  describe('queueTrendingScoresForSymbols', () => {
+    it('enqueues one deduped, delayed job per normalized symbol', async () => {
+      await service.queueTrendingScoresForSymbols(['alpha', 'ALPHA', ' beta ']);
+
+      expect(updateTrendingScoresQueue.add).toHaveBeenCalledTimes(2);
+      expect(updateTrendingScoresQueue.add).toHaveBeenCalledWith(
+        { symbol: 'ALPHA' },
+        expect.objectContaining({
+          jobId: 'updateTrendingScores-ALPHA',
+          delay: 5_000,
+          removeOnComplete: true,
+          removeOnFail: true,
+        }),
+      );
+      expect(updateTrendingScoresQueue.add).toHaveBeenCalledWith(
+        { symbol: 'BETA' },
+        expect.objectContaining({ jobId: 'updateTrendingScores-BETA' }),
+      );
+    });
+
+    it('does not enqueue anything for blank symbols', async () => {
+      await service.queueTrendingScoresForSymbols(['', '   ']);
+
+      expect(updateTrendingScoresQueue.add).not.toHaveBeenCalled();
+    });
+
+    it('configures retries so a transient failure does not permanently drop the recompute', async () => {
+      await service.queueTrendingScoresForSymbols(['alpha']);
+
+      expect(updateTrendingScoresQueue.add).toHaveBeenCalledWith(
+        { symbol: 'ALPHA' },
+        expect.objectContaining({
+          attempts: 3,
+          backoff: expect.objectContaining({ type: 'exponential' }),
+        }),
+      );
     });
   });
 });

--- a/src/tokens/tokens.service.spec.ts
+++ b/src/tokens/tokens.service.spec.ts
@@ -23,6 +23,7 @@ describe('TokensService', () => {
   let transactionsRepository: any;
   let postsRepository: any;
   let tokenEligibilityCountsRepository: any;
+  let tokenTradeEligibilityCountsRepository: any;
   let communityFactoryService: any;
   let pullTokenInfoQueue: any;
 
@@ -46,6 +47,9 @@ describe('TokensService', () => {
     tokenEligibilityCountsRepository = {
       findOne: jest.fn(),
     };
+    tokenTradeEligibilityCountsRepository = {
+      findOne: jest.fn(),
+    };
     communityFactoryService = {
       getCurrentFactory: jest.fn(),
     };
@@ -59,6 +63,7 @@ describe('TokensService', () => {
       transactionsRepository as any,
       postsRepository as any,
       tokenEligibilityCountsRepository as any,
+      tokenTradeEligibilityCountsRepository as any,
       {} as any,
       {} as any,
       {} as any,
@@ -281,8 +286,7 @@ describe('TokensService', () => {
       'eligibility_post_counts.symbol = UPPER(token.symbol)',
     );
     expect(tradeCountsAlias).toBe('eligibility_trade_counts');
-    expect(tradeCountsSql.startsWith('(')).toBe(true);
-    expect(tradeCountsSql).toContain('COUNT(*) AS trade_count');
+    expect(tradeCountsSql.name).toBe('TokenTradeEligibilityCounts');
     expect(tradeCountsCondition).toBe(
       'eligibility_trade_counts.sale_address = token.sale_address',
     );
@@ -415,22 +419,20 @@ describe('TokensService', () => {
       stored_post_count: 1,
       content_post_count: 2,
     });
-    tokensRepository.query.mockResolvedValue([
-      {
-        trade_count: '4',
-      },
-    ]);
+    tokenTradeEligibilityCountsRepository.findOne.mockResolvedValue({
+      trade_count: 4,
+    });
 
     const breakdown = await service.getTrendingEligibilityBreakdown('ct_sale');
 
-    const [eligibilityQuery, eligibilityParams] =
-      tokensRepository.query.mock.calls[0];
     expect(tokenEligibilityCountsRepository.findOne).toHaveBeenCalledWith({
       where: { symbol: 'TEST' },
     });
-    expect(eligibilityQuery).toContain('COUNT(*) AS trade_count');
-    expect(eligibilityQuery).toContain('tx.sale_address = $1');
-    expect(eligibilityParams).toEqual(['ct_sale']);
+    expect(tokenTradeEligibilityCountsRepository.findOne).toHaveBeenCalledWith(
+      {
+        where: { sale_address: 'ct_sale' },
+      },
+    );
     expect(breakdown).toEqual({
       sale_address: 'ct_sale',
       symbol: 'TEST',

--- a/src/tokens/tokens.service.ts
+++ b/src/tokens/tokens.service.ts
@@ -563,6 +563,7 @@ export class TokensService {
       price_data: any;
       sell_price_data: any;
       market_cap_data: any;
+      circulating_supply: BigNumber;
     }>
   > {
     const contract = await this.getTokenContracts(token);
@@ -610,6 +611,8 @@ export class TokensService {
     ]);
 
     const market_cap = total_supply.multipliedBy(price);
+    const aex9Address =
+      metaInfo?.token?.address || tokenContractInstance?.$options.address;
 
     const [price_data, sell_price_data, market_cap_data, dao_balance] =
       await Promise.all([
@@ -629,15 +632,45 @@ export class TokensService {
       price_data,
       market_cap,
       market_cap_data,
-      address:
-        metaInfo?.token?.address || tokenContractInstance?.$options.address,
+      address: aex9Address,
       name: metaInfo?.token?.name,
       symbol: metaInfo?.token?.symbol,
       beneficiary_address: metaInfo?.beneficiary,
       bonding_curve_address: metaInfo?.bondingCurve,
       owner_address: metaInfo?.owner,
       dao_balance: new BigNumber(dao_balance),
+      circulating_supply: await this.fetchCirculatingSupply(aex9Address),
     };
+  }
+
+  /**
+   * Middleware's AEX9 endpoint tracks `event_supply` off the token's
+   * Mint/Burn/Transfer event log independently of the bonding-curve
+   * contract's own `total_supply()` view read above; persisting it here lets
+   * the token page stop calling `{mdw}/v3/aex9/{address}` from the browser
+   * just to read this one field.
+   */
+  private async fetchCirculatingSupply(
+    aex9Address: string | undefined,
+  ): Promise<BigNumber | undefined> {
+    if (!aex9Address) {
+      return undefined;
+    }
+
+    try {
+      const data = await fetchJson(
+        `${ACTIVE_NETWORK.middlewareUrl}/v3/aex9/${aex9Address}`,
+      );
+      return data?.eventSupply != null
+        ? new BigNumber(data.eventSupply)
+        : undefined;
+    } catch (error) {
+      this.logger.error(
+        `fetchCirculatingSupply->error:: ${aex9Address}`,
+        error,
+      );
+      return undefined;
+    }
   }
 
   async updateTokenMetaDataFromCreateTx(

--- a/src/tokens/tokens.service.ts
+++ b/src/tokens/tokens.service.ts
@@ -728,14 +728,10 @@ export class TokensService {
 
     const rankedQuery = `
       WITH all_ranked_tokens AS (
-        SELECT 
-          token.*,
-          CAST(RANK() OVER (
-            ORDER BY 
-              CASE WHEN token.market_cap = 0 THEN 1 ELSE 0 END,
-              token.market_cap DESC,
-              token.created_at ASC
-          ) AS INTEGER) as rank
+        -- token.rank is persisted (RefreshTokenRanksService) instead of
+        -- computed here via RANK() OVER (...); that used to re-sort the
+        -- whole table on every list request regardless of orderBy.
+        SELECT token.*
         FROM token
         WHERE token.unlisted = false
       ),

--- a/src/tokens/tokens.service.ts
+++ b/src/tokens/tokens.service.ts
@@ -22,6 +22,7 @@ import { Queue } from 'bull';
 import moment from 'moment';
 import { TokenHolder } from './entities/token-holders.entity';
 import { TokenEligibilityCounts } from './entities/token-eligibility-counts.entity';
+import { TokenTradeEligibilityCounts } from './entities/token-trade-eligibility-counts.entity';
 import { Token } from './entities/token.entity';
 import { PULL_TOKEN_INFO_QUEUE } from './queues/constants';
 import { TokenWebsocketGateway } from './token-websocket.gateway';
@@ -141,6 +142,9 @@ export class TokensService {
 
     @InjectRepository(TokenEligibilityCounts)
     private tokenEligibilityCountsRepository: Repository<TokenEligibilityCounts>,
+
+    @InjectRepository(TokenTradeEligibilityCounts)
+    private tokenTradeEligibilityCountsRepository: Repository<TokenTradeEligibilityCounts>,
 
     private aeSdkService: AeSdkService,
 
@@ -766,19 +770,6 @@ export class TokensService {
     return `${alias}.${orderColumn} ${orderDirection}`;
   }
 
-  private buildEligibilityTradeCountsSubquery(): string {
-    return `
-      (
-        SELECT
-          tx.sale_address,
-          COUNT(*) AS trade_count
-        FROM transactions tx
-        WHERE tx.tx_type IN ('buy', 'sell')
-        GROUP BY tx.sale_address
-      )
-    `.trim();
-  }
-
   applyListEligibilityFilters(
     queryBuilder: SelectQueryBuilder<Token>,
   ): SelectQueryBuilder<Token> {
@@ -789,7 +780,7 @@ export class TokensService {
     );
 
     queryBuilder.leftJoin(
-      this.buildEligibilityTradeCountsSubquery(),
+      TokenTradeEligibilityCounts,
       'eligibility_trade_counts',
       'eligibility_trade_counts.sale_address = token.sale_address',
     );
@@ -823,22 +814,14 @@ export class TokensService {
       this.tokenEligibilityCountsRepository.findOne({
         where: { symbol: normalizedSymbol },
       }),
-      this.tokensRepository.query(
-        `
-          SELECT COUNT(*) AS trade_count
-          FROM transactions tx
-          WHERE tx.sale_address = $1
-            AND tx.tx_type IN ('buy', 'sell')
-        `,
-        [token.sale_address],
-      ),
+      this.tokenTradeEligibilityCountsRepository.findOne({
+        where: { sale_address: token.sale_address },
+      }),
     ]);
-
-    const rawBreakdown = tradeCounts[0] ?? {};
 
     const holdersCount = Number(token.holders_count || 0);
     const postCount = Number(counts?.post_count || 0);
-    const tradeCount = Number(rawBreakdown?.trade_count || 0);
+    const tradeCount = Number(tradeCounts?.trade_count || 0);
 
     const passes = {
       holders: holdersCount >= TOKEN_LIST_ELIGIBILITY_CONFIG.MIN_HOLDERS,

--- a/src/tokens/tokens.service.ts
+++ b/src/tokens/tokens.service.ts
@@ -24,7 +24,10 @@ import { TokenHolder } from './entities/token-holders.entity';
 import { TokenEligibilityCounts } from './entities/token-eligibility-counts.entity';
 import { TokenTradeEligibilityCounts } from './entities/token-trade-eligibility-counts.entity';
 import { Token } from './entities/token.entity';
-import { PULL_TOKEN_INFO_QUEUE } from './queues/constants';
+import {
+  PULL_TOKEN_INFO_QUEUE,
+  UPDATE_TRENDING_SCORES_QUEUE,
+} from './queues/constants';
 import { TokenWebsocketGateway } from './token-websocket.gateway';
 import { Transaction } from '@/transactions/entities/transaction.entity';
 import { Post } from '@/social/entities/post.entity';
@@ -156,6 +159,9 @@ export class TokensService {
 
     @InjectQueue(PULL_TOKEN_INFO_QUEUE)
     private readonly pullTokenInfoQueue: Queue,
+
+    @InjectQueue(UPDATE_TRENDING_SCORES_QUEUE)
+    private readonly updateTrendingScoresQueue: Queue,
   ) {
     this.init();
   }
@@ -1398,6 +1404,44 @@ export class TokensService {
       .sort((a, b) => b.getTime() - a.getTime());
 
     return validDates[0] ?? null;
+  }
+
+  /**
+   * Enqueues a trending-score recompute per symbol instead of running it
+   * inline. Saving a post synchronously ran a RECURSIVE thread CTE + tips +
+   * reads aggregation (`calculateTokenTrendingMetrics`) per mentioned symbol
+   * on the request path; each job here is deduped by symbol (`jobId`) with a
+   * short delay so a burst of posts mentioning the same symbol collapses
+   * into one recompute instead of one per post.
+   */
+  async queueTrendingScoresForSymbols(symbols: string[]): Promise<void> {
+    const normalizedSymbols = [
+      ...new Set(
+        symbols
+          .map((symbol) => (symbol || '').trim().toUpperCase())
+          .filter(Boolean),
+      ),
+    ];
+
+    await Promise.all(
+      normalizedSymbols.map((symbol) =>
+        this.updateTrendingScoresQueue.add(
+          { symbol },
+          {
+            jobId: `updateTrendingScores-${symbol}`,
+            delay: 5_000,
+            removeOnComplete: true,
+            removeOnFail: true,
+            // Bull defaults `attempts` to 1 -- without this, a transient DB
+            // blip during calculateTokenTrendingMetrics fails the job once
+            // and it's gone, silently leaving that symbol's trending score
+            // stale until another post happens to mention it again.
+            attempts: 3,
+            backoff: { type: 'exponential', delay: 5_000 },
+          },
+        ),
+      ),
+    );
   }
 
   async updateTrendingScoresForSymbols(symbols: string[]): Promise<void> {

--- a/src/transactions/entities/transaction.entity.ts
+++ b/src/transactions/entities/transaction.entity.ts
@@ -27,6 +27,7 @@ import {
   'address',
   'tx_type',
 ])
+@Index('IDX_TRANSACTION_SALE_ADDRESS_TX_TYPE', ['sale_address', 'tx_type'])
 export class Transaction {
   @Index()
   @PrimaryColumn()

--- a/src/transactions/services/transaction.service.spec.ts
+++ b/src/transactions/services/transaction.service.spec.ts
@@ -35,6 +35,7 @@ describe('TransactionService', () => {
       }),
       save: jest.fn(),
       update: jest.fn(),
+      manager: { query: jest.fn().mockResolvedValue(undefined) },
     } as any;
 
     tokenHolderRepository = {
@@ -185,6 +186,114 @@ describe('TransactionService', () => {
       expect(transactionRepository.save).toHaveBeenCalled();
       expect(result).toBeInstanceOf(Transaction);
     }
+  });
+
+  it('increments the trade eligibility counter for a new buy transaction', async () => {
+    const existingTxQuery = {
+      where: jest.fn().mockReturnThis(),
+      getOne: jest.fn().mockResolvedValue(null),
+    };
+    transactionRepository.createQueryBuilder.mockReturnValue(existingTxQuery);
+    tokenService.getToken = jest.fn().mockResolvedValue({
+      sale_address: 'ct_123',
+      factory_address: 'test_factory',
+      collection: 'default',
+    } as Token);
+    service.parseTransactionData = jest.fn().mockResolvedValue({
+      volume: new BigNumber(10),
+      amount: new BigNumber(100),
+      total_supply: new BigNumber(1000),
+      protocol_reward: new BigNumber(1),
+      _should_revalidate: false,
+    });
+    const transaction = {
+      tx: {
+        function: BCL_FUNCTIONS.buy,
+        contractId: 'ct_123',
+        callerId: 'ak_123',
+        decodedData: [
+          { name: 'Mint', args: [null, '100'] },
+          { name: 'PriceChange', args: [1, 2] },
+        ],
+      },
+      hash: 'tx_buy',
+      blockHeight: 100,
+      microIndex: 1,
+      microTime: moment().subtract(1, 'hour').valueOf(),
+    };
+    service.decodeTransactionData = jest.fn().mockResolvedValue(transaction);
+    aePricingService.getPriceData = jest
+      .fn()
+      .mockResolvedValue(new BigNumber(1));
+    transactionRepository.save = jest.fn().mockResolvedValue(new Transaction());
+
+    await service.saveTransaction(transaction as any);
+
+    expect(transactionRepository.manager.query).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO token_trade_eligibility_counts'),
+      ['ct_123'],
+    );
+  });
+
+  it('does not increment the trade eligibility counter for a create_community transaction', async () => {
+    const deleteOldCreateCommunityQuery = {
+      delete: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      execute: jest.fn().mockResolvedValue(undefined),
+    };
+    const existingTxQuery = {
+      where: jest.fn().mockReturnThis(),
+      getOne: jest.fn().mockResolvedValue(null),
+    };
+    transactionRepository.createQueryBuilder.mockImplementation(
+      (alias: string) =>
+        alias === 'transactions'
+          ? deleteOldCreateCommunityQuery
+          : existingTxQuery,
+    );
+    tokenService.getToken = jest.fn().mockResolvedValue({
+      sale_address: 'ct_123',
+      factory_address: 'test_factory',
+      collection: 'default',
+    } as Token);
+    service.parseTransactionData = jest.fn().mockResolvedValue({
+      volume: new BigNumber(10),
+      amount: new BigNumber(100),
+      total_supply: new BigNumber(1000),
+      protocol_reward: new BigNumber(1),
+      _should_revalidate: false,
+    });
+    const transaction = {
+      tx: {
+        function: BCL_FUNCTIONS.create_community,
+        contractId: 'ct_123',
+        callerId: 'ak_123',
+        decodedData: [
+          { name: 'Mint', args: [null, '100'] },
+          { name: 'PriceChange', args: [1, 2] },
+        ],
+        return: {
+          value: [{ value: 'ct_123' }, { value: 'ct_456' }],
+        },
+      },
+      hash: 'tx_create',
+      blockHeight: 100,
+      microIndex: 1,
+      microTime: moment().subtract(1, 'hour').valueOf(),
+    };
+    service.decodeTransactionData = jest.fn().mockResolvedValue(transaction);
+    aePricingService.getPriceData = jest
+      .fn()
+      .mockResolvedValue(new BigNumber(1));
+    transactionRepository.save = jest.fn().mockResolvedValue(new Transaction());
+
+    await service.saveTransaction(transaction as any);
+
+    expect(transactionRepository.manager.query).not.toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO token_trade_eligibility_counts'),
+      expect.anything(),
+    );
   });
 
   it('should handle parseTransactionData correctly', async () => {

--- a/src/transactions/services/transaction.service.spec.ts
+++ b/src/transactions/services/transaction.service.spec.ts
@@ -5,10 +5,8 @@ import { Transaction } from '../entities/transaction.entity';
 import { TokensService } from '@/tokens/tokens.service';
 import { AePricingService } from '@/ae-pricing/ae-pricing.service';
 import { CommunityFactoryService } from '@/ae/community-factory.service';
-import { TokenWebsocketGateway } from '@/tokens/token-websocket.gateway';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Token } from '@/tokens/entities/token.entity';
-import { TokenHolder } from '@/tokens/entities/token-holders.entity';
 import { BCL_FUNCTIONS } from '@/configs';
 import BigNumber from 'bignumber.js';
 import moment from 'moment';
@@ -16,7 +14,6 @@ import moment from 'moment';
 jest.mock('@/tokens/tokens.service');
 jest.mock('@/ae-pricing/ae-pricing.service');
 jest.mock('@/ae/community-factory.service');
-jest.mock('@/tokens/token-websocket.gateway');
 
 describe('TransactionService', () => {
   let service: TransactionService;
@@ -24,8 +21,6 @@ describe('TransactionService', () => {
   let tokenService: jest.Mocked<TokensService>;
   let aePricingService: jest.Mocked<AePricingService>;
   let communityFactoryService: jest.Mocked<CommunityFactoryService>;
-  let tokenWebsocketGateway: jest.Mocked<TokenWebsocketGateway>;
-  let tokenHolderRepository: any | jest.Mocked<Repository<TokenHolder>>;
 
   beforeEach(async () => {
     transactionRepository = {
@@ -36,17 +31,6 @@ describe('TransactionService', () => {
       save: jest.fn(),
       update: jest.fn(),
       manager: { query: jest.fn().mockResolvedValue(undefined) },
-    } as any;
-
-    tokenHolderRepository = {
-      createQueryBuilder: jest.fn().mockReturnValue({
-        where: jest.fn().mockReturnThis(),
-        andWhere: jest.fn().mockReturnThis(),
-        getCount: jest.fn().mockResolvedValue(0),
-        getOne: jest.fn().mockResolvedValue(null),
-      }),
-      save: jest.fn(),
-      update: jest.fn(),
     } as any;
 
     tokenService = {
@@ -74,10 +58,6 @@ describe('TransactionService', () => {
       }),
     } as any;
 
-    tokenWebsocketGateway = {
-      handleTokenHistory: jest.fn(),
-    } as any;
-
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         TransactionService,
@@ -88,11 +68,6 @@ describe('TransactionService', () => {
         { provide: TokensService, useValue: tokenService },
         { provide: AePricingService, useValue: aePricingService },
         { provide: CommunityFactoryService, useValue: communityFactoryService },
-        { provide: TokenWebsocketGateway, useValue: tokenWebsocketGateway },
-        {
-          provide: getRepositoryToken(TokenHolder),
-          useValue: tokenHolderRepository,
-        },
       ],
     }).compile();
 
@@ -314,91 +289,5 @@ describe('TransactionService', () => {
     expect(result.volume).toBeInstanceOf(BigNumber);
     expect(result.amount).toBeInstanceOf(BigNumber);
     expect(result.total_supply).toBeInstanceOf(BigNumber);
-  });
-
-  it('should not create a holder row for a sell with no existing holder', async () => {
-    const existingHolderQuery = {
-      where: jest.fn().mockReturnThis(),
-      andWhere: jest.fn().mockReturnThis(),
-      getOne: jest.fn().mockResolvedValue(null),
-    };
-
-    tokenHolderRepository.createQueryBuilder.mockReturnValueOnce(
-      existingHolderQuery,
-    );
-
-    await service.updateTokenHolder(
-      {
-        address: 'ct_token',
-        sale_address: 'ct_sale',
-        holders_count: 0,
-      } as Token,
-      {
-        tx: {
-          function: BCL_FUNCTIONS.sell,
-          callerId: 'ak_user',
-        },
-        hash: 'th_sell',
-        blockHeight: 42,
-      } as any,
-      new BigNumber(1),
-    );
-
-    // A sell with no existing holder is a no-op branch: no holder-count
-    // query should run (that query only happens on the buy-creates-a-new-
-    // holder path), and only the one createQueryBuilder call (the
-    // existence check) should have happened.
-    expect(tokenHolderRepository.createQueryBuilder).toHaveBeenCalledTimes(1);
-    expect(tokenHolderRepository.save).not.toHaveBeenCalled();
-    expect(tokenService.update).not.toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({ holders_count: expect.any(Number) }),
-    );
-    expect(tokenService.loadAndSaveTokenHoldersFromMdw).toHaveBeenCalledWith(
-      'ct_sale',
-    );
-  });
-
-  it('should query the holder count exactly once when a buy creates a new holder', async () => {
-    const existingHolderQuery = {
-      where: jest.fn().mockReturnThis(),
-      andWhere: jest.fn().mockReturnThis(),
-      getOne: jest.fn().mockResolvedValue(null),
-    };
-    const holderCountQuery = {
-      where: jest.fn().mockReturnThis(),
-      andWhere: jest.fn().mockReturnThis(),
-      getCount: jest.fn().mockResolvedValue(4),
-    };
-
-    tokenHolderRepository.createQueryBuilder
-      .mockReturnValueOnce(existingHolderQuery)
-      .mockReturnValueOnce(holderCountQuery);
-
-    await service.updateTokenHolder(
-      {
-        address: 'ct_token',
-        sale_address: 'ct_sale',
-        holders_count: 4,
-      } as Token,
-      {
-        tx: {
-          function: BCL_FUNCTIONS.buy,
-          callerId: 'ak_user',
-        },
-        hash: 'th_buy',
-        blockHeight: 42,
-      } as any,
-      new BigNumber(1),
-    );
-
-    expect(tokenHolderRepository.createQueryBuilder).toHaveBeenCalledTimes(2);
-    expect(tokenHolderRepository.save).toHaveBeenCalledWith(
-      expect.objectContaining({ address: 'ak_user', aex9_address: 'ct_token' }),
-    );
-    expect(tokenService.update).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({ holders_count: 5 }),
-    );
   });
 });

--- a/src/transactions/services/transaction.service.ts
+++ b/src/transactions/services/transaction.service.ts
@@ -14,6 +14,10 @@ import moment from 'moment';
 import { Repository } from 'typeorm';
 import { Transaction } from '../entities/transaction.entity';
 import { Tx } from '@/mdw-sync/entities/tx.entity';
+import {
+  TRADE_ELIGIBLE_TX_TYPES,
+  incrementTradeEligibilityCount,
+} from '@/plugins/bcl/utils/trade-eligibility.util';
 
 @Injectable()
 export class TransactionService {
@@ -172,6 +176,23 @@ export class TransactionService {
         moment().diff(moment(rawTransaction.microTime), 'hours') >= 5,
     };
     const transaction = await this.transactionRepository.save(txData);
+
+    // This legacy path's own `exists` check above already guarantees this is
+    // a first-time insert for tx_hash, so -- unlike TransactionPersistenceService --
+    // no extra race guard is needed here before incrementing.
+    if (TRADE_ELIGIBLE_TX_TYPES.has(txData.tx_type)) {
+      try {
+        await incrementTradeEligibilityCount(
+          saleAddress,
+          this.transactionRepository.manager,
+        );
+      } catch (error) {
+        this.logger.error(
+          `Failed to increment trade eligibility count for ${saleAddress}`,
+          error instanceof Error ? error.stack : String(error),
+        );
+      }
+    }
 
     if (!this.isTokenSupportedCollection(token)) {
       return transaction;

--- a/src/transactions/services/transaction.service.ts
+++ b/src/transactions/services/transaction.service.ts
@@ -1,9 +1,7 @@
 import { AePricingService } from '@/ae-pricing/ae-pricing.service';
 import { CommunityFactoryService } from '@/ae/community-factory.service';
 import { BCL_FUNCTIONS } from '@/configs';
-import { TokenHolder } from '@/tokens/entities/token-holders.entity';
 import { Token } from '@/tokens/entities/token.entity';
-import { TokenWebsocketGateway } from '@/tokens/token-websocket.gateway';
 import { TokensService } from '@/tokens/tokens.service';
 import { ITransaction } from '@/utils/types';
 import { Encoded, toAe } from '@aeternity/aepp-sdk';
@@ -27,13 +25,9 @@ export class TransactionService {
     private readonly communityFactoryService: CommunityFactoryService,
     private readonly aePricingService: AePricingService,
     private readonly tokenService: TokensService,
-    private readonly tokenWebsocketGateway: TokenWebsocketGateway,
 
     @InjectRepository(Transaction)
     private transactionRepository: Repository<Transaction>,
-
-    @InjectRepository(TokenHolder)
-    private tokenHolderRepository: Repository<TokenHolder>,
   ) {
     // this._testTransaction(
     //   'th_8B9qcMtArB59kBAHKKzPo4JXyECgBUBDH415gy8a3K69yr837',
@@ -48,7 +42,6 @@ export class TransactionService {
   async saveTransaction(
     rawTransaction: ITransaction,
     token?: Token,
-    shouldBroadcast?: boolean,
   ): Promise<Transaction> {
     if (
       !Object.keys(BCL_FUNCTIONS).includes(rawTransaction?.tx?.function) ||
@@ -194,21 +187,6 @@ export class TransactionService {
       }
     }
 
-    if (!this.isTokenSupportedCollection(token)) {
-      return transaction;
-    }
-    if (shouldBroadcast) {
-      // it should only broadcast if token is within supported collections
-      await this.tokenService.syncTokenPrice(token);
-      this.tokenWebsocketGateway?.handleTokenHistory({
-        sale_address: saleAddress,
-        data: txData,
-        token: token,
-      });
-      // update token holder
-      await this.updateTokenHolder(token, rawTransaction, volume);
-      await this.tokenService.updateTokenTrendingScore(token);
-    }
     return transaction;
   }
 
@@ -399,101 +377,6 @@ export class TransactionService {
   //     total_supply,
   //   } = await this.parseTransactionData(rawTransaction);
   // }
-
-  async updateTokenHolder(
-    token: Token,
-    rawTransaction: ITransaction,
-    volume: BigNumber,
-  ): Promise<void> {
-    try {
-      const bigNumberVolume = new BigNumber(volume).multipliedBy(10 ** 18);
-
-      const tokenHolder = await this.tokenHolderRepository
-        .createQueryBuilder('token_holders')
-        .where('token_holders.aex9_address = :aex9_address', {
-          aex9_address: token.address,
-        })
-        .andWhere('token_holders.address = :address', {
-          address: rawTransaction.tx.callerId,
-        })
-        .getOne();
-      if (tokenHolder) {
-        let tokenHolderBalance = tokenHolder.balance;
-        // if balance is negative, set it to 0
-        if (tokenHolderBalance.isNegative()) {
-          tokenHolderBalance = new BigNumber(0);
-        }
-        const wasHolder = tokenHolderBalance.gt(0);
-        let newBalance = tokenHolderBalance;
-        // if is buy
-        if (rawTransaction.tx.function === BCL_FUNCTIONS.buy) {
-          newBalance = tokenHolderBalance.plus(bigNumberVolume);
-        }
-        // if is sell
-        if (rawTransaction.tx.function === BCL_FUNCTIONS.sell) {
-          newBalance = tokenHolderBalance.minus(bigNumberVolume);
-          if (newBalance.isNegative()) {
-            newBalance = new BigNumber(0);
-          }
-        }
-        await this.tokenHolderRepository.update(tokenHolder.id, {
-          balance: newBalance,
-          last_tx_hash: rawTransaction.hash,
-          block_number: rawTransaction.blockHeight,
-        });
-
-        const isHolder = newBalance.gt(0);
-        if (wasHolder !== isHolder || (isHolder && token.holders_count == 0)) {
-          const currentHolderCount = await this.tokenHolderRepository
-            .createQueryBuilder('token_holders')
-            .where('token_holders.aex9_address = :aex9_address', {
-              aex9_address: token.address,
-            })
-            .andWhere('token_holders.balance > 0')
-            .getCount();
-          await this.tokenService.update(token, {
-            holders_count: currentHolderCount,
-          });
-        }
-      } else {
-        if (rawTransaction.tx.function === BCL_FUNCTIONS.buy) {
-          const tokenHolderCount = await this.tokenHolderRepository
-            .createQueryBuilder('token_holders')
-            .where('token_holders.aex9_address = :aex9_address', {
-              aex9_address: token.address,
-            })
-            .andWhere('token_holders.balance > 0')
-            .getCount();
-          // create token holder
-          await this.tokenHolderRepository.save({
-            id: `${rawTransaction.tx.callerId}_${token.address}`,
-            aex9_address: token.address,
-            address: rawTransaction.tx.callerId,
-            balance: bigNumberVolume,
-            last_tx_hash: rawTransaction.hash,
-            block_number: rawTransaction.blockHeight,
-          });
-          // increment token holders count
-          await this.tokenService.update(token, {
-            holders_count: tokenHolderCount + 1,
-          });
-        }
-      }
-    } catch (error) {
-      this.logger.error('Error updating token holder', error);
-    }
-    try {
-      await this.tokenService.loadAndSaveTokenHoldersFromMdw(
-        token.sale_address as Encoded.ContractAddress,
-      );
-    } catch (error: any) {
-      this.logger.error(
-        `Error loading and saving token holders from mdw`,
-        error,
-        error.stack,
-      );
-    }
-  }
 
   async deleteNonValidTransactionsInBlock(
     blockNumber: number,

--- a/src/utils/concurrency.util.spec.ts
+++ b/src/utils/concurrency.util.spec.ts
@@ -1,0 +1,54 @@
+import { mapWithConcurrency } from './concurrency.util';
+
+describe('mapWithConcurrency', () => {
+  it('returns [] for an empty input without invoking the mapper', async () => {
+    const mapper = jest.fn();
+    const result = await mapWithConcurrency([], 5, mapper);
+
+    expect(result).toEqual([]);
+    expect(mapper).not.toHaveBeenCalled();
+  });
+
+  it('preserves result order regardless of completion order', async () => {
+    const delays = [30, 10, 20, 0];
+    const result = await mapWithConcurrency(delays, 4, (delay, index) =>
+      new Promise<number>((resolve) =>
+        setTimeout(() => resolve(index), delay),
+      ),
+    );
+
+    expect(result).toEqual([0, 1, 2, 3]);
+  });
+
+  it('never runs more than `concurrency` mappers at once', async () => {
+    let active = 0;
+    let maxActive = 0;
+
+    await mapWithConcurrency(
+      Array.from({ length: 20 }, (_, i) => i),
+      3,
+      async () => {
+        active++;
+        maxActive = Math.max(maxActive, active);
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        active--;
+      },
+    );
+
+    expect(maxActive).toBeLessThanOrEqual(3);
+  });
+
+  it('clamps concurrency to the item count', async () => {
+    let maxActive = 0;
+    let active = 0;
+
+    await mapWithConcurrency([1, 2], 10, async () => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      await Promise.resolve();
+      active--;
+    });
+
+    expect(maxActive).toBeLessThanOrEqual(2);
+  });
+});

--- a/src/utils/concurrency.util.spec.ts
+++ b/src/utils/concurrency.util.spec.ts
@@ -11,10 +11,13 @@ describe('mapWithConcurrency', () => {
 
   it('preserves result order regardless of completion order', async () => {
     const delays = [30, 10, 20, 0];
-    const result = await mapWithConcurrency(delays, 4, (delay, index) =>
-      new Promise<number>((resolve) =>
-        setTimeout(() => resolve(index), delay),
-      ),
+    const result = await mapWithConcurrency(
+      delays,
+      4,
+      (delay, index) =>
+        new Promise<number>((resolve) =>
+          setTimeout(() => resolve(index), delay),
+        ),
     );
 
     expect(result).toEqual([0, 1, 2, 3]);

--- a/src/utils/concurrency.util.ts
+++ b/src/utils/concurrency.util.ts
@@ -1,0 +1,32 @@
+/**
+ * Runs `mapper` over `items` with at most `concurrency` in flight at once,
+ * preserving result order. A fixed-size worker pool pulls the next index
+ * as each one finishes, rather than chunking into fixed batches, so a slow
+ * item never idles the other workers.
+ */
+export async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  mapper: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  if (items.length === 0) {
+    return [];
+  }
+
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+  const workerCount = Math.min(Math.max(concurrency, 1), items.length);
+
+  const workers = Array.from({ length: workerCount }, async () => {
+    while (true) {
+      const currentIndex = nextIndex++;
+      if (currentIndex >= items.length) {
+        return;
+      }
+      results[currentIndex] = await mapper(items[currentIndex], currentIndex);
+    }
+  });
+
+  await Promise.all(workers);
+  return results;
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches leaderboard PnL SQL, transaction indexing side effects, and several schema migrations; feed cursor and eligibility counter logic need careful regression testing, but changes are largely read-path optimization and additive APIs.
> 
> **Overview**
> This PR is mainly a **performance and API consolidation** pass: new read endpoints replace multi-request client flows, hot paths batch work into fewer queries, and several expensive aggregates move to **materialized columns/tables** plus targeted indexes.
> 
> **New/changed HTTP APIs:** `GET /feed` merges posts, token creations, and trades with keyset cursors (including tie-breaking via `seenIds`); `GET /search` fans out tokens, accounts, and posts in parallel; `GET /accounts/:address/portfolio/value` returns a live ticker without full history; account detail adds **`holdings_count`**; invitations support **`inviter`** filter and derived claim fields; tips list adds optional **`post_id`**.
> 
> **Leaderboard & PnL:** Event-window leaderboard now calls **`calculateTokenPnlsBatchForAddresses`** once instead of up to hundreds of per-address PnL queries. Account chain-name resolution uses **bounded parallel middleware verification** with per-call timeouts; full account rebuild moves from boot to a **daily cron** when enabled.
> 
> **Tokens & transactions:** Trade-count eligibility uses **`token_trade_eligibility_counts`** (backfilled migration, incremented on new buy/sell saves with advisory locking); list ranking reads persisted **`token.rank`** (refreshed on a schedule). Trending score updates from posts/tips switch to **`queueTrendingScoresForSymbols`**. Token sync path gains **`circulating_supply`** persistence (per migration).
> 
> **Infra guardrails:** Generic REST/GraphQL list endpoints cap **`page` at 500** by default (`EntityConfig.maxPage` override for MDW mirror tables). Migrations add buy/sell transaction indexes, GIN on `posts.token_mentions`, and related token indexes; mention-exists SQL is shaped for index use.
> 
> **Other batching:** Popular-post ranking hydrates slimmer post rows; token-gated room eligibility batch-resolves pubkeys; post topic creation and orphan-comment cleanup use set-based SQL; shared **`mapWithConcurrency`** replaces duplicated helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 387200bc0a76520ab5b08fb52e0ffe110d3d6613. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->